### PR TITLE
Address Gemini review feedback on shortcuts and Now Playing

### DIFF
--- a/apps/web/src/components/shared/KeyboardShortcutsHelp.tsx
+++ b/apps/web/src/components/shared/KeyboardShortcutsHelp.tsx
@@ -11,6 +11,11 @@ import { NAV_VIEWS } from '@/hooks/useKeyboardShortcuts';
 const isMac = navigator.platform.toUpperCase().includes('MAC');
 const MOD = isMac ? '\u2318' : 'Ctrl';
 
+// Static film grain backdrop. Hoisted out of the JSX so the structural
+// markup stays scannable; this string never changes per render.
+const FILM_GRAIN_SVG =
+  "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")";
+
 interface Shortcut {
   keys: string[];
   actionKey: string;
@@ -22,9 +27,18 @@ interface ShortcutCategory {
   shortcuts: Shortcut[];
 }
 
-function getShortcutCategories(): ShortcutCategory[] {
-  return [
-    {
+// Returned as a keyed record (not an array) so consumers can destructure
+// by name without depending on positional order. Adding or reordering
+// categories here is now a compile-error if any consumer is missed.
+interface ShortcutCategories {
+  playback: ShortcutCategory;
+  navigation: ShortcutCategory;
+  panelsUi: ShortcutCategory;
+}
+
+function getShortcutCategories(): ShortcutCategories {
+  return {
+    playback: {
       titleKey: 'playback',
       glyph: '01',
       shortcuts: [
@@ -43,7 +57,7 @@ function getShortcutCategories(): ShortcutCategory[] {
         { keys: ['L'], actionKey: 'favoriteTrack' },
       ],
     },
-    {
+    navigation: {
       titleKey: 'navigation',
       glyph: '02',
       // Numeric nav entries are derived from NAV_VIEWS so the help dialog
@@ -56,7 +70,7 @@ function getShortcutCategories(): ShortcutCategory[] {
         { keys: [MOD, 'K'], actionKey: 'commandPalette' },
       ],
     },
-    {
+    panelsUi: {
       titleKey: 'panelsUi',
       glyph: '03',
       shortcuts: [
@@ -70,7 +84,7 @@ function getShortcutCategories(): ShortcutCategory[] {
         { keys: ['Esc'], actionKey: 'closePanel' },
       ],
     },
-  ];
+  };
 }
 
 function Kbd({ children }: { children: string }) {
@@ -158,15 +172,13 @@ function CategorySection({
 function KeyboardShortcutsHelp() {
   const { t } = useTranslation('shortcuts');
   const [open, setOpen] = useState(false);
-  const categories = useMemo(() => getShortcutCategories(), []);
+  const { playback, navigation, panelsUi } = useMemo(() => getShortcutCategories(), []);
 
   useEffect(() => {
     const handler = () => setOpen(true);
     window.addEventListener('open-shortcut-help', handler);
     return () => window.removeEventListener('open-shortcut-help', handler);
   }, []);
-
-  const [playback, navigation, panelsUi] = categories;
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -187,10 +199,7 @@ function KeyboardShortcutsHelp() {
         <div
           aria-hidden
           className="pointer-events-none absolute inset-0 opacity-[0.03] mix-blend-overlay"
-          style={{
-            backgroundImage:
-              "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")",
-          }}
+          style={{ backgroundImage: FILM_GRAIN_SVG }}
         />
 
         <div className="relative">

--- a/apps/web/src/hooks/useKeyboardShortcuts.test.ts
+++ b/apps/web/src/hooks/useKeyboardShortcuts.test.ts
@@ -315,7 +315,36 @@ describe('useKeyboardShortcuts', () => {
 
   // --- Escape ---
 
-  describe('Escape - clear selection / close panel', () => {
+  describe('Escape - back / clear selection / close panel', () => {
+    it('exits Now Playing view first, before any other Esc handling', () => {
+      setup();
+      // Set up: in Now Playing with an open right panel. Esc should
+      // exit the immersive view and leave the panel alone (the handler
+      // takes the now-playing branch and returns before reaching the
+      // panel-close branch).
+      //
+      // Note: we can't usefully assert on selection here. `useSelectionStore`
+      // has a module-level subscription on `useAppStore` (see
+      // useSelectionStore.ts:67-74) that auto-clears selection any time
+      // `activeView` changes. So `exitNowPlaying()` clears the selection
+      // as a side effect regardless of which Esc branch the handler
+      // takes — selection is unobservable for distinguishing branches.
+      // The panel is the cleaner signal.
+      useAppStore.setState({
+        activeView: 'now-playing',
+        previousView: 'library',
+        rightPanel: 'queue',
+      });
+
+      pressKey('Escape');
+
+      // Exited back to previousView via exitNowPlaying()
+      expect(useAppStore.getState().activeView).toBe('library');
+      // Panel untouched — handler returned early, never reached the
+      // setRightPanel(null) branch.
+      expect(useAppStore.getState().rightPanel).toBe('queue');
+    });
+
     it('clears selection when tracks are selected', () => {
       setup();
       useSelectionStore.setState({

--- a/apps/web/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/web/src/hooks/useKeyboardShortcuts.ts
@@ -217,6 +217,15 @@ export function useKeyboardShortcuts() {
         }
         case 'Escape': {
           if (document.querySelector('[data-radix-portal]')) return;
+          // Now Playing is a modal-like full-screen view; Esc should
+          // dismiss it before any background-state cleanup. Standard
+          // modal interaction.
+          const appState = useAppStore.getState();
+          if (appState.activeView === 'now-playing') {
+            e.preventDefault();
+            appState.exitNowPlaying();
+            return;
+          }
           // Clear track selection first
           const { selectedTrackIds, clearSelection } = useSelectionStore.getState();
           if (selectedTrackIds.size > 0) {
@@ -224,10 +233,9 @@ export function useKeyboardShortcuts() {
             clearSelection();
             return;
           }
-          const { rightPanel, setRightPanel } = useAppStore.getState();
-          if (rightPanel !== null) {
+          if (appState.rightPanel !== null) {
             e.preventDefault();
-            setRightPanel(null);
+            appState.setRightPanel(null);
           }
           return;
         }

--- a/apps/web/src/locales/en/shortcuts.json
+++ b/apps/web/src/locales/en/shortcuts.json
@@ -33,5 +33,5 @@
   "toggleNowPlaying": "Toggle Now Playing view",
   "toggleVisualizer": "Toggle visualizer",
   "showHelp": "Show this help",
-  "closePanel": "Clear selection / close panel"
+  "closePanel": "Back / clear selection / close panel"
 }

--- a/apps/web/src/locales/pl/shortcuts.json
+++ b/apps/web/src/locales/pl/shortcuts.json
@@ -33,5 +33,5 @@
   "toggleNowPlaying": "Przełącz widok Teraz odtwarzane",
   "toggleVisualizer": "Pokaż/ukryj wizualizator",
   "showHelp": "Pokaż tę pomoc",
-  "closePanel": "Wyczyść zaznaczenie / zamknij panel"
+  "closePanel": "Wstecz / wyczyść zaznaczenie / zamknij panel"
 }


### PR DESCRIPTION
## Summary

Three review-driven improvements following Gemini code-assist comments on PRs Shironex/shiranami#34 and Shironex/shiranami#32. Two further review items were investigated and intentionally left unfixed — see the breakdown below.

## What changed

**`KeyboardShortcutsHelp.tsx`** (PR Shironex/shiranami#34 review)

- `getShortcutCategories()` now returns a keyed `{ playback, navigation, panelsUi }` record instead of an array. Destructuring is name-based, TypeScript enforces every key exists, and reordering or renaming a category becomes a compile error if any consumer is missed. Replaces the previous fragile positional `[playback, navigation, panelsUi]` destructure that depended on element order.
- Inline ~200-character URL-encoded film grain SVG is hoisted to a module-level `FILM_GRAIN_SVG` constant. JSX is now one line: `style={{ backgroundImage: FILM_GRAIN_SVG }}`.

**`useKeyboardShortcuts.ts`** (PR Shironex/shiranami#32 review — partially)

- Esc now exits the Now Playing view as the **first** action, before selection-clearing or panel-closing. This matches standard modal-view interaction and addresses the legitimate part of Gemini's HIGH-priority comment on PR Shironex/shiranami#32.
- The `closePanel` translation key is updated to `"Back / clear selection / close panel"` (PL: `"Wstecz / wyczyść zaznaczenie / zamknij panel"`) to reflect the new priority order, and to align with the chevron-down "back" affordance already present in the Now Playing view.

**`useKeyboardShortcuts.test.ts`**

- New test covers the Esc → exit-Now-Playing branch with priority over panel-close. Includes a comment documenting an interesting gotcha discovered while writing it: `useSelectionStore.ts:67-74` has a module-level subscription to `useAppStore` that auto-clears the selection any time `activeView` changes. So `exitNowPlaying()` side-effects the selection regardless of which Esc branch the handler took, which makes selection unobservable as a test signal for distinguishing branches. The `rightPanel` field is the cleaner signal.

## Intentionally NOT fixed (with reasoning)

**Gemini PR Shironex/shiranami#32 review — `findActiveLine` linear scan (MEDIUM)**
Traced the call site: `findActiveLine` runs in render, driven by the `currentTime` subscription. The audio engine throttles store writes to **250ms** (`useAudioEngine.ts:357-360`), so the function runs ~4 times per second, not per animation frame. Typical LRC lyric files have 30–150 lines. That's ~600 comparisons per second worst case, with an early `break` once the loop passes `currentTime` halving the average. Sub-microsecond cost. Binary search would save nothing measurable. Skipping.

**Gemini PR Shironex/shiranami#32 review — Per-line arrow function in lyrics map (MEDIUM)**
The `synced.map` in `NowPlayingView.tsx:227-248` renders plain `<button>` elements inline inside `NowPlayingView` itself. They are NOT a memoized child component. Since the buttons aren't wrapped in `React.memo` and don't compare props, arrow function reference identity is irrelevant for reconciliation — React diffs the props but re-renders the same host element either way. Switching to `data-time` attributes would be a micro-optimization with zero observable benefit. Would only matter if the lines became a memoized child. Skipping.

**Gemini PR Shironex/shiranami#32 review — `previousView` corruption claim (HIGH)**
Gemini's specific claim was that pressing nav keys (1–7) while in Now Playing would corrupt `previousView` and lead to "exiting the Now Playing view will lead the user back to the wrong view." Traced the state machine concretely:

1. activeView=library, previousView=library (initial)
2. Cmd+Shift+P → enterNowPlaying captures `current='library'` into previousView → activeView=now-playing, previousView=library
3. Press `2` → navigateTo('playlists') sets activeView directly, previousView untouched → activeView=playlists, previousView=library (Now Playing torn down via the activeView change)
4. Cmd+Shift+P again → enterNowPlaying captures `current='playlists'` into previousView → activeView=now-playing, previousView=playlists (state self-healed)
5. Cmd+Shift+P third time → exitNowPlaying → activeView=playlists ✓

`enterNowPlaying` (`useAppStore.ts:229-233`) **unconditionally** captures `current` into `previousView` on every re-entry, so any staleness self-heals. There is no code path where exiting lands the user on a wrong view. Gemini's diagnosis is wrong. The Esc fix above is the only genuinely valid part of that review item.

## Test plan

- [ ] `pnpm --filter web typecheck` — clean
- [ ] `pnpm --filter web test` — 407 tests should pass (one new test for Esc-exits-Now-Playing)
- [ ] Press `?` and confirm the help dialog still renders correctly with the new keyed-record refactor
- [ ] In Now Playing, press `Esc` and verify it exits back to the previous view
- [ ] In Library with the right panel open, press `Esc` and verify the panel closes (no regression)
- [ ] In Library with selected tracks, press `Esc` and verify the selection clears (no regression)
- [ ] Switch language to Polish and verify the new `closePanel` label renders correctly