### PR TITLE
perf(visualizer): cache primary-rgb and gradients in hot draw paths

### DIFF
--- a/apps/web/src/components/player/AudioVisualizer.tsx
+++ b/apps/web/src/components/player/AudioVisualizer.tsx
@@ -1,9 +1,9 @@
 import { useRef, useCallback } from 'react';
 import { usePlayerStore } from '@/stores/usePlayerStore';
 import { getAnalyser } from '@/lib/audioAnalyser';
-import { getPrimaryRGB } from '@/lib/utils';
 import { useRafLoop } from '@/hooks/useRafLoop';
 import { useCanvasSize } from '@/hooks/useCanvasSize';
+import { usePrimaryRGB } from '@/hooks/usePrimaryRGB';
 
 /**
  * Canvas-based frequency visualizer with a soft lofi aesthetic.
@@ -18,6 +18,7 @@ export function AudioVisualizer() {
   const isPlaying = usePlayerStore((s) => s.isPlaying);
   const currentTrack = usePlayerStore((s) => s.currentTrack);
   const { widthRef, heightRef, dprRef } = useCanvasSize(canvasRef);
+  const { rgbRef } = usePrimaryRGB();
 
   const draw = useCallback(() => {
     const canvas = canvasRef.current;
@@ -68,6 +69,9 @@ export function AudioVisualizer() {
     // Slower easing for lofi smoothness
     const ease = 0.12;
 
+    // Hoist theme color once per frame (issue #49).
+    const [pr, pg, pb] = rgbRef.current;
+
     for (let i = 0; i < barCount; i++) {
       let sum = 0;
       const start = i * binsPerBar;
@@ -90,7 +94,6 @@ export function AudioVisualizer() {
       const edgeFade = Math.min(1, Math.min(edgePos, 1 - edgePos) * 5);
 
       // Color: theme-derived gradient across frequency range
-      const [pr, pg, pb] = getPrimaryRGB();
       const t = i / barCount;
       const r = Math.round(pr - 45 + t * 50);
       const g = Math.round(pg - 40 + t * 35);
@@ -111,7 +114,7 @@ export function AudioVisualizer() {
       ctx.shadowBlur = 0;
     }
 
-  }, [widthRef, heightRef, dprRef]);
+  }, [widthRef, heightRef, dprRef, rgbRef]);
 
   useRafLoop(draw, canvasRef, isPlaying && !!currentTrack);
 

--- a/apps/web/src/components/player/CircleVisualizer.tsx
+++ b/apps/web/src/components/player/CircleVisualizer.tsx
@@ -1,9 +1,9 @@
 import { useRef, useCallback } from 'react';
 import { usePlayerStore } from '@/stores/usePlayerStore';
 import { getAnalyser } from '@/lib/audioAnalyser';
-import { getPrimaryRGB } from '@/lib/utils';
 import { useRafLoop } from '@/hooks/useRafLoop';
 import { useCanvasSize } from '@/hooks/useCanvasSize';
+import { usePrimaryRGB } from '@/hooks/usePrimaryRGB';
 
 /**
  * Compact circular frequency visualizer.
@@ -18,6 +18,7 @@ export function CircleVisualizer() {
   const isPlaying = usePlayerStore((s) => s.isPlaying);
   const currentTrack = usePlayerStore((s) => s.currentTrack);
   const { widthRef, heightRef, dprRef } = useCanvasSize(canvasRef);
+  const { rgbRef } = usePrimaryRGB();
 
   const draw = useCallback(() => {
     const canvas = canvasRef.current;
@@ -70,6 +71,9 @@ export function CircleVisualizer() {
     // Compute average energy for the inner ring glow
     let totalEnergy = 0;
 
+    // Hoist theme color once per frame — was ~130 CSS-var lookups/frame (issue #49).
+    const [pr, pg, pb] = rgbRef.current;
+
     // ── Radial frequency bars (full 360°) ──
     for (let i = 0; i < barCount; i++) {
       let sum = 0;
@@ -97,7 +101,6 @@ export function CircleVisualizer() {
       const y2 = centerY + sin * (barBaseRadius + barLength);
 
       // Color: theme-derived with slight hue shift across the circle
-      const [pr, pg, pb] = getPrimaryRGB();
       const t = i / barCount;
       const r = Math.round(pr - 15 + t * 40);
       const g = Math.round(pg - 25 + t * 25);
@@ -127,13 +130,11 @@ export function CircleVisualizer() {
 
       ctx.beginPath();
       ctx.arc(dx, dy, dotSize, 0, Math.PI * 2);
-      const [pr, pg, pb] = getPrimaryRGB();
       ctx.fillStyle = `rgba(${pr}, ${pg}, ${pb}, ${0.25 + avgEnergy * 0.35})`;
       ctx.fill();
     }
 
     // ── Base ring line ──
-    const [pr, pg, pb] = getPrimaryRGB();
     ctx.beginPath();
     ctx.arc(centerX, centerY, barBaseRadius, 0, Math.PI * 2);
     ctx.strokeStyle = `rgba(${pr}, ${pg}, ${pb}, ${0.12 + avgEnergy * 0.2})`;
@@ -143,7 +144,7 @@ export function CircleVisualizer() {
     ctx.stroke();
     ctx.shadowBlur = 0;
 
-  }, [widthRef, heightRef, dprRef]);
+  }, [widthRef, heightRef, dprRef, rgbRef]);
 
   useRafLoop(draw, canvasRef, isPlaying && !!currentTrack);
 

--- a/apps/web/src/components/player/ParticleVisualizer.tsx
+++ b/apps/web/src/components/player/ParticleVisualizer.tsx
@@ -2,8 +2,8 @@ import { useRef, useCallback } from 'react';
 import { usePlayerStore } from '@/stores/usePlayerStore';
 import { useRafLoop } from '@/hooks/useRafLoop';
 import { useCanvasSize } from '@/hooks/useCanvasSize';
+import { usePrimaryRGB } from '@/hooks/usePrimaryRGB';
 import { getAnalyser } from '@/lib/audioAnalyser';
-import { getPrimaryRGB } from '@/lib/utils';
 
 /**
  * Smooth wave visualizer with gradient fill.
@@ -18,6 +18,17 @@ export function ParticleVisualizer() {
   const isPlaying = usePlayerStore((s) => s.isPlaying);
   const currentTrack = usePlayerStore((s) => s.currentTrack);
   const { widthRef, heightRef, dprRef } = useCanvasSize(canvasRef);
+  const { rgbRef, versionRef } = usePrimaryRGB();
+
+  // Cached gradients for drawWaveFill. Invalidated when centerY, primary-rgb,
+  // or the canvas context changes — see issue #50. Pre-cache avoids allocating
+  // two CanvasGradient objects every frame (120/sec during playback).
+  const gradientCacheRef = useRef<{
+    top: CanvasGradient | null;
+    bottom: CanvasGradient | null;
+    key: string;
+    ctx: CanvasRenderingContext2D | null;
+  }>({ top: null, bottom: null, key: '', ctx: null });
 
   const draw = useCallback(() => {
     const canvas = canvasRef.current;
@@ -62,6 +73,27 @@ export function ParticleVisualizer() {
     const centerY = h * 0.5;
     const maxAmp = h * 0.38;
 
+    // Hoist theme color once per frame (issue #49).
+    const [pr, pg, pb] = rgbRef.current;
+
+    // Rebuild gradient cache if centerY, theme color, or ctx identity changed.
+    const cache = gradientCacheRef.current;
+    const key = `${centerY}|${pr},${pg},${pb}|${versionRef.current}`;
+    if (cache.key !== key || cache.ctx !== ctx) {
+      const topGrad = ctx.createLinearGradient(0, centerY - 15, 0, centerY);
+      topGrad.addColorStop(0, `rgba(${pr - 15}, ${pg - 15}, ${pb - 15}, 0.15)`);
+      topGrad.addColorStop(1, `rgba(${pr - 15}, ${pg - 15}, ${pb - 15}, 0.0)`);
+
+      const bottomGrad = ctx.createLinearGradient(0, centerY + 15, 0, centerY);
+      bottomGrad.addColorStop(0, `rgba(${pr - 15}, ${pg - 15}, ${pb - 15}, 0.15)`);
+      bottomGrad.addColorStop(1, `rgba(${pr - 15}, ${pg - 15}, ${pb - 15}, 0.0)`);
+
+      cache.top = topGrad;
+      cache.bottom = bottomGrad;
+      cache.key = key;
+      cache.ctx = ctx;
+    }
+
     // Build smoothed data points
     const points: { x: number; y: number }[] = [];
 
@@ -88,14 +120,14 @@ export function ParticleVisualizer() {
     }
 
     // ── Draw the mirrored wave (top half) ──
-    drawWaveFill(ctx, points, centerY, w, h, false);
+    drawWaveFill(ctx, points, centerY, cache.top!);
 
     // ── Draw the mirrored wave (bottom half — reflected) ──
     const mirrorPoints = points.map((p) => ({
       x: p.x,
       y: centerY + (centerY - p.y),
     }));
-    drawWaveFill(ctx, mirrorPoints, centerY, w, h, true);
+    drawWaveFill(ctx, mirrorPoints, centerY, cache.bottom!);
 
     // ── Draw the wave stroke line (top) ──
     ctx.beginPath();
@@ -108,7 +140,6 @@ export function ParticleVisualizer() {
     }
     const last = points[points.length - 1];
     ctx.lineTo(last.x, last.y);
-    const [pr, pg, pb] = getPrimaryRGB();
     ctx.strokeStyle = `rgba(${pr}, ${pg}, ${pb}, 0.5)`;
     ctx.lineWidth = 1.5;
     ctx.shadowColor = `rgba(${pr}, ${pg}, ${pb}, 0.3)`;
@@ -124,7 +155,7 @@ export function ParticleVisualizer() {
     ctx.lineWidth = 1;
     ctx.stroke();
 
-  }, [widthRef, heightRef, dprRef]);
+  }, [widthRef, heightRef, dprRef, rgbRef, versionRef]);
 
   useRafLoop(draw, canvasRef, isPlaying && !!currentTrack);
 
@@ -137,14 +168,12 @@ export function ParticleVisualizer() {
   );
 }
 
-/** Draw a smooth bezier wave path with gradient fill toward centerY */
+/** Draw a smooth bezier wave path with a pre-built gradient fill toward centerY. */
 function drawWaveFill(
   ctx: CanvasRenderingContext2D,
   points: { x: number; y: number }[],
   centerY: number,
-  _w: number,
-  _h: number,
-  isMirror: boolean
+  gradient: CanvasGradient,
 ) {
   if (points.length < 2) return;
 
@@ -164,14 +193,7 @@ function drawWaveFill(
   ctx.lineTo(last.x, centerY);
   ctx.closePath();
 
-  // Gradient from wave peak toward center
-  const gradStart = isMirror ? centerY + 15 : centerY - 15;
-  const gradEnd = centerY;
-  const grad = ctx.createLinearGradient(0, gradStart, 0, gradEnd);
-  const [pr, pg, pb] = getPrimaryRGB();
-  grad.addColorStop(0, `rgba(${pr - 15}, ${pg - 15}, ${pb - 15}, 0.15)`);
-  grad.addColorStop(1, `rgba(${pr - 15}, ${pg - 15}, ${pb - 15}, 0.0)`);
-  ctx.fillStyle = grad;
+  ctx.fillStyle = gradient;
   ctx.fill();
 }
 

--- a/apps/web/src/components/player/ParticleVisualizer.tsx
+++ b/apps/web/src/components/player/ParticleVisualizer.tsx
@@ -24,11 +24,10 @@ export function ParticleVisualizer() {
   // or the canvas context changes — see issue #50. Pre-cache avoids allocating
   // two CanvasGradient objects every frame (120/sec during playback).
   const gradientCacheRef = useRef<{
-    top: CanvasGradient | null;
-    bottom: CanvasGradient | null;
+    grad: CanvasGradient | null;
     key: string;
     ctx: CanvasRenderingContext2D | null;
-  }>({ top: null, bottom: null, key: '', ctx: null });
+  }>({ grad: null, key: '', ctx: null });
 
   const draw = useCallback(() => {
     const canvas = canvasRef.current;
@@ -77,19 +76,19 @@ export function ParticleVisualizer() {
     const [pr, pg, pb] = rgbRef.current;
 
     // Rebuild gradient cache if centerY, theme color, or ctx identity changed.
+    // versionRef bumps on any primary-rgb change, so we don't need to stringify
+    // pr/pg/pb in the key.
     const cache = gradientCacheRef.current;
-    const key = `${centerY}|${pr},${pg},${pb}|${versionRef.current}`;
+    const key = `${centerY}|${versionRef.current}`;
     if (cache.key !== key || cache.ctx !== ctx) {
-      const topGrad = ctx.createLinearGradient(0, centerY - 15, 0, centerY);
-      topGrad.addColorStop(0, `rgba(${pr - 15}, ${pg - 15}, ${pb - 15}, 0.15)`);
-      topGrad.addColorStop(1, `rgba(${pr - 15}, ${pg - 15}, ${pb - 15}, 0.0)`);
+      // Single gradient shared by both halves — the bottom wave is drawn with
+      // a scale(1,-1) transform, which mirrors the gradient's CTM-space
+      // endpoints automatically.
+      const grad = ctx.createLinearGradient(0, centerY - 15, 0, centerY);
+      grad.addColorStop(0, `rgba(${pr - 15}, ${pg - 15}, ${pb - 15}, 0.15)`);
+      grad.addColorStop(1, `rgba(${pr - 15}, ${pg - 15}, ${pb - 15}, 0.0)`);
 
-      const bottomGrad = ctx.createLinearGradient(0, centerY + 15, 0, centerY);
-      bottomGrad.addColorStop(0, `rgba(${pr - 15}, ${pg - 15}, ${pb - 15}, 0.15)`);
-      bottomGrad.addColorStop(1, `rgba(${pr - 15}, ${pg - 15}, ${pb - 15}, 0.0)`);
-
-      cache.top = topGrad;
-      cache.bottom = bottomGrad;
+      cache.grad = grad;
       cache.key = key;
       cache.ctx = ctx;
     }
@@ -119,15 +118,17 @@ export function ParticleVisualizer() {
       points.push({ x, y: centerY - amp });
     }
 
-    // ── Draw the mirrored wave (top half) ──
-    drawWaveFill(ctx, points, centerY, cache.top!);
+    // ── Top half ──
+    drawWaveFill(ctx, points, centerY, cache.grad!);
 
-    // ── Draw the mirrored wave (bottom half — reflected) ──
-    const mirrorPoints = points.map((p) => ({
-      x: p.x,
-      y: centerY + (centerY - p.y),
-    }));
-    drawWaveFill(ctx, mirrorPoints, centerY, cache.bottom!);
+    // ── Bottom half via canvas Y-mirror ──
+    // Reusing `points` with a transform avoids allocating ~64 new objects +
+    // an array per frame (~3800 allocs/sec at 60fps).
+    ctx.save();
+    ctx.translate(0, centerY * 2);
+    ctx.scale(1, -1);
+    drawWaveFill(ctx, points, centerY, cache.grad!);
+    ctx.restore();
 
     // ── Draw the wave stroke line (top) ──
     ctx.beginPath();

--- a/apps/web/src/components/player/WaveformVisualizer.tsx
+++ b/apps/web/src/components/player/WaveformVisualizer.tsx
@@ -1,9 +1,9 @@
 import { useRef, useCallback } from 'react';
 import { usePlayerStore } from '@/stores/usePlayerStore';
 import { getAnalyser } from '@/lib/audioAnalyser';
-import { getPrimaryRGB } from '@/lib/utils';
 import { useRafLoop } from '@/hooks/useRafLoop';
 import { useCanvasSize } from '@/hooks/useCanvasSize';
+import { usePrimaryRGB } from '@/hooks/usePrimaryRGB';
 
 /**
  * Dense vertical-bar waveform visualizer inspired by ElevenLabs UI.
@@ -18,6 +18,7 @@ export function WaveformVisualizer() {
   const isPlaying = usePlayerStore((s) => s.isPlaying);
   const currentTrack = usePlayerStore((s) => s.currentTrack);
   const { widthRef, heightRef, dprRef } = useCanvasSize(canvasRef);
+  const { rgbRef } = usePrimaryRGB();
 
   const draw = useCallback(() => {
     const canvas = canvasRef.current;
@@ -70,6 +71,9 @@ export function WaveformVisualizer() {
     const maxBarH = h * 0.4;
     const minBarH = 2;
 
+    // Hoist theme color once per frame — was ~120 CSS-var lookups/frame (issue #49).
+    const [pr, pg, pb] = rgbRef.current;
+
     for (let i = 0; i < barCount; i++) {
       // Map bar index to frequency bin (with interpolation)
       const binPos = (i / barCount) * binCount;
@@ -92,8 +96,6 @@ export function WaveformVisualizer() {
 
       const alpha = (0.4 + value * 0.5) * edgeFade;
 
-      // Color: theme-derived
-      const [pr, pg, pb] = getPrimaryRGB();
       ctx.fillStyle = `rgba(${pr}, ${pg}, ${pb}, ${alpha})`;
 
       // Center-aligned bar (grows from center up and down)
@@ -102,7 +104,7 @@ export function WaveformVisualizer() {
       ctx.fill();
     }
 
-  }, [widthRef, heightRef, dprRef]);
+  }, [widthRef, heightRef, dprRef, rgbRef]);
 
   useRafLoop(draw, canvasRef, isPlaying && !!currentTrack);
 

--- a/apps/web/src/hooks/usePrimaryRGB.test.ts
+++ b/apps/web/src/hooks/usePrimaryRGB.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePrimaryRGB } from './usePrimaryRGB';
+
+describe('usePrimaryRGB', () => {
+  beforeEach(() => {
+    document.documentElement.style.setProperty('--primary-rgb', '10, 20, 30');
+  });
+
+  afterEach(() => {
+    document.documentElement.style.removeProperty('--primary-rgb');
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('reads --primary-rgb from documentElement on mount', () => {
+    const { result } = renderHook(() => usePrimaryRGB());
+    expect(result.current.rgbRef.current).toEqual([10, 20, 30]);
+  });
+
+  it('falls back to default when the var is missing or malformed', () => {
+    document.documentElement.style.removeProperty('--primary-rgb');
+    const { result } = renderHook(() => usePrimaryRGB());
+    expect(result.current.rgbRef.current).toEqual([155, 125, 235]);
+  });
+
+  it('updates rgbRef and bumps versionRef when --primary-rgb changes', async () => {
+    const { result } = renderHook(() => usePrimaryRGB());
+    const initialVersion = result.current.versionRef.current;
+
+    await act(async () => {
+      document.documentElement.style.setProperty('--primary-rgb', '200, 100, 50');
+      // MutationObserver callbacks are microtask-scheduled.
+      await Promise.resolve();
+    });
+
+    expect(result.current.rgbRef.current).toEqual([200, 100, 50]);
+    expect(result.current.versionRef.current).toBe(initialVersion + 1);
+  });
+
+  it('does not bump version when the value is unchanged', async () => {
+    const { result } = renderHook(() => usePrimaryRGB());
+    const initialVersion = result.current.versionRef.current;
+
+    await act(async () => {
+      // Touch an unrelated attribute — value does not change.
+      document.documentElement.setAttribute('data-theme', 'dark');
+      await Promise.resolve();
+    });
+
+    expect(result.current.versionRef.current).toBe(initialVersion);
+  });
+
+  it('disconnects the observer on unmount', async () => {
+    const { result, unmount } = renderHook(() => usePrimaryRGB());
+    unmount();
+
+    await act(async () => {
+      document.documentElement.style.setProperty('--primary-rgb', '1, 2, 3');
+      await Promise.resolve();
+    });
+
+    expect(result.current.rgbRef.current).not.toEqual([1, 2, 3]);
+  });
+});

--- a/apps/web/src/hooks/usePrimaryRGB.ts
+++ b/apps/web/src/hooks/usePrimaryRGB.ts
@@ -1,0 +1,60 @@
+// Shared hook for reading --primary-rgb from CSS. Exposes a ref so RAF draw
+// loops can read the current tuple without triggering re-renders, and a
+// versionRef that increments whenever the value changes so consumers can
+// invalidate derived caches (e.g. CanvasGradient objects).
+
+import { useRef, useEffect, type MutableRefObject } from 'react';
+
+export interface UsePrimaryRGBResult {
+  rgbRef: MutableRefObject<[number, number, number]>;
+  versionRef: MutableRefObject<number>;
+}
+
+const FALLBACK: [number, number, number] = [155, 125, 235];
+
+function parsePrimaryRGB(raw: string): [number, number, number] {
+  const parts = raw.split(',').map((p) => Number(p.trim()));
+  if (parts.length === 3 && parts.every((n) => !Number.isNaN(n))) {
+    return parts as [number, number, number];
+  }
+  return FALLBACK;
+}
+
+function readFromDocument(): [number, number, number] {
+  if (typeof document === 'undefined') return FALLBACK;
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue('--primary-rgb')
+    .trim();
+  if (!raw) return FALLBACK;
+  return parsePrimaryRGB(raw);
+}
+
+export function usePrimaryRGB(): UsePrimaryRGBResult {
+  const rgbRef = useRef<[number, number, number]>(FALLBACK);
+  const versionRef = useRef(0);
+
+  useEffect(() => {
+    const update = () => {
+      const next = readFromDocument();
+      const [r, g, b] = rgbRef.current;
+      if (next[0] !== r || next[1] !== g || next[2] !== b) {
+        rgbRef.current = next;
+        versionRef.current++;
+      }
+    };
+
+    update();
+
+    // Watch <html> for attribute changes so a future theme switcher (class
+    // toggle, data-theme swap, or inline style setProperty) triggers a re-read.
+    const observer = new MutationObserver(update);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style', 'data-theme'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return { rgbRef, versionRef };
+}

--- a/apps/web/src/hooks/usePrimaryRGB.ts
+++ b/apps/web/src/hooks/usePrimaryRGB.ts
@@ -30,7 +30,9 @@ function readFromDocument(): [number, number, number] {
 }
 
 export function usePrimaryRGB(): UsePrimaryRGBResult {
-  const rgbRef = useRef<[number, number, number]>(FALLBACK);
+  // Read synchronously on first render so the very first RAF frame gets the
+  // real color — avoids a one-frame flash of the fallback purple.
+  const rgbRef = useRef<[number, number, number]>(readFromDocument());
   const versionRef = useRef(0);
 
   useEffect(() => {


### PR DESCRIPTION
Closes #49, closes #50.

## Summary
- New `usePrimaryRGB` hook reads `--primary-rgb` once and exposes `rgbRef` + `versionRef`; a `MutationObserver` on `<html>` invalidates on future theme swaps (class/style/data-theme).
- Hoist `[pr, pg, pb]` once per `draw()` in Waveform, Circle, Audio, and Particle visualizers. Previously called inside inner loops (up to ~120×/frame in Waveform, ~130×/frame in Circle).
- Cache both `CanvasGradient` objects in `ParticleVisualizer.drawWaveFill`, keyed by `centerY | primary-rgb | ctx`. Eliminates 2 `createLinearGradient` allocations per frame under stable conditions; rebuilds only on resize or theme change.
- `getPrimaryRGB()` in `lib/utils.ts` left intact for any non-React callers.

## Test plan
- [x] `pnpm --filter @shiranami/web test` — 434 tests pass, incl. 5 new for `usePrimaryRGB` (mount read, fallback, mutation-triggered update, no-op on unchanged value, unmount cleanup).
- [x] `pnpm --filter @shiranami/web typecheck` clean.
- [x] `pnpm lint` clean.
- [ ] Manual: play a track with each visualizer (Waveform / Circle / Audio / Particle) — visual output unchanged.
- [ ] Manual: DevTools Performance profile during Particle playback — `createLinearGradient` no longer appears in the per-frame flame graph.
- [ ] Manual: live-change `document.documentElement.style.setProperty('--primary-rgb', '255,0,0')` — all four visualizers recolor within a frame.