### PR TITLE
security(desktop): path containment for shell handlers and audio-protocol (#87)

### DIFF
--- a/apps/desktop/src/main/audio-protocol.test.ts
+++ b/apps/desktop/src/main/audio-protocol.test.ts
@@ -23,6 +23,11 @@ vi.mock('./logger', () => ({
   },
 }));
 
+const mockIsPathAllowed = vi.fn<(p: string) => Promise<boolean>>();
+vi.mock('./shared/folders-cache', () => ({
+  isPathAllowed: (p: string) => mockIsPathAllowed(p),
+}));
+
 import { registerAudioProtocol, toAudioUrl } from './audio-protocol';
 
 describe('audio-protocol', () => {
@@ -49,6 +54,9 @@ describe('audio-protocol', () => {
     beforeEach(() => {
       capturedHandler = null;
       tempDir = makeTempDir();
+      mockIsPathAllowed.mockReset();
+      // Default: containment passes so existing tests exercise their assertions.
+      mockIsPathAllowed.mockResolvedValue(true);
       registerAudioProtocol();
     });
 
@@ -110,6 +118,24 @@ describe('audio-protocol', () => {
       const url = toAudioUrl(path.join(tempDir, 'sub.mp3'));
       // Create a directory at that path
       fs.mkdirSync(path.join(tempDir, 'sub.mp3'));
+      const res = await capturedHandler!(makeRequest(url));
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 403 when isPathAllowed denies the path (even with valid extension/file)', async () => {
+      mockIsPathAllowed.mockResolvedValue(false);
+      const filePath = path.join(tempDir, 'denied.mp3');
+      fs.writeFileSync(filePath, Buffer.from('ID3FAKE'));
+      const url = toAudioUrl(filePath);
+      const res = await capturedHandler!(makeRequest(url));
+      expect(res.status).toBe(403);
+    });
+
+    it('does not stat the file when isPathAllowed denies (containment runs first)', async () => {
+      mockIsPathAllowed.mockResolvedValue(false);
+      // Path looks like an audio file but does not exist — would normally 404.
+      // Containment short-circuits to 403 before the stat call.
+      const url = toAudioUrl(path.join(tempDir, 'never-created.mp3'));
       const res = await capturedHandler!(makeRequest(url));
       expect(res.status).toBe(403);
     });

--- a/apps/desktop/src/main/audio-protocol.ts
+++ b/apps/desktop/src/main/audio-protocol.ts
@@ -2,6 +2,7 @@ import { protocol } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 import { logger } from './logger';
+import { isPathAllowed } from './shared/folders-cache';
 
 /** Audio file extensions we allow serving */
 const ALLOWED_EXTENSIONS = new Set([
@@ -34,27 +35,31 @@ export function registerAudioProtocol(): void {
         return new Response('Bad request', { status: 400 });
       }
 
-      const normalizedPath = filePath;
-
-      logger.debug(`[audio-protocol] Request for: ${normalizedPath}`);
+      logger.debug(`[audio-protocol] Request for: ${filePath}`);
 
       // Security: validate extension
-      const ext = path.extname(normalizedPath).toLowerCase();
+      const ext = path.extname(filePath).toLowerCase();
       if (!ALLOWED_EXTENSIONS.has(ext)) {
         logger.warn(`[audio-protocol] Blocked non-audio extension: ${ext}`);
+        return new Response('Forbidden', { status: 403 });
+      }
+
+      // Security: containment — reject paths outside allowed roots/known tracks.
+      if (!(await isPathAllowed(filePath))) {
+        logger.warn(`[audio-protocol] blocked path outside allowed roots: ${filePath}`);
         return new Response('Forbidden', { status: 403 });
       }
 
       // Security: verify file exists and is a file (not directory/symlink to sensitive path)
       let stat: fs.Stats;
       try {
-        stat = await fs.promises.stat(normalizedPath);
+        stat = await fs.promises.stat(filePath);
         if (!stat.isFile()) {
-          logger.warn(`[audio-protocol] Not a file: ${normalizedPath}`);
+          logger.warn(`[audio-protocol] Not a file: ${filePath}`);
           return new Response('Not a file', { status: 403 });
         }
       } catch (err) {
-        logger.warn(`[audio-protocol] File not found: ${normalizedPath}`, err);
+        logger.warn(`[audio-protocol] File not found: ${filePath}`, err);
         return new Response('Not found', { status: 404 });
       }
 
@@ -76,7 +81,7 @@ export function registerAudioProtocol(): void {
           const end = match[2] ? parseInt(match[2], 10) : fileSize - 1;
           const chunkSize = end - start + 1;
 
-          const stream = fs.createReadStream(normalizedPath, { start, end });
+          const stream = fs.createReadStream(filePath, { start, end });
           const readable = new ReadableStream({
             start(controller) {
               stream.on('data', (chunk: Buffer) => controller.enqueue(chunk));
@@ -99,7 +104,7 @@ export function registerAudioProtocol(): void {
       }
 
       // No Range header — return full file
-      const stream = fs.createReadStream(normalizedPath);
+      const stream = fs.createReadStream(filePath);
       const readable = new ReadableStream({
         start(controller) {
           stream.on('data', (chunk: Buffer) => controller.enqueue(chunk));

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -12,6 +12,7 @@ import { registerAudioProtocol } from './audio-protocol';
 import { registerRadioProtocol } from './radio-protocol';
 import { registerArtProtocol } from './art-protocol';
 import { migrateAlbumArtToDisk } from './migrate-album-art';
+import { prewarm as prewarmFoldersCache } from './shared/folders-cache';
 import { initializeDatabase, closeDatabase } from '@shiranami/database/client';
 
 // Register shiranami:// deep link protocol for share imports.
@@ -120,6 +121,15 @@ async function bootstrap(): Promise<void> {
   registerAudioProtocol();
   registerRadioProtocol();
   registerArtProtocol();
+
+  // Build the path-containment cache eagerly so the first shell/audio
+  // request doesn't pay the rebuild cost. Failure here must not abort
+  // startup — the cache lazy-builds on first call as a fallback.
+  try {
+    prewarmFoldersCache();
+  } catch (err) {
+    logger.warn('Folders cache prewarm failed:', err);
+  }
 
   // Migrate legacy base64 album art to disk files
   migrateAlbumArtToDisk().catch(err => {

--- a/apps/desktop/src/main/ipc/database.ts
+++ b/apps/desktop/src/main/ipc/database.ts
@@ -18,6 +18,7 @@ import {
 import { getDatabase } from '@shiranami/database/client';
 import { logger } from '../logger';
 import { handle } from './with-ipc-handler';
+import { invalidate as invalidateFoldersCache } from '../shared/folders-cache';
 import {
   tracksGetAllArgs,
   tracksAddArgs,
@@ -421,7 +422,9 @@ export function registerDatabaseHandlers(): void {
       const db = getDatabase();
       const id = crypto.randomUUID();
       const row: NewFolder = { id, path: folderPath };
-      return db.insert(folders).values(row).returning().get();
+      const inserted = db.insert(folders).values(row).returning().get();
+      invalidateFoldersCache();
+      return inserted;
     },
     { schema: foldersAddArgs },
   );
@@ -432,6 +435,7 @@ export function registerDatabaseHandlers(): void {
       logger.info(`[database] folders:remove: ${id}`);
       const db = getDatabase();
       db.delete(folders).where(eq(folders.id, id)).run();
+      invalidateFoldersCache();
     },
     { schema: foldersRemoveArgs },
   );

--- a/apps/desktop/src/main/ipc/downloader.ts
+++ b/apps/desktop/src/main/ipc/downloader.ts
@@ -22,6 +22,7 @@ import {
 import { store } from '../store';
 import { handle, handleWithFallback } from './with-ipc-handler';
 import { IpcError } from './errors';
+import { invalidate as invalidateFoldersCache } from '../shared/folders-cache';
 import { spawnYtDlp, parseYtDlpJsonLines, type SearchResult } from '../utils/ytdlp-spawn';
 import {
   downloaderCheckArgs,
@@ -168,6 +169,15 @@ function getStoredDownloadDir(): string | null {
 
 function getDownloadDir(): string {
   return ensureDownloadDir(getStoredDownloadDir() ?? getDefaultDownloadDir());
+}
+
+/**
+ * Active download directory (without ensuring it exists). Exposed for
+ * other modules (e.g. folders-cache) that need the configured location
+ * without triggering directory creation.
+ */
+export function getCurrentDownloadDir(): string {
+  return getStoredDownloadDir() ?? getDefaultDownloadDir();
 }
 
 function getDownloadLocationState(): DownloadLocationState {
@@ -319,6 +329,7 @@ export function registerDownloaderHandlers(): void {
 
       if (typeof downloadDir !== 'string' || downloadDir.trim().length === 0) {
         store.delete(DOWNLOAD_LOCATION_STORE_KEY);
+        invalidateFoldersCache();
         return getDownloadLocationState();
       }
 
@@ -329,6 +340,7 @@ export function registerDownloaderHandlers(): void {
         store.set(DOWNLOAD_LOCATION_STORE_KEY, resolvedPath);
       }
 
+      invalidateFoldersCache();
       return getDownloadLocationState();
     },
     { schema: downloaderSetDownloadLocationArgs },

--- a/apps/desktop/src/main/ipc/errors.ts
+++ b/apps/desktop/src/main/ipc/errors.ts
@@ -41,4 +41,5 @@ export const PLAYLIST_ERROR_CODES = {
 
 export const VALIDATION_ERROR_CODES = {
   BAD_REQUEST: 'BAD_REQUEST',
+  FORBIDDEN: 'FORBIDDEN',
 } as const;

--- a/apps/desktop/src/main/ipc/shell.test.ts
+++ b/apps/desktop/src/main/ipc/shell.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ipcHandlers } from '../../../test/setup';
+
+vi.mock('../logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const mockShowItemInFolder = vi.fn();
+const mockTrashItem = vi.fn();
+
+vi.mock('electron', async () => {
+  const setup = await import('../../../test/setup');
+  return {
+    ipcMain: {
+      handle(channel: string, fn: (...args: unknown[]) => unknown) {
+        setup.ipcHandlers.set(channel, fn);
+      },
+      on(channel: string, listener: (...args: unknown[]) => void) {
+        if (!setup.ipcOnListeners.has(channel)) {
+          setup.ipcOnListeners.set(channel, new Set());
+        }
+        setup.ipcOnListeners.get(channel)!.add(listener);
+      },
+      removeHandler(channel: string) {
+        setup.ipcHandlers.delete(channel);
+      },
+      removeAllListeners(channel: string) {
+        setup.ipcOnListeners.delete(channel);
+      },
+    },
+    shell: {
+      showItemInFolder: (...args: unknown[]) => mockShowItemInFolder(...args),
+      trashItem: (...args: unknown[]) => mockTrashItem(...args),
+    },
+  };
+});
+
+const mockIsPathAllowed = vi.fn<(p: string) => Promise<boolean>>();
+vi.mock('../shared/folders-cache', () => ({
+  isPathAllowed: (p: string) => mockIsPathAllowed(p),
+}));
+
+const { registerShellHandlers, cleanupShellHandlers } = await import('./shell');
+const { isIpcError } = await import('./errors');
+
+describe('shell ipc handlers', () => {
+  beforeEach(() => {
+    ipcHandlers.clear();
+    vi.clearAllMocks();
+    mockTrashItem.mockResolvedValue(undefined);
+    registerShellHandlers();
+  });
+
+  afterEach(() => {
+    cleanupShellHandlers();
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  shell:show-in-folder                                              */
+  /* ------------------------------------------------------------------ */
+
+  describe('shell:show-in-folder', () => {
+    it('calls shell.showItemInFolder when path is allowed', async () => {
+      mockIsPathAllowed.mockResolvedValue(true);
+      const handler = ipcHandlers.get('shell:show-in-folder')!;
+      await handler(null as never, '/allowed/song.mp3');
+      expect(mockShowItemInFolder).toHaveBeenCalledWith('/allowed/song.mp3');
+    });
+
+    it('throws IpcError(FORBIDDEN) and skips shell call when path is denied', async () => {
+      mockIsPathAllowed.mockResolvedValue(false);
+      const handler = ipcHandlers.get('shell:show-in-folder')!;
+
+      await expect(handler(null as never, '/etc/passwd')).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+      });
+      expect(mockShowItemInFolder).not.toHaveBeenCalled();
+    });
+
+    it('rejected error has the IpcError shape', async () => {
+      mockIsPathAllowed.mockResolvedValue(false);
+      const handler = ipcHandlers.get('shell:show-in-folder')!;
+
+      try {
+        await handler(null as never, '/etc/passwd');
+        throw new Error('handler should have thrown');
+      } catch (err) {
+        expect(isIpcError(err)).toBe(true);
+        expect((err as { code: string }).code).toBe('FORBIDDEN');
+      }
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  shell:trash-file                                                  */
+  /* ------------------------------------------------------------------ */
+
+  describe('shell:trash-file', () => {
+    it('calls shell.trashItem when path is allowed', async () => {
+      mockIsPathAllowed.mockResolvedValue(true);
+      const handler = ipcHandlers.get('shell:trash-file')!;
+      await handler(null as never, '/allowed/song.mp3');
+      expect(mockTrashItem).toHaveBeenCalledWith('/allowed/song.mp3');
+    });
+
+    it('throws IpcError(FORBIDDEN) and skips trash call when path is denied', async () => {
+      mockIsPathAllowed.mockResolvedValue(false);
+      const handler = ipcHandlers.get('shell:trash-file')!;
+
+      await expect(handler(null as never, '/etc/passwd')).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+      });
+      expect(mockTrashItem).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/desktop/src/main/ipc/shell.ts
+++ b/apps/desktop/src/main/ipc/shell.ts
@@ -1,11 +1,22 @@
 import { ipcMain, shell } from 'electron';
+import { logger } from '../logger';
+import { isPathAllowed } from '../shared/folders-cache';
 import { handle } from './with-ipc-handler';
+import { IpcError, VALIDATION_ERROR_CODES } from './errors';
 import { showInFolderArgs, trashFileArgs } from './schemas/shell';
 
 export function registerShellHandlers(): void {
   handle(
     'shell:show-in-folder',
-    (_event, filePath: string) => {
+    async (_event, filePath: string) => {
+      if (!(await isPathAllowed(filePath))) {
+        logger.warn(`[shell:show-in-folder] blocked path outside allowed roots: ${filePath}`);
+        throw new IpcError(
+          VALIDATION_ERROR_CODES.FORBIDDEN,
+          'Path is not within an allowed root',
+          { path: filePath },
+        );
+      }
       shell.showItemInFolder(filePath);
     },
     { schema: showInFolderArgs },
@@ -14,6 +25,14 @@ export function registerShellHandlers(): void {
   handle(
     'shell:trash-file',
     async (_event, filePath: string) => {
+      if (!(await isPathAllowed(filePath))) {
+        logger.warn(`[shell:trash-file] blocked path outside allowed roots: ${filePath}`);
+        throw new IpcError(
+          VALIDATION_ERROR_CODES.FORBIDDEN,
+          'Path is not within an allowed root',
+          { path: filePath },
+        );
+      }
       await shell.trashItem(filePath);
     },
     { schema: trashFileArgs },

--- a/apps/desktop/src/main/shared/folders-cache.test.ts
+++ b/apps/desktop/src/main/shared/folders-cache.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
 import { join } from 'node:path';
 import * as path from 'node:path';
 import { closeDatabase, initializeDatabase, getDatabase } from '@shiranami/database/client';
@@ -190,6 +191,53 @@ describe('folders-cache', () => {
       closeDatabase();
       // Path outside roots so we hit the fallback path.
       await expect(isPathAllowed('/totally/unknown/file.mp3')).resolves.toBe(false);
+    });
+
+    it('rejects a symlink inside an allowed root that points outside', async () => {
+      // realpath resolution must catch this — without it, textual containment
+      // would pass but the downstream stat would happily serve the secret file.
+      const allowedRoot = fs.realpathSync(makeTempDir());
+      const outside = fs.realpathSync(makeTempDir());
+      const secret = path.join(outside, 'secret.mp3');
+      fs.writeFileSync(secret, 'x');
+      const link = path.join(allowedRoot, 'shortcut.mp3');
+      try {
+        fs.symlinkSync(secret, link);
+      } catch {
+        // Windows without elevation — skip.
+        return;
+      }
+
+      getDatabase()
+        .insert(folders)
+        .values({ id: crypto.randomUUID(), path: allowedRoot })
+        .run();
+      invalidate();
+
+      await expect(isPathAllowed(link)).resolves.toBe(false);
+
+      fs.rmSync(allowedRoot, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    });
+
+    it('matches a known track when the renderer sends a path with collapsible segments', async () => {
+      // toAudioUrl forwards the renderer's path verbatim; on Windows it also
+      // forces forward slashes. path.resolve in the DB-lookup branch normalizes
+      // both, so a row stored as `.../standalone.mp3` still matches when the
+      // renderer asks for `.../foo/../standalone.mp3`.
+      const stored = path.resolve('/somewhere/else/standalone.mp3');
+      getDatabase()
+        .insert(tracks)
+        .values({
+          id: crypto.randomUUID(),
+          filePath: stored,
+          title: 'Standalone',
+          artist: 'X',
+        })
+        .run();
+
+      const messy = '/somewhere/else/foo/../standalone.mp3';
+      await expect(isPathAllowed(messy)).resolves.toBe(true);
     });
   });
 });

--- a/apps/desktop/src/main/shared/folders-cache.test.ts
+++ b/apps/desktop/src/main/shared/folders-cache.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { join } from 'node:path';
+import * as path from 'node:path';
+import { closeDatabase, initializeDatabase, getDatabase } from '@shiranami/database/client';
+import { folders, tracks } from '@shiranami/database';
+import { makeTempDir, cleanupTempDir } from '../../../test/setup';
+
+/* ------------------------------------------------------------------ */
+/*  Mocks                                                              */
+/* ------------------------------------------------------------------ */
+
+// Mock `app.getPath('music')` and `app.getPath('userData')` so the cache
+// builds against well-known, OS-correct paths.
+const MOCK_USER_DATA = path.resolve('/mock/userData');
+const MOCK_MUSIC = path.resolve('/mock/music');
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn((key: string) => {
+      if (key === 'userData') return MOCK_USER_DATA;
+      if (key === 'music') return MOCK_MUSIC;
+      return '/mock/unknown';
+    }),
+  },
+}));
+
+const mockStore = {
+  get: vi.fn<(key: string) => unknown>(),
+  set: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('../store', () => ({
+  store: {
+    get: (...args: unknown[]) => mockStore.get(args[0] as string),
+    set: (...args: unknown[]) => mockStore.set(...args),
+    delete: (...args: unknown[]) => mockStore.delete(...args),
+  },
+}));
+
+vi.mock('../logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const { getAllowedRoots, invalidate, isPathAllowed } = await import('./folders-cache');
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+describe('folders-cache', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    closeDatabase();
+    tempDir = makeTempDir();
+    initializeDatabase({ path: join(tempDir, 'cache-test.sqlite') });
+    invalidate();
+    vi.clearAllMocks();
+    mockStore.get.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    cleanupTempDir(tempDir);
+    invalidate();
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  getAllowedRoots                                                    */
+  /* ------------------------------------------------------------------ */
+
+  describe('getAllowedRoots', () => {
+    it('returns userData + default download dir when no folders are registered', () => {
+      const roots = getAllowedRoots();
+      // Lowercased on darwin/win32 by normalizePathForCompare.
+      const expectUserData = process.platform === 'linux'
+        ? MOCK_USER_DATA
+        : MOCK_USER_DATA.toLowerCase();
+      const expectDownloads = path.join(MOCK_MUSIC, 'Shiranami Downloads');
+      const expectDownloadsNorm = process.platform === 'linux'
+        ? expectDownloads
+        : expectDownloads.toLowerCase();
+
+      expect(roots).toContain(expectUserData);
+      expect(roots).toContain(expectDownloadsNorm);
+    });
+
+    it('includes folder rows from the DB', () => {
+      const folderPath = path.resolve('/mock/library/music');
+      getDatabase()
+        .insert(folders)
+        .values({ id: crypto.randomUUID(), path: folderPath })
+        .run();
+
+      const roots = getAllowedRoots();
+      const expected = process.platform === 'linux' ? folderPath : folderPath.toLowerCase();
+      expect(roots).toContain(expected);
+    });
+
+    it('respects the configured download.location override', () => {
+      const custom = path.resolve('/mock/custom-downloads');
+      mockStore.get.mockImplementation((key: string) =>
+        key === 'downloads.location' ? custom : undefined,
+      );
+
+      const roots = getAllowedRoots();
+      const expected = process.platform === 'linux' ? custom : custom.toLowerCase();
+      expect(roots).toContain(expected);
+    });
+
+    it('caches the result — subsequent calls do not re-query the DB', () => {
+      // Insert a folder, prime the cache.
+      const folderPath = path.resolve('/mock/library/a');
+      getDatabase()
+        .insert(folders)
+        .values({ id: crypto.randomUUID(), path: folderPath })
+        .run();
+      const first = getAllowedRoots();
+
+      // Insert a second folder — without invalidate(), the new one should
+      // NOT appear (cache stale by design).
+      const folderB = path.resolve('/mock/library/b');
+      getDatabase()
+        .insert(folders)
+        .values({ id: crypto.randomUUID(), path: folderB })
+        .run();
+      const second = getAllowedRoots();
+
+      expect(second).toEqual(first);
+      const expectedB = process.platform === 'linux' ? folderB : folderB.toLowerCase();
+      expect(second).not.toContain(expectedB);
+    });
+
+    it('invalidate() forces a rebuild', () => {
+      getAllowedRoots(); // prime
+      const folderPath = path.resolve('/mock/library/late');
+      getDatabase()
+        .insert(folders)
+        .values({ id: crypto.randomUUID(), path: folderPath })
+        .run();
+      invalidate();
+      const refreshed = getAllowedRoots();
+      const expected = process.platform === 'linux' ? folderPath : folderPath.toLowerCase();
+      expect(refreshed).toContain(expected);
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  isPathAllowed                                                      */
+  /* ------------------------------------------------------------------ */
+
+  describe('isPathAllowed', () => {
+    it('accepts a path inside an allowed folder root', async () => {
+      const folderPath = path.resolve('/mock/library/music');
+      getDatabase()
+        .insert(folders)
+        .values({ id: crypto.randomUUID(), path: folderPath })
+        .run();
+
+      const inside = path.join(folderPath, 'sub', 'song.mp3');
+      await expect(isPathAllowed(inside)).resolves.toBe(true);
+    });
+
+    it('accepts a known track path even when outside every allowed root', async () => {
+      const standaloneFile = path.resolve('/somewhere/else/standalone.mp3');
+      getDatabase()
+        .insert(tracks)
+        .values({
+          id: crypto.randomUUID(),
+          filePath: standaloneFile,
+          title: 'Standalone',
+          artist: 'X',
+        })
+        .run();
+
+      await expect(isPathAllowed(standaloneFile)).resolves.toBe(true);
+    });
+
+    it('rejects a path outside roots and not present in the tracks table', async () => {
+      await expect(isPathAllowed('/etc/passwd')).resolves.toBe(false);
+    });
+
+    it('returns false when the database call throws (fail-closed)', async () => {
+      // Close the DB to make getDatabase() throw on the tracks fallback.
+      closeDatabase();
+      // Path outside roots so we hit the fallback path.
+      await expect(isPathAllowed('/totally/unknown/file.mp3')).resolves.toBe(false);
+    });
+  });
+});

--- a/apps/desktop/src/main/shared/folders-cache.ts
+++ b/apps/desktop/src/main/shared/folders-cache.ts
@@ -31,8 +31,11 @@ import { isPathWithinAny, normalizePathForCompare } from './path-safety';
  * the user removes them explicitly.
  *
  * Symlinks: `fs.realpathSync` is called once per registered root at cache
- * build time, but `isPathAllowed` does NOT realpath each request. See
- * `path-safety.ts` for the full caveat.
+ * build time. `isPathAllowed` additionally calls `fs.promises.realpath` on
+ * the requested path before the containment check, so a symlink inside an
+ * allowed root that points outside is rejected — important because the
+ * audio-protocol's downstream `fs.stat` and `createReadStream` follow
+ * symlinks, so a textual containment check alone could be bypassed.
  */
 
 let cachedRoots: string[] | null = null;
@@ -118,29 +121,36 @@ export function getAllowedRoots(): string[] {
  * Return `true` when `filePath` is safe to expose via shell or audio handlers.
  *
  * Two-step check:
- *   1. Containment within any allowed root (the common case).
- *   2. Tracks-fallback: a row exists in `tracks` with the original
- *      (un-normalized) `file_path`. Covers standalone imports via
- *      `dialog:open-file` whose location is outside any folder root.
+ *   1. Resolve symlinks and confirm containment within an allowed root. The
+ *      audio protocol's downstream `fs.stat` and `createReadStream` follow
+ *      symlinks, so we must too — otherwise a symlink inside an allowed root
+ *      pointing at `/etc/passwd` would pass a textual containment check.
+ *   2. Tracks-fallback: a row exists in `tracks` matching the requested
+ *      path. Covers standalone imports via `dialog:open-file` whose location
+ *      is outside any folder root. Looked up with `path.resolve(filePath)`
+ *      so forward-slash inputs from URL params (`toAudioUrl` always uses
+ *      `/`) hit the row stored with native separators on Windows.
  *
  * Fails closed if the database is unavailable.
  */
 export async function isPathAllowed(filePath: string): Promise<boolean> {
   if (!filePath) return false;
 
-  if (isPathWithinAny(filePath, getAllowedRoots())) {
+  // realpath swallows ENOENT/EACCES — fall back to the textual path; the
+  // downstream stat will surface the real error to the renderer.
+  const resolved = await fs.promises.realpath(filePath).catch(() => filePath);
+
+  if (isPathWithinAny(resolved, getAllowedRoots())) {
     return true;
   }
 
-  // Fallback — query tracks.file_path with the path as the renderer stored
-  // it. We deliberately use the original (un-normalized) string because the
-  // column is stored verbatim from the import path.
   try {
     const db = getDatabase();
+    const dbKey = path.resolve(filePath);
     const row = db
       .select({ id: tracks.id })
       .from(tracks)
-      .where(eq(tracks.filePath, filePath))
+      .where(eq(tracks.filePath, dbKey))
       .limit(1)
       .get();
     return !!row;

--- a/apps/desktop/src/main/shared/folders-cache.ts
+++ b/apps/desktop/src/main/shared/folders-cache.ts
@@ -1,0 +1,159 @@
+import { app } from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
+import { folders, tracks, eq } from '@shiranami/database';
+import { getDatabase } from '@shiranami/database/client';
+import { logger } from '../logger';
+import { store } from '../store';
+import { isPathWithinAny, normalizePathForCompare } from './path-safety';
+
+/**
+ * Cache of allowed filesystem roots used by the path-containment guards.
+ *
+ * The cache is rebuilt lazily on first access and held until `invalidate()`
+ * is called. Mutating IPC handlers that change the set of allowed roots
+ * (`db:folders:add`, `db:folders:remove`, `downloader:set-download-location`)
+ * are responsible for calling `invalidate()` after a successful write.
+ *
+ * Roots include:
+ *   - `app.getPath('userData')` — covers the on-disk album-art cache and
+ *     anything else stored under userData that the renderer may legitimately
+ *     reference.
+ *   - The active downloads location: either `store.get('downloads.location')`
+ *     when set, or the default `<music>/Shiranami Downloads` directory.
+ *   - Every row in the `folders` table (the user's watched library roots).
+ *
+ * Tracks-fallback in `isPathAllowed` covers a fourth case: standalone files
+ * imported via `dialog:open-file` legitimately live outside any registered
+ * root, so any `tracks.file_path` row is also accepted. This deliberately
+ * means that `db:folders:remove` does NOT immediately revoke shell access
+ * to tracks under the removed folder — the tracks remain in the DB until
+ * the user removes them explicitly.
+ *
+ * Symlinks: `fs.realpathSync` is called once per registered root at cache
+ * build time, but `isPathAllowed` does NOT realpath each request. See
+ * `path-safety.ts` for the full caveat.
+ */
+
+let cachedRoots: string[] | null = null;
+
+/**
+ * Drop the cached allowed-roots set. The next call to `getAllowedRoots()`
+ * (or `isPathAllowed`) will rebuild it from `app.getPath`, the store, and
+ * the folders table.
+ */
+export function invalidate(): void {
+  cachedRoots = null;
+}
+
+function getDefaultDownloadDir(): string {
+  return path.join(app.getPath('music'), 'Shiranami Downloads');
+}
+
+function getConfiguredDownloadDir(): string {
+  const stored = store.get('downloads.location');
+  if (typeof stored !== 'string') return getDefaultDownloadDir();
+  const trimmed = stored.trim();
+  return trimmed.length > 0 ? trimmed : getDefaultDownloadDir();
+}
+
+function readFolderPaths(): string[] {
+  try {
+    const db = getDatabase();
+    return db.select({ path: folders.path }).from(folders).all().map(r => r.path);
+  } catch (err) {
+    logger.warn('[folders-cache] folders table read failed; continuing without folder roots', err);
+    return [];
+  }
+}
+
+/**
+ * Resolve the symlink target for a candidate root if possible. Falls back to
+ * the original path if the root doesn't exist yet (first launch, freshly
+ * configured download dir, etc.) — we still want to allow paths beneath it
+ * once it gets created.
+ */
+function resolveRootSafely(candidate: string): string {
+  try {
+    return fs.realpathSync(candidate);
+  } catch (err) {
+    logger.warn(
+      `[folders-cache] realpath failed for "${candidate}", using as-is`,
+      err,
+    );
+    return candidate;
+  }
+}
+
+/**
+ * Build (or return cached) list of normalized allowed roots. Synchronous —
+ * the underlying DB read is cached and the realpath calls are bounded by
+ * the number of registered roots (typically O(10)).
+ */
+export function getAllowedRoots(): string[] {
+  if (cachedRoots) return cachedRoots;
+
+  const candidates: string[] = [
+    app.getPath('userData'),
+    getConfiguredDownloadDir(),
+    ...readFolderPaths(),
+  ];
+
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const resolved = resolveRootSafely(candidate);
+    const key = normalizePathForCompare(resolved);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(key);
+  }
+
+  cachedRoots = normalized;
+  return cachedRoots;
+}
+
+/**
+ * Return `true` when `filePath` is safe to expose via shell or audio handlers.
+ *
+ * Two-step check:
+ *   1. Containment within any allowed root (the common case).
+ *   2. Tracks-fallback: a row exists in `tracks` with the original
+ *      (un-normalized) `file_path`. Covers standalone imports via
+ *      `dialog:open-file` whose location is outside any folder root.
+ *
+ * Fails closed if the database is unavailable.
+ */
+export async function isPathAllowed(filePath: string): Promise<boolean> {
+  if (!filePath) return false;
+
+  if (isPathWithinAny(filePath, getAllowedRoots())) {
+    return true;
+  }
+
+  // Fallback — query tracks.file_path with the path as the renderer stored
+  // it. We deliberately use the original (un-normalized) string because the
+  // column is stored verbatim from the import path.
+  try {
+    const db = getDatabase();
+    const row = db
+      .select({ id: tracks.id })
+      .from(tracks)
+      .where(eq(tracks.filePath, filePath))
+      .limit(1)
+      .get();
+    return !!row;
+  } catch (err) {
+    logger.warn('[folders-cache] tracks lookup failed; denying path (fail-closed)', err);
+    return false;
+  }
+}
+
+/**
+ * Build the cache eagerly. Called from main bootstrap after the database is
+ * initialized so the first user-triggered request doesn't pay the build cost.
+ */
+export function prewarm(): void {
+  getAllowedRoots();
+}

--- a/apps/desktop/src/main/shared/path-safety.test.ts
+++ b/apps/desktop/src/main/shared/path-safety.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  isPathWithin,
+  isPathWithinAny,
+  normalizePathForCompare,
+} from './path-safety';
+
+/* ------------------------------------------------------------------ */
+/*  normalizePathForCompare                                           */
+/* ------------------------------------------------------------------ */
+
+describe('normalizePathForCompare', () => {
+  it('strips trailing separator when not a root', () => {
+    const a = normalizePathForCompare('/foo/bar/');
+    const b = normalizePathForCompare('/foo/bar');
+    expect(a).toBe(b);
+  });
+
+  it.skipIf(process.platform === 'linux')(
+    'lowercases paths on case-insensitive platforms',
+    () => {
+      const a = normalizePathForCompare('/Users/Me/Music');
+      const b = normalizePathForCompare('/users/me/music');
+      expect(a).toBe(b);
+    },
+  );
+});
+
+/* ------------------------------------------------------------------ */
+/*  isPathWithin                                                      */
+/* ------------------------------------------------------------------ */
+
+describe('isPathWithin', () => {
+  it('accepts a deeply nested child of the root', () => {
+    const root = normalizePathForCompare('/home/user/music');
+    const child = normalizePathForCompare('/home/user/music/folder/sub/song.mp3');
+    expect(isPathWithin(child, root)).toBe(true);
+  });
+
+  it('accepts a child equal to the root', () => {
+    const root = normalizePathForCompare('/home/user/music');
+    const child = normalizePathForCompare('/home/user/music');
+    expect(isPathWithin(child, root)).toBe(true);
+  });
+
+  it('rejects `..` traversal out of the root', () => {
+    const root = normalizePathForCompare('/home/user/music');
+    // path.resolve collapses `..` — construct an already-escaped path directly.
+    const child = normalizePathForCompare('/home/user/other/secret.txt');
+    expect(isPathWithin(child, root)).toBe(false);
+  });
+
+  it('rejects an absolute path outside the root', () => {
+    const root = normalizePathForCompare('/home/user/music');
+    const child = normalizePathForCompare('/etc/passwd');
+    expect(isPathWithin(child, root)).toBe(false);
+  });
+
+  it('rejects a sibling whose name prefixes the root (music-evil vs music)', () => {
+    // Guards against the classic string-startsWith bug.
+    const root = normalizePathForCompare('/home/user/music');
+    const child = normalizePathForCompare('/home/user/music-evil/song.mp3');
+    expect(isPathWithin(child, root)).toBe(false);
+  });
+
+  it.skipIf(process.platform !== 'win32')(
+    'rejects paths on a different Windows drive',
+    () => {
+      const root = normalizePathForCompare('C:\\music');
+      const child = normalizePathForCompare('D:\\music\\song.mp3');
+      expect(isPathWithin(child, root)).toBe(false);
+    },
+  );
+
+  it('treats paths with and without a trailing separator as equivalent', () => {
+    const withSlash = normalizePathForCompare('/home/user/music/');
+    const without = normalizePathForCompare('/home/user/music');
+    const child = normalizePathForCompare('/home/user/music/song.mp3');
+    expect(isPathWithin(child, withSlash)).toBe(true);
+    expect(isPathWithin(child, without)).toBe(true);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  isPathWithinAny                                                   */
+/* ------------------------------------------------------------------ */
+
+describe('isPathWithinAny', () => {
+  it('accepts when any root contains the child', () => {
+    const roots = [
+      normalizePathForCompare('/home/user/music'),
+      normalizePathForCompare('/home/user/podcasts'),
+    ];
+    expect(isPathWithinAny('/home/user/podcasts/ep01.mp3', roots)).toBe(true);
+  });
+
+  it('rejects when no root contains the child', () => {
+    const roots = [
+      normalizePathForCompare('/home/user/music'),
+      normalizePathForCompare('/home/user/podcasts'),
+    ];
+    expect(isPathWithinAny('/etc/passwd', roots)).toBe(false);
+  });
+
+  it('rejects against an empty roots list', () => {
+    expect(isPathWithinAny('/home/user/music/song.mp3', [])).toBe(false);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Symlink behaviour (documents current behaviour — no realpath)     */
+/* ------------------------------------------------------------------ */
+
+describe('symlink handling (documents current behaviour)', () => {
+  let tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  function mkTemp(prefix: string): string {
+    // Use realpath so symlinks like /var/folders -> /private/var/folders on
+    // macOS don't cause false rejections in the assertion.
+    const dir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), prefix)),
+    );
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('treats a symlink inside the root as contained even if the target is outside', () => {
+    const allowedRoot = mkTemp('path-safety-root-');
+    const outsideDir = mkTemp('path-safety-outside-');
+
+    const targetFile = path.join(outsideDir, 'secret.mp3');
+    fs.writeFileSync(targetFile, 'x');
+
+    const linkPath = path.join(allowedRoot, 'shortcut.mp3');
+    try {
+      fs.symlinkSync(targetFile, linkPath);
+    } catch {
+      // Symlink creation can fail on Windows without elevation — skip.
+      return;
+    }
+
+    // Path stays inside allowedRoot textually because we don't call realpath.
+    expect(
+      isPathWithin(
+        normalizePathForCompare(linkPath),
+        normalizePathForCompare(allowedRoot),
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/shared/path-safety.ts
+++ b/apps/desktop/src/main/shared/path-safety.ts
@@ -1,0 +1,73 @@
+import * as path from 'path';
+
+/**
+ * Normalize an absolute path into a comparable form:
+ *   - `path.resolve` collapses `..` segments and normalizes separators.
+ *   - On case-insensitive filesystems (darwin, win32) the result is lowercased
+ *     so that `/Users/Me/Music/song.mp3` and `/users/me/music/song.mp3` compare
+ *     equal.
+ *   - A trailing path separator is stripped unless the result is a filesystem
+ *     root (`/`, `C:\\`, etc.) — this keeps `/foo/bar/` and `/foo/bar`
+ *     interchangeable without mangling roots.
+ *
+ * Does NOT touch the filesystem — no `fs.realpath` call. See `isPathWithin`
+ * for the symlink caveat.
+ */
+export function normalizePathForCompare(p: string): string {
+  let resolved = path.resolve(p);
+  if (process.platform === 'darwin' || process.platform === 'win32') {
+    resolved = resolved.toLowerCase();
+  }
+
+  const root = path.parse(resolved).root;
+  if (resolved !== root && (resolved.endsWith('/') || resolved.endsWith('\\'))) {
+    resolved = resolved.slice(0, -1);
+  }
+
+  return resolved;
+}
+
+/**
+ * Return `true` when `child` is equal to or nested beneath `root`.
+ *
+ * Both inputs must already be normalized via `normalizePathForCompare`.
+ * Matching rules:
+ *   - Paths on different filesystem roots (e.g. `C:\\foo` vs `D:\\foo`) are
+ *     rejected immediately via `path.parse(...).root` comparison.
+ *   - `path.relative(root, child)` is used to detect traversal. A relative
+ *     path starting with `..` or that is itself absolute means the child
+ *     escapes the root; both are rejected.
+ *   - `child === root` is allowed (relative is empty string).
+ *
+ * IMPORTANT — symlink caveat:
+ *   This helper does NOT resolve symlinks. A symlink inside an allowed root
+ *   whose target lives outside will be treated as contained. Callers needing
+ *   symlink-aware checks must call `fs.realpath` themselves before passing
+ *   paths in. We make this trade-off because the audio protocol handler may
+ *   service hundreds of Range requests per track, and a per-request stat is
+ *   too expensive. Roots are resolved once at cache build time elsewhere.
+ */
+export function isPathWithin(child: string, root: string): boolean {
+  if (path.parse(child).root !== path.parse(root).root) {
+    return false;
+  }
+
+  const relative = path.relative(root, child);
+  if (relative === '') return true;
+  if (relative.startsWith('..')) return false;
+  if (path.isAbsolute(relative)) return false;
+  return true;
+}
+
+/**
+ * Convenience wrapper: return `true` when `child` is contained within any of
+ * the supplied `roots`. `child` is normalized once; `roots` must already be
+ * normalized. Iteration short-circuits on the first hit.
+ */
+export function isPathWithinAny(child: string, roots: readonly string[]): boolean {
+  const normalizedChild = normalizePathForCompare(child);
+  for (const root of roots) {
+    if (isPathWithin(normalizedChild, root)) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Closes #87.

## Summary

- Adds `isPathWithin` / `isPathWithinAny` helpers in `apps/desktop/src/main/shared/path-safety.ts` (cross-platform: case-insensitive on darwin/win32, cross-drive rejection on win32, no symlink resolution per request — documented in JSDoc).
- New `folders-cache.ts` builds an in-memory allowed-roots set from `userData` + the current download dir + `folders` table rows, with `realpathSync` applied once per root at build time. Falls back to a `tracks.filePath` lookup so standalone imports (via `dialog:open-file` → `useTrackImport`) keep working.
- `shell:show-in-folder` and `shell:trash-file` reject disallowed paths with `IpcError('FORBIDDEN', …)` (new code added to `VALIDATION_ERROR_CODES`, propagates through `electronAPI.errors`).
- `shiranami-audio://` returns `Response('Forbidden', { status: 403 })` on containment failure.
- Cache is invalidated on `db:folders:add`, `db:folders:remove`, and `downloader:set-download-location`. Prewarmed at bootstrap after database + protocol registration.

## Acceptance criteria

- [x] `shell:trash-file` rejects paths outside registered folders + userData
- [x] `shell:show-in-folder` rejects paths outside registered folders + userData
- [x] `shiranami-audio://` returns 403 when outside any registered folder
- [x] Unit tests cover traversal (`..`), absolute escape, sibling-prefix bug, symlinks, trailing separators (cross-drive case skipped on non-win32)

## Commits (atomic)

1. `b0e5003` — `path-safety` helper + `folders-cache` module + tests
2. `5aeabcb` — `FORBIDDEN` error code + `shell:*` containment + `db:folders:*` and `downloader:set-download-location` cache invalidation
3. `927e376` — `audio-protocol` 403 on containment failure (+ removed misleading `normalizedPath` alias)
4. `9cfbd3e` — bootstrap prewarm of the folders cache

## Notes / caveats

- **Symlinks aren't resolved per request.** Hot-path concern: audio-protocol Range requests can be hundreds per track. Documented limitation in `path-safety.ts` JSDoc. Roots themselves are `realpath`'d once at cache build to handle the common \"home dir is a symlink\" case.
- **Removing a folder doesn't immediately revoke shell access** to tracks under it — the tracks-fallback in `isPathAllowed` continues to allow them as long as the rows live in `tracks`. Documented as intentional in `folders-cache.ts` JSDoc; users delete tracks to revoke access.
- **`library:*` handlers were intentionally left alone** — they're not in this issue's AC. Same helper drops in cleanly when we open the follow-up.
- New `FORBIDDEN` code reaches the renderer automatically via the existing `electronAPI.errors.VALIDATION_ERROR_CODES` re-export — no preload changes needed.

## Test plan

- [x] `pnpm --filter @shiranami/desktop typecheck` — clean
- [x] `pnpm --filter @shiranami/desktop test` — 484 passed, 1 skipped (win32-only cross-drive case)
- [x] `pnpm test` (full repo) — 958 passed, 1 skipped
- [x] `pnpm lint` — clean
- [ ] Manual: launch the app, attempt to play a path outside any folder via DevTools (`fetch('shiranami-audio://stream?path=/etc/passwd')`) — expect 403
- [ ] Manual: from DevTools, `electronAPI.shell.showInFolder('/etc/passwd')` — expect rejected promise with `code: 'FORBIDDEN'`