### PR TITLE
feat(lyrics): support local .lrc/.txt, Lyrics/ subfolder, and embedded tags

### DIFF
--- a/apps/desktop/src/main/embedded-lyrics.test.ts
+++ b/apps/desktop/src/main/embedded-lyrics.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readEmbeddedLyrics } from './embedded-lyrics';
+
+// music-metadata is dynamically imported inside embedded-lyrics; mock at the
+// import specifier to return controlled fixtures.
+const parseFileMock = vi.fn();
+vi.mock('music-metadata', () => ({
+  parseFile: (...args: unknown[]) => parseFileMock(...args),
+}));
+
+const warnMock = vi.fn();
+vi.mock('./logger', () => ({
+  logger: { warn: (...args: unknown[]) => warnMock(...args), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe('readEmbeddedLyrics', () => {
+  beforeEach(() => {
+    parseFileMock.mockReset();
+    warnMock.mockReset();
+  });
+
+  it('returns synced lyrics from syncText (ms → s conversion)', async () => {
+    parseFileMock.mockResolvedValueOnce({
+      common: {
+        lyrics: [
+          {
+            syncText: [
+              { timestamp: 1000, text: 'first' },
+              { timestamp: 2500, text: 'second' },
+              { timestamp: 5000, text: 'third' },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = await readEmbeddedLyrics('/fake/track.mp3');
+    expect(result).not.toBeNull();
+    expect(result?.source).toBe('embedded');
+    expect(result?.plain).toBeNull();
+    expect(result?.synced).toEqual([
+      { time: 1, text: 'first' },
+      { time: 2.5, text: 'second' },
+      { time: 5, text: 'third' },
+    ]);
+  });
+
+  it('sorts syncText entries by time', async () => {
+    parseFileMock.mockResolvedValueOnce({
+      common: {
+        lyrics: [
+          {
+            syncText: [
+              { timestamp: 5000, text: 'c' },
+              { timestamp: 1000, text: 'a' },
+              { timestamp: 3000, text: 'b' },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = await readEmbeddedLyrics('/fake/track.mp3');
+    expect(result?.synced?.map(l => l.text)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('parses raw LRC string in text field into synced lines', async () => {
+    const lrc = '[00:01.00]line one\n[00:02.50]line two\n[00:05.00]line three';
+    parseFileMock.mockResolvedValueOnce({
+      common: {
+        lyrics: [{ text: lrc }],
+      },
+    });
+
+    const result = await readEmbeddedLyrics('/fake/track.mp3');
+    expect(result?.source).toBe('embedded');
+    expect(result?.plain).toBeNull();
+    expect(result?.synced).toEqual([
+      { time: 1, text: 'line one' },
+      { time: 2.5, text: 'line two' },
+      { time: 5, text: 'line three' },
+    ]);
+  });
+
+  it('returns plain for text without timestamps', async () => {
+    parseFileMock.mockResolvedValueOnce({
+      common: {
+        lyrics: [{ text: 'just some lyrics\nanother line' }],
+      },
+    });
+
+    const result = await readEmbeddedLyrics('/fake/track.mp3');
+    expect(result).toEqual({
+      synced: null,
+      plain: 'just some lyrics\nanother line',
+      source: 'embedded',
+    });
+  });
+
+  it('returns null when common.lyrics is undefined', async () => {
+    parseFileMock.mockResolvedValueOnce({ common: {} });
+    const result = await readEmbeddedLyrics('/fake/track.mp3');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when common.lyrics is empty array', async () => {
+    parseFileMock.mockResolvedValueOnce({ common: { lyrics: [] } });
+    const result = await readEmbeddedLyrics('/fake/track.mp3');
+    expect(result).toBeNull();
+  });
+
+  it('logs warn and returns null when parseFile throws', async () => {
+    parseFileMock.mockRejectedValueOnce(new Error('boom'));
+    const result = await readEmbeddedLyrics('/fake/bad.mp3');
+    expect(result).toBeNull();
+    expect(warnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers syncText entry over plain text entry when both exist', async () => {
+    parseFileMock.mockResolvedValueOnce({
+      common: {
+        lyrics: [
+          { text: 'some plain lyrics with lots of text that would otherwise win' },
+          {
+            syncText: [
+              { timestamp: 1000, text: 'synced line' },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = await readEmbeddedLyrics('/fake/track.mp3');
+    expect(result?.synced).toEqual([{ time: 1, text: 'synced line' }]);
+    expect(result?.plain).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/embedded-lyrics.ts
+++ b/apps/desktop/src/main/embedded-lyrics.ts
@@ -1,0 +1,110 @@
+import { logger } from './logger';
+import { parseLrc, type LyricsResult, type LyricLine } from './lyrics-service';
+
+export type EmbeddedLyricsResult = Omit<LyricsResult, 'source'> & {
+  source: 'embedded';
+};
+
+// Minimal local shape for a lyrics tag entry. music-metadata's runtime shape
+// varies by format/version, so we only type what we read and treat fields as
+// optional.
+interface SyncTextEntry {
+  timestamp?: number;
+  text?: string;
+}
+
+interface LyricsTagEntry {
+  syncText?: SyncTextEntry[];
+  text?: string;
+  descriptor?: string;
+  language?: string;
+}
+
+// Cache the dynamic import — match pattern in metadata-service.ts
+let mmModule: typeof import('music-metadata') | null = null;
+
+async function getModule() {
+  if (!mmModule) {
+    mmModule = await import('music-metadata');
+  }
+  return mmModule;
+}
+
+const LRC_TIMESTAMP_RE = /\[\d{2}:\d{2}[.:]/;
+
+function looksLikeLrc(text: string): boolean {
+  return LRC_TIMESTAMP_RE.test(text);
+}
+
+/**
+ * Read lyrics embedded in an audio file's metadata tags (ID3 USLT/SYLT, Vorbis
+ * LYRICS, etc.). Returns null when the file has no embedded lyrics or when
+ * parsing fails.
+ */
+export async function readEmbeddedLyrics(
+  audioFilePath: string
+): Promise<EmbeddedLyricsResult | null> {
+  const mm = await getModule();
+
+  let metadata: Awaited<ReturnType<typeof mm.parseFile>>;
+  try {
+    metadata = await mm.parseFile(audioFilePath, {
+      skipCovers: true,
+      duration: false,
+    });
+  } catch (error) {
+    logger.warn(
+      `[embedded-lyrics] Failed to parse file: ${audioFilePath}`,
+      error
+    );
+    return null;
+  }
+
+  const raw = (metadata.common as { lyrics?: unknown }).lyrics;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return null;
+  }
+
+  const entries = raw as LyricsTagEntry[];
+
+  // Precedence: prefer an entry with a non-empty syncText array.
+  const syncEntry = entries.find(
+    e => Array.isArray(e?.syncText) && e.syncText.length > 0
+  );
+
+  if (syncEntry && syncEntry.syncText) {
+    const lines: LyricLine[] = [];
+    for (const s of syncEntry.syncText) {
+      if (typeof s?.timestamp === 'number' && typeof s?.text === 'string') {
+        lines.push({ time: s.timestamp / 1000, text: s.text });
+      }
+    }
+    if (lines.length > 0) {
+      lines.sort((a, b) => a.time - b.time);
+      return { synced: lines, plain: null, source: 'embedded' };
+    }
+  }
+
+  // Otherwise, fall back to text entries. If multiple, pick the longest.
+  const textEntries = entries
+    .filter(e => typeof e?.text === 'string' && e.text.length > 0)
+    .sort((a, b) => (b.text?.length ?? 0) - (a.text?.length ?? 0));
+
+  const textEntry = textEntries[0];
+  if (!textEntry || !textEntry.text) {
+    return null;
+  }
+
+  const text = textEntry.text;
+
+  if (looksLikeLrc(text)) {
+    const lines = parseLrc(text);
+    if (lines.length > 0) {
+      return { synced: lines, plain: null, source: 'embedded' };
+    }
+    // Fell through — treat as plain
+    return { synced: null, plain: text, source: 'embedded' };
+  }
+
+  return { synced: null, plain: text, source: 'embedded' };
+}

--- a/apps/desktop/src/main/ipc/lyrics.ts
+++ b/apps/desktop/src/main/ipc/lyrics.ts
@@ -9,9 +9,10 @@ export function registerLyricsHandlers(): void {
       title: string,
       artist: string,
       album?: string,
-      duration?: number
+      duration?: number,
+      filePath?: string
     ): Promise<LyricsResult> => {
-      return fetchLyrics(title, artist, album, duration);
+      return fetchLyrics(title, artist, album, duration, filePath);
     }
   );
 }

--- a/apps/desktop/src/main/local-lyrics.test.ts
+++ b/apps/desktop/src/main/local-lyrics.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'path';
+
+const accessMock = vi.fn();
+const readFileMock = vi.fn();
+
+vi.mock('fs', () => ({
+  promises: {
+    access: (...args: unknown[]) => accessMock(...args),
+    readFile: (...args: unknown[]) => readFileMock(...args),
+  },
+}));
+
+vi.mock('./logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { loadLocalLyrics, stripLyricsHeader } from './local-lyrics';
+
+const AUDIO = path.join('C:', 'Music', 'Artist', 'Song.mp3');
+const DIR = path.dirname(AUDIO);
+const BASE = 'Song';
+
+/**
+ * Helper: build a filesystem map and wire up access/readFile mocks.
+ * Keys are absolute file paths; values are file contents.
+ */
+function setupFs(files: Record<string, string>): void {
+  accessMock.mockImplementation(async (p: string) => {
+    if (p in files) return undefined;
+    throw new Error('ENOENT');
+  });
+  readFileMock.mockImplementation(async (p: string) => {
+    if (p in files) return files[p];
+    throw new Error('ENOENT');
+  });
+}
+
+describe('stripLyricsHeader', () => {
+  it('strips a simple key/value header with blank separator', () => {
+    const input = 'Artist: Gary Moore\nTitle: Still Got The Blues\n\nWoke up this morning';
+    expect(stripLyricsHeader(input)).toBe('Woke up this morning');
+  });
+
+  it('returns original when nothing looks like a header', () => {
+    const input = 'Just some lyrics\nSecond line';
+    expect(stripLyricsHeader(input)).toBe(input);
+  });
+
+  it('returns original if the whole file is header-shaped', () => {
+    const input = 'Title: X\nArtist: Y';
+    expect(stripLyricsHeader(input)).toBe(input);
+  });
+
+  it('does not strip [Chorus] section markers', () => {
+    const input = '[Chorus]\nSing a song';
+    expect(stripLyricsHeader(input)).toBe(input);
+  });
+});
+
+describe('loadLocalLyrics', () => {
+  beforeEach(() => {
+    accessMock.mockReset();
+    readFileMock.mockReset();
+  });
+
+  it('loads sibling .lrc with 3 timestamped lines', async () => {
+    const lrcPath = path.join(DIR, `${BASE}.lrc`);
+    setupFs({
+      [lrcPath]: '[00:01.00]One\n[00:02.00]Two\n[00:03.00]Three',
+    });
+    const result = await loadLocalLyrics(AUDIO);
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('local-lrc');
+    expect(result!.synced).toHaveLength(3);
+    expect(result!.plain).toBeNull();
+  });
+
+  it('loads sibling .txt with BOM and header stripped', async () => {
+    const txtPath = path.join(DIR, `${BASE}.txt`);
+    setupFs({
+      [txtPath]: '\uFEFFArtist: Gary Moore\n\nWoke up this morning\nNo lyrics on my mind',
+    });
+    const result = await loadLocalLyrics(AUDIO);
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('local-txt');
+    expect(result!.synced).toBeNull();
+    expect(result!.plain).toBe('Woke up this morning\nNo lyrics on my mind');
+  });
+
+  it('falls back to plain when .lrc has no timestamps', async () => {
+    const lrcPath = path.join(DIR, `${BASE}.lrc`);
+    const content = 'Just plain text\nNo timestamps here';
+    setupFs({ [lrcPath]: content });
+    const result = await loadLocalLyrics(AUDIO);
+    expect(result).toEqual({
+      synced: null,
+      plain: content,
+      source: 'local-lrc',
+    });
+  });
+
+  it('finds lyrics via Lyrics/ subfolder', async () => {
+    const subPath = path.join(DIR, 'Lyrics', `${BASE}.lrc`);
+    setupFs({
+      [subPath]: '[00:05.00]From subfolder',
+    });
+    const result = await loadLocalLyrics(AUDIO);
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('local-lrc');
+    expect(result!.synced).toEqual([{ time: 5, text: 'From subfolder' }]);
+  });
+
+  it('prefers .lrc over .txt when both exist', async () => {
+    const lrcPath = path.join(DIR, `${BASE}.lrc`);
+    const txtPath = path.join(DIR, `${BASE}.txt`);
+    setupFs({
+      [lrcPath]: '[00:01.00]From lrc',
+      [txtPath]: 'From txt',
+    });
+    const result = await loadLocalLyrics(AUDIO);
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('local-lrc');
+    expect(result!.synced).toEqual([{ time: 1, text: 'From lrc' }]);
+  });
+
+  it('returns null when no lyrics file exists', async () => {
+    setupFs({});
+    const result = await loadLocalLyrics(AUDIO);
+    expect(result).toBeNull();
+  });
+
+  it('parses .lrc with CRLF line endings', async () => {
+    const lrcPath = path.join(DIR, `${BASE}.lrc`);
+    setupFs({
+      [lrcPath]: '[00:01.00]One\r\n[00:02.00]Two\r\n[00:03.00]Three',
+    });
+    const result = await loadLocalLyrics(AUDIO);
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('local-lrc');
+    expect(result!.synced).toHaveLength(3);
+    expect(result!.synced![0]).toEqual({ time: 1, text: 'One' });
+  });
+
+  it('returns header-only .txt unchanged rather than empty', async () => {
+    const txtPath = path.join(DIR, `${BASE}.txt`);
+    const content = 'Title: X\nArtist: Y';
+    setupFs({ [txtPath]: content });
+    const result = await loadLocalLyrics(AUDIO);
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('local-txt');
+    expect(result!.plain).toBe(content);
+  });
+});

--- a/apps/desktop/src/main/local-lyrics.ts
+++ b/apps/desktop/src/main/local-lyrics.ts
@@ -27,7 +27,9 @@ function normalizeNewlines(content: string): string {
   return content.replace(/\r\n?/g, '\n');
 }
 
-const HEADER_LINE_RE = /^([A-Za-z][A-Za-z ]{0,30}):\s*(.+)$/;
+// Whitelist of known metadata keys so we don't strip dialogue/duet lines
+// like "He: Hello" or "She: Hi" that often appear at the top of lyrics.
+const HEADER_LINE_RE = /^(Artist|Title|Album|Author|Lyrics|By|Offset|Composer|Year|Writer|Track):\s*(.+)$/i;
 
 /**
  * Strip a leading "Key: Value" header block from plain text lyrics.

--- a/apps/desktop/src/main/local-lyrics.ts
+++ b/apps/desktop/src/main/local-lyrics.ts
@@ -1,0 +1,119 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { logger } from './logger';
+import { parseLrc, type LyricsResult } from './lyrics-service';
+
+export type LocalLyricsResult = Omit<LyricsResult, 'source'> & {
+  source: 'local-lrc' | 'local-txt';
+};
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function stripBom(content: string): string {
+  if (content.charCodeAt(0) === 0xfeff) {
+    return content.slice(1);
+  }
+  return content;
+}
+
+function normalizeNewlines(content: string): string {
+  return content.replace(/\r\n?/g, '\n');
+}
+
+const HEADER_LINE_RE = /^([A-Za-z][A-Za-z ]{0,30}):\s*(.+)$/;
+
+/**
+ * Strip a leading "Key: Value" header block from plain text lyrics.
+ * Stops at the first blank line or first non-Key:Value line.
+ * If the whole file looks like header, returns the original content.
+ */
+export function stripLyricsHeader(content: string): string {
+  const lines = content.split('\n');
+  let i = 0;
+  let consumed = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.length >= 120) break;
+    if (!HEADER_LINE_RE.test(line)) break;
+    consumed++;
+    i++;
+  }
+
+  if (consumed === 0) return content;
+
+  // If we consumed everything (no body), return original
+  const hasBodyAhead = lines.slice(i).some((l) => l.trim().length > 0);
+  if (!hasBodyAhead) return content;
+
+  // Skip one blank separator line after the header block
+  if (i < lines.length && lines[i].trim() === '') {
+    i++;
+  }
+
+  return lines.slice(i).join('\n').replace(/\s+$/, '');
+}
+
+function buildCandidatePaths(audioFilePath: string): string[] {
+  const dir = path.dirname(audioFilePath);
+  const base = path.parse(audioFilePath).name;
+  return [
+    path.join(dir, `${base}.lrc`),
+    path.join(dir, 'Lyrics', `${base}.lrc`),
+    path.join(dir, 'lyrics', `${base}.lrc`),
+    path.join(dir, `${base}.txt`),
+    path.join(dir, 'Lyrics', `${base}.txt`),
+    path.join(dir, 'lyrics', `${base}.txt`),
+  ];
+}
+
+/**
+ * Look for a sibling .lrc or .txt lyrics file next to the given audio file.
+ * Returns null if none of the candidate paths exist.
+ */
+export async function loadLocalLyrics(
+  audioFilePath: string
+): Promise<LocalLyricsResult | null> {
+  const candidates = buildCandidatePaths(audioFilePath);
+
+  for (const candidate of candidates) {
+    if (!(await fileExists(candidate))) continue;
+
+    try {
+      const raw = await fs.readFile(candidate, 'utf-8');
+      const content = normalizeNewlines(stripBom(raw));
+      const ext = path.extname(candidate).toLowerCase();
+
+      if (ext === '.lrc') {
+        const synced = parseLrc(content);
+        if (synced.length >= 1) {
+          logger.debug(`[local-lyrics] Loaded synced lyrics: ${candidate}`);
+          return { synced, plain: null, source: 'local-lrc' };
+        }
+        // Fallback: show raw text so something is visible
+        logger.debug(
+          `[local-lyrics] .lrc had no timestamps, using plain fallback: ${candidate}`
+        );
+        return { synced: null, plain: content, source: 'local-lrc' };
+      }
+
+      if (ext === '.txt') {
+        const stripped = stripLyricsHeader(content);
+        logger.debug(`[local-lyrics] Loaded plain lyrics: ${candidate}`);
+        return { synced: null, plain: stripped, source: 'local-txt' };
+      }
+    } catch (error) {
+      logger.debug(`[local-lyrics] Failed to read ${candidate}: ${String(error)}`);
+      continue;
+    }
+  }
+
+  return null;
+}

--- a/apps/desktop/src/main/lyrics-service.ts
+++ b/apps/desktop/src/main/lyrics-service.ts
@@ -1,4 +1,6 @@
+import path from 'path';
 import { logger } from './logger';
+import { store } from './store';
 
 export interface LyricLine {
   time: number; // seconds
@@ -8,14 +10,21 @@ export interface LyricLine {
 export interface LyricsResult {
   synced: LyricLine[] | null; // Timestamped lyrics
   plain: string | null; // Plain text lyrics
-  source: 'lrclib' | 'cache' | null;
+  source: 'lrclib' | 'cache' | 'local-lrc' | 'local-txt' | 'embedded' | null;
 }
 
 // In-memory cache for current session
 const lyricsCache = new Map<string, LyricsResult>();
 const LYRICS_CACHE_MAX = 200;
 
-function getCacheKey(title: string, artist: string): string {
+function getCacheKey(
+  title: string,
+  artist: string,
+  filePath?: string
+): string {
+  if (filePath) {
+    return `file::${path.normalize(filePath).toLowerCase()}`;
+  }
   return `${title.toLowerCase().trim()}::${artist.toLowerCase().trim()}`;
 }
 
@@ -112,24 +121,20 @@ export function buildSearchQueries(title: string, artist: string): string[] {
   return queries;
 }
 
-/**
- * Fetch lyrics for a track from LRCLIB.
- * Returns synced (timestamped) lyrics if available, otherwise plain text.
- */
-export async function fetchLyrics(
+function hasSynced(r: LyricsResult | null | undefined): boolean {
+  return !!r && Array.isArray(r.synced) && r.synced.length > 0;
+}
+
+function hasPlain(r: LyricsResult | null | undefined): boolean {
+  return !!r && typeof r.plain === 'string' && r.plain.length > 0;
+}
+
+async function fetchFromLrclib(
   title: string,
   artist: string,
   album?: string,
   duration?: number
-): Promise<LyricsResult> {
-  const key = getCacheKey(title, artist);
-
-  // Check memory cache
-  const cached = cacheGet(key);
-  if (cached) {
-    return { ...cached, source: 'cache' };
-  }
-
+): Promise<LyricsResult | null> {
   try {
     const { Client } = require('lrclib-api');
     const client = new Client();
@@ -163,7 +168,6 @@ export async function fetchLyrics(
               plain: best.plainLyrics || null,
               source: 'lrclib',
             };
-            cacheSet(key, lyricsResult);
             logger.info(`[lyrics] Found lyrics via search "${sq}" for: ${title} - ${artist}`);
             return lyricsResult;
           }
@@ -173,9 +177,7 @@ export async function fetchLyrics(
       }
 
       logger.debug(`[lyrics] No lyrics found for: ${title} - ${artist}`);
-      const empty: LyricsResult = { synced: null, plain: null, source: null };
-      cacheSet(key, empty);
-      return empty;
+      return null;
     }
 
     const lyricsResult: LyricsResult = {
@@ -183,10 +185,8 @@ export async function fetchLyrics(
       plain: result.plainLyrics || null,
       source: 'lrclib',
     };
-
-    cacheSet(key, lyricsResult);
     logger.info(
-      `[lyrics] Found ${lyricsResult.synced ? 'synced' : 'plain'} lyrics for: ${title} - ${artist}`
+      `[lyrics] Found ${lyricsResult.synced ? 'synced' : 'plain'} lyrics via lrclib for: ${title} - ${artist}`
     );
     return lyricsResult;
   } catch (error) {
@@ -194,6 +194,149 @@ export async function fetchLyrics(
       `[lyrics] Failed to fetch lyrics for: ${title} - ${artist}`,
       error
     );
-    return { synced: null, plain: null, source: null };
+    return null;
   }
+}
+
+function getPreferSynced(): boolean {
+  try {
+    const settings = store.get('settings') as Record<string, unknown> | undefined;
+    return settings?.preferSyncedOverLocalPlain !== false; // default true
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Fetch lyrics for a track. Precedence when `filePath` is provided:
+ *
+ *   preferSynced = true:
+ *     local(synced) → embedded(synced) → lrclib(synced) →
+ *     local(plain) → embedded(plain) → lrclib(plain)
+ *
+ *   preferSynced = false:
+ *     local(synced) → embedded(synced) → local(plain) → embedded(plain) →
+ *     lrclib(synced) → lrclib(plain)
+ *
+ * Without `filePath`, falls back to lrclib-only (legacy behavior).
+ */
+export async function fetchLyrics(
+  title: string,
+  artist: string,
+  album?: string,
+  duration?: number,
+  filePath?: string
+): Promise<LyricsResult> {
+  const key = getCacheKey(title, artist, filePath);
+
+  // Check memory cache
+  const cached = cacheGet(key);
+  if (cached) {
+    return { ...cached, source: 'cache' };
+  }
+
+  // Resolve local + embedded (in parallel) if filePath is provided
+  let local: LyricsResult | null = null;
+  let embedded: LyricsResult | null = null;
+
+  if (filePath) {
+    const [localRes, embeddedRes] = await Promise.all([
+      (async (): Promise<LyricsResult | null> => {
+        try {
+          const { loadLocalLyrics } = await import('./local-lyrics');
+          return (await loadLocalLyrics(filePath)) ?? null;
+        } catch (error) {
+          logger.debug(`[lyrics] loadLocalLyrics threw: ${String(error)}`);
+          return null;
+        }
+      })(),
+      (async (): Promise<LyricsResult | null> => {
+        try {
+          const { readEmbeddedLyrics } = await import('./embedded-lyrics');
+          return (await readEmbeddedLyrics(filePath)) ?? null;
+        } catch (error) {
+          logger.debug(`[lyrics] readEmbeddedLyrics threw: ${String(error)}`);
+          return null;
+        }
+      })(),
+    ]);
+    local = localRes;
+    embedded = embeddedRes;
+  }
+
+  const preferSynced = getPreferSynced();
+
+  // Short-circuit: local synced always wins, skip lrclib entirely.
+  if (hasSynced(local)) {
+    const winner = local as LyricsResult;
+    cacheSet(key, winner);
+    logger.info(`[lyrics] Using local synced lyrics for: ${title} - ${artist}`);
+    return winner;
+  }
+
+  // If preferSynced=false, any local/embedded content (synced or plain) beats
+  // lrclib — so we can skip the network call.
+  if (!preferSynced) {
+    const localPlainCandidate = hasPlain(local) ? local : null;
+    const embeddedSyncedCandidate = hasSynced(embedded) ? embedded : null;
+    const embeddedPlainCandidate = hasPlain(embedded) ? embedded : null;
+    const winner =
+      embeddedSyncedCandidate ??
+      localPlainCandidate ??
+      embeddedPlainCandidate ??
+      null;
+    if (winner) {
+      cacheSet(key, winner);
+      logger.info(
+        `[lyrics] Using ${winner.source} lyrics (preferSynced=false) for: ${title} - ${artist}`
+      );
+      return winner;
+    }
+  } else {
+    // preferSynced=true: embedded synced beats lrclib, so we can short-circuit.
+    if (hasSynced(embedded)) {
+      const winner = embedded as LyricsResult;
+      cacheSet(key, winner);
+      logger.info(
+        `[lyrics] Using embedded synced lyrics for: ${title} - ${artist}`
+      );
+      return winner;
+    }
+  }
+
+  // Need lrclib to complete the decision.
+  const lrclib = await fetchFromLrclib(title, artist, album, duration);
+
+  // Build ordered candidate list based on preferSynced.
+  const orderedCandidates: Array<LyricsResult | null> = preferSynced
+    ? [
+        hasSynced(local) ? local : null,
+        hasSynced(embedded) ? embedded : null,
+        hasSynced(lrclib) ? lrclib : null,
+        hasPlain(local) ? local : null,
+        hasPlain(embedded) ? embedded : null,
+        hasPlain(lrclib) ? lrclib : null,
+      ]
+    : [
+        hasSynced(local) ? local : null,
+        hasSynced(embedded) ? embedded : null,
+        hasPlain(local) ? local : null,
+        hasPlain(embedded) ? embedded : null,
+        hasSynced(lrclib) ? lrclib : null,
+        hasPlain(lrclib) ? lrclib : null,
+      ];
+
+  const winner = orderedCandidates.find((c): c is LyricsResult => c !== null);
+
+  if (winner) {
+    cacheSet(key, winner);
+    logger.info(
+      `[lyrics] Using ${winner.source} ${winner.synced ? 'synced' : 'plain'} lyrics for: ${title} - ${artist}`
+    );
+    return winner;
+  }
+
+  const empty: LyricsResult = { synced: null, plain: null, source: null };
+  cacheSet(key, empty);
+  return empty;
 }

--- a/apps/desktop/src/main/lyrics-service.ts
+++ b/apps/desktop/src/main/lyrics-service.ts
@@ -240,28 +240,24 @@ export async function fetchLyrics(
   let embedded: LyricsResult | null = null;
 
   if (filePath) {
-    const [localRes, embeddedRes] = await Promise.all([
-      (async (): Promise<LyricsResult | null> => {
-        try {
-          const { loadLocalLyrics } = await import('./local-lyrics');
-          return (await loadLocalLyrics(filePath)) ?? null;
-        } catch (error) {
-          logger.debug(`[lyrics] loadLocalLyrics threw: ${String(error)}`);
-          return null;
-        }
-      })(),
-      (async (): Promise<LyricsResult | null> => {
-        try {
-          const { readEmbeddedLyrics } = await import('./embedded-lyrics');
-          return (await readEmbeddedLyrics(filePath)) ?? null;
-        } catch (error) {
-          logger.debug(`[lyrics] readEmbeddedLyrics threw: ${String(error)}`);
-          return null;
-        }
-      })(),
-    ]);
-    local = localRes;
-    embedded = embeddedRes;
+    try {
+      const { loadLocalLyrics } = await import('./local-lyrics');
+      local = (await loadLocalLyrics(filePath)) ?? null;
+    } catch (error) {
+      logger.debug(`[lyrics] loadLocalLyrics threw: ${String(error)}`);
+    }
+
+    // Skip embedded parse when local is already synced — it would be
+    // discarded by the precedence logic below, and music-metadata
+    // parseFile is expensive (disk I/O + tag parse).
+    if (!hasSynced(local)) {
+      try {
+        const { readEmbeddedLyrics } = await import('./embedded-lyrics');
+        embedded = (await readEmbeddedLyrics(filePath)) ?? null;
+      } catch (error) {
+        logger.debug(`[lyrics] readEmbeddedLyrics threw: ${String(error)}`);
+      }
+    }
   }
 
   const preferSynced = getPreferSynced();

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -265,11 +265,12 @@ export interface ElectronAPI {
       title: string,
       artist: string,
       album?: string,
-      duration?: number
+      duration?: number,
+      filePath?: string
     ) => Promise<{
       synced: Array<{ time: number; text: string }> | null;
       plain: string | null;
-      source: 'lrclib' | 'cache' | null;
+      source: 'lrclib' | 'cache' | 'local-lrc' | 'local-txt' | 'embedded' | null;
     }>;
   };
   media: {
@@ -561,8 +562,8 @@ const electronAPI: ElectronAPI = {
     },
   },
   lyrics: {
-    fetch: (title: string, artist: string, album?: string, duration?: number) =>
-      ipcRenderer.invoke('lyrics:fetch', title, artist, album, duration),
+    fetch: (title: string, artist: string, album?: string, duration?: number, filePath?: string) =>
+      ipcRenderer.invoke('lyrics:fetch', title, artist, album, duration, filePath),
   },
   media: {
     onCommand: createIpcListener<string>('media:command'),

--- a/apps/landing/src/components/Suite.astro
+++ b/apps/landing/src/components/Suite.astro
@@ -1,0 +1,55 @@
+---
+const cards = [
+  {
+    kanji: '\u767D\u6CE2',
+    name: 'Shiranami',
+    roleKey: 'suite.shiranamiRole',
+    roleFallback: 'Music sanctuary \u00B7 you are here',
+    href: '#top',
+    self: true,
+  },
+  {
+    kanji: '\u767D\u30A2\u30CB',
+    name: 'ShiroAni',
+    roleKey: 'suite.shiroaniRole',
+    roleFallback: 'Anime tracker',
+    href: 'https://shiroani.app/',
+    self: false,
+  },
+  {
+    kanji: '\u7DBA\u9E97\u6F2B\u753B',
+    name: 'KireiManga',
+    roleKey: 'suite.kireimangaRole',
+    roleFallback: 'Manga reader',
+    href: 'https://kireimanga.app/',
+    self: false,
+  },
+];
+---
+
+<section class="section-shell section-stack" id="suite">
+  <div class="section-heading reveal">
+    <div class="pill" data-i18n="suite.pill">Shiro Suite</div>
+    <h2 data-i18n="suite.heading">One quiet shelf for manga, anime, and music.</h2>
+    <p data-i18n="suite.body">
+      Three sibling apps, one monorepo, one design language. All local-first, all
+      built to stay calm and easy to live with.
+    </p>
+  </div>
+
+  <div class="suite-grid reveal-stagger">
+    {cards.map((card) => (
+      <a
+        class={`suite-card reveal${card.self ? ' is-self' : ''}`}
+        href={card.href}
+        target={card.self ? '_self' : '_blank'}
+        rel={card.self ? undefined : 'noopener noreferrer'}
+        aria-current={card.self ? 'page' : undefined}
+      >
+        <span class="suite-kanji" aria-hidden="true">{card.kanji}</span>
+        <span class="suite-name">{card.name}</span>
+        <span class="suite-role" data-i18n={card.roleKey}>{card.roleFallback}</span>
+      </a>
+    ))}
+  </div>
+</section>

--- a/apps/landing/src/lib/i18n.ts
+++ b/apps/landing/src/lib/i18n.ts
@@ -63,6 +63,15 @@ export const translations: Record<LandingLanguage, Record<string, string>> = {
     'preview.body': 'Your library, now playing, and queue, all in one calm view.',
     'preview.alt': 'Shiranami desktop app showing the library view with a track playing',
 
+    // Shiro Suite
+    'suite.pill': 'Shiro Suite',
+    'suite.heading': 'One quiet shelf for manga, anime, and music.',
+    'suite.body':
+      'Three sibling apps, one monorepo, one design language. All local-first, all built to stay calm and easy to live with.',
+    'suite.shiranamiRole': 'Music sanctuary · you are here',
+    'suite.shiroaniRole': 'Anime tracker',
+    'suite.kireimangaRole': 'Manga reader',
+
     // Download CTA
     'cta.versionPill': 'is out',
     'cta.heading': 'Ready to listen?',
@@ -172,6 +181,15 @@ export const translations: Record<LandingLanguage, Record<string, string>> = {
     'preview.heading': 'Zobacz, jak to wygląda.',
     'preview.body': 'Biblioteka, aktualnie grany utwór i kolejka w jednym spokojnym widoku.',
     'preview.alt': 'Aplikacja Shiranami pokazująca widok biblioteki z odtwarzanym utworem',
+
+    // Shiro Suite
+    'suite.pill': 'Shiro Suite',
+    'suite.heading': 'Jedna spokojna półka na mangę, anime i muzykę.',
+    'suite.body':
+      'Trzy siostrzane aplikacje, jedno monorepo, jeden język projektowy. Wszystkie działają lokalnie i są pomyślane tak, by dało się z nimi spokojnie żyć na co dzień.',
+    'suite.shiranamiRole': 'Przystań dla muzyki · jesteś tutaj',
+    'suite.shiroaniRole': 'Śledzenie anime',
+    'suite.kireimangaRole': 'Czytnik mangi',
 
     // Download CTA
     'cta.versionPill': 'już dostępna',

--- a/apps/landing/src/lib/i18n.ts
+++ b/apps/landing/src/lib/i18n.ts
@@ -67,7 +67,7 @@ export const translations: Record<LandingLanguage, Record<string, string>> = {
     'suite.pill': 'Shiro Suite',
     'suite.heading': 'One quiet shelf for manga, anime, and music.',
     'suite.body':
-      'Three sibling apps, one monorepo, one design language. All local-first, all built to stay calm and easy to live with.',
+      'Shiranami is one of three sibling apps built around the same idea — local-first, calm, and easy to live with. Different repos, shared architecture and design language.',
     'suite.shiranamiRole': 'Music sanctuary · you are here',
     'suite.shiroaniRole': 'Anime tracker',
     'suite.kireimangaRole': 'Manga reader',
@@ -186,7 +186,7 @@ export const translations: Record<LandingLanguage, Record<string, string>> = {
     'suite.pill': 'Shiro Suite',
     'suite.heading': 'Jedna spokojna półka na mangę, anime i muzykę.',
     'suite.body':
-      'Trzy siostrzane aplikacje, jedno monorepo, jeden język projektowy. Wszystkie działają lokalnie i są pomyślane tak, by dało się z nimi spokojnie żyć na co dzień.',
+      'Shiranami to jedna z trzech siostrzanych aplikacji zbudowanych wokół tej samej idei — lokalnie, spokojnie, na co dzień. Różne repozytoria, wspólna architektura i język wizualny.',
     'suite.shiranamiRole': 'Przystań dla muzyki · jesteś tutaj',
     'suite.shiroaniRole': 'Śledzenie anime',
     'suite.kireimangaRole': 'Czytnik mangi',

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -5,6 +5,7 @@ import FeatureGrid from '../components/FeatureGrid.astro';
 import Footer from '../components/Footer.astro';
 import Hero from '../components/Hero.astro';
 import Navbar from '../components/Navbar.astro';
+import Suite from '../components/Suite.astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
@@ -17,6 +18,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <Hero />
     <FeatureGrid />
     <AppPreview />
+    <Suite />
     <DownloadSection />
   </main>
   <Footer />

--- a/apps/landing/src/styles/global.css
+++ b/apps/landing/src/styles/global.css
@@ -810,6 +810,78 @@
       inset 0 1px 0 oklch(1 0 0 / 0.05);
   }
 
+  .suite-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1rem;
+  }
+
+  .suite-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 1.5rem;
+    border: 1px solid var(--line);
+    border-radius: 1.2rem;
+    background: linear-gradient(180deg, oklch(0.12 0.02 280 / 0.92), oklch(0.09 0.02 280 / 0.92));
+    box-shadow:
+      inset 0 1px 0 oklch(1 0 0 / 0.06),
+      0 20px 60px -30px oklch(0 0 0 / 0.8);
+    color: inherit;
+    transition:
+      border-color 280ms ease,
+      background 280ms ease,
+      transform 280ms ease;
+  }
+
+  .suite-card:hover {
+    border-color: oklch(from var(--primary) l c h / 0.35);
+    background: linear-gradient(180deg, oklch(0.13 0.025 280 / 0.95), oklch(0.1 0.02 280 / 0.95));
+    transform: translateY(-2px);
+  }
+
+  .suite-kanji {
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    letter-spacing: 0.04em;
+    color: oklch(from var(--primary) l c h / 0.85);
+  }
+
+  .suite-name {
+    font-family: var(--font-display);
+    font-size: 1.1rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin-top: 0.15rem;
+  }
+
+  .suite-role {
+    font-size: 0.85rem;
+    color: var(--muted-foreground);
+    line-height: 1.55;
+  }
+
+  .suite-card.is-self {
+    border-color: oklch(from var(--primary) l c h / 0.32);
+    background: linear-gradient(
+      180deg,
+      oklch(from var(--primary) l c h / 0.14),
+      oklch(0.1 0.02 280 / 0.92)
+    );
+    box-shadow:
+      inset 0 1px 0 oklch(1 0 0 / 0.08),
+      0 28px 80px -40px oklch(from var(--primary) l c h / 0.55);
+  }
+
+  .suite-card.is-self .suite-kanji {
+    color: var(--primary);
+  }
+
+  .suite-card.is-self .suite-role {
+    color: var(--primary);
+    font-weight: 600;
+  }
+
   .app-frame img {
     display: block;
     width: 100%;
@@ -1031,7 +1103,8 @@
     }
 
     .feature-grid,
-    .platform-grid {
+    .platform-grid,
+    .suite-grid {
       grid-template-columns: 1fr;
     }
 

--- a/apps/web/src/components/lyrics/LyricsPanel.tsx
+++ b/apps/web/src/components/lyrics/LyricsPanel.tsx
@@ -23,10 +23,20 @@ export function LyricsPanel() {
     currentTrack?.artist ?? '',
     currentTrack?.album,
     currentTrack?.duration,
+    currentTrack?.filePath,
   );
 
   const synced = data?.synced ?? null;
   const plain = data?.plain ?? null;
+  const source = data?.source ?? null;
+  const sourceLabel =
+    source === 'local-lrc' || source === 'local-txt'
+      ? t('source.local')
+      : source === 'embedded'
+        ? t('source.embedded')
+        : source === 'lrclib'
+          ? t('source.lrclib')
+          : null;
   const activeLine = useActiveLineIndex(synced);
 
   const handleLineClick = useCallback((time: number) => seek(time), [seek]);
@@ -78,10 +88,18 @@ export function LyricsPanel() {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="px-5 py-3.5 border-b border-border/20 shrink-0">
+      <div className="px-5 py-3.5 border-b border-border/20 shrink-0 flex items-center justify-between gap-2">
         <h2 className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground/50">
           {t('title')}
         </h2>
+        {sourceLabel && (
+          <span
+            title={t('source.tooltip')}
+            className="inline-flex items-center px-1.5 py-0.5 rounded-full border border-border/30 bg-muted/20 text-[9px] font-semibold uppercase tracking-[0.1em] leading-none text-muted-foreground/70"
+          >
+            {sourceLabel}
+          </span>
+        )}
       </div>
       {content}
     </div>

--- a/apps/web/src/components/settings/LyricsSection.tsx
+++ b/apps/web/src/components/settings/LyricsSection.tsx
@@ -1,0 +1,80 @@
+import { useTranslation } from 'react-i18next';
+import { Mic2 } from 'lucide-react';
+import { SettingsCard } from '@/components/settings/SettingsCard';
+import { Switch } from '@/components/ui/switch';
+import { IS_ELECTRON } from '@/lib/platform';
+import { useState, useEffect, useCallback } from 'react';
+
+interface LyricsSettings {
+  preferSyncedOverLocalPlain: boolean;
+}
+
+const DEFAULT_LYRICS_SETTINGS: LyricsSettings = {
+  preferSyncedOverLocalPlain: true,
+};
+
+export function LyricsSection() {
+  const { t } = useTranslation('settings');
+  const [lyricsSettings, setLyricsSettings] = useState<LyricsSettings>(DEFAULT_LYRICS_SETTINGS);
+
+  useEffect(() => {
+    if (!IS_ELECTRON) return;
+
+    async function load() {
+      try {
+        const saved = await window.electronAPI.store.get<LyricsSettings & Record<string, unknown>>('settings');
+        if (saved) {
+          setLyricsSettings({
+            preferSyncedOverLocalPlain: saved.preferSyncedOverLocalPlain ?? true,
+          });
+        }
+      } catch (err) {
+        console.error('Failed to load lyrics settings:', err);
+      }
+    }
+
+    load();
+  }, []);
+
+  const updateLyricsSetting = useCallback(
+    async (key: keyof LyricsSettings, value: boolean) => {
+      const updated = { ...lyricsSettings, [key]: value };
+      setLyricsSettings(updated);
+      if (IS_ELECTRON) {
+        try {
+          const existing =
+            (await window.electronAPI.store.get<Record<string, unknown>>('settings')) ?? {};
+          await window.electronAPI.store.set('settings', { ...existing, ...updated });
+        } catch (err) {
+          console.error('Failed to save lyrics settings:', err);
+        }
+      }
+    },
+    [lyricsSettings],
+  );
+
+  return (
+    <SettingsCard
+      icon={Mic2}
+      title={t('lyrics.title')}
+      subtitle={t('lyrics.subtitle')}
+    >
+      <div className="space-y-1">
+        <div className="flex items-center justify-between px-3 py-3 rounded-xl hover:bg-accent/30 transition-colors">
+          <div className="pr-4">
+            <p className="text-sm font-medium text-foreground">
+              {t('lyrics.preferSyncedOverLocalPlain.label')}
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {t('lyrics.preferSyncedOverLocalPlain.description')}
+            </p>
+          </div>
+          <Switch
+            checked={lyricsSettings.preferSyncedOverLocalPlain}
+            onChange={(v) => updateLyricsSetting('preferSyncedOverLocalPlain', v)}
+          />
+        </div>
+      </div>
+    </SettingsCard>
+  );
+}

--- a/apps/web/src/components/settings/SettingsView.tsx
+++ b/apps/web/src/components/settings/SettingsView.tsx
@@ -6,6 +6,7 @@ import {
   ArrowDownToLine,
   Settings2,
   AudioLines,
+  Mic2,
   Monitor,
   RefreshCcw,
   Info,
@@ -15,6 +16,7 @@ import { MusicFoldersSection } from '@/components/settings/MusicFoldersSection';
 import { LibrarySection } from '@/components/settings/LibrarySection';
 import { DownloadsSection } from '@/components/settings/downloads/DownloadsSection';
 import { PlaybackSection } from '@/components/settings/PlaybackSection';
+import { LyricsSection } from '@/components/settings/LyricsSection';
 import { VisualizerSection } from '@/components/settings/VisualizerSection';
 import { UpdatesSection } from '@/components/settings/UpdatesSection';
 import { AppearanceSection } from '@/components/settings/AppearanceSection';
@@ -25,6 +27,7 @@ type SettingsSection =
   | 'library'
   | 'downloads'
   | 'playback'
+  | 'lyrics'
   | 'visualizer'
   | 'appearance'
   | 'updates'
@@ -35,6 +38,7 @@ const SECTIONS: { id: SettingsSection; labelKey: string; Icon: typeof FolderOpen
   { id: 'library', labelKey: 'library', Icon: HardDrive },
   { id: 'downloads', labelKey: 'downloads', Icon: ArrowDownToLine },
   { id: 'playback', labelKey: 'playback', Icon: Settings2 },
+  { id: 'lyrics', labelKey: 'lyricsSection', Icon: Mic2 },
   { id: 'visualizer', labelKey: 'visualizer', Icon: AudioLines },
   { id: 'appearance', labelKey: 'appearance', Icon: Monitor },
   { id: 'updates', labelKey: 'updates', Icon: RefreshCcw },
@@ -46,6 +50,7 @@ const SECTION_PANEL: Record<SettingsSection, ComponentType> = {
   library: LibrarySection,
   downloads: DownloadsSection,
   playback: PlaybackSection,
+  lyrics: LyricsSection,
   visualizer: VisualizerSection,
   appearance: AppearanceSection,
   updates: UpdatesSection,

--- a/apps/web/src/hooks/queries/useLyrics.ts
+++ b/apps/web/src/hooks/queries/useLyrics.ts
@@ -5,14 +5,17 @@ export interface LyricLine {
   text: string;
 }
 
+export type LyricsSource = 'lrclib' | 'cache' | 'local-lrc' | 'local-txt' | 'embedded' | null;
+
 interface LyricsResult {
   synced: LyricLine[] | null;
   plain: string | null;
-  source: string | null;
+  source: LyricsSource;
 }
 
 export const lyricsKeys = {
-  track: (trackId: string) => ['lyrics', trackId] as const,
+  track: (trackId: string, filePath?: string) =>
+    ['lyrics', trackId, filePath ?? ''] as const,
 };
 
 export function useLyricsQuery(
@@ -21,14 +24,15 @@ export function useLyricsQuery(
   artist: string,
   album?: string,
   duration?: number,
+  filePath?: string,
 ) {
   return useQuery({
-    queryKey: lyricsKeys.track(trackId!),
+    queryKey: lyricsKeys.track(trackId!, filePath),
     queryFn: async (): Promise<LyricsResult> => {
       if (!window.electronAPI?.lyrics) {
         return { synced: null, plain: null, source: null };
       }
-      return await window.electronAPI.lyrics.fetch(title, artist, album, duration);
+      return await window.electronAPI.lyrics.fetch(title, artist, album, duration, filePath);
     },
     enabled: !!trackId,
     staleTime: Infinity, // lyrics don't change

--- a/apps/web/src/locales/en/lyrics.json
+++ b/apps/web/src/locales/en/lyrics.json
@@ -1,5 +1,11 @@
 {
   "title": "Lyrics",
   "finding": "Finding lyrics...",
-  "notFound": "No lyrics found"
+  "notFound": "No lyrics found",
+  "source": {
+    "local": "Local",
+    "embedded": "Embedded",
+    "lrclib": "LRCLIB",
+    "tooltip": "Lyrics source"
+  }
 }

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -3,6 +3,7 @@
   "library": "Library",
   "downloads": "Downloads",
   "playback": "Playback",
+  "lyricsSection": "Lyrics",
   "visualizer": "Visualizer",
   "appearance": "Appearance",
   "updates": "Updates",
@@ -72,6 +73,14 @@
     "duration": "Duration",
     "discordRpc": "Discord Rich Presence",
     "discordDesc": "Show currently playing track in Discord"
+  },
+  "lyrics": {
+    "title": "Lyrics",
+    "subtitle": "Control how lyrics are sourced for your tracks",
+    "preferSyncedOverLocalPlain": {
+      "label": "Prefer synced lyrics from LRCLIB over local plain text",
+      "description": "When enabled, a local .txt file will be overridden if LRCLIB has a synced version. Local .lrc files always win."
+    }
   },
   "vis": {
     "title": "Visualizer",

--- a/apps/web/src/locales/pl/lyrics.json
+++ b/apps/web/src/locales/pl/lyrics.json
@@ -1,5 +1,11 @@
 {
   "title": "Tekst piosenki",
   "finding": "Szukam tekstu...",
-  "notFound": "Nie znaleziono tekstu"
+  "notFound": "Nie znaleziono tekstu",
+  "source": {
+    "local": "Lokalne",
+    "embedded": "Wbudowane",
+    "lrclib": "LRCLIB",
+    "tooltip": "Źródło tekstu"
+  }
 }

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -3,6 +3,7 @@
   "library": "Biblioteka",
   "downloads": "Pobieranie",
   "playback": "Odtwarzanie",
+  "lyricsSection": "Teksty",
   "visualizer": "Wizualizator",
   "appearance": "Wygląd",
   "updates": "Aktualizacje",
@@ -72,6 +73,14 @@
     "duration": "Czas trwania",
     "discordRpc": "Discord Rich Presence",
     "discordDesc": "Pokazuj aktualnie odtwarzany utwór w Discordzie"
+  },
+  "lyrics": {
+    "title": "Teksty",
+    "subtitle": "Zarządzaj źródłami tekstów dla Twoich utworów",
+    "preferSyncedOverLocalPlain": {
+      "label": "Preferuj zsynchronizowane teksty z LRCLIB zamiast lokalnego pliku tekstowego",
+      "description": "Gdy włączone, lokalny plik .txt zostanie zastąpiony, jeśli LRCLIB ma zsynchronizowaną wersję. Lokalne pliki .lrc zawsze mają priorytet."
+    }
   },
   "vis": {
     "title": "Wizualizator",

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -131,10 +131,16 @@ export interface ElectronAPI {
     clearState: () => void;
   };
   lyrics: {
-    fetch: (title: string, artist: string, album?: string, duration?: number) => Promise<{
+    fetch: (
+      title: string,
+      artist: string,
+      album?: string,
+      duration?: number,
+      filePath?: string,
+    ) => Promise<{
       synced: Array<{ time: number; text: string }> | null;
       plain: string | null;
-      source: 'lrclib' | 'cache' | null;
+      source: 'lrclib' | 'cache' | 'local-lrc' | 'local-txt' | 'embedded' | null;
     }>;
   };
   db: {


### PR DESCRIPTION
Closes #42.

## Summary
Resolve lyrics from disk before hitting the network. Supports all three sources the contributor asked for in the issue + follow-up comments:

1. **Sidecar files** — `song.lrc` / `song.txt` next to the audio file
2. **`Lyrics/` (or `lyrics/`) subfolder** — same-basename files inside a sibling folder
3. **Embedded tags** — `USLT` / Vorbis `LYRICS` / MP4 `©lyr` via the existing `music-metadata` dependency

### Precedence
When multiple sources have lyrics for a track, resolution order is:

**With *Prefer synced from LRCLIB* ON (default)**
1. Local `.lrc` (synced)
2. Embedded (synced)
3. LRCLIB (synced)
4. Local `.txt` (plain)
5. Embedded (plain)
6. LRCLIB (plain)

**With the toggle OFF**
1. Local `.lrc` (synced)
2. Embedded (synced)
3. Local `.txt` (plain)
4. Embedded (plain)
5. LRCLIB (synced)
6. LRCLIB (plain)

Any local/embedded win **short-circuits the lrclib network call**, so users with complete local libraries stay fully offline.

### UI
- Small source badge in the `LyricsPanel` header — `Local` / `Embedded` / `LRCLIB` — with tooltip.
- New Settings → Lyrics section with the *Prefer synced from LRCLIB* toggle. EN + PL i18n.

### Note to @jo-el414
Thanks for the detailed report and the sample files — they made implementation + testing much easier. To answer your second question from the original issue: yes, Shiranami already uses [lrclib.net](https://lrclib.net/) via the `lrclib-api` npm client. This PR keeps that and adds the local-first behavior you asked for.

## Out of scope (follow-ups)
- Enhanced LRC `<mm:ss.xx>` word-level sync
- `[offset:±N]` tag honoring + user-facing delay slider (tracked separately — sync drift affects a lot of lrclib tracks)
- Non-UTF-8 encoding detection (GBK / Shift-JIS / CP1251)
- Embedded + `Lyrics/` cache-scan at library-scan time (current impl is lazy on panel open)

## Files changed
- **new** `apps/desktop/src/main/local-lyrics.ts` (+ test) — sibling + subfolder resolver, BOM strip, CRLF normalization, `.txt` header stripping
- **new** `apps/desktop/src/main/embedded-lyrics.ts` (+ test) — `music-metadata` tag reader, synced vs plain detection
- **mod** `apps/desktop/src/main/lyrics-service.ts` — widened `source` union, orchestrator with settings-aware precedence, short-circuit
- **mod** `apps/desktop/src/main/ipc/lyrics.ts` + `preload.ts` + `apps/web/src/types/electron.d.ts` — threaded `filePath` through IPC
- **new** `apps/web/src/components/settings/LyricsSection.tsx` — toggle UI
- **mod** `apps/web/src/components/lyrics/LyricsPanel.tsx` — source badge + `filePath` wiring
- **mod** `apps/web/src/hooks/queries/useLyrics.ts` — filePath in query key
- **mod** `apps/web/src/locales/{en,pl}/{settings,lyrics}.json` — i18n strings

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 732/732 pass (20 new tests across `local-lyrics` + `embedded-lyrics`)
- [x] Manual: local `.txt` sibling renders without highlight (expected — no timestamps)
- [x] Manual: source badge shows correct label across lrclib / local paths
- [ ] Manual: local `.lrc` sidecar (needs a sample with real timestamps — please test before merging)
- [ ] Manual: embedded `USLT` tag on a real MP3