### PR TITLE
security(desktop): SSRF guard for shiranami-radio:// (#88)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -27,6 +27,7 @@
     "electron-store": "^8.2.0",
     "electron-updater": "^6.8.3",
     "flac-tagger": "^2.0.0",
+    "ipaddr.js": "^2.3.0",
     "lrclib-api": "^2.0.4",
     "music-metadata": "^11.12.3",
     "node-addon-api": "^8.6.0",

--- a/apps/desktop/src/main/radio-protocol.test.ts
+++ b/apps/desktop/src/main/radio-protocol.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 let capturedHandler: ((req: Request) => Promise<Response>) | null = null;
 const mockFetch = vi.fn();
+const mockIsStreamUrlAllowed = vi.fn();
+const loggerMock = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
 
 vi.mock('electron', () => ({
   protocol: {
@@ -16,26 +23,61 @@ vi.mock('electron', () => ({
 
 vi.mock('./logger', () => ({
   logger: {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
+    info: (...args: unknown[]) => loggerMock.info(...args),
+    warn: (...args: unknown[]) => loggerMock.warn(...args),
+    error: (...args: unknown[]) => loggerMock.error(...args),
+    debug: (...args: unknown[]) => loggerMock.debug(...args),
   },
 }));
 
+vi.mock('./shared/url-safety', () => ({
+  isStreamUrlAllowed: (...args: unknown[]) => mockIsStreamUrlAllowed(...args),
+}));
+
 import { registerRadioProtocol } from './radio-protocol';
+
+const STREAM_URL = 'http://stream.example.com/live';
+const STREAM_REQUEST_URL = `shiranami-radio://stream?url=${encodeURIComponent(STREAM_URL)}`;
+
+function okGuardFor(url: string) {
+  return { ok: true, url: new URL(url) } as const;
+}
+
+function makeResponse(init: {
+  status: number;
+  body?: ReadableStream | null;
+  headers?: HeadersInit;
+}) {
+  return {
+    ok: init.status >= 200 && init.status < 300,
+    status: init.status,
+    body: init.body ?? null,
+    headers: new Headers(init.headers ?? {}),
+  };
+}
 
 describe('radio-protocol', () => {
   beforeEach(() => {
     capturedHandler = null;
     mockFetch.mockReset();
+    mockIsStreamUrlAllowed.mockReset();
+    mockIsStreamUrlAllowed.mockResolvedValue(okGuardFor(STREAM_URL));
+    loggerMock.info.mockReset();
+    loggerMock.warn.mockReset();
+    loggerMock.error.mockReset();
+    loggerMock.debug.mockReset();
     registerRadioProtocol();
   });
+
+  /* ---------------------------------------------------------------- */
+  /*  Existing baseline behaviour                                     */
+  /* ---------------------------------------------------------------- */
 
   it('returns 400 when url parameter is missing', async () => {
     const res = await capturedHandler!(new Request('shiranami-radio://stream'));
     expect(res.status).toBe(400);
     expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockIsStreamUrlAllowed).not.toHaveBeenCalled();
   });
 
   it('proxies upstream stream with forwarded content-type', async () => {
@@ -45,52 +87,46 @@ describe('radio-protocol', () => {
         controller.close();
       },
     });
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      body: upstreamBody,
-      headers: new Headers({ 'content-type': 'audio/aac' }),
-    });
+    mockFetch.mockResolvedValue(
+      makeResponse({
+        status: 200,
+        body: upstreamBody,
+        headers: { 'content-type': 'audio/aac' },
+      }),
+    );
 
-    const url = `shiranami-radio://stream?url=${encodeURIComponent('http://stream.example.com/live')}`;
-    const res = await capturedHandler!(new Request(url));
+    const res = await capturedHandler!(new Request(STREAM_REQUEST_URL));
 
     expect(res.status).toBe(200);
     expect(res.headers.get('Content-Type')).toBe('audio/aac');
     expect(res.headers.get('Accept-Ranges')).toBe('none');
     expect(res.headers.get('Cache-Control')).toBe('no-cache, no-store');
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://stream.example.com/live',
+      STREAM_URL,
       expect.objectContaining({
         headers: expect.objectContaining({ 'Icy-MetaData': '0' }),
+        redirect: 'manual',
       }),
     );
   });
 
   it('defaults Content-Type to audio/mpeg when upstream omits it', async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      body: new ReadableStream({ start(c) { c.close(); } }),
-      headers: new Headers(),
-    });
+    mockFetch.mockResolvedValue(
+      makeResponse({
+        status: 200,
+        body: new ReadableStream({ start(c) { c.close(); } }),
+      }),
+    );
 
-    const url = `shiranami-radio://stream?url=${encodeURIComponent('http://stream.example.com/live')}`;
-    const res = await capturedHandler!(new Request(url));
+    const res = await capturedHandler!(new Request(STREAM_REQUEST_URL));
 
     expect(res.headers.get('Content-Type')).toBe('audio/mpeg');
   });
 
   it('forwards upstream error status', async () => {
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 502,
-      body: null,
-      headers: new Headers(),
-    });
+    mockFetch.mockResolvedValue(makeResponse({ status: 502 }));
 
-    const url = `shiranami-radio://stream?url=${encodeURIComponent('http://stream.example.com/live')}`;
-    const res = await capturedHandler!(new Request(url));
+    const res = await capturedHandler!(new Request(STREAM_REQUEST_URL));
     expect(res.status).toBe(502);
   });
 
