### PR TITLE
perf(lyrics): memoize list + subscribe only to active-line index

### DIFF
--- a/apps/web/src/components/lyrics/LyricsList.tsx
+++ b/apps/web/src/components/lyrics/LyricsList.tsx
@@ -1,0 +1,106 @@
+import { memo, useEffect, useRef } from 'react';
+import { cn } from '@/lib/utils';
+import type { LyricLine } from '@/hooks/queries/useLyrics';
+
+interface LyricLineButtonProps {
+  text: string;
+  time: number;
+  isActive: boolean;
+  isPast: boolean;
+  onSelect: (time: number) => void;
+  activeRef?: React.Ref<HTMLButtonElement>;
+  baseClassName: string;
+  activeClassName: string;
+  pastClassName: string;
+  idleClassName: string;
+}
+
+const LyricLineButton = memo(function LyricLineButton({
+  text,
+  time,
+  isActive,
+  isPast,
+  onSelect,
+  activeRef,
+  baseClassName,
+  activeClassName,
+  pastClassName,
+  idleClassName,
+}: LyricLineButtonProps) {
+  return (
+    <button
+      ref={isActive ? activeRef : null}
+      onClick={() => onSelect(time)}
+      type="button"
+      className={cn(
+        baseClassName,
+        isActive && activeClassName,
+        isPast && pastClassName,
+        !isActive && !isPast && idleClassName,
+      )}
+    >
+      {text}
+    </button>
+  );
+});
+
+interface LyricsListProps {
+  lines: LyricLine[];
+  activeIndex: number;
+  onLineClick: (time: number) => void;
+  containerClassName?: string;
+  spacingClassName?: string;
+  bottomSpacerClassName?: string;
+  baseClassName: string;
+  activeClassName: string;
+  pastClassName: string;
+  idleClassName: string;
+}
+
+export const LyricsList = memo(function LyricsList({
+  lines,
+  activeIndex,
+  onLineClick,
+  containerClassName,
+  spacingClassName,
+  bottomSpacerClassName,
+  baseClassName,
+  activeClassName,
+  pastClassName,
+  idleClassName,
+}: LyricsListProps) {
+  const activeLineRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (activeLineRef.current) {
+      activeLineRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [activeIndex]);
+
+  return (
+    <div className={cn('flex-1 overflow-y-auto scrollbar-hide', containerClassName)}>
+      <div className={spacingClassName}>
+        {lines.map((line, index) => {
+          const isActive = index === activeIndex;
+          const isPast = index < activeIndex;
+          return (
+            <LyricLineButton
+              key={index}
+              text={line.text}
+              time={line.time}
+              isActive={isActive}
+              isPast={isPast}
+              onSelect={onLineClick}
+              activeRef={activeLineRef}
+              baseClassName={baseClassName}
+              activeClassName={activeClassName}
+              pastClassName={pastClassName}
+              idleClassName={idleClassName}
+            />
+          );
+        })}
+        {bottomSpacerClassName && <div className={bottomSpacerClassName} />}
+      </div>
+    </div>
+  );
+});

--- a/apps/web/src/components/lyrics/LyricsPanel.tsx
+++ b/apps/web/src/components/lyrics/LyricsPanel.tsx
@@ -1,26 +1,21 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlayerStore } from '@/stores/usePlayerStore';
 import { useLyricsQuery } from '@/hooks/queries/useLyrics';
-import { cn } from '@/lib/utils';
+import { useActiveLineIndex } from '@/lib/lyrics';
+import { LyricsList } from '@/components/lyrics/LyricsList';
 import { Loader2, Music2 } from 'lucide-react';
 
