### PR TITLE
chore(store): guard redundant writes in setLibraryHeroCardEnabled

### DIFF
--- a/apps/web/src/stores/useAppStore.ts
+++ b/apps/web/src/stores/useAppStore.ts
@@ -264,6 +264,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     set({ nowPlayingLyricsVisible: next });
   },
   setLibraryHeroCardEnabled: (enabled) => {
+    if (get().libraryHeroCardEnabled === enabled) return;
     persistLibraryHeroCardEnabled(enabled);
     set({ libraryHeroCardEnabled: enabled });
   },


### PR DESCRIPTION
Small followup to #43 addressing the gemini-code-assist review comment.

## Summary
- Adds an early-return to `setLibraryHeroCardEnabled` when the new value matches the current state, skipping the redundant `localStorage` write and `set()` call.

## Why this is narrow
The reviewer suggested this pattern is "already used in other actions within this store, such as `setCompactMode` and `setCompactAlwaysOnTop`". Those guards exist for a different reason though — those actions perform expensive async IPC round-trips to the Electron main process. The other simple synchronous boolean setters in this store (`setNowPlayingViewEnabled`, `setSidebarPlaylistsVisible`, `setVisualizerStyle`, etc.) do **not** use this guard and are left as-is to avoid unrelated churn.

The real benefit here is avoiding the synchronous `localStorage.setItem` call on redundant toggles. Minor but legitimate.

## Test plan
- [ ] Toggle the "Now playing banner" setting a few times in Settings → Appearance; confirm it still works as before
- [ ] Reload the app with the toggle off; confirm the state persists
- [ ] Toggle back on; confirm the banner returns