### PR TITLE
feat(web): add React ErrorBoundary with per-view fallbacks

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import { LibraryView } from '@/components/library/LibraryView';
 import { FavoritesView } from '@/components/favorites/FavoritesView';
 import { PlaylistsView } from '@/components/playlists/PlaylistsView';
 import { AmbientBackground } from '@/components/shared/AmbientBackground';
+import ErrorBoundary from '@/components/shared/ErrorBoundary';
 
 const SettingsView = lazy(() => import('@/components/settings/SettingsView'));
 const SearchView = lazy(() => import('@/components/search/SearchView'));
@@ -120,127 +121,161 @@ function App() {
 
       {splashDone && (
         <AmbientColorProvider>
-          <div
-            className={cn(
-              'h-screen w-screen bg-background text-foreground overflow-hidden relative',
-              !compactMode && 'flex',
-              IS_ELECTRON && 'rounded-t-[10px]'
-            )}
-          >
-            <AmbientBackground />
-            <CommandPalette />
-            <Suspense fallback={null}>
-              <KeyboardShortcutsHelp />
-            </Suspense>
-            <Suspense fallback={null}>
-              <ShareDialogManager />
-            </Suspense>
+          <ErrorBoundary root viewName="Root">
+            <div
+              className={cn(
+                'h-screen w-screen bg-background text-foreground overflow-hidden relative',
+                !compactMode && 'flex',
+                IS_ELECTRON && 'rounded-t-[10px]'
+              )}
+            >
+              <AmbientBackground />
+              <CommandPalette />
+              <ErrorBoundary viewName="KeyboardShortcutsHelp">
+                <Suspense fallback={null}>
+                  <KeyboardShortcutsHelp />
+                </Suspense>
+              </ErrorBoundary>
+              <ErrorBoundary viewName="ShareDialogManager">
+                <Suspense fallback={null}>
+                  <ShareDialogManager />
+                </Suspense>
+              </ErrorBoundary>
 
-            {compactMode ? (
-              <CompactPlayer />
-            ) : (
-              <>
-                {/* Skip to content link for keyboard users */}
-                <a
-                  href="#main-content"
-                  className="sr-only focus:not-sr-only focus:absolute focus:z-[9999] focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:rounded-lg focus:bg-primary focus:text-primary-foreground focus:text-sm focus:font-medium"
-                >
-                  Skip to main content
-                </a>
+              {compactMode ? (
+                <CompactPlayer />
+              ) : (
+                <>
+                  {/* Skip to content link for keyboard users */}
+                  <a
+                    href="#main-content"
+                    className="sr-only focus:not-sr-only focus:absolute focus:z-[9999] focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:rounded-lg focus:bg-primary focus:text-primary-foreground focus:text-sm focus:font-medium"
+                  >
+                    Skip to main content
+                  </a>
 
-                {/* Sidebar */}
-                <Sidebar />
+                  {/* Sidebar */}
+                  <Sidebar />
 
-                {/* Main content area */}
-                <div className="flex-1 flex flex-col min-w-0 relative">
-                  <TopBar
-                    onAddFile={handleOpenFile}
-                    onAddFolder={handleOpenFolder}
-                    isScanning={isScanning}
-                  />
+                  {/* Main content area */}
+                  <div className="flex-1 flex flex-col min-w-0 relative">
+                    <TopBar
+                      onAddFile={handleOpenFile}
+                      onAddFolder={handleOpenFolder}
+                      isScanning={isScanning}
+                    />
 
-                  <main id="main-content" aria-label={activeView} className={cn(
-                    'flex-1 flex overflow-hidden min-h-0',
-                    activeView === 'now-playing'
-                      ? ''
-                      : currentTrack && showVisualizer && !lowPerformanceMode ? 'pb-[136px]' : currentTrack ? 'pb-[88px]' : ''
-                  )}>
-                    {/* Center content */}
-                    <div className="flex-1 min-w-0 min-h-0 overflow-hidden flex flex-col">
-                      {activeView === 'library' && <LibraryView />}
-                      {activeView === 'playlists' && (
-                        selectedPlaylistId ? (
+                    <main id="main-content" aria-label={activeView} className={cn(
+                      'flex-1 flex overflow-hidden min-h-0',
+                      activeView === 'now-playing'
+                        ? ''
+                        : currentTrack && showVisualizer && !lowPerformanceMode ? 'pb-[136px]' : currentTrack ? 'pb-[88px]' : ''
+                    )}>
+                      {/* Center content */}
+                      <div className="flex-1 min-w-0 min-h-0 overflow-hidden flex flex-col">
+                        {activeView === 'library' && (
+                          <ErrorBoundary viewName="LibraryView">
+                            <LibraryView />
+                          </ErrorBoundary>
+                        )}
+                        {activeView === 'playlists' && (
+                          <ErrorBoundary viewName="PlaylistsView">
+                            {selectedPlaylistId ? (
+                              <Suspense fallback={null}>
+                                <PlaylistDetailView />
+                              </Suspense>
+                            ) : <PlaylistsView />}
+                          </ErrorBoundary>
+                        )}
+                        {activeView === 'favorites' && (
+                          <ErrorBoundary viewName="FavoritesView">
+                            <FavoritesView />
+                          </ErrorBoundary>
+                        )}
+                        {activeView === 'history' && (
+                          <ErrorBoundary viewName="HistoryView">
+                            <Suspense fallback={null}>
+                              <HistoryView />
+                            </Suspense>
+                          </ErrorBoundary>
+                        )}
+                        {activeView === 'mixes' && (
+                          <ErrorBoundary viewName="MixesView">
+                            <Suspense fallback={null}>
+                              <MixesView />
+                            </Suspense>
+                          </ErrorBoundary>
+                        )}
+                        {activeView === 'search' && (
+                          <ErrorBoundary viewName="SearchView">
+                            <Suspense fallback={null}>
+                              <SearchView />
+                            </Suspense>
+                          </ErrorBoundary>
+                        )}
+                        {activeView === 'import-playlist' && (
+                          <ErrorBoundary viewName="PlaylistImportView">
+                            <Suspense fallback={null}>
+                              <PlaylistImportView />
+                            </Suspense>
+                          </ErrorBoundary>
+                        )}
+                        {activeView === 'radio' && (
+                          <ErrorBoundary viewName="RadioView">
+                            <Suspense fallback={null}>
+                              <RadioView />
+                            </Suspense>
+                          </ErrorBoundary>
+                        )}
+                        {activeView === 'now-playing' && (
+                          <ErrorBoundary viewName="NowPlayingView">
+                            <Suspense fallback={null}>
+                              <NowPlayingView />
+                            </Suspense>
+                          </ErrorBoundary>
+                        )}
+                        {activeView === 'settings' && (
+                          <ErrorBoundary viewName="SettingsView">
+                            <Suspense fallback={null}>
+                              <SettingsView />
+                            </Suspense>
+                          </ErrorBoundary>
+                        )}
+                      </div>
+
+                      {/* Right panel (hidden in now-playing view — lyrics are inline) */}
+                      {currentTrack && activeView !== 'now-playing' && (rightPanel === 'lyrics' || rightPanel === 'queue') && (
+                        <div className="w-[320px] border-l border-border/30 shrink-0 flex flex-col overflow-hidden bg-surface/30">
+                          <ErrorBoundary viewName="RightPanel">
+                            <Suspense fallback={null}>
+                              {rightPanel === 'lyrics' ? <LyricsPanel /> : <QueuePanel />}
+                            </Suspense>
+                          </ErrorBoundary>
+                        </div>
+                      )}
+                    </main>
+
+                    {/* Visualizer strip above player bar (hidden in now-playing view and in low performance mode) */}
+                    {currentTrack && showVisualizer && !lowPerformanceMode && activeView !== 'now-playing' && (
+                      <div className="absolute bottom-[88px] left-0 right-0 z-40 h-[48px]">
+                        <ErrorBoundary viewName="Visualizer">
                           <Suspense fallback={null}>
-                            <PlaylistDetailView />
+                            {visualizerStyle === 'waveform' ? <WaveformVisualizer /> :
+                             visualizerStyle === 'circle' ? <CircleVisualizer /> :
+                             visualizerStyle === 'particles' ? <ParticleVisualizer /> :
+                             <AudioVisualizer />}
                           </Suspense>
-                        ) : <PlaylistsView />
-                      )}
-                      {activeView === 'favorites' && <FavoritesView />}
-                      {activeView === 'history' && (
-                        <Suspense fallback={null}>
-                          <HistoryView />
-                        </Suspense>
-                      )}
-                      {activeView === 'mixes' && (
-                        <Suspense fallback={null}>
-                          <MixesView />
-                        </Suspense>
-                      )}
-                      {activeView === 'search' && (
-                        <Suspense fallback={null}>
-                          <SearchView />
-                        </Suspense>
-                      )}
-                      {activeView === 'import-playlist' && (
-                        <Suspense fallback={null}>
-                          <PlaylistImportView />
-                        </Suspense>
-                      )}
-                      {activeView === 'radio' && (
-                        <Suspense fallback={null}>
-                          <RadioView />
-                        </Suspense>
-                      )}
-                      {activeView === 'now-playing' && (
-                        <Suspense fallback={null}>
-                          <NowPlayingView />
-                        </Suspense>
-                      )}
-                      {activeView === 'settings' && (
-                        <Suspense fallback={null}>
-                          <SettingsView />
-                        </Suspense>
-                      )}
-                    </div>
-
-                    {/* Right panel (hidden in now-playing view — lyrics are inline) */}
-                    {currentTrack && activeView !== 'now-playing' && (rightPanel === 'lyrics' || rightPanel === 'queue') && (
-                      <div className="w-[320px] border-l border-border/30 shrink-0 flex flex-col overflow-hidden bg-surface/30">
-                        <Suspense fallback={null}>
-                          {rightPanel === 'lyrics' ? <LyricsPanel /> : <QueuePanel />}
-                        </Suspense>
+                        </ErrorBoundary>
                       </div>
                     )}
-                  </main>
 
-                  {/* Visualizer strip above player bar (hidden in now-playing view and in low performance mode) */}
-                  {currentTrack && showVisualizer && !lowPerformanceMode && activeView !== 'now-playing' && (
-                    <div className="absolute bottom-[88px] left-0 right-0 z-40 h-[48px]">
-                      <Suspense fallback={null}>
-                        {visualizerStyle === 'waveform' ? <WaveformVisualizer /> :
-                         visualizerStyle === 'circle' ? <CircleVisualizer /> :
-                         visualizerStyle === 'particles' ? <ParticleVisualizer /> :
-                         <AudioVisualizer />}
-                      </Suspense>
-                    </div>
-                  )}
-
-                  {/* Player bar (hidden in now-playing view — controls are inline) */}
-                  {activeView !== 'now-playing' && <PlayerBar />}
-                </div>
-              </>
-            )}
-          </div>
+                    {/* Player bar (hidden in now-playing view — controls are inline) */}
+                    {activeView !== 'now-playing' && <PlayerBar />}
+                  </div>
+                </>
+              )}
+            </div>
+          </ErrorBoundary>
         </AmbientColorProvider>
       )}
     </>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -64,7 +64,9 @@ function App() {
       id: 'library-load-error',
       action: {
         label: t('retry', { ns: 'common' }),
-        onClick: () => { void refetchLibrary(); },
+        onClick: () => {
+          void refetchLibrary();
+        },
       },
     });
   }, [libraryError, refetchLibrary, t]);