-function findActiveLine(lines: Array<{ time: number }>, currentTime: number): number {
-  let active = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].time <= currentTime) {
-      active = i;
-    } else {
-      break;
-    }
-  }
-  return active;
-}
+const PANEL_BASE =
+  'block w-full text-left text-base leading-relaxed font-medium cursor-pointer transition-all duration-500 rounded-md px-1 -mx-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40';
+const PANEL_ACTIVE = 'text-foreground text-lg font-semibold';
+const PANEL_PAST = 'text-muted-foreground/25';
+const PANEL_IDLE = 'text-muted-foreground/45 hover:text-muted-foreground/70';
 
 export function LyricsPanel() {
   const { t } = useTranslation('lyrics');
   const currentTrack = usePlayerStore(s => s.currentTrack);
-  const currentTime = usePlayerStore(s => s.currentTime);
+  const seek = usePlayerStore(s => s.seek);
 
   const { data, isLoading } = useLyricsQuery(
     currentTrack?.id ?? null,
@@ -32,18 +27,8 @@ export function LyricsPanel() {
 
   const synced = data?.synced ?? null;
   const plain = data?.plain ?? null;
+  const activeLine = useActiveLineIndex(synced);
 
-  const activeLineRef = useRef<HTMLButtonElement>(null);
-
-  const activeLine = synced ? findActiveLine(synced, currentTime) : -1;
-
-  useEffect(() => {
-    if (activeLineRef.current) {
-      activeLineRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }
-  }, [activeLine]);
-
-  const seek = usePlayerStore(s => s.seek);
   const handleLineClick = useCallback((time: number) => seek(time), [seek]);
 
   if (!currentTrack) return null;
@@ -61,31 +46,18 @@ export function LyricsPanel() {
     );
   } else if (synced && synced.length > 0) {
     content = (
-      <div className="flex-1 overflow-y-auto scrollbar-hide px-5 py-6">
-        <div className="space-y-4">
-          {synced.map((line, index) => {
-            const isActive = index === activeLine;
-            const isPast = index < activeLine;
-            return (
-              <button
-                key={index}
-                ref={isActive ? activeLineRef : null}
-                onClick={() => handleLineClick(line.time)}
-                type="button"
-                className={cn(
-                  'block w-full text-left text-base leading-relaxed font-medium cursor-pointer transition-all duration-500 rounded-md px-1 -mx-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40',
-                  isActive && 'text-foreground text-lg font-semibold',
-                  isPast && 'text-muted-foreground/25',
-                  !isActive && !isPast && 'text-muted-foreground/45 hover:text-muted-foreground/70'
-                )}
-              >
-                {line.text}
-              </button>
-            );
-          })}
-          <div className="h-[50vh]" />
-        </div>
-      </div>
+      <LyricsList
+        lines={synced}
+        activeIndex={activeLine}
+        onLineClick={handleLineClick}
+        containerClassName="px-5 py-6"
+        spacingClassName="space-y-4"
+        bottomSpacerClassName="h-[50vh]"
+        baseClassName={PANEL_BASE}
+        activeClassName={PANEL_ACTIVE}
+        pastClassName={PANEL_PAST}
+        idleClassName={PANEL_IDLE}
+      />
     );
   } else if (plain) {
     content = (

--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlayerStore } from '@/stores/usePlayerStore';
 import { useAppStore } from '@/stores/useAppStore';
 import { useLyricsQuery } from '@/hooks/queries/useLyrics';
+import { useActiveLineIndex } from '@/lib/lyrics';
+import { LyricsList } from '@/components/lyrics/LyricsList';
 import { cn } from '@/lib/utils';
 import { formatDuration } from '@shiranami/shared';
 import { PlayerControls } from '@/components/player/PlayerControls';
@@ -13,22 +15,15 @@ import { Music, ArrowLeft, Loader2, Music2, Mic2, MicOff } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 
-function findActiveLine(lines: Array<{ time: number }>, currentTime: number): number {
-  let active = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].time <= currentTime) {
-      active = i;
-    } else {
-      break;
-    }
-  }
-  return active;
-}
+const NP_BASE =
+  'block w-full text-left leading-relaxed font-medium cursor-pointer transition-all duration-500 rounded-md px-1 -mx-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40 text-base @5xl:text-lg @7xl:text-xl';
+const NP_ACTIVE = 'text-foreground text-xl @5xl:!text-2xl @7xl:!text-3xl font-semibold';
+const NP_PAST = 'text-muted-foreground/20';
+const NP_IDLE = 'text-muted-foreground/40 hover:text-muted-foreground/65';
 
 export function NowPlayingView() {
   const { t } = useTranslation('nowPlaying');
   const currentTrack = usePlayerStore(s => s.currentTrack);
-  const currentTime = usePlayerStore(s => s.currentTime);
   const duration = usePlayerStore(s => s.duration);
   const seek = usePlayerStore(s => s.seek);
   const exitNowPlaying = useAppStore(s => s.exitNowPlaying);
@@ -45,15 +40,7 @@ export function NowPlayingView() {
 
   const synced = data?.synced ?? null;
   const plain = data?.plain ?? null;
-  const activeLine = synced ? findActiveLine(synced, currentTime) : -1;
-
-  const activeLineRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    if (activeLineRef.current) {
-      activeLineRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }
-  }, [activeLine]);
+  const activeLine = useActiveLineIndex(synced);
 
   const handleLineClick = useCallback((time: number) => seek(time), [seek]);
 
