### PR TITLE
perf(visualizer): pause RAF loop when window is hidden or off-screen

### DIFF
--- a/apps/web/src/components/player/AudioVisualizer.tsx
+++ b/apps/web/src/components/player/AudioVisualizer.tsx
@@ -1,7 +1,8 @@
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
 import { usePlayerStore } from '@/stores/usePlayerStore';
 import { getAnalyser } from '@/lib/audioAnalyser';
 import { getPrimaryRGB } from '@/lib/utils';
+import { useRafLoop } from '@/hooks/useRafLoop';
 
 /**
  * Canvas-based frequency visualizer with a soft lofi aesthetic.
@@ -11,7 +12,6 @@ import { getPrimaryRGB } from '@/lib/utils';
  */
 export function AudioVisualizer() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const rafRef = useRef<number>(0);
   const bufferRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
   const smoothedRef = useRef<Float32Array<ArrayBuffer> | null>(null);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
@@ -23,7 +23,6 @@ export function AudioVisualizer() {
 
     const analyser = getAnalyser();
     if (!analyser) {
-      rafRef.current = requestAnimationFrame(draw);
       return;
     }
 
@@ -111,20 +110,9 @@ export function AudioVisualizer() {
       ctx.shadowBlur = 0;
     }
 
-    rafRef.current = requestAnimationFrame(draw);
   }, []);
 