@@ -99,16 +135,177 @@ describe('radio-protocol', () => {
     abortErr.name = 'AbortError';
     mockFetch.mockRejectedValue(abortErr);
 
-    const url = `shiranami-radio://stream?url=${encodeURIComponent('http://stream.example.com/live')}`;
-    const res = await capturedHandler!(new Request(url));
+    const res = await capturedHandler!(new Request(STREAM_REQUEST_URL));
     expect(res.status).toBe(499);
   });
 
   it('returns 500 on unexpected errors', async () => {
     mockFetch.mockRejectedValue(new Error('boom'));
 
-    const url = `shiranami-radio://stream?url=${encodeURIComponent('http://stream.example.com/live')}`;
-    const res = await capturedHandler!(new Request(url));
+    const res = await capturedHandler!(new Request(STREAM_REQUEST_URL));
     expect(res.status).toBe(500);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  SSRF guard — initial URL                                        */
+  /* ---------------------------------------------------------------- */
+
+  describe('SSRF guard — initial URL', () => {
+    it('returns 403 when guard rejects with reason `scheme`', async () => {
+      mockIsStreamUrlAllowed.mockResolvedValueOnce({ ok: false, reason: 'scheme' });
+
+      const res = await capturedHandler!(new Request(STREAM_REQUEST_URL));
+      expect(res.status).toBe(403);
+      expect(await res.text()).toBe('Forbidden');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when guard rejects with reason `private-ip`', async () => {
+      mockIsStreamUrlAllowed.mockResolvedValueOnce({ ok: false, reason: 'private-ip' });
+
+      const res = await capturedHandler!(new Request(STREAM_REQUEST_URL));
+      expect(res.status).toBe(403);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when guard rejects with reason `parse`', async () => {
+      mockIsStreamUrlAllowed.mockResolvedValueOnce({ ok: false, reason: 'parse' });
+
+      const res = await capturedHandler!(new Request(STREAM_REQUEST_URL));
+      expect(res.status).toBe(403);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('logs a warn including the attempted URL on rejection', async () => {
+      mockIsStreamUrlAllowed.mockResolvedValueOnce({ ok: false, reason: 'private-ip' });
+
+      await capturedHandler!(new Request(STREAM_REQUEST_URL));
+
+      expect(loggerMock.warn).toHaveBeenCalledTimes(1);
+      const message = loggerMock.warn.mock.calls[0]?.[0] as string;
+      expect(message).toContain(STREAM_URL);
+      expect(message).toContain('private-ip');
+    });
+
+    it('calls the guard before any fetch', async () => {
+      const order: string[] = [];
+      mockIsStreamUrlAllowed.mockImplementationOnce(async () => {
+        order.push('guard');
+        return okGuardFor(STREAM_URL);
+      });
+      mockFetch.mockImplementationOnce(async () => {
+        order.push('fetch');
+        return makeResponse({ status: 200, body: new ReadableStream({ start(c) { c.close(); } }) });
+      });
+
+      await capturedHandler!(new Request(STREAM_REQUEST_URL));
+      expect(order).toEqual(['guard', 'fetch']);
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Redirect re-validation                                          */
+  /* ---------------------------------------------------------------- */
+
+  describe('redirect re-validation', () => {
+    it('follows a single safe redirect and streams the final body', async () => {
+      const redirectTarget = 'http://other.example.com/path';
+      mockIsStreamUrlAllowed
+        .mockResolvedValueOnce(okGuardFor(STREAM_URL))
+        .mockResolvedValueOnce(okGuardFor(redirectTarget));
+
+      const finalBody = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([42]));
+          controller.close();
+        },
+      });
+
+      mockFetch
+        .mockResolvedValueOnce(
+          makeResponse({
+            status: 302,
+            headers: { location: redirectTarget },
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeResponse({
+            status: 200,
+            body: finalBody,
+            headers: { 'content-type': 'audio/aac' },
+          }),
+        );
+
+      const res = await capturedHandler!(new Request(STREAM_REQUEST_URL));
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Type')).toBe('audio/aac');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        STREAM_URL,
+        expect.objectContaining({ redirect: 'manual' }),
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        redirectTarget,
+        expect.objectContaining({ redirect: 'manual' }),
+      );
+    });
+
+    it('rejects with 403 when redirect target is denied', async () => {
+      const evilTarget = 'http://10.0.0.1/';
+      mockIsStreamUrlAllowed
+        .mockResolvedValueOnce(okGuardFor(STREAM_URL))
+        .mockResolvedValueOnce({ ok: false, reason: 'private-ip' });
+
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({
+          status: 302,
+          headers: { location: evilTarget },
+        }),
+      );
+
+      const res = await capturedHandler!(new Request(STREAM_REQUEST_URL));
+
+      expect(res.status).toBe(403);
+      expect(await res.text()).toBe('Forbidden');
+      // Only the initial fetch should have happened — the redirected hop is
+      // refused before the second net.fetch call.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const warns = loggerMock.warn.mock.calls.map((c) => String(c[0]));
+      expect(warns.some((m) => m.includes('blocked redirect') && m.includes('private-ip'))).toBe(true);
+    });
+
+    it('rejects with 403 after MAX_REDIRECTS hops', async () => {
+      // 6 consecutive redirects; all guard-ok. The handler must give up.
+      mockIsStreamUrlAllowed.mockImplementation(async (input: string) => okGuardFor(input));
+
+      const targets = [
+        'http://r1.example.com/',
+        'http://r2.example.com/',
+        'http://r3.example.com/',
+        'http://r4.example.com/',
+        'http://r5.example.com/',
+        'http://r6.example.com/',
+      ];
+
+      // Initial fetch + each subsequent hop returns another 302.
+      mockFetch.mockImplementation(async () => {
+        const callIndex = mockFetch.mock.calls.length - 1;
+        return makeResponse({
+          status: 302,
+          headers: { location: targets[callIndex] ?? targets[targets.length - 1]! },
+        });
+      });
+
+      const res = await capturedHandler!(new Request(STREAM_REQUEST_URL));
+
+      expect(res.status).toBe(403);
+      // Initial call + MAX_REDIRECTS (5) follows = 6 fetches, no infinite loop.
+      expect(mockFetch).toHaveBeenCalledTimes(6);
+      const warns = loggerMock.warn.mock.calls.map((c) => String(c[0]));
+      expect(warns.some((m) => m.includes('redirect chain exceeded'))).toBe(true);
+    });
   });
 });

--- a/apps/desktop/src/main/radio-protocol.ts
+++ b/apps/desktop/src/main/radio-protocol.ts
@@ -1,5 +1,29 @@
 import { net, protocol } from 'electron';
 import { logger } from './logger';
+import { isStreamUrlAllowed } from './shared/url-safety';
+
+/**
+ * Maximum redirect hops we will follow before giving up. Each hop's
+ * `Location` is re-validated through `isStreamUrlAllowed`, otherwise the SSRF
+ * guard would be trivially bypassed via `https://attacker/ -> http://10.0.0.1/`.
+ *
+ * yt-dlp googlevideo URLs and some shoutcast clusters legitimately redirect
+ * once or twice, so we leave headroom but stop well below `net.fetch`'s
+ * default of 20.
+ */
+const MAX_REDIRECTS = 5;
+
+/** HTTP statuses that carry a Location header we should follow. */
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Generic 403 response handed back to the renderer on any guard rejection.
+ * The reason is logged main-side at `warn` — never include it in the body
+ * (info leak: lets a malicious page probe internal resolution).
+ */
+function forbidden(): Response {
+  return new Response('Forbidden', { status: 403 });
+}
 
 /**
  * Register the shiranami-radio: protocol for proxying internet radio streams.
@@ -21,20 +45,77 @@ export function registerRadioProtocol(): void {
         return new Response('Bad request: missing url parameter', { status: 400 });
       }
 
+      // SSRF guard — reject before any network I/O if the renderer-supplied
+      // URL points at a private / reserved address. See `shared/url-safety.ts`.
+      const initialGuard = await isStreamUrlAllowed(streamUrl);
+      if (!initialGuard.ok) {
+        logger.warn(
+          `[radio-protocol] blocked URL (${initialGuard.reason}): ${streamUrl}`,
+        );
+        return forbidden();
+      }
+
       logger.debug(`[radio-protocol] Proxying stream: ${streamUrl}`);
 
-      // Use Electron's net module to fetch the stream - it bypasses CORS
-      // and handles HTTP properly from the main process
-      const response = await net.fetch(streamUrl, {
-        headers: {
-          'User-Agent': 'Shiranami/0.2.1',
-          'Icy-MetaData': '0',
-        },
-        signal: request.signal,
-      });
+      // Manual redirect handling — follow up to MAX_REDIRECTS hops, running
+      // every Location through the same guard. If we delegated to net.fetch's
+      // built-in follower, an attacker could 302 us into a private address.
+      let currentUrl = initialGuard.url.toString();
+      let response: Response | null = null;
+
+      for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+        response = await net.fetch(currentUrl, {
+          headers: {
+            'User-Agent': 'Shiranami/0.2.1',
+            'Icy-MetaData': '0',
+          },
+          signal: request.signal,
+          redirect: 'manual',
+        });
+
+        if (!REDIRECT_STATUSES.has(response.status)) break;
+
+        const location = response.headers.get('location');
+        if (!location) break;
+
+        if (hop === MAX_REDIRECTS) {
+          logger.warn(
+            `[radio-protocol] redirect chain exceeded ${MAX_REDIRECTS} hops, last URL: ${currentUrl}`,
+          );
+          return forbidden();
+        }
+
+        // Resolve relative redirects against the current absolute URL.
+        let nextUrl: string;
+        try {
+          nextUrl = new URL(location, currentUrl).toString();
+        } catch {
+          logger.warn(
+            `[radio-protocol] invalid Location header on redirect from ${currentUrl}: ${location}`,
+          );
+          return forbidden();
+        }
+
+        const hopGuard = await isStreamUrlAllowed(nextUrl);
+        if (!hopGuard.ok) {
+          logger.warn(
+            `[radio-protocol] blocked redirect (${hopGuard.reason}) from ${currentUrl} -> ${nextUrl}`,
+          );
+          return forbidden();
+        }
+
+        currentUrl = hopGuard.url.toString();
+      }
+
+      // Loop guarantees `response` is set (we always assign before any break /
+      // return), but TS can't narrow that — assert and continue.
+      if (!response) {
+        logger.error('[radio-protocol] internal: redirect loop produced no response');
+        return new Response('Internal error', { status: 500 });
+      }
 
       if (!response.ok) {
-        logger.warn(`[radio-protocol] Upstream returned ${response.status} for: ${streamUrl}`);
+        logger.warn(`[radio-protocol] Upstream returned ${response.status} for: ${currentUrl}`);
         return new Response(`Upstream error: ${response.status}`, { status: response.status });
       }
 

--- a/apps/desktop/src/main/shared/url-safety.test.ts
+++ b/apps/desktop/src/main/shared/url-safety.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as dns from 'node:dns';
+
+vi.mock('node:dns', () => ({
+  promises: { lookup: vi.fn() },
+}));
+
+import { isStreamUrlAllowed, parseStreamUrl } from './url-safety';
+
+const mockedLookup = vi.mocked(dns.promises.lookup);
+
+beforeEach(() => {
+  mockedLookup.mockReset();
+});
+
+/* ------------------------------------------------------------------ */
+/*  parseStreamUrl                                                    */
+/* ------------------------------------------------------------------ */
+
+describe('parseStreamUrl', () => {
+  it('returns null for empty string', () => {
+    expect(parseStreamUrl('')).toBeNull();
+  });
+
+  it('returns null for invalid input', () => {
+    expect(parseStreamUrl('not a url')).toBeNull();
+  });
+
+  it('returns a URL for a valid input', () => {
+    const u = parseStreamUrl('http://stream.example.com/live');
+    expect(u).toBeInstanceOf(URL);
+    expect(u?.hostname).toBe('stream.example.com');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  isStreamUrlAllowed — parse / scheme failures                      */
+/* ------------------------------------------------------------------ */
+
+describe('isStreamUrlAllowed — parse / scheme', () => {
+  it('rejects empty string with reason `parse`', async () => {
+    const r = await isStreamUrlAllowed('');
+    expect(r).toEqual({ ok: false, reason: 'parse' });
+  });
+
+  it('rejects garbage with reason `parse`', async () => {
+    const r = await isStreamUrlAllowed('not a url');
+    expect(r).toEqual({ ok: false, reason: 'parse' });
+  });
+
+  it('rejects data: URLs', async () => {
+    const r = await isStreamUrlAllowed('data:text/plain,hello');
+    expect(r).toEqual({ ok: false, reason: 'scheme' });
+  });
+
+  it('rejects file: URLs', async () => {
+    const r = await isStreamUrlAllowed('file:///etc/passwd');
+    expect(r).toEqual({ ok: false, reason: 'scheme' });
+  });
+
+  it('rejects javascript: URLs', async () => {
+    const r = await isStreamUrlAllowed('javascript:alert(1)');
+    expect(r).toEqual({ ok: false, reason: 'scheme' });
+  });
+
+  it('rejects ftp: URLs', async () => {
+    const r = await isStreamUrlAllowed('ftp://example.com/');
+    expect(r).toEqual({ ok: false, reason: 'scheme' });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  isStreamUrlAllowed — literal IPv4 deny ranges                     */
+/* ------------------------------------------------------------------ */
+
+describe('isStreamUrlAllowed — literal IPv4', () => {
+  it('rejects loopback (127.0.0.1)', async () => {
+    const r = await isStreamUrlAllowed('http://127.0.0.1/');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+    expect(mockedLookup).not.toHaveBeenCalled();
+  });
+
+  it('rejects RFC1918 10.0.0.0/8', async () => {
+    const r = await isStreamUrlAllowed('http://10.0.0.5/stream');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+
+  it('rejects RFC1918 192.168.0.0/16', async () => {
+    const r = await isStreamUrlAllowed('http://192.168.1.1/');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+
+  it('rejects RFC1918 172.16.0.0/12', async () => {
+    const r = await isStreamUrlAllowed('http://172.16.0.1/');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+
+  it('rejects link-local / AWS metadata 169.254.169.254', async () => {
+    const r = await isStreamUrlAllowed('http://169.254.169.254/latest/meta-data/');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+
+  it('rejects multicast 224.0.0.1', async () => {
+    const r = await isStreamUrlAllowed('http://224.0.0.1/');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+
+  it('rejects unspecified 0.0.0.0', async () => {
+    const r = await isStreamUrlAllowed('http://0.0.0.0/');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+
+  it('rejects WHATWG-canonicalized decimal-IP form (http://2130706433/ → 127.0.0.1)', async () => {
+    // WHATWG URL parser canonicalizes decimal IPs to dotted-quad. The literal
+    // path fires and the loopback check rejects. If Node ever stops doing this,
+    // the test should still reject (via parse / scheme / dns). Either way: deny.
+    const r = await isStreamUrlAllowed('http://2130706433/');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('private-ip');
+    }
+    expect(mockedLookup).not.toHaveBeenCalled();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  isStreamUrlAllowed — literal IPv6 deny ranges                     */
+/* ------------------------------------------------------------------ */
+
+describe('isStreamUrlAllowed — literal IPv6', () => {
+  it('rejects bracketed loopback [::1]', async () => {
+    const r = await isStreamUrlAllowed('http://[::1]/');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+
+  it('rejects IPv4-mapped IPv6 [::ffff:127.0.0.1] (no IPv4 bypass via v6 form)', async () => {
+    const r = await isStreamUrlAllowed('http://[::ffff:127.0.0.1]/');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+
+  it('rejects IPv6 link-local fe80::/10', async () => {
+    const r = await isStreamUrlAllowed('http://[fe80::1]/');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+
+  it('rejects IPv6 unique-local fc00::/7', async () => {
+    const r = await isStreamUrlAllowed('http://[fc00::1]/');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+
+  it('rejects IPv6 multicast ff00::/8', async () => {
+    const r = await isStreamUrlAllowed('http://[ff00::1]/');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  isStreamUrlAllowed — DNS resolution path                          */
+/* ------------------------------------------------------------------ */
+
+describe('isStreamUrlAllowed — DNS', () => {
+  it('accepts a hostname resolving to a public IP', async () => {
+    mockedLookup.mockResolvedValueOnce([{ address: '8.8.8.8', family: 4 }]);
+
+    const r = await isStreamUrlAllowed('http://stream.example.com/live');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.url.hostname).toBe('stream.example.com');
+    }
+    expect(mockedLookup).toHaveBeenCalledWith('stream.example.com', {
+      all: true,
+      verbatim: true,
+    });
+  });
+
+  it('rejects a hostname that resolves to loopback (DNS rebinding)', async () => {
+    mockedLookup.mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }]);
+
+    const r = await isStreamUrlAllowed('http://stream.example.com/live');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+
+  it('rejects when ANY returned address is denied (any-deny rule)', async () => {
+    mockedLookup.mockResolvedValueOnce([
+      { address: '8.8.8.8', family: 4 },
+      { address: '10.0.0.1', family: 4 },
+    ]);
+
+    const r = await isStreamUrlAllowed('http://stream.example.com/live');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+
+  it('returns reason `dns` when lookup throws (ENOTFOUND)', async () => {
+    const err = Object.assign(new Error('not found'), { code: 'ENOTFOUND' });
+    mockedLookup.mockRejectedValueOnce(err);
+
+    const r = await isStreamUrlAllowed('http://nope.example.invalid/');
+    expect(r).toEqual({ ok: false, reason: 'dns' });
+  });
+
+  it('preserves port and query string on success', async () => {
+    mockedLookup.mockResolvedValueOnce([{ address: '8.8.8.8', family: 4 }]);
+
+    const r = await isStreamUrlAllowed('http://stream.example.com:8000/path?q=1');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.url.port).toBe('8000');
+      expect(r.url.pathname).toBe('/path');
+      expect(r.url.search).toBe('?q=1');
+    }
+  });
+});

--- a/apps/desktop/src/main/shared/url-safety.test.ts
+++ b/apps/desktop/src/main/shared/url-safety.test.ts
@@ -138,6 +138,20 @@ describe('isStreamUrlAllowed — literal IPv6', () => {
     expect(r).toEqual({ ok: false, reason: 'private-ip' });
   });
 
+  it('rejects deprecated IPv4-compatible IPv6 [::127.0.0.1] form', async () => {
+    // ipaddr.js v2.x classifies this as `ipv4Mapped` and isIPv4MappedAddress()
+    // returns true, so the unwrap branch fires and we re-classify as IPv4
+    // loopback. This test guards against a future library version tightening
+    // that detection and silently letting `::127.0.0.1` through.
+    const r = await isStreamUrlAllowed('http://[::127.0.0.1]/');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+
+  it('rejects deprecated IPv4-compatible IPv6 form for AWS metadata IP', async () => {
+    const r = await isStreamUrlAllowed('http://[::169.254.169.254]/latest/meta-data/');
+    expect(r).toEqual({ ok: false, reason: 'private-ip' });
+  });
+
   it('rejects IPv6 link-local fe80::/10', async () => {
     const r = await isStreamUrlAllowed('http://[fe80::1]/');
     expect(r).toEqual({ ok: false, reason: 'private-ip' });

--- a/apps/desktop/src/main/shared/url-safety.ts
+++ b/apps/desktop/src/main/shared/url-safety.ts
@@ -94,11 +94,36 @@ function unbracket(hostname: string): string {
   return hostname;
 }
 
+const V6_PREFIX_ZERO = ipaddr.parse('::');
+
+/**
+ * Extract the embedded IPv4 from an IPv6 address that has 96 leading zero
+ * bits (the deprecated IPv4-compatible block, RFC 4291 §2.5.5.1) — the form
+ * `::d.d.d.d`. WHATWG URL canonicalization rewrites `::127.0.0.1` to
+ * `::7f00:1`, which `ipaddr.js` does NOT detect via `isIPv4MappedAddress()`,
+ * so without this unwrap a renderer could bypass the IPv4 loopback / RFC1918
+ * / metadata checks via the IPv6 syntax.
+ */
+function ipv4FromCompatV6(v6: ipaddr.IPv6): ipaddr.IPv4 {
+  const a = (v6.parts[6] >> 8) & 0xff;
+  const b = v6.parts[6] & 0xff;
+  const c = (v6.parts[7] >> 8) & 0xff;
+  const d = v6.parts[7] & 0xff;
+  return new ipaddr.IPv4([a, b, c, d]);
+}
+
 /**
  * Classify a single literal IP. Returns `'denied'` if it falls in any range
- * we refuse to proxy to, `'ok'` otherwise. IPv4-mapped IPv6 addresses
- * (`::ffff:127.0.0.1`) are unwrapped and re-classified as IPv4 — without that
- * unwrap an attacker could bypass the IPv4 loopback check via the IPv6 form.
+ * we refuse to proxy to, `'ok'` otherwise.
+ *
+ * IPv6-embedded IPv4 forms are unwrapped and re-classified as IPv4 so the
+ * loopback / RFC1918 / metadata checks can't be bypassed via the IPv6 syntax.
+ * Two forms are handled:
+ *   - IPv4-mapped (`::ffff:127.0.0.1`) via ipaddr.js's `isIPv4MappedAddress()`.
+ *   - IPv4-compatible (`::127.0.0.1`, deprecated per RFC 4291) via a manual
+ *     `::/96` containment check + lower-32-bit extraction. Needed because
+ *     WHATWG URL canonicalizes `::127.0.0.1` to `::7f00:1` and ipaddr.js
+ *     doesn't recognize that as IPv4-embedded.
  */
 function classifyAddress(address: string): 'ok' | 'denied' {
   let parsed: ReturnType<typeof ipaddr.parse>;
@@ -113,6 +138,10 @@ function classifyAddress(address: string): 'ok' | 'denied' {
     const v6 = parsed as ipaddr.IPv6;
     if (v6.isIPv4MappedAddress()) {
       const unwrapped = v6.toIPv4Address();
+      return DENIED_IPV4_RANGES.has(unwrapped.range()) ? 'denied' : 'ok';
+    }
+    if (v6.match(V6_PREFIX_ZERO, 96)) {
+      const unwrapped = ipv4FromCompatV6(v6);
       return DENIED_IPV4_RANGES.has(unwrapped.range()) ? 'denied' : 'ok';
     }
     return DENIED_IPV6_RANGES.has(v6.range()) ? 'denied' : 'ok';

--- a/apps/desktop/src/main/shared/url-safety.ts
+++ b/apps/desktop/src/main/shared/url-safety.ts
@@ -1,0 +1,170 @@
+import * as dns from 'node:dns';
+import ipaddr from 'ipaddr.js';
+
+/**
+ * SSRF guard for URLs that the renderer hands to the main process for outbound
+ * `net.fetch` (currently the `shiranami-radio://` protocol handler — see
+ * `radio-protocol.ts`).
+ *
+ * Why this exists
+ * ---------------
+ * The radio protocol passes an arbitrary `?url=` value through to Electron's
+ * `net.fetch`. Without a guard, a malicious page (or a compromised
+ * radio-browser entry, or a tampered playlist) could point us at
+ * `http://127.0.0.1:8080/`, `http://10.0.0.1/`, `http://169.254.169.254/`
+ * (cloud metadata), and so on, exfiltrating internal services through the
+ * Electron app.
+ *
+ * Design choices (locked in — see issue #88)
+ * ------------------------------------------
+ * - **No allowlist.** radio-browser is worldwide and yt-dlp googlevideo URLs
+ *   are dynamic; an allowlist is infeasible without breaking real usage.
+ * - **No localhost / dev-mode override.** Security wins over dev convenience;
+ *   any future opt-in must be gated explicitly behind a build-time flag.
+ * - **No CGNAT (100.64/10) block.** Legitimate ISPs use that range for real
+ *   subscribers — blocking it would break radio listeners on those networks.
+ *
+ * DNS rebinding caveat — "Option B"
+ * ---------------------------------
+ * We resolve the hostname once via `dns.promises.lookup` and reject if ANY
+ * returned address is in a denied range. The fetch that follows performs its
+ * own resolution inside Chromium's network stack, so a malicious server with
+ * a low-TTL record could in principle return a public IP at lookup time and a
+ * private IP at fetch time. We accept this small residual race window because
+ * the alternative (pre-resolving and rewriting the URL) breaks TLS/SNI and is
+ * ignored by Chromium's network stack anyway.
+ *
+ * // TODO(security): Extend this guard to other `net.fetch` / `net.request`
+ * // call sites that handle renderer-derived URLs (e.g. `metadata-lookup.ts`,
+ * // `playlist.ts` if its scope grows). Today the radio protocol is the only
+ * // hot path; widen as new entry points appear.
+ */
+
+/** Why a URL was rejected. Renderer never sees this — main-side log only. */
+export type UrlGuardReason = 'parse' | 'scheme' | 'private-ip' | 'dns';
+
+export type UrlGuardResult =
+  | { ok: true; url: URL }
+  | { ok: false; reason: UrlGuardReason };
+
+const ALLOWED_SCHEMES = new Set(['http:', 'https:']);
+
+/** IPv4 ranges (per `ipaddr.js` `range()` classification) we never proxy to. */
+const DENIED_IPV4_RANGES = new Set([
+  'loopback',
+  'private',
+  'linkLocal',
+  'multicast',
+  'unspecified',
+  'broadcast',
+  'reserved',
+]);
+
+/** IPv6 ranges we never proxy to. `uniqueLocal` is the IPv6 equivalent of RFC1918. */
+const DENIED_IPV6_RANGES = new Set([
+  'loopback',
+  'linkLocal',
+  'multicast',
+  'uniqueLocal',
+  'unspecified',
+]);
+
+/**
+ * Best-effort URL parse. Returns `null` on any failure, including non-string
+ * input — callers must treat `null` as "reject".
+ */
+export function parseStreamUrl(input: string): URL | null {
+  if (typeof input !== 'string' || input.length === 0) return null;
+  try {
+    return new URL(input);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Strip the surrounding `[...]` from a bracketed IPv6 hostname. WHATWG's
+ * `URL.hostname` keeps the brackets for IPv6 literals, but `ipaddr.js` rejects
+ * the bracketed form — normalize before parsing.
+ */
+function unbracket(hostname: string): string {
+  if (hostname.length >= 2 && hostname.startsWith('[') && hostname.endsWith(']')) {
+    return hostname.slice(1, -1);
+  }
+  return hostname;
+}
+
+/**
+ * Classify a single literal IP. Returns `'denied'` if it falls in any range
+ * we refuse to proxy to, `'ok'` otherwise. IPv4-mapped IPv6 addresses
+ * (`::ffff:127.0.0.1`) are unwrapped and re-classified as IPv4 — without that
+ * unwrap an attacker could bypass the IPv4 loopback check via the IPv6 form.
+ */
+function classifyAddress(address: string): 'ok' | 'denied' {
+  let parsed: ReturnType<typeof ipaddr.parse>;
+  try {
+    parsed = ipaddr.parse(address);
+  } catch {
+    // Defensive — if DNS hands us something that won't parse, treat as denied.
+    return 'denied';
+  }
+
+  if (parsed.kind() === 'ipv6') {
+    const v6 = parsed as ipaddr.IPv6;
+    if (v6.isIPv4MappedAddress()) {
+      const unwrapped = v6.toIPv4Address();
+      return DENIED_IPV4_RANGES.has(unwrapped.range()) ? 'denied' : 'ok';
+    }
+    return DENIED_IPV6_RANGES.has(v6.range()) ? 'denied' : 'ok';
+  }
+
+  // ipv4
+  return DENIED_IPV4_RANGES.has((parsed as ipaddr.IPv4).range()) ? 'denied' : 'ok';
+}
+
+/**
+ * Resolve and classify a URL string for outbound proxying. See file-level
+ * JSDoc for the full design rationale.
+ *
+ * Steps:
+ *   1. Parse the URL.
+ *   2. Reject any scheme other than `http:` / `https:`.
+ *   3. If the hostname is a literal IP, classify it directly.
+ *   4. Otherwise resolve via DNS and reject if ANY returned address is denied.
+ */
+export async function isStreamUrlAllowed(input: string): Promise<UrlGuardResult> {
+  const url = parseStreamUrl(input);
+  if (!url) return { ok: false, reason: 'parse' };
+
+  if (!ALLOWED_SCHEMES.has(url.protocol)) {
+    return { ok: false, reason: 'scheme' };
+  }
+
+  const hostname = unbracket(url.hostname);
+  if (hostname.length === 0) return { ok: false, reason: 'parse' };
+
+  if (ipaddr.isValid(hostname)) {
+    if (classifyAddress(hostname) === 'denied') {
+      return { ok: false, reason: 'private-ip' };
+    }
+    return { ok: true, url };
+  }
+
+  // Hostname path: resolve once, fail-closed on any denied result.
+  let addresses: dns.LookupAddress[];
+  try {
+    addresses = await dns.promises.lookup(hostname, { all: true, verbatim: true });
+  } catch {
+    return { ok: false, reason: 'dns' };
+  }
+
+  if (addresses.length === 0) return { ok: false, reason: 'dns' };
+
+  for (const { address } of addresses) {
+    if (classifyAddress(address) === 'denied') {
+      return { ok: false, reason: 'private-ip' };
+    }
+  }
+
+  return { ok: true, url };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       flac-tagger:
         specifier: ^2.0.0
         version: 2.0.0
+      ipaddr.js:
+        specifier: ^2.3.0
+        version: 2.3.0
       lrclib-api:
         specifier: ^2.0.4
         version: 2.0.4


### PR DESCRIPTION
Closes #88.

## Summary

- Adds `apps/desktop/src/main/shared/url-safety.ts` with `isStreamUrlAllowed(url)` returning a tagged-union result (`{ ok, url } | { ok: false, reason }`). Validates scheme (http/https only), parses literal IPs (incl. WHATWG-canonicalized decimal forms, IPv6 literals, IPv4-mapped IPv6), and resolves hostnames via `dns.promises.lookup({ all: true, verbatim: true })` rejecting if any returned address is private/loopback/link-local/multicast/etc.
- Wires the guard into `shiranami-radio://` before `net.fetch`, returning `Response('Forbidden', { status: 403 })` on rejection.
- **Redirects are revalidated**: switched to `redirect: 'manual'` and follows up to 5 hops, running each `Location` target through the same guard. Without this the guard would be bypassable by a `https://attacker.com/ → http://10.0.0.1/` redirect.
- Adds `ipaddr.js@^2.3.0` as a direct dependency of `apps/desktop` (already transitive via the server's `proxy-addr`, no version churn).

## Acceptance criteria

- [x] `shiranami-radio://` rejects non-http(s) schemes (`data:`, `file:`, `javascript:`, `ftp:`)
- [x] Rejects URLs that resolve to private/loopback/link-local IPs (`127.0.0.1`, `[::1]`, `[::ffff:127.0.0.1]`, `10.x`, `192.168.x`, `172.16.x`, `169.254.169.254`, `224.x`, `0.0.0.0`, `[fe80::]`, `[fc00::]`, `[ff00::]`)
- [x] Existing radio-browser streams still play (default-ok mock keeps the 6 baseline tests green; manual smoke pending)
- [x] Tests cover localhost, AWS metadata, RFC1918, multicast, unspecified, IPv6 link-local + unique-local + multicast, decimal-IP form (`http://2130706433/`), DNS rebinding (host returns mixed safe+private), DNS NXDOMAIN, redirect-to-private rejection, MAX_REDIRECTS bound

## Commits (atomic)

1. `b6fb9cc` — `url-safety` helper + 27 unit tests
2. `a9eea33` — wire into radio-protocol with `redirect: 'manual'` + bounded re-validating follow

## Design decisions

- **DNS rebinding (Option B)**: resolve once, accept the small race window. Pre-resolving + URL-rewriting breaks SNI/TLS for legitimate radio CDNs and Chromium's network stack ignores it anyway. Documented in JSDoc.
- **No allowlist**: radio-browser stations are worldwide and `useAudioPreview.ts` pipes yt-dlp googlevideo URLs through here too.
- **No localhost dev-override**: security wins over dev convenience.
- **CGNAT (`100.64/10`) NOT blocked**: real ISPs use it for legit customer traffic.
- **`reserved` IPv4 IS blocked**: includes RFC 5737 documentation ranges (`192.0.2.0/24`, `203.0.113.0/24`) and `240.0.0.0/4`. Real radio shouldn't live there.
- **No `ssrf-req-filter`/similar**: those patch Node http; Electron's `net.fetch` goes through Chromium.

## Test plan

- [x] `pnpm --filter @shiranami/desktop typecheck` — clean
- [x] `pnpm --filter @shiranami/desktop test` — 522 passed, 1 skipped (win32-only carryover from #94)
- [x] `pnpm test` (full repo) — 996 passed, 1 skipped
- [x] `pnpm lint` — clean
- [ ] Manual: play any radio-browser station — expect normal playback
- [ ] Manual: from DevTools, fetch `shiranami-radio://stream?url=http://127.0.0.1:8080/` — expect 403

## Future scope (not this PR)

`url-safety.ts` carries a `// TODO(security)` flagging `metadata-lookup.ts` and `playlist.ts` for the same guard if their renderer-derived URL handling expands.