@@ -212,33 +199,18 @@ export function NowPlayingView() {
                 </div>
               </div>
             ) : synced && synced.length > 0 ? (
-              <div className="flex-1 overflow-y-auto scrollbar-hide pr-2 @3xl:pr-4">
-                <div className="space-y-4 @5xl:space-y-5 @7xl:space-y-6">
-                  {synced.map((line, index) => {
-                    const isActive = index === activeLine;
-                    const isPast = index < activeLine;
-                    return (
-                      <button
-                        key={index}
-                        ref={isActive ? activeLineRef : null}
-                        onClick={() => handleLineClick(line.time)}
-                        type="button"
-                        className={cn(
-                          'block w-full text-left leading-relaxed font-medium cursor-pointer transition-all duration-500 rounded-md px-1 -mx-1',
-                          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40',
-                          'text-base @5xl:text-lg @7xl:text-xl',
-                          isActive && 'text-foreground text-xl @5xl:!text-2xl @7xl:!text-3xl font-semibold',
-                          isPast && 'text-muted-foreground/20',
-                          !isActive && !isPast && 'text-muted-foreground/40 hover:text-muted-foreground/65'
-                        )}
-                      >
-                        {line.text}
-                      </button>
-                    );
-                  })}
-                  <div className="h-[40vh]" />
-                </div>
-              </div>
+              <LyricsList
+                lines={synced}
+                activeIndex={activeLine}
+                onLineClick={handleLineClick}
+                containerClassName="pr-2 @3xl:pr-4"
+                spacingClassName="space-y-4 @5xl:space-y-5 @7xl:space-y-6"
+                bottomSpacerClassName="h-[40vh]"
+                baseClassName={NP_BASE}
+                activeClassName={NP_ACTIVE}
+                pastClassName={NP_PAST}
+                idleClassName={NP_IDLE}
+              />
             ) : plain ? (
               <div className="flex-1 overflow-y-auto scrollbar-hide pr-2 @3xl:pr-4">
                 <pre className="text-sm @5xl:text-base @7xl:text-lg text-muted-foreground/45 whitespace-pre-wrap font-sans leading-relaxed">

--- a/apps/web/src/lib/lyrics.ts
+++ b/apps/web/src/lib/lyrics.ts
@@ -1,0 +1,18 @@
+import { usePlayerStore } from '@/stores/usePlayerStore';
+import type { LyricLine } from '@/hooks/queries/useLyrics';
+
+export function findActiveLine(lines: Array<{ time: number }>, currentTime: number): number {
+  let active = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].time <= currentTime) {
+      active = i;
+    } else {
+      break;
+    }
+  }
+  return active;
+}
+
+export function useActiveLineIndex(lines: LyricLine[] | null | undefined): number {
+  return usePlayerStore((s) => (lines && lines.length > 0 ? findActiveLine(lines, s.currentTime) : -1));
+}


### PR DESCRIPTION
Closes #55.

## Summary
- `LyricsPanel` and `NowPlayingView` no longer subscribe to `currentTime` (updated every 250ms). They now read a derived active-line **index** via a Zustand selector — Zustand's default `Object.is` equality bails out until the index actually flips, collapsing ~4Hz full re-renders to ~once per line transition.
- Extracted shared `LyricsList` + `LyricLineButton` (`React.memo`). With the stable `seek` callback, only the outgoing and incoming lines reconcile per transition; the other ~78 buttons skip rendering entirely.
- Moved duplicated `findActiveLine` to `apps/web/src/lib/lyrics.ts` alongside the new `useActiveLineIndex` hook.
- `scrollIntoView` lives in a `useEffect([activeIndex])` inside `LyricsList` (single fire per change, not twice via ref detach/attach).

## Files
- **new** `apps/web/src/lib/lyrics.ts` — `findActiveLine`, `useActiveLineIndex`
- **new** `apps/web/src/components/lyrics/LyricsList.tsx` — memoized list + button, className slots for panel vs. now-playing typography
- **edit** `LyricsPanel.tsx`, `NowPlayingView.tsx` — drop `currentTime` subscription, drop local `findActiveLine`, delegate to `<LyricsList>`

## Test plan
- [ ] Profile a track (~80 synced lines) in React DevTools — `LyricsList` re-renders only on active-line change; only 2 `LyricLineButton` instances reconcile per transition
- [ ] Active line still auto-scrolls into view smoothly
- [ ] Clicking a lyric line still seeks to that timestamp
- [ ] Switching tracks loads new lyrics in both `LyricsPanel` and `NowPlayingView`
- [ ] Plain (non-synced) and empty states still render correctly in both views