### PR TITLE
fix: address v0.15.0 full-screen player UI feedback

### DIFF
--- a/apps/web/src/components/lyrics/LyricsPanel.tsx
+++ b/apps/web/src/components/lyrics/LyricsPanel.tsx
@@ -73,8 +73,8 @@ export function LyricsPanel() {
                 onClick={() => handleLineClick(line.time)}
                 type="button"
                 className={cn(
-                  'block w-full text-left text-[15px] leading-relaxed font-medium cursor-pointer transition-all duration-500 rounded-md px-1 -mx-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40',
-                  isActive && 'text-foreground text-base',
+                  'block w-full text-left text-base leading-relaxed font-medium cursor-pointer transition-all duration-500 rounded-md px-1 -mx-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40',
+                  isActive && 'text-foreground text-lg font-semibold',
                   isPast && 'text-muted-foreground/25',
                   !isActive && !isPast && 'text-muted-foreground/45 hover:text-muted-foreground/70'
                 )}
@@ -90,7 +90,7 @@ export function LyricsPanel() {
   } else if (plain) {
     content = (
       <div className="flex-1 overflow-y-auto scrollbar-hide px-5 py-6">
-        <pre className="text-xs text-muted-foreground/50 whitespace-pre-wrap font-sans leading-relaxed">
+        <pre className="text-sm text-muted-foreground/50 whitespace-pre-wrap font-sans leading-relaxed">
           {plain}
         </pre>
       </div>

--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -10,7 +10,7 @@ import { PlayerControls } from '@/components/player/PlayerControls';
 import { SeekBar } from '@/components/player/SeekBar';
 import { VolumeControl } from '@/components/player/VolumeControl';
 import { TimeDisplay } from '@/components/player/TimeDisplay';
-import { Music, ChevronDown, Loader2, Music2, Mic2, MicOff } from 'lucide-react';
+import { Music, ArrowLeft, Loader2, Music2, Mic2, MicOff } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 
@@ -86,13 +86,13 @@ export function NowPlayingView() {
 
       {/* Header: back button + lyrics toggle */}
       <div className="relative px-6 @3xl:px-10 pt-4 pb-2 shrink-0 flex items-center justify-between">
-        <button
+        <motion.button
+          whileTap={{ scale: 0.9 }}
           onClick={exitNowPlaying}
-          className="flex items-center gap-2 text-muted-foreground/60 hover:text-foreground transition-colors group"
+          className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
         >
-          <ChevronDown className="w-5 h-5 group-hover:translate-y-0.5 transition-transform" />
-          <span className="text-xs font-medium uppercase tracking-wider">{t('back')}</span>
-        </button>
+          <ArrowLeft className="w-4 h-4" />
+        </motion.button>
 
         <Tooltip>
           <TooltipTrigger asChild>
@@ -152,8 +152,8 @@ export function NowPlayingView() {
                 'aspect-square rounded-2xl @5xl:rounded-3xl overflow-hidden',
                 'shadow-2xl shadow-black/40 bg-muted flex items-center justify-center',
                 lyricsVisible
-                  ? 'w-[55%] min-w-[180px] max-w-[240px] @3xl:w-full @3xl:max-w-[300px] @5xl:max-w-[360px] @6xl:max-w-[420px] @7xl:max-w-[480px]'
-                  : 'w-full max-w-[320px] @5xl:max-w-[380px] @7xl:max-w-[440px]'
+                  ? 'w-[55%] min-w-[180px] max-w-[240px] @3xl:w-full @3xl:max-w-[clamp(280px,22vw,480px)]'
+                  : 'w-full max-w-[clamp(300px,24vw,440px)]'
               )}
             >
               {currentTrack.albumArt ? (
@@ -239,8 +239,8 @@ export function NowPlayingView() {
                         className={cn(
                           'block w-full text-left leading-relaxed font-medium cursor-pointer transition-all duration-500 rounded-md px-1 -mx-1',
                           'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40',
-                          'text-[14px] @5xl:text-[16px] @7xl:text-[18px]',
-                          isActive && 'text-foreground !text-[16px] @5xl:!text-[19px] @7xl:!text-[22px]',
+                          'text-base @5xl:text-lg @7xl:text-xl',
+                          isActive && 'text-foreground !text-xl @5xl:!text-2xl @7xl:!text-3xl font-semibold',
                           isPast && 'text-muted-foreground/20',
                           !isActive && !isPast && 'text-muted-foreground/40 hover:text-muted-foreground/65'
                         )}
@@ -254,7 +254,7 @@ export function NowPlayingView() {
               </div>
             ) : plain ? (
               <div className="flex-1 overflow-y-auto scrollbar-hide pr-2 @3xl:pr-4">
-                <pre className="text-[13px] @5xl:text-sm @7xl:text-base text-muted-foreground/45 whitespace-pre-wrap font-sans leading-relaxed">
+                <pre className="text-sm @5xl:text-base @7xl:text-lg text-muted-foreground/45 whitespace-pre-wrap font-sans leading-relaxed">
                   {plain}
                 </pre>
               </div>

--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -90,6 +90,7 @@ export function NowPlayingView() {
           whileTap={{ scale: 0.9 }}
           onClick={exitNowPlaying}
           className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+          aria-label={t('back')}
         >
           <ArrowLeft className="w-4 h-4" />
         </motion.button>
@@ -240,7 +241,7 @@ export function NowPlayingView() {
                           'block w-full text-left leading-relaxed font-medium cursor-pointer transition-all duration-500 rounded-md px-1 -mx-1',
                           'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40',
                           'text-base @5xl:text-lg @7xl:text-xl',
-                          isActive && 'text-foreground !text-xl @5xl:!text-2xl @7xl:!text-3xl font-semibold',
+                          isActive && 'text-foreground text-xl @5xl:!text-2xl @7xl:!text-3xl font-semibold',
                           isPast && 'text-muted-foreground/20',
                           !isActive && !isPast && 'text-muted-foreground/40 hover:text-muted-foreground/65'
                         )}


### PR DESCRIPTION
## Summary

Closes #60

- **Album art sizing**: Replaced stepped `@container` breakpoints with viewport-based `clamp()` so the image scales fluidly and no longer jumps size when the sidebar toggles
- **Back button**: Replaced `ChevronDown` + "Back" text with an `ArrowLeft` icon-only `motion.button`, matching the pattern in AlbumDetailView and PlaylistDetailView
- **Lyrics readability**: Increased font sizes for both synced and plain lyrics in the full-screen view and sidebar panel. Active line now uses `font-semibold` for stronger differentiation. Switched from fixed `px` to `rem`-based Tailwind classes so the global UI scale setting actually affects lyrics text

## Test plan

- [ ] Toggle sidebar open/closed on the now-playing view — album art should scale smoothly without jumping
- [ ] Verify the back button is now an arrow-left icon matching other detail views
- [ ] Check lyrics font sizes are larger and the active line stands out clearly
- [ ] Adjust UI scale in settings (e.g. 110%) and confirm lyrics text scales accordingly
- [ ] Verify LyricsPanel (sidebar) also has improved font sizes