### PR TITLE
feat(library): show year and genre in album header

### DIFF
--- a/apps/web/src/components/library/AlbumDetailView.tsx
+++ b/apps/web/src/components/library/AlbumDetailView.tsx
@@ -10,6 +10,22 @@ import { TrackRowContent } from '@/components/shared/TrackRowContent';
 import { BulkActionBar } from '@/components/shared/BulkActionBar';
 import { sortAlbumTracks } from '@/lib/albumSort';
 
+function mostFrequent<T>(values: Array<T | null | undefined>): T | undefined {
+  const counts = new Map<T, number>();
+  let best: T | undefined;
+  let maxCount = 0;
+  for (const v of values) {
+    if (v == null || v === '') continue;
+    const count = (counts.get(v as T) ?? 0) + 1;
+    counts.set(v as T, count);
+    if (count > maxCount) {
+      maxCount = count;
+      best = v as T;
+    }
+  }
+  return best;
+}
+
 export function AlbumDetailView() {
   const { t } = useTranslation('library');
   const selectedAlbumName = useAppStore(s => s.selectedAlbumName);
@@ -57,23 +73,6 @@ export function AlbumDetailView() {
     const artists = new Set(albumTracks.map(t => t.artist));
     return Array.from(artists).join(', ');
   }, [albumTracks]);
-
-  const mostFrequent = <T,>(values: Array<T | null | undefined>): T | undefined => {
-    const counts = new Map<T, number>();
-    for (const v of values) {
-      if (v === null || v === undefined || v === '') continue;
-      counts.set(v as T, (counts.get(v as T) ?? 0) + 1);
-    }
-    let best: T | undefined;
-    let bestCount = 0;
-    for (const [value, count] of counts) {
-      if (count > bestCount) {
-        best = value;
-        bestCount = count;
-      }
-    }
-    return best;
-  };
 
   const year = useMemo(
     () => mostFrequent(albumTracks.map(t => t.year)),

--- a/apps/web/src/components/library/AlbumDetailView.tsx
+++ b/apps/web/src/components/library/AlbumDetailView.tsx
@@ -58,6 +58,38 @@ export function AlbumDetailView() {
     return Array.from(artists).join(', ');
   }, [albumTracks]);
 
+  const mostFrequent = <T,>(values: Array<T | null | undefined>): T | undefined => {
+    const counts = new Map<T, number>();
+    for (const v of values) {
+      if (v === null || v === undefined || v === '') continue;
+      counts.set(v as T, (counts.get(v as T) ?? 0) + 1);
+    }
+    let best: T | undefined;
+    let bestCount = 0;
+    for (const [value, count] of counts) {
+      if (count > bestCount) {
+        best = value;
+        bestCount = count;
+      }
+    }
+    return best;
+  };
+
+  const year = useMemo(
+    () => mostFrequent(albumTracks.map(t => t.year)),
+    [albumTracks]
+  );
+
+  const genre = useMemo(
+    () => mostFrequent(albumTracks.map(t => t.genre)),
+    [albumTracks]
+  );
+
+  const headerMeta = useMemo(
+    () => [artist, year?.toString(), genre].filter(Boolean).join(' · '),
+    [artist, year, genre]
+  );
+
   const totalDuration = useMemo(
     () => albumTracks.reduce((sum, t) => sum + t.duration, 0),
     [albumTracks]
@@ -140,7 +172,7 @@ export function AlbumDetailView() {
             <p className="font-display text-lg font-semibold text-foreground truncate">
               {selectedAlbumName}
             </p>
-            <p className="text-sm text-muted-foreground/60 truncate">{artist}</p>
+            <p className="text-sm text-muted-foreground/60 truncate">{headerMeta}</p>
             <p className="text-xs text-muted-foreground/50 mt-0.5">
               {t('trackCount', { count: albumTracks.length })}
               {totalDuration > 0 && ` · ${formatDuration(totalDuration)}`}


### PR DESCRIPTION
## Summary
- Album detail header now renders `Artist · Year · Genre` instead of just the artist, per request in #61.
- Year/genre are picked by most-frequent value across the album's tracks; missing segments are silently omitted.
- No new i18n keys, store, or backend changes — data was already flowing through `Track.year` / `Track.genre`.

## Implementation notes
- Added a small `mostFrequent<T>()` helper and two memos (`year`, `genre`) alongside the existing `artist` memo in `AlbumDetailView.tsx`.
- Built a `headerMeta` memo via `[artist, year, genre].filter(Boolean).join(' · ')` so albums with partial metadata degrade gracefully.
- Separator matches the `·` already used on the `trackCount · duration` row directly below.

## Test plan
- [ ] Open an album with full metadata → header shows `Artist · 2019 · Rock`.
- [ ] Open an album missing genre → header shows `Artist · 2019`.
- [ ] Open an album missing both year and genre → header shows `Artist` (no stray separators).
- [ ] Multi-artist album still joins artists with `, ` as before.
- [ ] Multi-disc album header unaffected.

Closes #61