### PR TITLE
perf(ui): reduce glass blur, opt-in noise, dedupe ambient gradients (#52 #53 #54)

### DIFF
--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlayerStore } from '@/stores/usePlayerStore';
 import { useAppStore } from '@/stores/useAppStore';
-import { useAmbientColor } from '@/hooks/useAmbientColor';
 import { useLyricsQuery } from '@/hooks/queries/useLyrics';
 import { cn } from '@/lib/utils';
 import { formatDuration } from '@shiranami/shared';
@@ -32,11 +31,9 @@ export function NowPlayingView() {
   const currentTime = usePlayerStore(s => s.currentTime);
   const duration = usePlayerStore(s => s.duration);
   const seek = usePlayerStore(s => s.seek);
-  const ambientColor = useAmbientColor();
   const exitNowPlaying = useAppStore(s => s.exitNowPlaying);
   const lyricsVisible = useAppStore(s => s.nowPlayingLyricsVisible);
   const toggleLyrics = useAppStore(s => s.toggleNowPlayingLyrics);
-  const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
 
   const { data, isLoading: lyricsLoading } = useLyricsQuery(
     currentTrack?.id ?? null,
@@ -71,18 +68,7 @@ export function NowPlayingView() {
 
   return (
     <div className="@container flex-1 flex flex-col overflow-hidden relative">
-      {/* Full ambient gradient background — skipped in low performance mode */}
-      {!lowPerformanceMode && (
-        <div
-          className="absolute inset-0 pointer-events-none transition-all duration-[2s]"
-          style={{
-            background: `
-              radial-gradient(ellipse at 20% 30%, rgba(${ambientColor.rgb}, 0.18) 0%, transparent 60%),
-              radial-gradient(ellipse at 80% 70%, rgba(${ambientColor.rgb}, 0.10) 0%, transparent 55%)
-            `,
-          }}
-        />
-      )}
+      {/* Ambient gradient is painted globally by <AmbientBackground /> — no local duplicate here. */}
 
       {/* Header: back button + lyrics toggle */}
       <div className="relative px-6 @3xl:px-10 pt-4 pb-2 shrink-0 flex items-center justify-between">

--- a/apps/web/src/components/player/CompactPlayer.tsx
+++ b/apps/web/src/components/player/CompactPlayer.tsx
@@ -11,6 +11,7 @@ import { useAmbientColor } from '@/hooks/useAmbientColor';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { TimeDisplay } from './TimeDisplay';
 import { Maximize2, Minimize2, Music, Pin, X } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
 
 export function CompactPlayer() {
   const { t } = useTranslation('compact');
@@ -36,12 +37,19 @@ export function CompactPlayer() {
   return (
     <div className="relative flex h-full flex-col overflow-hidden">
       {!lowPerformanceMode && (
-        <div
-          className="pointer-events-none absolute inset-0 opacity-[0.08] transition-all duration-[2s]"
-          style={{
-            background: `radial-gradient(circle at 18% 24%, rgba(${ambientColor.rgb}, 0.95) 0%, transparent 48%)`,
-          }}
-        />
+        <AnimatePresence>
+          <motion.div
+            key={ambientColor.hex}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 0.08 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 2 }}
+            className="pointer-events-none absolute inset-0"
+            style={{
+              background: `radial-gradient(circle at 18% 24%, rgba(${ambientColor.rgb}, 0.95) 0%, transparent 48%)`,
+            }}
+          />
+        </AnimatePresence>
       )}
 
       <div className="drag flex h-9 shrink-0 items-center justify-between border-b border-border/20 px-3">

--- a/apps/web/src/components/settings/AppearanceSection.tsx
+++ b/apps/web/src/components/settings/AppearanceSection.tsx
@@ -40,6 +40,8 @@ export function AppearanceSection() {
   const setLibraryHeroCardEnabled = useAppStore((s) => s.setLibraryHeroCardEnabled);
   const lowPerformanceMode = useAppStore((s) => s.lowPerformanceMode);
   const setLowPerformanceMode = useAppStore((s) => s.setLowPerformanceMode);
+  const noiseOverlayEnabled = useAppStore((s) => s.noiseOverlayEnabled);
+  const setNoiseOverlayEnabled = useAppStore((s) => s.setNoiseOverlayEnabled);
   const sidebarHiddenItems = useAppStore((s) => s.sidebarHiddenItems);
   const toggleSidebarItem = useAppStore((s) => s.toggleSidebarItem);
   const sidebarPlaylistsVisible = useAppStore((s) => s.sidebarPlaylistsVisible);
@@ -171,6 +173,20 @@ export function AppearanceSection() {
             <Switch
               checked={lowPerformanceMode}
               onChange={setLowPerformanceMode}
+            />
+          </div>
+        </div>
+
+        {/* Noise overlay — opt-in film-grain texture, forced off under low-perf mode */}
+        <div className="px-3">
+          <div className="flex items-center justify-between py-2.5 rounded-xl hover:bg-accent/30 transition-colors px-3 -mx-3">
+            <div className="pr-4">
+              <p className="text-sm font-medium text-foreground">{t('app.noiseOverlay')}</p>
+              <p className="text-xs text-muted-foreground mt-0.5">{t('app.noiseOverlayDesc')}</p>
+            </div>
+            <Switch
+              checked={noiseOverlayEnabled}
+              onChange={setNoiseOverlayEnabled}
             />
           </div>
         </div>

--- a/apps/web/src/components/shared/AmbientBackground.tsx
+++ b/apps/web/src/components/shared/AmbientBackground.tsx
@@ -13,9 +13,7 @@ export function AmbientBackground() {
 
   return (
     <>
-      {noiseOverlayEnabled && (
-        <div className="noise fixed inset-0 z-[9998] pointer-events-none" />
-      )}
+      {noiseOverlayEnabled && <div className="noise" />}
 
       <AnimatePresence>
         {currentTrack && (

--- a/apps/web/src/components/shared/AmbientBackground.tsx
+++ b/apps/web/src/components/shared/AmbientBackground.tsx
@@ -7,13 +7,15 @@ export function AmbientBackground() {
   const currentTrack = usePlayerStore(s => s.currentTrack);
   const ambientColor = useAmbientColor();
   const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
+  const noiseOverlayEnabled = useAppStore(s => s.noiseOverlayEnabled);
 
   if (lowPerformanceMode) return null;
 
   return (
     <>
-      {/* Noise texture overlay */}
-      <div className="noise fixed inset-0 z-[9998] pointer-events-none" />
+      {noiseOverlayEnabled && (
+        <div className="noise fixed inset-0 z-[9998] pointer-events-none" />
+      )}
 
       <AnimatePresence>
         {currentTrack && (

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -103,6 +103,8 @@
     "libraryHeroCardDesc": "Show the large now-playing card above Library and Favorites. Turn off to give albums more room — the player bar still shows track info.",
     "lowPerfMode": "Low performance mode",
     "lowPerfModeDesc": "Disable visualizer, glass blur, noise overlay, and ambient gradients. Recommended for older or integrated-GPU machines.",
+    "noiseOverlay": "Noise texture",
+    "noiseOverlayDesc": "Subtle film-grain texture layered over the UI. Off by default — adds a small amount of GPU work.",
     "new": "New",
     "sidebarPlaylists": "Show playlists",
     "sidebarPlaylistsDesc": "Display your playlists in the sidebar"

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -103,6 +103,8 @@
     "libraryHeroCardDesc": "Pokazuj dużą kartę nad Biblioteką i Ulubionymi. Wyłącz, aby zyskać więcej miejsca na albumy — pasek odtwarzacza i tak pokazuje informacje o utworze.",
     "lowPerfMode": "Tryb niskiej wydajności",
     "lowPerfModeDesc": "Wyłącza wizualizator, rozmycie szkła, nakładkę szumu i gradienty tła. Zalecane na starszych komputerach lub z zintegrowaną kartą graficzną.",
+    "noiseOverlay": "Tekstura szumu",
+    "noiseOverlayDesc": "Subtelna tekstura ziarna filmu nałożona na interfejs. Domyślnie wyłączona — dodaje niewielkie obciążenie GPU.",
     "new": "Nowość",
     "sidebarPlaylists": "Pokaż playlisty",
     "sidebarPlaylistsDesc": "Wyświetlaj playlisty w panelu bocznym"

--- a/apps/web/src/stores/useAppStore.ts
+++ b/apps/web/src/stores/useAppStore.ts
@@ -85,6 +85,7 @@ const NOW_PLAYING_LYRICS_VISIBLE_STORAGE_KEY = 'shiranami.now-playing-lyrics-vis
 const LIBRARY_HERO_CARD_ENABLED_STORAGE_KEY = 'shiranami.library-hero-card-enabled';
 const UI_SCALE_STORAGE_KEY = 'shiranami.ui-scale';
 const LOW_PERFORMANCE_MODE_STORAGE_KEY = 'shiranami.low-performance-mode';
+const NOISE_OVERLAY_ENABLED_STORAGE_KEY = 'shiranami.noise-overlay-enabled';
 
 export const UI_SCALE_MIN = 80;
 export const UI_SCALE_MAX = 120;
@@ -135,6 +136,16 @@ function getInitialLowPerformanceMode(): boolean {
 function persistLowPerformanceMode(enabled: boolean) {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem(LOW_PERFORMANCE_MODE_STORAGE_KEY, enabled ? 'true' : 'false');
+}
+
+function getInitialNoiseOverlayEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.localStorage.getItem(NOISE_OVERLAY_ENABLED_STORAGE_KEY) === 'true';
+}
+
+function persistNoiseOverlayEnabled(enabled: boolean) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(NOISE_OVERLAY_ENABLED_STORAGE_KEY, enabled ? 'true' : 'false');
 }
 
 function getInitialSidebarCollapsed() {
@@ -270,6 +281,7 @@ interface AppState {
   nowPlayingLyricsVisible: boolean;
   libraryHeroCardEnabled: boolean;
   lowPerformanceMode: boolean;
+  noiseOverlayEnabled: boolean;
   previousView: AppView;
 }
 
@@ -281,6 +293,7 @@ interface AppActions {
   toggleNowPlayingLyrics: () => void;
   setLibraryHeroCardEnabled: (enabled: boolean) => void;
   setLowPerformanceMode: (enabled: boolean) => void;
+  setNoiseOverlayEnabled: (enabled: boolean) => void;
   selectPlaylist: (id: string | null) => void;
   setRightPanel: (panel: RightPanel) => void;
   setSidebarCollapsed: (sidebarCollapsed: boolean) => void;
@@ -328,6 +341,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   nowPlayingLyricsVisible: getInitialNowPlayingLyricsVisible(),
   libraryHeroCardEnabled: getInitialLibraryHeroCardEnabled(),
   lowPerformanceMode: getInitialLowPerformanceMode(),
+  noiseOverlayEnabled: getInitialNoiseOverlayEnabled(),
   previousView: 'library',
 
   navigateTo: (view, playlistId) =>
@@ -364,6 +378,10 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     applyLowPerformanceMode(enabled);
     persistLowPerformanceMode(enabled);
     set({ lowPerformanceMode: enabled });
+  },
+  setNoiseOverlayEnabled: (enabled) => {
+    persistNoiseOverlayEnabled(enabled);
+    set({ noiseOverlayEnabled: enabled });
   },
   selectPlaylist: (id) => set({ selectedPlaylistId: id }),
   setRightPanel: (panel) => set({ rightPanel: panel }),

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -153,13 +153,13 @@
 }
 
 @utility glass {
-  backdrop-filter: blur(16px) saturate(1.4);
-  background: oklch(0.1 0.02 280 / 0.7);
+  backdrop-filter: blur(8px) saturate(1.4);
+  background: oklch(0.1 0.02 280 / 0.82);
 }
 
 @utility glass-subtle {
-  backdrop-filter: blur(8px) saturate(1.2);
-  background: oklch(0.08 0.02 280 / 0.5);
+  backdrop-filter: blur(6px) saturate(1.2);
+  background: oklch(0.08 0.02 280 / 0.6);
 }
 
 @utility text-gradient {


### PR DESCRIPTION
Closes #52, #53, #54 (all children of the #33 perf umbrella).

## Summary
- **#52** — Halve `.glass` blur radius (16px → 8px) and bump its background alpha (0.7 → 0.82) to preserve contrast. `.glass-subtle` also tuned down (8px → 6px, 0.5 → 0.6). `backdrop-filter` cost scales roughly with blur-radius², so this is the biggest per-frame win on the compact player bar and compact inner panel. Low-perf override in `globals.css` already neutralizes both utilities — no change needed there.
- **#53** — Noise texture is now a persisted, opt-in setting (`shiranami.noise-overlay-enabled`, default **off**). New Switch row in *Settings → Appearance*, below the existing Low performance mode toggle, with EN + PL strings. `AmbientBackground` already bails out entirely when low-perf mode is on, so the noise layer is forced off there regardless of this new setting.
- **#54** — Consolidated full-viewport ambient gradient:
  - Deleted the duplicate radial-gradient div inside `NowPlayingView` — it's now painted solely by the global `<AmbientBackground />` (which already sits in the same tree per `App.tsx`).
  - Replaced `CompactPlayer`'s `transition-all duration-[2s]` on its local hot-spot gradient with an `AnimatePresence` + `motion.div` opacity fade keyed on `ambientColor.hex`. Same 2s visual, but the animation runs on the compositor layer (opacity) instead of triggering a 2-second continuous repaint of a viewport-sized background.

## Files touched
- `apps/web/src/styles/globals.css` — blur radii + background alphas
- `apps/web/src/stores/useAppStore.ts` — `noiseOverlayEnabled` state, action, and `localStorage` persistence
- `apps/web/src/components/shared/AmbientBackground.tsx` — gate noise div on the new setting
- `apps/web/src/components/settings/AppearanceSection.tsx` — new Switch row
- `apps/web/src/locales/{en,pl}/settings.json` — `app.noiseOverlay` + `app.noiseOverlayDesc`
- `apps/web/src/components/now-playing/NowPlayingView.tsx` — delete local gradient + unused `useAmbientColor` import
- `apps/web/src/components/player/CompactPlayer.tsx` — drop `transition-all`, wrap gradient in `AnimatePresence`

## Verification
- `pnpm --filter web typecheck` clean
- `pnpm --filter web test --run` — 33 files / 434 tests passing
- Manual UI checks to perform:
  - Toggle noise setting → overlay appears/disappears; survives reload.
  - Enable Low performance mode → noise forced off regardless.
  - Switch tracks in main player and in compact window → ambient color fades smoothly (opacity crossfade, not CSS background transition).
  - Open Now Playing view → only one full-viewport gradient layer in the DOM (from `AmbientBackground`).

## Test plan
- [ ] Verify `.glass` still looks translucent but noticeably more solid on PlayerBar / CompactPlayer inner panel
- [ ] Noise toggle persists across reload, default off for fresh profiles
- [ ] Noise forced off when Low performance mode is enabled
- [ ] Ambient color fade on track change is smooth (visual) and does not cause full-viewport repaint (DevTools Performance)
- [ ] Only one full-viewport radial-gradient layer exists in the Now Playing view
- [ ] PL translations render correctly in Settings → Appearance