-  useEffect(() => {
-    if (isPlaying && currentTrack) {
-      rafRef.current = requestAnimationFrame(draw);
-    } else {
-      cancelAnimationFrame(rafRef.current);
-    }
-
-    return () => {
-      cancelAnimationFrame(rafRef.current);
-    };
-  }, [isPlaying, currentTrack, draw]);
+  useRafLoop(draw, canvasRef, isPlaying && !!currentTrack);
 
   return (
     <canvas

--- a/apps/web/src/components/player/CircleVisualizer.tsx
+++ b/apps/web/src/components/player/CircleVisualizer.tsx
@@ -1,7 +1,8 @@
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
 import { usePlayerStore } from '@/stores/usePlayerStore';
 import { getAnalyser } from '@/lib/audioAnalyser';
 import { getPrimaryRGB } from '@/lib/utils';
+import { useRafLoop } from '@/hooks/useRafLoop';
 
 /**
  * Compact circular frequency visualizer.
@@ -11,7 +12,6 @@ import { getPrimaryRGB } from '@/lib/utils';
  */
 export function CircleVisualizer() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const rafRef = useRef<number>(0);
   const bufferRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
   const smoothedRef = useRef<Float32Array<ArrayBuffer> | null>(null);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
@@ -23,7 +23,6 @@ export function CircleVisualizer() {
 
     const analyser = getAnalyser();
     if (!analyser) {
-      rafRef.current = requestAnimationFrame(draw);
       return;
     }
 
@@ -143,20 +142,9 @@ export function CircleVisualizer() {
     ctx.stroke();
     ctx.shadowBlur = 0;
 
-    rafRef.current = requestAnimationFrame(draw);
   }, []);
 
-  useEffect(() => {
-    if (isPlaying && currentTrack) {
-      rafRef.current = requestAnimationFrame(draw);
-    } else {
-      cancelAnimationFrame(rafRef.current);
-    }
-
-    return () => {
-      cancelAnimationFrame(rafRef.current);
-    };
-  }, [isPlaying, currentTrack, draw]);
+  useRafLoop(draw, canvasRef, isPlaying && !!currentTrack);
 
   return (
     <canvas

--- a/apps/web/src/components/player/ParticleVisualizer.tsx
+++ b/apps/web/src/components/player/ParticleVisualizer.tsx
@@ -1,5 +1,6 @@
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
 import { usePlayerStore } from '@/stores/usePlayerStore';
+import { useRafLoop } from '@/hooks/useRafLoop';
 import { getAnalyser } from '@/lib/audioAnalyser';
 import { getPrimaryRGB } from '@/lib/utils';
 
@@ -11,7 +12,6 @@ import { getPrimaryRGB } from '@/lib/utils';
  */
 export function ParticleVisualizer() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const rafRef = useRef<number>(0);
   const bufferRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
   const smoothedRef = useRef<Float32Array<ArrayBuffer> | null>(null);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
@@ -23,7 +23,6 @@ export function ParticleVisualizer() {
 
     const analyser = getAnalyser();
     if (!analyser) {
-      rafRef.current = requestAnimationFrame(draw);
       return;
     }
 
@@ -124,20 +123,9 @@ export function ParticleVisualizer() {
     ctx.lineWidth = 1;
     ctx.stroke();
 
-    rafRef.current = requestAnimationFrame(draw);
   }, []);
 
-  useEffect(() => {
-    if (isPlaying && currentTrack) {
-      rafRef.current = requestAnimationFrame(draw);
-    } else {
-      cancelAnimationFrame(rafRef.current);
-    }
-
-    return () => {
-      cancelAnimationFrame(rafRef.current);
-    };
-  }, [isPlaying, currentTrack, draw]);
+  useRafLoop(draw, canvasRef, isPlaying && !!currentTrack);
 
   return (
     <canvas

--- a/apps/web/src/components/player/WaveformVisualizer.tsx
+++ b/apps/web/src/components/player/WaveformVisualizer.tsx
@@ -1,7 +1,8 @@
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
 import { usePlayerStore } from '@/stores/usePlayerStore';
 import { getAnalyser } from '@/lib/audioAnalyser';
 import { getPrimaryRGB } from '@/lib/utils';
+import { useRafLoop } from '@/hooks/useRafLoop';
 
 /**
  * Dense vertical-bar waveform visualizer inspired by ElevenLabs UI.
@@ -11,7 +12,6 @@ import { getPrimaryRGB } from '@/lib/utils';
  */
 export function WaveformVisualizer() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const rafRef = useRef<number>(0);
   const bufferRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
   const smoothedRef = useRef<Float32Array<ArrayBuffer> | null>(null);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
@@ -23,7 +23,6 @@ export function WaveformVisualizer() {
 
     const analyser = getAnalyser();
     if (!analyser) {
-      rafRef.current = requestAnimationFrame(draw);
       return;
     }
 
@@ -102,20 +101,9 @@ export function WaveformVisualizer() {
       ctx.fill();
     }
 
-    rafRef.current = requestAnimationFrame(draw);
   }, []);
 
-  useEffect(() => {
-    if (isPlaying && currentTrack) {
-      rafRef.current = requestAnimationFrame(draw);
-    } else {
-      cancelAnimationFrame(rafRef.current);
-    }
-
-    return () => {
-      cancelAnimationFrame(rafRef.current);
-    };
-  }, [isPlaying, currentTrack, draw]);
+  useRafLoop(draw, canvasRef, isPlaying && !!currentTrack);
 
   return (
     <canvas

--- a/apps/web/src/hooks/useRafLoop.ts
+++ b/apps/web/src/hooks/useRafLoop.ts
@@ -1,0 +1,58 @@
+// Shared RAF loop hook gated by caller activity, page visibility, and element intersection.
+
+import { useRef, useEffect, useState } from 'react';
+
+export function useRafLoop(
+  callback: () => void,
+  elementRef: React.RefObject<HTMLElement | null>,
+  isActive: boolean,
+): void {
+  const callbackRef = useRef(callback);
+  const [isVisible, setIsVisible] = useState(
+    () => typeof document !== 'undefined' && document.visibilityState === 'visible',
+  );
+  const [isIntersecting, setIsIntersecting] = useState(false);
+
+  // Keep the callback ref fresh without restarting effects.
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  // Track page visibility.
+  useEffect(() => {
+    const onChange = () => {
+      setIsVisible(document.visibilityState === 'visible');
+    };
+    document.addEventListener('visibilitychange', onChange);
+    return () => document.removeEventListener('visibilitychange', onChange);
+  }, []);
+
+  // Track element intersection.
+  useEffect(() => {
+    const el = elementRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsIntersecting(entry.isIntersecting),
+      { threshold: 0 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [elementRef.current]);
+
+  // Run the RAF loop when all three signals are true.
+  useEffect(() => {
+    if (!isActive || !isVisible || !isIntersecting) return;
+
+    let rafId: number;
+
+    const loop = () => {
+      callbackRef.current();
+      rafId = requestAnimationFrame(loop);
+    };
+
+    rafId = requestAnimationFrame(loop);
+
+    return () => cancelAnimationFrame(rafId);
+  }, [isActive, isVisible, isIntersecting]);
+}


### PR DESCRIPTION
## Summary

- Extract a shared `useRafLoop` hook that gates `requestAnimationFrame` on three signals: playback state (`isPlaying && currentTrack`), `document.visibilityState`, and `IntersectionObserver` on the canvas element
- Refactor all four visualizers (`AudioVisualizer`, `WaveformVisualizer`, `CircleVisualizer`, `ParticleVisualizer`) to use the hook, eliminating duplicated RAF lifecycle logic
- Visualizer RAF loops now fully pause (not just throttle) when the Electron window is minimized/hidden or the canvas is scrolled out of view

## Test plan

- [ ] Play a track with any visualizer active and verify it renders normally
- [ ] Minimize the Electron window → verify RAF stops (DevTools Performance tab or `console.log` in draw)
- [ ] Restore the window → verify visualizer resumes cleanly
- [ ] Navigate to Settings (canvas scrolls off-screen) → verify RAF stops via IntersectionObserver
- [ ] Navigate back → verify visualizer resumes
- [ ] Switch between all four visualizer styles while playing → verify each works correctly
- [ ] Pause playback → verify RAF stops (existing behavior preserved)

Closes #47 