### PR TITLE
perf(desktop): rate-limit outbound HTTP with MinIntervalGate

### DIFF
--- a/apps/desktop/src/main/http.test.ts
+++ b/apps/desktop/src/main/http.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('./logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+/* ---------------------------------------------------------------- */
+/*  electron.net.request stub — modelled after ipc/share.test.ts.    */
+/*                                                                    */
+/*  Each call to `net.request(url)` pops the next `responseQueue`     */
+/*  entry for that URL's host (or uses a global default). The stub    */
+/*  fires `response` → `data` → `end` asynchronously via setImmediate */
+/*  so Electron's real async surface is preserved.                    */
+/* ---------------------------------------------------------------- */
+
+type FakeResponse = {
+  statusCode: number;
+  headers?: Record<string, string | string[]>;
+  body?: string;
+};
+
+type NetCall = { url: string; time: number };
+
+const netCalls: NetCall[] = [];
+const responsesByHost = new Map<string, FakeResponse[]>();
+let defaultResponse: FakeResponse = { statusCode: 200, body: 'ok' };
+
+function queueResponse(hostname: string, response: FakeResponse): void {
+  const list = responsesByHost.get(hostname) ?? [];
+  list.push(response);
+  responsesByHost.set(hostname, list);
+}
+
+function popResponse(hostname: string): FakeResponse {
+  const list = responsesByHost.get(hostname);
+  if (list && list.length > 0) {
+    return list.shift()!;
+  }
+  return defaultResponse;
+}
+
+vi.mock('electron', () => ({
+  net: {
+    request: vi.fn((url: string) => {
+      const handlers: Record<string, (...args: unknown[]) => void> = {};
+      const hostname = new URL(url).hostname;
+      netCalls.push({ url, time: Date.now() });
+      return {
+        setHeader: vi.fn(),
+        abort: vi.fn(),
+        on(event: string, cb: (...args: unknown[]) => void) {
+          handlers[event] = cb;
+        },
+        end() {
+          const response = popResponse(hostname);
+          // Simulate async response flow. We use setTimeout (not
+          // setImmediate) so that vi.advanceTimersByTimeAsync flushes
+          // the response callback — setImmediate is not a timer API
+          // and is not controlled by fake timers.
+          setTimeout(() => {
+            const responseHandlers: Record<string, (...args: unknown[]) => void> = {};
+            handlers['response']?.({
+              statusCode: response.statusCode,
+              headers: response.headers ?? {},
+              on(event: string, cb: (...args: unknown[]) => void) {
+                responseHandlers[event] = cb;
+              },
+            });
+            if (response.statusCode >= 200 && response.statusCode < 300) {
+              responseHandlers['data']?.(Buffer.from(response.body ?? ''));
+              responseHandlers['end']?.();
+            }
+          }, 0);
+        },
+      };
+    }),
+  },
+}));
+
+import {
+  parseRetryAfter,
+  HttpError,
+  requestText,
+  __resetGatesForTests,
+} from './http';
+
+/* ---------------------------------------------------------------- */
+/*  Helper: advance fake timers until `netCalls` reaches a target    */
+/*  length OR the current promise settles. Vitest's                  */
+/*  advanceTimersByTimeAsync also flushes microtasks, so setImmediate*/
+/*  callbacks fire in order.                                         */
+/* ---------------------------------------------------------------- */
+
+async function waitForNetCalls(target: number, timeoutMs = 120_000): Promise<void> {
+  let elapsed = 0;
+  while (netCalls.length < target && elapsed < timeoutMs) {
+    await vi.advanceTimersByTimeAsync(50);
+    elapsed += 50;
+  }
+  // Advance once more so any pending response setTimeout(..., 0) handlers
+  // (and their follow-up microtasks) run before we return.
+  await vi.advanceTimersByTimeAsync(50);
+}
+
+beforeEach(() => {
+  netCalls.length = 0;
+  responsesByHost.clear();
+  defaultResponse = { statusCode: 200, body: 'ok' };
+  __resetGatesForTests();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/* ---------------------------------------------------------------- */
+/*  parseRetryAfter                                                   */
+/* ---------------------------------------------------------------- */
+
+describe('parseRetryAfter', () => {
+  it('parses integer seconds', () => {
+    expect(parseRetryAfter({ 'retry-after': '30' })).toBe(30_000);
+    expect(parseRetryAfter({ 'Retry-After': '5' })).toBe(5_000);
+  });
+
+  it('parses HTTP-date', () => {
+    vi.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+    const tenSecondsLater = new Date('2025-01-01T00:00:10Z').toUTCString();
+    const result = parseRetryAfter({ 'retry-after': tenSecondsLater });
+    expect(result).toBeGreaterThanOrEqual(9_000);
+    expect(result).toBeLessThanOrEqual(11_000);
+  });
+
+  it('clamps values > 5 minutes to 300_000 ms', () => {
+    // 10 minutes in seconds.
+    expect(parseRetryAfter({ 'retry-after': '600' })).toBe(300_000);
+  });
+
+  it('returns null on garbage', () => {
+    expect(parseRetryAfter({ 'retry-after': 'not-a-date' })).toBeNull();
+    expect(parseRetryAfter({})).toBeNull();
+    expect(parseRetryAfter({ 'retry-after': '' })).toBeNull();
+  });
+
+  it('falls back to x-ratelimit-reset (epoch seconds)', () => {
+    vi.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+    const now = Math.floor(Date.now() / 1000);
+    const resetIn30s = now + 30;
+    const result = parseRetryAfter({ 'x-ratelimit-reset': String(resetIn30s) });
+    expect(result).toBeGreaterThanOrEqual(29_000);
+    expect(result).toBeLessThanOrEqual(31_000);
+  });
+
+  it('returns null for negative x-ratelimit-reset', () => {
+    vi.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+    const past = Math.floor(Date.now() / 1000) - 60;
+    expect(parseRetryAfter({ 'x-ratelimit-reset': String(past) })).toBeNull();
+  });
+});
+
+/* ---------------------------------------------------------------- */
+/*  HttpError                                                         */
+/* ---------------------------------------------------------------- */
+
+describe('HttpError', () => {
+  it('preserves status and retryAfterMs', () => {
+    const err = new HttpError(
+      'https://example.com',
+      429,
+      { 'retry-after': '3' },
+      3_000,
+    );
+    expect(err.name).toBe('HttpError');
+    expect(err.status).toBe(429);
+    expect(err.url).toBe('https://example.com');
+    expect(err.headers).toEqual({ 'retry-after': '3' });
+    expect(err.retryAfterMs).toBe(3_000);
+    expect(err.message).toContain('429');
+  });
+});
+
+/* ---------------------------------------------------------------- */
+/*  Gate integration                                                  */
+/* ---------------------------------------------------------------- */
+
+describe('requestText gate integration', () => {
+  it('gates known host (lrclib.net): three calls spaced >= 250 ms apart', async () => {
+    const p1 = requestText('https://lrclib.net/a');
+    const p2 = requestText('https://lrclib.net/b');
+    const p3 = requestText('https://lrclib.net/c');
+
+    await waitForNetCalls(3);
+    await Promise.all([p1, p2, p3]);
+
+    expect(netCalls).toHaveLength(3);
+    expect(netCalls[1].time - netCalls[0].time).toBeGreaterThanOrEqual(250);
+    expect(netCalls[2].time - netCalls[1].time).toBeGreaterThanOrEqual(250);
+  });
+
+  it('does not gate unknown host: three calls fire ~t=0', async () => {
+    const t0 = Date.now();
+    const p1 = requestText('https://api.shiranami.app/a');
+    const p2 = requestText('https://api.shiranami.app/b');
+    const p3 = requestText('https://api.shiranami.app/c');
+
+    await waitForNetCalls(3);
+    await Promise.all([p1, p2, p3]);
+
+    expect(netCalls).toHaveLength(3);
+    for (const call of netCalls) {
+      expect(call.time - t0).toBeLessThan(100);
+    }
+  });
+
+  it('on 429 with Retry-After: 3, next call waits 3000 ms', async () => {
+    queueResponse('lrclib.net', {
+      statusCode: 429,
+      headers: { 'retry-after': '3' },
+    });
+    queueResponse('lrclib.net', { statusCode: 200, body: 'ok' });
+
+    const p1 = requestText('https://lrclib.net/x');
+    const p2 = requestText('https://lrclib.net/y');
+
+    // Drive the first call to rejection.
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(p1).rejects.toBeInstanceOf(HttpError);
+    await expect(p1.catch((e) => e)).resolves.toMatchObject({ status: 429 });
+
+    // Second call should now be gated by ~3000 ms.
+    await waitForNetCalls(2);
+    await p2;
+
+    expect(netCalls).toHaveLength(2);
+    const delta = netCalls[1].time - netCalls[0].time;
+    expect(delta).toBeGreaterThanOrEqual(3_000);
+  });
+
+  it('429 without Retry-After uses 60_000 ms fallback', async () => {
+    queueResponse('lrclib.net', { statusCode: 429, headers: {} });
+    queueResponse('lrclib.net', { statusCode: 200, body: 'ok' });
+
+    const p1 = requestText('https://lrclib.net/x');
+    const p2 = requestText('https://lrclib.net/y');
+
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(p1).rejects.toBeInstanceOf(HttpError);
+
+    await waitForNetCalls(2, 120_000);
+    await p2;
+
+    const delta = netCalls[1].time - netCalls[0].time;
+    expect(delta).toBeGreaterThanOrEqual(60_000);
+  });
+
+  it('non-429 error (500) does not bump gate — next call waits only minIntervalMs', async () => {
+    queueResponse('lrclib.net', { statusCode: 500 });
+    queueResponse('lrclib.net', { statusCode: 200, body: 'ok' });
+
+    const p1 = requestText('https://lrclib.net/x');
+    const p2 = requestText('https://lrclib.net/y');
+
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(p1).rejects.toBeInstanceOf(HttpError);
+
+    await waitForNetCalls(2);
+    await p2;
+
+    const delta = netCalls[1].time - netCalls[0].time;
+    // Only the baseline 250 ms spacing — definitely well under the 60 s fallback.
+    expect(delta).toBeGreaterThanOrEqual(250);
+    expect(delta).toBeLessThan(5_000);
+  });
+
+  it('per-host isolation: lrclib.net and i.ytimg.com do not block each other', async () => {
+    const t0 = Date.now();
+    const pL = requestText('https://lrclib.net/x');
+    const pY = requestText('https://i.ytimg.com/y');
+
+    await waitForNetCalls(2);
+    await Promise.all([pL, pY]);
+
+    expect(netCalls).toHaveLength(2);
+    // Both first-in-gate calls fire immediately.
+    for (const call of netCalls) {
+      expect(call.time - t0).toBeLessThan(100);
+    }
+  });
+});

--- a/apps/desktop/src/main/http.ts
+++ b/apps/desktop/src/main/http.ts
@@ -1,5 +1,6 @@
 import { net } from 'electron';
 import { logger } from './logger';
+import { MinIntervalGate } from './utils/min-interval-gate';
 
 type RequestOptions = {
   headers?: Record<string, string>;
@@ -8,7 +9,118 @@ type RequestOptions = {
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
-export function requestText(url: string, options: RequestOptions = {}): Promise<string> {
+const RETRY_AFTER_MAX_MS = 300_000; // 5 minutes
+const DEFAULT_429_BACKOFF_MS = 60_000; // 1 minute fallback when no Retry-After
+
+/**
+ * Raised when a request completes with a non-2xx status.
+ * `retryAfterMs` is populated from `Retry-After` / `x-ratelimit-reset` if
+ * present (clamped to 5 minutes).
+ */
+export class HttpError extends Error {
+  constructor(
+    public readonly url: string,
+    public readonly status: number,
+    public readonly headers: Record<string, string | string[]>,
+    public readonly retryAfterMs: number | null,
+  ) {
+    super(`Request failed with status ${status}: ${url}`);
+    this.name = 'HttpError';
+  }
+}
+
+/**
+ * Parse a `Retry-After` header value (integer seconds or HTTP-date), falling
+ * back to `x-ratelimit-reset` (epoch seconds). Returns the wait in
+ * milliseconds, clamped to [0, 300_000]. Returns null when unparseable.
+ */
+export function parseRetryAfter(
+  headers: Record<string, string | string[] | undefined>,
+): number | null {
+  const lower: Record<string, string | string[] | undefined> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    lower[key.toLowerCase()] = value;
+  }
+
+  const retryAfterRaw = lower['retry-after'];
+  const retryAfter = Array.isArray(retryAfterRaw) ? retryAfterRaw[0] : retryAfterRaw;
+  if (typeof retryAfter === 'string' && retryAfter.trim().length > 0) {
+    const trimmed = retryAfter.trim();
+    // Integer seconds form.
+    if (/^\d+$/.test(trimmed)) {
+      const seconds = parseInt(trimmed, 10);
+      if (Number.isFinite(seconds)) {
+        return clampRetryAfter(seconds * 1000);
+      }
+    }
+    // HTTP-date form.
+    const asDate = Date.parse(trimmed);
+    if (!Number.isNaN(asDate)) {
+      return clampRetryAfter(asDate - Date.now());
+    }
+    // Unparseable retry-after string — fall through to x-ratelimit-reset.
+  }
+
+  const resetRaw = lower['x-ratelimit-reset'];
+  const reset = Array.isArray(resetRaw) ? resetRaw[0] : resetRaw;
+  if (typeof reset === 'string' && /^\d+$/.test(reset.trim())) {
+    const epochSeconds = parseInt(reset.trim(), 10);
+    if (Number.isFinite(epochSeconds)) {
+      return clampRetryAfter(epochSeconds * 1000 - Date.now());
+    }
+  }
+
+  return null;
+}
+
+function clampRetryAfter(ms: number): number | null {
+  if (!Number.isFinite(ms) || ms < 0) return null;
+  return Math.min(ms, RETRY_AFTER_MAX_MS);
+}
+
+/**
+ * Minimum spacing (ms) between requests per hostname. Hosts not listed here
+ * are ungated — this is intentional for our own backend and internal flows.
+ */
+const HTTP_HOST_GATES: Record<string, number> = {
+  'lrclib.net': 250,
+  'i.ytimg.com': 100,
+  'api.github.com': 1000,
+  'itunes.apple.com': 500,
+  'clients1.google.com': 250,
+};
+
+const gates = new Map<string, MinIntervalGate>();
+
+function gateFor(hostname: string): MinIntervalGate | null {
+  const interval = HTTP_HOST_GATES[hostname];
+  if (interval === undefined) return null;
+  let gate = gates.get(hostname);
+  if (!gate) {
+    gate = new MinIntervalGate({ minIntervalMs: interval });
+    gates.set(hostname, gate);
+  }
+  return gate;
+}
+
+/**
+ * Return (lazily create) the gate for `lrclib.net` so the lyrics service can
+ * serialize its lrclib-api library calls through the same spacing rules.
+ */
+export function getLrclibGate(): MinIntervalGate {
+  // lrclib.net is always in HTTP_HOST_GATES; the cast is safe.
+  return gateFor('lrclib.net') as MinIntervalGate;
+}
+
+/**
+ * Test-only: clear all gate state so each test starts from a fresh clock.
+ * Exported unconditionally — callers outside tests have no reason to touch it.
+ */
+export function __resetGatesForTests(): void {
+  gates.clear();
+}
+
+function requestTextRaw(url: string, options: RequestOptions = {}): Promise<string> {
   const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const startTime = Date.now();
 
@@ -31,12 +143,15 @@ export function requestText(url: string, options: RequestOptions = {}): Promise<
 
     request.on('response', (response) => {
       const statusCode = response.statusCode;
+      const responseHeaders = response.headers as Record<string, string | string[]>;
 
       if (statusCode < 200 || statusCode >= 300) {
         clearTimeout(timer);
         settled = true;
         logger.warn(`[http] Request failed: ${url} - status ${statusCode}`);
-        reject(new Error(`Request failed with status ${statusCode}: ${url}`));
+        reject(
+          new HttpError(url, statusCode, responseHeaders, parseRetryAfter(responseHeaders)),
+        );
         return;
       }
 
@@ -76,6 +191,137 @@ export function requestText(url: string, options: RequestOptions = {}): Promise<
 
     request.end();
   });
+}
+
+function requestBufferRaw(
+  url: string,
+  options: RequestOptions & { maxBytes?: number } = {},
+): Promise<Buffer> {
+  const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBytes = options.maxBytes;
+  const startTime = Date.now();
+
+  return new Promise<Buffer>((resolve, reject) => {
+    let settled = false;
+    const request = net.request(url);
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        request.abort();
+        logger.warn(`[http] Request timed out after ${timeout}ms: ${url}`);
+        reject(new Error(`Request timed out after ${timeout}ms: ${url}`));
+      }
+    }, timeout);
+
+    for (const [key, value] of Object.entries(options.headers ?? {})) {
+      request.setHeader(key, value);
+    }
+
+    request.on('response', (response) => {
+      const statusCode = response.statusCode;
+      const responseHeaders = response.headers as Record<string, string | string[]>;
+
+      if (statusCode < 200 || statusCode >= 300) {
+        clearTimeout(timer);
+        settled = true;
+        logger.warn(`[http] Request failed: ${url} - status ${statusCode}`);
+        reject(
+          new HttpError(url, statusCode, responseHeaders, parseRetryAfter(responseHeaders)),
+        );
+        return;
+      }
+
+      const chunks: Buffer[] = [];
+      let totalSize = 0;
+
+      response.on('data', (chunk: Buffer) => {
+        if (settled) return;
+        totalSize += chunk.length;
+        if (maxBytes !== undefined && totalSize > maxBytes) {
+          clearTimeout(timer);
+          settled = true;
+          request.abort();
+          reject(new Error(`Response exceeded maxBytes (${maxBytes}): ${url}`));
+          return;
+        }
+        chunks.push(chunk);
+      });
+
+      response.on('end', () => {
+        if (!settled) {
+          clearTimeout(timer);
+          settled = true;
+          logger.debug(`[http] ${statusCode} ${url} (${Date.now() - startTime}ms)`);
+          resolve(Buffer.concat(chunks));
+        }
+      });
+
+      response.on('error', (err: Error) => {
+        if (!settled) {
+          clearTimeout(timer);
+          settled = true;
+          logger.warn(`[http] Response error: ${url}`, err.message);
+          reject(err);
+        }
+      });
+    });
+
+    request.on('error', (err: Error) => {
+      if (!settled) {
+        clearTimeout(timer);
+        settled = true;
+        logger.warn(`[http] Request error: ${url}`, err.message);
+        reject(err);
+      }
+    });
+
+    request.end();
+  });
+}
+
+/**
+ * Apply the per-host gate to `op`. On a 429 from that host, extend the gate
+ * by the server's Retry-After (or a 60s fallback) before rethrowing — the
+ * caller still gets the rejection, we just don't hammer the host further.
+ */
+function runGated<T>(
+  url: string,
+  op: () => Promise<T>,
+): Promise<T> {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    // Malformed URL — let the raw call fail naturally with a clearer message.
+    return op();
+  }
+  const gate = gateFor(hostname);
+  if (!gate) return op();
+
+  return gate.run(async () => {
+    try {
+      return await op();
+    } catch (err) {
+      if (err instanceof HttpError && err.status === 429) {
+        const retry = err.retryAfterMs ?? DEFAULT_429_BACKOFF_MS;
+        logger.warn(`[http] 429 from ${hostname}, backing off ${retry}ms`);
+        gate.bumpBy(retry);
+      }
+      throw err;
+    }
+  });
+}
+
+export function requestText(url: string, options: RequestOptions = {}): Promise<string> {
+  return runGated(url, () => requestTextRaw(url, options));
+}
+
+export function requestBuffer(
+  url: string,
+  options: RequestOptions & { maxBytes?: number } = {},
+): Promise<Buffer> {
+  return runGated(url, () => requestBufferRaw(url, options));
 }
 
 export async function requestJson<T>(url: string, options: RequestOptions = {}): Promise<T> {

--- a/apps/desktop/src/main/lyrics-service.ts
+++ b/apps/desktop/src/main/lyrics-service.ts
@@ -1,3 +1,4 @@
+import { getLrclibGate } from './http';
 import { logger } from './logger';
 
 export interface LyricLine {
@@ -143,9 +144,12 @@ export async function fetchLyrics(
 
     logger.debug(`[lyrics] Fetching lyrics for: ${title} - ${artist}`);
 
-    let result: { syncedLyrics?: string | null; plainLyrics?: string | null } | null = null;
+    type FindResult = { syncedLyrics?: string | null; plainLyrics?: string | null } | null;
+    let result: FindResult = null;
     try {
-      result = await client.findLyrics(query);
+      // lrclib-api uses global fetch; we can only enforce spacing here, not
+      // honor Retry-After the way the electron-net path does.
+      result = await getLrclibGate().run<FindResult>(() => client.findLyrics(query));
     } catch (err) {
       // Any error (NotFound, NoResult, RequestError) — fall through to search
       logger.debug('[lyrics] findLyrics failed, falling through to search', err);
@@ -156,7 +160,10 @@ export async function fetchLyrics(
       const searchQueries = buildSearchQueries(title, artist);
       for (const sq of searchQueries) {
         try {
-          const searchResults = await client.searchLyrics({ query: sq });
+          type SearchResult = Array<{ syncedLyrics?: string | null; plainLyrics?: string | null }>;
+          const searchResults = await getLrclibGate().run<SearchResult>(() =>
+            client.searchLyrics({ query: sq }),
+          );
           if (searchResults && searchResults.length > 0) {
             const best = searchResults[0];
             const lyricsResult: LyricsResult = {

--- a/apps/desktop/src/main/metadata-lookup.ts
+++ b/apps/desktop/src/main/metadata-lookup.ts
@@ -1,6 +1,5 @@
 import { spawn } from 'child_process';
-import { net } from 'electron';
-import { requestJson } from './http';
+import { requestBuffer, requestJson } from './http';
 import { getYtDlpPath, isYtDlpInstalled } from './ytdlp-manager';
 import { logger } from './logger';
 
@@ -232,69 +231,13 @@ const IMAGE_MAX_SIZE = 10 * 1024 * 1024; // 10 MB
 
 /**
  * Download an image from a URL and return it as a Buffer.
+ * Routed through `requestBuffer` so cover-art hosts (e.g. i.ytimg.com,
+ * iTunes thumbnails) share the per-host spacing + 429 handling.
  */
 export function downloadImage(url: string): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    const request = net.request(url);
-
-    const timer = setTimeout(() => {
-      if (!settled) {
-        settled = true;
-        request.abort();
-        reject(new Error(`Image download timed out after ${IMAGE_TIMEOUT_MS}ms`));
-      }
-    }, IMAGE_TIMEOUT_MS);
-
-    request.on('response', (response) => {
-      if (response.statusCode < 200 || response.statusCode >= 300) {
-        clearTimeout(timer);
-        settled = true;
-        reject(new Error(`Image download failed with status ${response.statusCode}`));
-        return;
-      }
-
-      const chunks: Buffer[] = [];
-      let totalSize = 0;
-
-      response.on('data', (chunk: Buffer) => {
-        totalSize += chunk.length;
-        if (totalSize > IMAGE_MAX_SIZE) {
-          clearTimeout(timer);
-          settled = true;
-          request.abort();
-          reject(new Error(`Image exceeds maximum size of ${IMAGE_MAX_SIZE} bytes`));
-          return;
-        }
-        chunks.push(chunk);
-      });
-
-      response.on('end', () => {
-        if (!settled) {
-          clearTimeout(timer);
-          settled = true;
-          resolve(Buffer.concat(chunks));
-        }
-      });
-
-      response.on('error', (err) => {
-        if (!settled) {
-          clearTimeout(timer);
-          settled = true;
-          reject(err);
-        }
-      });
-    });
-
-    request.on('error', (err) => {
-      if (!settled) {
-        clearTimeout(timer);
-        settled = true;
-        reject(err);
-      }
-    });
-
-    request.end();
+  return requestBuffer(url, {
+    timeoutMs: IMAGE_TIMEOUT_MS,
+    maxBytes: IMAGE_MAX_SIZE,
   });
 }
 

--- a/apps/desktop/src/main/utils/min-interval-gate.test.ts
+++ b/apps/desktop/src/main/utils/min-interval-gate.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MinIntervalGate } from './min-interval-gate';
+
+/* ---------------------------------------------------------------- */
+/*  Injected clock + sleep helpers.                                  */
+/*                                                                    */
+/*  The gate accepts `now` and `sleep` overrides, which we use        */
+/*  instead of fake timers. A pending sleep is recorded and only      */
+/*  resolves when the test manually advances the clock and calls      */
+/*  `tick()`, which flushes microtasks so the gate can progress.      */
+/* ---------------------------------------------------------------- */
+
+let currentTime = 0;
+let pendingSleeps: Array<{ dueAt: number; resolve: () => void }> = [];
+
+const now = () => currentTime;
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    pendingSleeps.push({ dueAt: currentTime + ms, resolve });
+  });
+
+/** Flush queued microtasks so awaited promises settle. */
+async function flush(): Promise<void> {
+  // Multiple cycles let chained .then() callbacks resolve.
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
+/** Advance clock and resolve any sleeps whose due time has passed. */
+async function advance(ms: number): Promise<void> {
+  currentTime += ms;
+  await flush();
+  // Resolve any due sleeps, then flush again.
+  while (true) {
+    const ready = pendingSleeps.filter((s) => s.dueAt <= currentTime);
+    if (ready.length === 0) break;
+    pendingSleeps = pendingSleeps.filter((s) => s.dueAt > currentTime);
+    for (const s of ready) s.resolve();
+    await flush();
+  }
+}
+
+beforeEach(() => {
+  currentTime = 0;
+  pendingSleeps = [];
+});
+
+describe('MinIntervalGate', () => {
+  it('run() resolves with fn return value', async () => {
+    const gate = new MinIntervalGate({ minIntervalMs: 1000, now, sleep });
+    const result = await gate.run(async () => 'hello');
+    expect(result).toBe('hello');
+  });
+
+  it('first call fires immediately (no waiting)', async () => {
+    const gate = new MinIntervalGate({ minIntervalMs: 1000, now, sleep });
+    let ran = false;
+    const p = gate.run(async () => {
+      ran = true;
+      return 1;
+    });
+    // No clock advance — microtask flush alone should execute the fn.
+    await flush();
+    expect(ran).toBe(true);
+    expect(pendingSleeps).toHaveLength(0);
+    await p;
+  });
+
+  it('second call waits minIntervalMs after first resolves', async () => {
+    const gate = new MinIntervalGate({ minIntervalMs: 1000, now, sleep });
+    const starts: number[] = [];
+
+    const p1 = gate.run(async () => {
+      starts.push(currentTime);
+    });
+    const p2 = gate.run(async () => {
+      starts.push(currentTime);
+    });
+
+    await flush();
+    // First runs at t=0.
+    expect(starts).toEqual([0]);
+    // Second is now sleeping, waiting for the interval.
+    expect(pendingSleeps).toHaveLength(1);
+    expect(pendingSleeps[0].dueAt).toBe(1000);
+
+    await advance(1000);
+    expect(starts).toEqual([0, 1000]);
+
+    await p1;
+    await p2;
+  });
+
+  it('rejected fn does not stall the queue', async () => {
+    const gate = new MinIntervalGate({ minIntervalMs: 1000, now, sleep });
+    const starts: number[] = [];
+
+    const p1 = gate.run(async () => {
+      starts.push(currentTime);
+      throw new Error('boom');
+    });
+    const p2 = gate.run(async () => {
+      starts.push(currentTime);
+      return 'ok';
+    });
+
+    // Swallow the expected rejection.
+    await expect(p1).rejects.toThrow('boom');
+
+    // Second call should still be scheduled.
+    await flush();
+    expect(pendingSleeps).toHaveLength(1);
+
+    await advance(1000);
+    expect(starts).toEqual([0, 1000]);
+    await expect(p2).resolves.toBe('ok');
+  });
+
+  it('preserves order across five sequential run() calls', async () => {
+    const gate = new MinIntervalGate({ minIntervalMs: 500, now, sleep });
+    const seen: number[] = [];
+
+    const promises = [1, 2, 3, 4, 5].map((n) =>
+      gate.run(async () => {
+        seen.push(n);
+      }),
+    );
+
+    // First runs immediately at t=0.
+    await flush();
+    expect(seen).toEqual([1]);
+
+    for (let i = 2; i <= 5; i++) {
+      await advance(500);
+      expect(seen).toEqual([1, 2, 3, 4, 5].slice(0, i));
+    }
+
+    await Promise.all(promises);
+  });
+
+  it('bumpBy(5000) delays the next call by ~5 s', async () => {
+    const gate = new MinIntervalGate({ minIntervalMs: 1000, now, sleep });
+    const starts: number[] = [];
+
+    const p1 = gate.run(async () => {
+      starts.push(currentTime);
+    });
+    await flush();
+    expect(starts).toEqual([0]);
+    await p1;
+
+    // After first call, nextAllowedAt = 1000. bumpBy should push it to 5000.
+    gate.bumpBy(5000);
+
+    const p2 = gate.run(async () => {
+      starts.push(currentTime);
+    });
+    await flush();
+    // p2 should be sleeping until t=5000.
+    expect(pendingSleeps).toHaveLength(1);
+    expect(pendingSleeps[0].dueAt).toBe(5000);
+
+    await advance(5000);
+    expect(starts).toEqual([0, 5000]);
+    await p2;
+  });
+
+  it('bumpBy(10_000) followed by bumpBy(1_000) still waits ~10 s', async () => {
+    const gate = new MinIntervalGate({ minIntervalMs: 1000, now, sleep });
+
+    const p1 = gate.run(async () => {});
+    await flush();
+    await p1;
+
+    gate.bumpBy(10_000);
+    // Second bump is smaller — must not shorten the delay.
+    gate.bumpBy(1_000);
+
+    const starts: number[] = [];
+    const p2 = gate.run(async () => {
+      starts.push(currentTime);
+    });
+    await flush();
+    expect(pendingSleeps[0].dueAt).toBe(10_000);
+
+    await advance(10_000);
+    expect(starts).toEqual([10_000]);
+    await p2;
+  });
+
+  it('two separate gate instances do not block each other', async () => {
+    const gateA = new MinIntervalGate({ minIntervalMs: 1000, now, sleep });
+    const gateB = new MinIntervalGate({ minIntervalMs: 1000, now, sleep });
+    const starts: string[] = [];
+
+    const pA = gateA.run(async () => {
+      starts.push(`A@${currentTime}`);
+    });
+    const pB = gateB.run(async () => {
+      starts.push(`B@${currentTime}`);
+    });
+
+    await flush();
+    // Both should fire immediately — no pending sleeps.
+    expect(pendingSleeps).toHaveLength(0);
+    expect(starts.sort()).toEqual(['A@0', 'B@0']);
+
+    await pA;
+    await pB;
+  });
+});

--- a/apps/desktop/src/main/utils/min-interval-gate.ts
+++ b/apps/desktop/src/main/utils/min-interval-gate.ts
@@ -25,7 +25,12 @@ export class MinIntervalGate {
 
   constructor(options: MinIntervalGateOptions) {
     this.minIntervalMs = options.minIntervalMs;
-    this.now = options.now ?? (() => Date.now());
+    // Monotonic clock so gate spacing is immune to wall-clock jumps (NTP,
+    // manual changes). Retry-After / X-RateLimit-Reset values are parsed as
+    // durations against wall clock, then fed to `bumpBy`, which adds the
+    // duration to the monotonic clock — durations are clock-agnostic, so
+    // correctness holds either way.
+    this.now = options.now ?? (() => performance.now());
     this.sleep = options.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
   }
 

--- a/apps/desktop/src/main/utils/min-interval-gate.ts
+++ b/apps/desktop/src/main/utils/min-interval-gate.ts
@@ -1,0 +1,63 @@
+/**
+ * Serializes async operations with a minimum spacing between them.
+ *
+ * Guarantees:
+ * - Only one `fn` runs at a time (FIFO order preserved).
+ * - At least `minIntervalMs` elapses between the completion of one `fn` and
+ *   the start of the next.
+ * - A rejecting `fn` does NOT stall the queue — the tail chain always
+ *   continues, and `nextAllowedAt` is still advanced in `finally`.
+ * - `bumpBy(ms)` lets callers extend the next allowed start time to honor
+ *   server-dictated backoffs (e.g. `Retry-After`).
+ */
+export interface MinIntervalGateOptions {
+  minIntervalMs: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export class MinIntervalGate {
+  private readonly minIntervalMs: number;
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private tail: Promise<void> = Promise.resolve();
+  private nextAllowedAt = 0;
+
+  constructor(options: MinIntervalGateOptions) {
+    this.minIntervalMs = options.minIntervalMs;
+    this.now = options.now ?? (() => Date.now());
+    this.sleep = options.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  }
+
+  run<T>(fn: () => Promise<T>): Promise<T> {
+    const runSlot = this.tail.then(async () => {
+      const wait = Math.max(0, this.nextAllowedAt - this.now());
+      if (wait > 0) await this.sleep(wait);
+      try {
+        return await fn();
+      } finally {
+        // Use max() so a bumpBy() called during `fn` (e.g. from a 429
+        // handler inside the wrapped op) isn't clobbered by the baseline
+        // interval.
+        this.nextAllowedAt = Math.max(
+          this.nextAllowedAt,
+          this.now() + this.minIntervalMs,
+        );
+      }
+    });
+    // Keep the tail chain alive even if the slot rejects.
+    this.tail = runSlot.then(
+      () => undefined,
+      () => undefined,
+    );
+    return runSlot;
+  }
+
+  /**
+   * Extend the next allowed start time by at least `ms` from now.
+   * Never shortens an already-scheduled delay.
+   */
+  bumpBy(ms: number): void {
+    this.nextAllowedAt = Math.max(this.nextAllowedAt, this.now() + ms);
+  }
+}


### PR DESCRIPTION
Closes #91.

## Summary
- New `MinIntervalGate` helper at `apps/desktop/src/main/utils/min-interval-gate.ts` — rejection-resilient promise-chain serializer with `run<T>()` and `bumpBy(ms)`.
- Per-host registry in `http.ts` with sensible defaults: lrclib.net (250 ms), i.ytimg.com (100 ms), api.github.com (1 s), itunes.apple.com (500 ms), clients1.google.com (250 ms). Unknown hosts (e.g. our own `api.shiranami.app`) stay un-gated.
- Typed `HttpError` carries `status`, `headers`, and a pre-parsed `retryAfterMs` so callers can handle 429s without re-parsing.
- `parseRetryAfter` honors `Retry-After` (integer seconds or HTTP-date) and falls back to `X-RateLimit-Reset` (epoch seconds). Result clamped to `[0, 300_000]` so a misconfigured server can't lock the app out for hours.
- On 429, the gate is bumped by the parsed delay so all queued callers wait the server-dictated cooldown. **No auto-retry** — callers decide.
- New `requestBuffer()` export replaces the hand-rolled `net.request` loop in `metadata-lookup.downloadImage`, routing ytimg traffic through the gate for free.
- `lrclib-api` uses global `fetch` internally, so it can't be gated at the `http.ts` layer. Call sites in `lyrics-service.ts` use `getLrclibGate().run(...)` for spacing (no 429 awareness — the library doesn't expose response headers).

## Why
Every outbound request to lyrics / artwork / radio metadata hosts previously fired with zero spacing. Bulk metadata enrichment (100+ tracks) or rapid search keystrokes could trip server-side throttles. This gives each host a principled spacing budget and a real back-off path on 429.

## Notes on approach
- **Rejection resilience**: `run()` returns `runSlot` (which rejects with the underlying error) but `this.tail` gets `runSlot.then(() => undefined, () => undefined)`. One failed call never stalls the queue.
- **`Math.max` in `finally`**: deviation from the strictest reading of the plan, load-bearing for 429 handling. If a `bumpBy()` is called while `fn()` is still executing (from the 429 catch block), a plain `nextAllowedAt = now + interval` in `finally` would clobber it. `Math.max` preserves the longer delay.
- **Not gated on purpose**: radio stream URLs (streaming, long-lived), our own backend, yt-dlp/ffmpeg release downloads (one-shot, non-hot).

## Test plan
- [x] 8 new `MinIntervalGate` unit tests (injected clock + sleep, no fake timers)
- [x] 13 new `http.test.ts` tests covering `parseRetryAfter`, `HttpError`, gate sequencing, 429 bump, per-host isolation
- [x] `pnpm --filter @shiranami/desktop typecheck` — pass
- [x] `pnpm --filter @shiranami/desktop test` — 545/545 pass (47 files)
- [x] `pnpm -w lint` — clean
- [ ] Manual: bulk-enrich a large library, confirm ytimg requests are paced ≥ 100 ms apart (reviewer verification)
- [ ] Manual: force a 429 from lrclib (e.g. by spamming), confirm the app backs off without retry loop

## Follow-ups
- Renderer-side `radio-browser-api` calls (in `useRadioStore`) are not gated here — separate issue worth filing; gate is in main only.