@@ -96,12 +98,12 @@ function App() {
   const visualizerStyle = useAppStore(s => s.visualizerStyle);
   const compactMode = useAppStore(s => s.compactMode);
   const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
-  const updateDependencyInstall = useDownloadStore((s) => s.updateDependencyInstall);
-  const updateEnrichProgress = useMetadataEnrichStore((s) => s.updateProgress);
+  const updateDependencyInstall = useDownloadStore(s => s.updateDependencyInstall);
+  const updateEnrichProgress = useMetadataEnrichStore(s => s.updateProgress);
 
   useEffect(() => {
     if (!IS_ELECTRON) return;
-    const cleanup = window.electronAPI.downloader.onDependencyInstallProgress((progress) => {
+    const cleanup = window.electronAPI.downloader.onDependencyInstallProgress(progress => {
       updateDependencyInstall(progress);
     });
     return cleanup;
@@ -109,7 +111,7 @@ function App() {
 
   useEffect(() => {
     if (!IS_ELECTRON) return;
-    const cleanup = window.electronAPI.metadata.onEnrichProgress((progress) => {
+    const cleanup = window.electronAPI.metadata.onEnrichProgress(progress => {
       updateEnrichProgress(progress);
     });
     return cleanup;
@@ -121,130 +123,141 @@ function App() {
 
       {splashDone && (
         <AmbientColorProvider>
-          <ErrorBoundary root viewName="Root">
-            <div
-              className={cn(
-                'h-screen w-screen bg-background text-foreground overflow-hidden relative',
-                !compactMode && 'flex',
-                IS_ELECTRON && 'rounded-t-[10px]'
-              )}
-            >
-              <AmbientBackground />
-              <CommandPalette />
-              <ErrorBoundary viewName="KeyboardShortcutsHelp">
-                <Suspense fallback={null}>
-                  <KeyboardShortcutsHelp />
-                </Suspense>
-              </ErrorBoundary>
-              <ErrorBoundary viewName="ShareDialogManager">
-                <Suspense fallback={null}>
-                  <ShareDialogManager />
-                </Suspense>
-              </ErrorBoundary>
+          <div
+            className={cn(
+              'h-screen w-screen bg-background text-foreground overflow-hidden relative',
+              !compactMode && 'flex',
+              IS_ELECTRON && 'rounded-t-[10px]'
+            )}
+          >
+            <AmbientBackground />
+            <CommandPalette />
+            <ErrorBoundary viewName="KeyboardShortcutsHelp">
+              <Suspense fallback={null}>
+                <KeyboardShortcutsHelp />
+              </Suspense>
+            </ErrorBoundary>
+            <ErrorBoundary viewName="ShareDialogManager">
+              <Suspense fallback={null}>
+                <ShareDialogManager />
+              </Suspense>
+            </ErrorBoundary>
 
-              {compactMode ? (
-                <CompactPlayer />
-              ) : (
-                <>
-                  {/* Skip to content link for keyboard users */}
-                  <a
-                    href="#main-content"
-                    className="sr-only focus:not-sr-only focus:absolute focus:z-[9999] focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:rounded-lg focus:bg-primary focus:text-primary-foreground focus:text-sm focus:font-medium"
-                  >
-                    Skip to main content
-                  </a>
+            {compactMode ? (
+              <CompactPlayer />
+            ) : (
+              <>
+                {/* Skip to content link for keyboard users */}
+                <a
+                  href="#main-content"
+                  className="sr-only focus:not-sr-only focus:absolute focus:z-[9999] focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:rounded-lg focus:bg-primary focus:text-primary-foreground focus:text-sm focus:font-medium"
+                >
+                  Skip to main content
+                </a>
 
-                  {/* Sidebar */}
-                  <Sidebar />
+                {/* Sidebar */}
+                <Sidebar />
 
-                  {/* Main content area */}
-                  <div className="flex-1 flex flex-col min-w-0 relative">
-                    <TopBar
-                      onAddFile={handleOpenFile}
-                      onAddFolder={handleOpenFolder}
-                      isScanning={isScanning}
-                    />
+                {/* Main content area */}
+                <div className="flex-1 flex flex-col min-w-0 relative">
+                  <TopBar
+                    onAddFile={handleOpenFile}
+                    onAddFolder={handleOpenFolder}
+                    isScanning={isScanning}
+                  />
 
-                    <main id="main-content" aria-label={activeView} className={cn(
+                  <main
+                    id="main-content"
+                    aria-label={activeView}
+                    className={cn(
                       'flex-1 flex overflow-hidden min-h-0',
                       activeView === 'now-playing'
                         ? ''
-                        : currentTrack && showVisualizer && !lowPerformanceMode ? 'pb-[136px]' : currentTrack ? 'pb-[88px]' : ''
-                    )}>
-                      {/* Center content */}
-                      <div className="flex-1 min-w-0 min-h-0 overflow-hidden flex flex-col">
-                        {activeView === 'library' && (
-                          <ErrorBoundary viewName="LibraryView">
-                            <LibraryView />
-                          </ErrorBoundary>
-                        )}
-                        {activeView === 'playlists' && (
-                          <ErrorBoundary viewName="PlaylistsView">
-                            {selectedPlaylistId ? (
-                              <Suspense fallback={null}>
-                                <PlaylistDetailView />
-                              </Suspense>
-                            ) : <PlaylistsView />}
-                          </ErrorBoundary>
-                        )}
-                        {activeView === 'favorites' && (
-                          <ErrorBoundary viewName="FavoritesView">
-                            <FavoritesView />
-                          </ErrorBoundary>
-                        )}
-                        {activeView === 'history' && (
-                          <ErrorBoundary viewName="HistoryView">
+                        : currentTrack && showVisualizer && !lowPerformanceMode
+                          ? 'pb-[136px]'
+                          : currentTrack
+                            ? 'pb-[88px]'
+                            : ''
+                    )}
+                  >
+                    {/* Center content */}
+                    <div className="flex-1 min-w-0 min-h-0 overflow-hidden flex flex-col">
+                      {activeView === 'library' && (
+                        <ErrorBoundary viewName="LibraryView">
+                          <LibraryView />
+                        </ErrorBoundary>
+                      )}
+                      {activeView === 'playlists' && (
+                        <ErrorBoundary viewName="PlaylistsView">
+                          {selectedPlaylistId ? (
                             <Suspense fallback={null}>
-                              <HistoryView />
+                              <PlaylistDetailView />
                             </Suspense>
-                          </ErrorBoundary>
-                        )}
-                        {activeView === 'mixes' && (
-                          <ErrorBoundary viewName="MixesView">
-                            <Suspense fallback={null}>
-                              <MixesView />
-                            </Suspense>
-                          </ErrorBoundary>
-                        )}
-                        {activeView === 'search' && (
-                          <ErrorBoundary viewName="SearchView">
-                            <Suspense fallback={null}>
-                              <SearchView />
-                            </Suspense>
-                          </ErrorBoundary>
-                        )}
-                        {activeView === 'import-playlist' && (
-                          <ErrorBoundary viewName="PlaylistImportView">
-                            <Suspense fallback={null}>
-                              <PlaylistImportView />
-                            </Suspense>
-                          </ErrorBoundary>
-                        )}
-                        {activeView === 'radio' && (
-                          <ErrorBoundary viewName="RadioView">
-                            <Suspense fallback={null}>
-                              <RadioView />
-                            </Suspense>
-                          </ErrorBoundary>
-                        )}
-                        {activeView === 'now-playing' && (
-                          <ErrorBoundary viewName="NowPlayingView">
-                            <Suspense fallback={null}>
-                              <NowPlayingView />
-                            </Suspense>
-                          </ErrorBoundary>
-                        )}
-                        {activeView === 'settings' && (
-                          <ErrorBoundary viewName="SettingsView">
-                            <Suspense fallback={null}>
-                              <SettingsView />
-                            </Suspense>
-                          </ErrorBoundary>
-                        )}
-                      </div>
+                          ) : (
+                            <PlaylistsView />
+                          )}
+                        </ErrorBoundary>
+                      )}
+                      {activeView === 'favorites' && (
+                        <ErrorBoundary viewName="FavoritesView">
+                          <FavoritesView />
+                        </ErrorBoundary>
+                      )}
+                      {activeView === 'history' && (
+                        <ErrorBoundary viewName="HistoryView">
+                          <Suspense fallback={null}>
+                            <HistoryView />
+                          </Suspense>
+                        </ErrorBoundary>
+                      )}
+                      {activeView === 'mixes' && (
+                        <ErrorBoundary viewName="MixesView">
+                          <Suspense fallback={null}>
+                            <MixesView />
+                          </Suspense>
+                        </ErrorBoundary>
+                      )}
+                      {activeView === 'search' && (
+                        <ErrorBoundary viewName="SearchView">
+                          <Suspense fallback={null}>
+                            <SearchView />
+                          </Suspense>
+                        </ErrorBoundary>
+                      )}
+                      {activeView === 'import-playlist' && (
+                        <ErrorBoundary viewName="PlaylistImportView">
+                          <Suspense fallback={null}>
+                            <PlaylistImportView />
+                          </Suspense>
+                        </ErrorBoundary>
+                      )}
+                      {activeView === 'radio' && (
+                        <ErrorBoundary viewName="RadioView">
+                          <Suspense fallback={null}>
+                            <RadioView />
+                          </Suspense>
+                        </ErrorBoundary>
+                      )}
+                      {activeView === 'now-playing' && (
+                        <ErrorBoundary viewName="NowPlayingView">
+                          <Suspense fallback={null}>
+                            <NowPlayingView />
+                          </Suspense>
+                        </ErrorBoundary>
+                      )}
+                      {activeView === 'settings' && (
+                        <ErrorBoundary viewName="SettingsView">
+                          <Suspense fallback={null}>
+                            <SettingsView />
+                          </Suspense>
+                        </ErrorBoundary>
+                      )}
+                    </div>
 
-                      {/* Right panel (hidden in now-playing view — lyrics are inline) */}
-                      {currentTrack && activeView !== 'now-playing' && (rightPanel === 'lyrics' || rightPanel === 'queue') && (
+                    {/* Right panel (hidden in now-playing view — lyrics are inline) */}
+                    {currentTrack &&
+                      activeView !== 'now-playing' &&
+                      (rightPanel === 'lyrics' || rightPanel === 'queue') && (
                         <div className="w-[320px] border-l border-border/30 shrink-0 flex flex-col overflow-hidden bg-surface/30">
                           <ErrorBoundary viewName="RightPanel">
                             <Suspense fallback={null}>
@@ -253,29 +266,36 @@ function App() {
                           </ErrorBoundary>
                         </div>
                       )}
-                    </main>
+                  </main>
 
-                    {/* Visualizer strip above player bar (hidden in now-playing view and in low performance mode) */}
-                    {currentTrack && showVisualizer && !lowPerformanceMode && activeView !== 'now-playing' && (
+                  {/* Visualizer strip above player bar (hidden in now-playing view and in low performance mode) */}
+                  {currentTrack &&
+                    showVisualizer &&
+                    !lowPerformanceMode &&
+                    activeView !== 'now-playing' && (
                       <div className="absolute bottom-[88px] left-0 right-0 z-40 h-[48px]">
                         <ErrorBoundary viewName="Visualizer">
                           <Suspense fallback={null}>
-                            {visualizerStyle === 'waveform' ? <WaveformVisualizer /> :
-                             visualizerStyle === 'circle' ? <CircleVisualizer /> :
-                             visualizerStyle === 'particles' ? <ParticleVisualizer /> :
-                             <AudioVisualizer />}
+                            {visualizerStyle === 'waveform' ? (
+                              <WaveformVisualizer />
+                            ) : visualizerStyle === 'circle' ? (
+                              <CircleVisualizer />
+                            ) : visualizerStyle === 'particles' ? (
+                              <ParticleVisualizer />
+                            ) : (
+                              <AudioVisualizer />
+                            )}
                           </Suspense>
                         </ErrorBoundary>
                       </div>
                     )}
 
-                    {/* Player bar (hidden in now-playing view — controls are inline) */}
-                    {activeView !== 'now-playing' && <PlayerBar />}
-                  </div>
-                </>
-              )}
-            </div>
-          </ErrorBoundary>
+                  {/* Player bar (hidden in now-playing view — controls are inline) */}
+                  {activeView !== 'now-playing' && <PlayerBar />}
+                </div>
+              </>
+            )}
+          </div>
         </AmbientColorProvider>
       )}
     </>

--- a/apps/web/src/components/shared/ErrorBoundary.test.tsx
+++ b/apps/web/src/components/shared/ErrorBoundary.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useState } from 'react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import ErrorBoundary from './ErrorBoundary';
+import { toast } from 'sonner';
+
+function Thrower({ shouldThrow, message = 'boom' }: { shouldThrow: boolean; message?: string }) {
+  if (shouldThrow) throw new Error(message);
+  return <div>child-content</div>;
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Silence expected React error-boundary logging from error throws during render
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('renders children when no error is thrown', () => {
+    render(
+      <ErrorBoundary viewName="Test">
+        <div>hello-child</div>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('hello-child')).toBeInTheDocument();
+  });
+
+  it('renders fallback with title and error message when child throws', () => {
+    render(
+      <ErrorBoundary viewName="Test">
+        <Thrower shouldThrow message="something exploded" />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('title')).toBeInTheDocument();
+    expect(screen.getByText('something exploded')).toBeInTheDocument();
+  });
+
+  it('reload view button resets and re-renders children after child stops throwing', async () => {
+    const user = userEvent.setup();
+
+    function TestTree() {
+      const [shouldThrow, setShouldThrow] = useState(true);
+      return (
+        <>
+          <button data-testid="stop" onClick={() => setShouldThrow(false)}>
+            stop
+          </button>
+          <ErrorBoundary viewName="Test">
+            <Thrower shouldThrow={shouldThrow} />
+          </ErrorBoundary>
+        </>
+      );
+    }
+
+    render(<TestTree />);
+
+    // Fallback is visible
+    expect(screen.getByText('title')).toBeInTheDocument();
+
+    // Flip parent state so children no longer throw
+    await user.click(screen.getByTestId('stop'));
+
+    // Click the reloadView button to reset the boundary
+    await user.click(screen.getByRole('button', { name: /reloadView/ }));
+
+    expect(screen.getByText('child-content')).toBeInTheDocument();
+    expect(screen.queryByText('title')).not.toBeInTheDocument();
+  });
+
+  it('report button copies error details and fires success toast', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(
+      <ErrorBoundary viewName="MyView">
+        <Thrower shouldThrow message="kaboom" />
+      </ErrorBoundary>
+    );
+
+    await user.click(screen.getByRole('button', { name: /report$/ }));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const payload = writeText.mock.calls[0][0] as string;
+    expect(payload).toContain('MyView');
+    expect(payload).toContain('kaboom');
+    expect(toast.success).toHaveBeenCalledWith('reportCopied');
+  });
+
+  it('renders rootTitle and rootMessage in root variant', () => {
+    render(
+      <ErrorBoundary root viewName="Root">
+        <Thrower shouldThrow message="fatal" />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('rootTitle')).toBeInTheDocument();
+    expect(screen.getByText('rootMessage')).toBeInTheDocument();
+    expect(screen.queryByText('title')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reloadApp/ })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/shared/ErrorBoundary.tsx
+++ b/apps/web/src/components/shared/ErrorBoundary.tsx
@@ -1,0 +1,137 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { AlertCircle, RefreshCw, ClipboardCopy } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { logger } from '@/lib/logger';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  viewName?: string;
+  root?: boolean;
+  onReset?: () => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+}
+
+interface ErrorBoundaryFallbackProps {
+  error: Error;
+  errorInfo: ErrorInfo | null;
+  viewName?: string;
+  root?: boolean;
+  onReset: () => void;
+}
+
+function ErrorBoundaryFallback({
+  error,
+  errorInfo,
+  viewName,
+  root,
+  onReset,
+}: ErrorBoundaryFallbackProps) {
+  const { t } = useTranslation('errorBoundary');
+
+  const handleReport = async () => {
+    const payload = [
+      `View: ${viewName ?? 'unknown'}`,
+      `Message: ${error.message}`,
+      `Stack: ${error.stack ?? '(no stack)'}`,
+      `Component stack: ${errorInfo?.componentStack ?? '(none)'}`,
+    ].join('\n');
+    try {
+      await navigator.clipboard.writeText(payload);
+      toast.success(t('reportCopied'));
+    } catch {
+      toast.error(t('reportFailed'));
+    }
+  };
+
+  const handlePrimary = () => {
+    if (root) {
+      window.location.reload();
+    } else {
+      onReset();
+    }
+  };
+
+  const title = root ? t('rootTitle') : t('title');
+  const message = root
+    ? t('rootMessage')
+    : error.message || t('messageFallback');
+  const primaryLabel = root ? t('reloadApp') : t('reloadView');
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-center p-8',
+        root ? 'min-h-screen w-screen bg-background' : 'flex-1 min-h-full'
+      )}
+    >
+      <div
+        className={cn(
+          'w-full rounded-2xl border border-destructive/20 bg-card p-6 flex flex-col gap-4',
+          root ? 'max-w-lg' : 'max-w-md'
+        )}
+      >
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-xl bg-destructive/10 flex items-center justify-center">
+            <AlertCircle className="w-5 h-5 text-destructive" />
+          </div>
+          <h2 className="font-display text-base font-semibold">{title}</h2>
+        </div>
+        <p className="text-sm text-muted-foreground">{message}</p>
+        <div className="flex gap-2">
+          <Button size="sm" onClick={handlePrimary}>
+            <RefreshCw /> {primaryLabel}
+          </Button>
+          <Button size="sm" variant="outline" onClick={handleReport}>
+            <ClipboardCopy /> {t('report')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null, errorInfo: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error, errorInfo: null };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    this.setState({ error, errorInfo });
+    logger.error(
+      '[ErrorBoundary:' + (this.props.viewName ?? 'unknown') + ']',
+      error,
+      errorInfo.componentStack
+    );
+  }
+
+  reset = (): void => {
+    this.setState({ error: null, errorInfo: null });
+    this.props.onReset?.();
+  };
+
+  render(): ReactNode {
+    const { error, errorInfo } = this.state;
+    if (!error) return this.props.children;
+    return (
+      <ErrorBoundaryFallback
+        error={error}
+        errorInfo={errorInfo}
+        viewName={this.props.viewName}
+        root={this.props.root}
+        onReset={this.reset}
+      />
+    );
+  }
+}

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -26,6 +26,7 @@ import importEn from '@/locales/en/import.json';
 import shareEn from '@/locales/en/share.json';
 import mixesEn from '@/locales/en/mixes.json';
 import nowPlayingEn from '@/locales/en/nowPlaying.json';
+import errorBoundaryEn from '@/locales/en/errorBoundary.json';
 
 import commonPl from '@/locales/pl/common.json';
 import sidebarPl from '@/locales/pl/sidebar.json';
@@ -51,6 +52,7 @@ import importPl from '@/locales/pl/import.json';
 import sharePl from '@/locales/pl/share.json';
 import mixesPl from '@/locales/pl/mixes.json';
 import nowPlayingPl from '@/locales/pl/nowPlaying.json';
+import errorBoundaryPl from '@/locales/pl/errorBoundary.json';
 
 export const SUPPORTED_LANGUAGES = [
   { code: 'en', label: 'English' },
@@ -82,6 +84,7 @@ const namespaces = [
   'playlists', 'search', 'radio', 'history', 'settings', 'queue',
   'lyrics', 'compact', 'commandPalette', 'shortcuts', 'sleepTimer',
   'contextMenu', 'toast', 'splash', 'import', 'share', 'mixes', 'nowPlaying',
+  'errorBoundary',
 ] as const;
 
 i18n.use(initReactI18next).init({
@@ -111,6 +114,7 @@ i18n.use(initReactI18next).init({
       share: shareEn,
       mixes: mixesEn,
       nowPlaying: nowPlayingEn,
+      errorBoundary: errorBoundaryEn,
     },
     pl: {
       common: commonPl,
@@ -137,6 +141,7 @@ i18n.use(initReactI18next).init({
       share: sharePl,
       mixes: mixesPl,
       nowPlaying: nowPlayingPl,
+      errorBoundary: errorBoundaryPl,
     },
   },
   lng: getInitialLanguage(),

--- a/apps/web/src/locales/en/errorBoundary.json
+++ b/apps/web/src/locales/en/errorBoundary.json
@@ -1,0 +1,11 @@
+{
+  "title": "Something went wrong",
+  "messageFallback": "This view hit an unexpected error.",
+  "reloadView": "Reload view",
+  "report": "Report",
+  "reportCopied": "Error details copied to clipboard",
+  "reportFailed": "Failed to copy error details",
+  "rootTitle": "Shiranami crashed",
+  "rootMessage": "The app hit an unrecoverable error. Try reloading the window.",
+  "reloadApp": "Reload app"
+}

--- a/apps/web/src/locales/pl/errorBoundary.json
+++ b/apps/web/src/locales/pl/errorBoundary.json
@@ -1,0 +1,11 @@
+{
+  "title": "Coś poszło nie tak",
+  "messageFallback": "Ten widok napotkał nieoczekiwany błąd.",
+  "reloadView": "Załaduj ponownie",
+  "report": "Zgłoś",
+  "reportCopied": "Szczegóły błędu skopiowane do schowka",
+  "reportFailed": "Nie udało się skopiować szczegółów błędu",
+  "rootTitle": "Shiranami uległ awarii",
+  "rootMessage": "Aplikacja napotkała krytyczny błąd. Spróbuj odświeżyć okno.",
+  "reloadApp": "Uruchom ponownie aplikację"
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
 import App from './App';
+import ErrorBoundary from '@/components/shared/ErrorBoundary';
 import { Toaster } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import './styles/globals.css';
@@ -18,7 +19,9 @@ createRoot(rootElement).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <TooltipProvider delayDuration={300}>
-        <App />
+        <ErrorBoundary root viewName="Root">
+          <App />
+        </ErrorBoundary>
         <Toaster />
       </TooltipProvider>
     </QueryClientProvider>


### PR DESCRIPTION
Closes #89.

## Summary
- New `ErrorBoundary` class component at `apps/web/src/components/shared/ErrorBoundary.tsx` with two layouts: a compact per-view card and a full-screen root variant.
- Wraps every lazy view, the eager views (`LibraryView`, `PlaylistsView`, `FavoritesView`), the right panel region, and the visualizer strip in `App.tsx` individually — a crash in one view can no longer take the whole app down.
- Root-level boundary inside `AmbientColorProvider` as a last-resort catch that offers a full window reload.
- New `errorBoundary` i18n namespace registered in `lib/i18n.ts` with parallel EN + PL strings.
- Fallback UI uses the existing `Button`, `sonner`, and `lucide-react` conventions; Report button copies `view + message + stack + component stack` to the clipboard.

## Why
`grep ErrorBoundary` returned zero hits in `apps/web`. A throw in any lazy view (e.g. failed IPC in a `useEffect`) previously bubbled all the way to a blank window. React error boundaries are the only idiomatic fix — they must be class components because `getDerivedStateFromError` / `componentDidCatch` have no hook equivalent.

## Notes on approach
- Wrapper order is **`<ErrorBoundary><Suspense>…</Suspense></ErrorBoundary>`** so the boundary also catches lazy-chunk load failures (e.g. after a deploy invalidates a chunk URL).
- `useLibraryActions` async error toast path is intentionally **not** wrapped — async/event errors aren't caught by React error boundaries, and that path already has its own `toast.error` handling.
- Did not wrap `Sidebar`, `TopBar`, `PlayerBar`, `CompactPlayer`, `SplashScreen`, `AmbientBackground`, or `CommandPalette` — root boundary covers them, and per-view isolation is only meaningful for the main content column.

## Test plan
- [x] `pnpm --filter @shiranami/web typecheck` — passes
- [x] `pnpm --filter @shiranami/web test` — 442/442 pass (5 new ErrorBoundary tests)
- [x] `pnpm -w lint` — clean
- [ ] Manual: force a throw inside one view and confirm the rest of the app stays interactive (reviewer verification)
- [ ] Manual: click Report, confirm clipboard contents include view name + stack