### PR TITLE
fix: address v0.15.0 UI feedback (#57)

### DIFF
--- a/apps/web/src/components/playlists/PlaylistsView.tsx
+++ b/apps/web/src/components/playlists/PlaylistsView.tsx
@@ -1,10 +1,11 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAppStore } from '@/stores/useAppStore';
-import { ListMusic, Plus, Loader2 } from 'lucide-react';
+import { useAppStore, type AlbumGridSize } from '@/stores/useAppStore';
+import { ListMusic, Plus, Loader2, Grid2x2, LayoutGrid, Grid3x3 } from 'lucide-react';
 import { ViewEmptyState } from '@/components/shared/ViewEmptyState';
 import { motion, AnimatePresence } from 'motion/react';
 import { toast } from 'sonner';
+import { cn } from '@/lib/utils';
 import { usePlaylistsQuery, useCreatePlaylistMutation } from '@/hooks/queries/usePlaylists';
 
 export function PlaylistsView() {
@@ -13,6 +14,8 @@ export function PlaylistsView() {
   const selectPlaylist = useAppStore(s => s.selectPlaylist);
   const { data: playlists = [], isLoading } = usePlaylistsQuery();
   const createPlaylist = useCreatePlaylistMutation();
+  const playlistGridSize = useAppStore(s => s.playlistGridSize);
+  const setPlaylistGridSize = useAppStore(s => s.setPlaylistGridSize);
   const [showNewForm, setShowNewForm] = useState(false);
   const [newName, setNewName] = useState('');
 
@@ -40,6 +43,20 @@ export function PlaylistsView() {
     [handleCreate]
   );
 
+  const gridClassName = useMemo(() => {
+    switch (playlistGridSize) {
+      case 'small':
+        return 'grid grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-2';
+      case 'large':
+        return 'grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4';
+      case 'medium':
+      default:
+        return 'grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-3';
+    }
+  }, [playlistGridSize]);
+
+  const cardPaddingClass = playlistGridSize === 'small' ? 'p-3' : 'p-4';
+
   if (isLoading) {
     return (
       <div className="flex-1 flex items-center justify-center">
@@ -60,6 +77,36 @@ export function PlaylistsView() {
           <Plus className="w-3.5 h-3.5" />
           {t('newPlaylist')}
         </motion.button>
+
+        <div className="flex-1" />
+
+        {/* Grid size toggle */}
+        <div
+          className="flex items-center rounded-xl border border-border/50 bg-card p-1 gap-0.5"
+          role="group"
+          aria-label={t('gridSize')}
+        >
+          {([
+            { size: 'large', icon: Grid2x2, label: t('gridSizeLarge') },
+            { size: 'medium', icon: LayoutGrid, label: t('gridSizeMedium') },
+            { size: 'small', icon: Grid3x3, label: t('gridSizeSmall') },
+          ] as const).map(({ size, icon: Icon, label }) => (
+            <button
+              key={size}
+              onClick={() => setPlaylistGridSize(size as AlbumGridSize)}
+              className={cn(
+                'p-2 rounded-lg transition-colors',
+                playlistGridSize === size
+                  ? 'bg-primary/15 text-primary'
+                  : 'text-muted-foreground/50 hover:text-foreground'
+              )}
+              aria-label={label}
+              title={label}
+            >
+              <Icon className="w-4 h-4" />
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Inline create form */}
@@ -116,7 +163,7 @@ export function PlaylistsView() {
       ) : (
         <div className="flex-1 overflow-y-auto scrollbar-thin px-6 pb-4">
           <motion.div
-            className="grid grid-cols-2 lg:grid-cols-3 gap-3"
+            className={gridClassName}
             initial="hidden"
             animate="visible"
             variants={{
@@ -134,7 +181,7 @@ export function PlaylistsView() {
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
                 onClick={() => selectPlaylist(playlist.id)}
-                className="text-left p-4 rounded-2xl bg-surface/60 border border-border/30 hover:border-border/60 hover:bg-surface transition-all duration-200 group"
+                className={cn("text-left rounded-2xl bg-surface/60 border border-border/30 hover:border-border/60 hover:bg-surface transition-all duration-200 group", cardPaddingClass)}
               >
                 <div className="w-full aspect-square rounded-xl bg-muted/30 flex items-center justify-center mb-3 overflow-hidden">
                   {playlist.coverArt ? (

--- a/apps/web/src/locales/en/library.json
+++ b/apps/web/src/locales/en/library.json
@@ -1,6 +1,6 @@
 {
-  "filterPlaceholder": "Filter tracks...",
-  "filterAlbumsPlaceholder": "Filter albums...",
+  "filterPlaceholder": "Search tracks...",
+  "filterAlbumsPlaceholder": "Search albums...",
   "filterCount": "{{filtered}} of {{total}} tracks",
   "albumFilterCount": "{{filtered}} of {{total}} albums",
   "emptyTitle": "No tracks yet",

--- a/apps/web/src/locales/en/playlists.json
+++ b/apps/web/src/locales/en/playlists.json
@@ -20,5 +20,9 @@
   "uploadCustomImage": "Upload Custom Image",
   "useTrackArtwork": "Use Track Artwork",
   "removeCover": "Remove Cover",
-  "editCover": "Edit playlist cover"
+  "editCover": "Edit playlist cover",
+  "gridSize": "Grid size",
+  "gridSizeSmall": "Small",
+  "gridSizeMedium": "Medium",
+  "gridSizeLarge": "Large"
 }

--- a/apps/web/src/locales/pl/library.json
+++ b/apps/web/src/locales/pl/library.json
@@ -1,6 +1,6 @@
 {
-  "filterPlaceholder": "Filtruj utwory...",
-  "filterAlbumsPlaceholder": "Filtruj albumy...",
+  "filterPlaceholder": "Szukaj utworów...",
+  "filterAlbumsPlaceholder": "Szukaj albumów...",
   "filterCount": "{{filtered}} z {{total}} utworów",
   "albumFilterCount": "{{filtered}} z {{total}} albumów",
   "emptyTitle": "Brak utworów",

--- a/apps/web/src/locales/pl/playlists.json
+++ b/apps/web/src/locales/pl/playlists.json
@@ -22,5 +22,9 @@
   "uploadCustomImage": "Wgraj własny obraz",
   "useTrackArtwork": "Użyj okładki utworu",
   "removeCover": "Usuń okładkę",
-  "editCover": "Edytuj okładkę playlisty"
+  "editCover": "Edytuj okładkę playlisty",
+  "gridSize": "Rozmiar siatki",
+  "gridSizeSmall": "Mały",
+  "gridSizeMedium": "Średni",
+  "gridSizeLarge": "Duży"
 }

--- a/apps/web/src/stores/useAppStore.ts
+++ b/apps/web/src/stores/useAppStore.ts
@@ -33,6 +33,18 @@ function persistAlbumGridSize(size: AlbumGridSize) {
   window.localStorage.setItem(ALBUM_GRID_SIZE_STORAGE_KEY, size);
 }
 
+function getInitialPlaylistGridSize(): AlbumGridSize {
+  if (typeof window === 'undefined') return 'medium';
+  const stored = window.localStorage.getItem(PLAYLIST_GRID_SIZE_STORAGE_KEY);
+  if (stored === 'small' || stored === 'medium' || stored === 'large') return stored;
+  return 'medium';
+}
+
+function persistPlaylistGridSize(size: AlbumGridSize) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(PLAYLIST_GRID_SIZE_STORAGE_KEY, size);
+}
+
 function getInitialAlbumSortMode(): AlbumSortMode {
   if (typeof window === 'undefined') return 'name';
   const stored = window.localStorage.getItem(ALBUM_SORT_MODE_STORAGE_KEY);
@@ -59,6 +71,7 @@ function persistAlbumSortOrder(order: AlbumSortOrder) {
 
 const LIBRARY_VIEW_MODE_STORAGE_KEY = 'shiranami.library-view-mode';
 const ALBUM_GRID_SIZE_STORAGE_KEY = 'shiranami.album-grid-size';
+const PLAYLIST_GRID_SIZE_STORAGE_KEY = 'shiranami.playlist-grid-size';
 const ALBUM_SORT_MODE_STORAGE_KEY = 'shiranami.album-sort-mode';
 const ALBUM_SORT_ORDER_STORAGE_KEY = 'shiranami.album-sort-order';
 const SIDEBAR_COLLAPSED_STORAGE_KEY = 'shiranami.sidebar-collapsed';
@@ -248,6 +261,7 @@ interface AppState {
   uiScale: number;
   libraryViewMode: LibraryViewMode;
   albumGridSize: AlbumGridSize;
+  playlistGridSize: AlbumGridSize;
   albumSortMode: AlbumSortMode;
   albumSortOrder: AlbumSortOrder;
   selectedAlbumName: string | null;
@@ -284,6 +298,7 @@ interface AppActions {
   resetUiScale: () => void;
   setLibraryViewMode: (mode: LibraryViewMode) => void;
   setAlbumGridSize: (size: AlbumGridSize) => void;
+  setPlaylistGridSize: (size: AlbumGridSize) => void;
   setAlbumSortMode: (mode: AlbumSortMode) => void;
   setAlbumSortOrder: (order: AlbumSortOrder) => void;
   selectAlbum: (name: string | null) => void;
@@ -304,6 +319,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   uiScale: getInitialUiScale(),
   libraryViewMode: getInitialLibraryViewMode(),
   albumGridSize: getInitialAlbumGridSize(),
+  playlistGridSize: getInitialPlaylistGridSize(),
   albumSortMode: getInitialAlbumSortMode(),
   albumSortOrder: getInitialAlbumSortOrder(),
   selectedAlbumName: null,
@@ -449,6 +465,10 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   setAlbumGridSize: (size) => {
     persistAlbumGridSize(size);
     set({ albumGridSize: size });
+  },
+  setPlaylistGridSize: (size) => {
+    persistPlaylistGridSize(size);
+    set({ playlistGridSize: size });
   },
   setAlbumSortMode: (mode) => {
     persistAlbumSortMode(mode);

--- a/apps/web/src/stores/usePlayerStore.ts
+++ b/apps/web/src/stores/usePlayerStore.ts
@@ -197,7 +197,7 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
 
     // If more than 3 seconds in, restart the current track
     if (currentTime > 3) {
-      set({ currentTime: 0 });
+      set({ currentTime: 0, _seekTarget: 0 });
       return;
     }
 


### PR DESCRIPTION
## Summary

Addresses all three issues reported in #57:

- **Previous/back button fix**: The `previous()` action in the player store was setting `currentTime: 0` without `_seekTarget: 0`, causing a visual-only reset (progress bar flickers to 0s then snaps back). The audio engine's RAF loop only seeks when `_seekTarget !== null`, so the `<audio>` element never actually sought to position 0. Fixed by adding `_seekTarget: 0` to the `set()` call.
- **Playlist grid density**: The playlist grid was stuck on a hardcoded 2-column layout. Added a configurable grid size toggle (small/medium/large) matching the album grid's existing pattern, with localStorage persistence.
- **Search placeholder text**: Renamed "Filter tracks/albums..." to "Search tracks/albums..." in both EN and PL translations, matching the radio screen's existing "Search" wording.

## Test plan

- [x] Play a track past 3 seconds, press previous — track should restart from 0 (not flicker)
- [x] Press previous within first 3 seconds — should go to previous track in queue
- [x] Test previous button in all 3 views: main player bar, compact mode, now-playing
- [x] Open playlists view — grid size toggle should appear in header
- [x] Toggle between small/medium/large — grid columns should change responsively
- [x] Refresh app — playlist grid size preference should persist
- [x] Check library search bars show "Search tracks..." / "Search albums..." in EN
- [x] Switch to PL — should show "Szukaj utworów..." / "Szukaj albumów..."