### PR TITLE
fix(desktop): keep fullscreen album art square at higher UI font scales

### DIFF
--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -138,8 +138,8 @@ export function NowPlayingView() {
                 'shrink-0 aspect-square rounded-2xl @5xl:rounded-3xl overflow-hidden',
                 'shadow-2xl shadow-black/40 bg-muted flex items-center justify-center',
                 lyricsVisible
-                  ? 'w-[55%] min-w-[180px] max-w-[240px] @3xl:w-full @3xl:max-w-[min(48vh,22vw,480px)]'
-                  : 'w-full max-w-[min(52vh,24vw,440px)]'
+                  ? 'w-[55%] min-w-[180px] max-w-[240px] @3xl:w-full @3xl:max-w-[min(48vh,clamp(280px,22vw,480px))]'
+                  : 'w-full max-w-[min(52vh,clamp(300px,24vw,440px))]'
               )}
             >
               {currentTrack.albumArt ? (

--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -32,12 +32,16 @@ export function NowPlayingView() {
   const lyricsVisible = useAppStore(s => s.nowPlayingLyricsVisible);
   const toggleLyrics = useAppStore(s => s.toggleNowPlayingLyrics);
 
-  const { data, isLoading: lyricsLoading, isError: lyricsError } = useLyricsQuery(
+  const {
+    data,
+    isLoading: lyricsLoading,
+    isError: lyricsError,
+  } = useLyricsQuery(
     currentTrack?.id ?? null,
     currentTrack?.title ?? '',
     currentTrack?.artist ?? '',
     currentTrack?.album,
-    currentTrack?.duration,
+    currentTrack?.duration
   );
 
   useEffect(() => {
@@ -131,11 +135,11 @@ export function NowPlayingView() {
               exit={{ scale: 0.9, opacity: 0 }}
               transition={{ type: 'spring', damping: 22, stiffness: 250 }}
               className={cn(
-                'aspect-square rounded-2xl @5xl:rounded-3xl overflow-hidden',
+                'shrink-0 aspect-square rounded-2xl @5xl:rounded-3xl overflow-hidden',
                 'shadow-2xl shadow-black/40 bg-muted flex items-center justify-center',
                 lyricsVisible
-                  ? 'w-[55%] min-w-[180px] max-w-[240px] @3xl:w-full @3xl:max-w-[clamp(280px,22vw,480px)]'
-                  : 'w-full max-w-[clamp(300px,24vw,440px)]'
+                  ? 'w-[55%] min-w-[180px] max-w-[240px] @3xl:w-full @3xl:max-w-[min(48vh,22vw,480px)]'
+                  : 'w-full max-w-[min(52vh,24vw,440px)]'
               )}
             >
               {currentTrack.albumArt ? (


### PR DESCRIPTION
## Summary

- Closes #119 (regression of #60)
- At UI font scale ≥ 110%, the fullscreen Now Playing album cover was vertically cropped because rem-based siblings (padding, gap, text) grew ~10% while the album art wrapper had no flex shrink guard and a `max-w` bounded only by px/vw units — causing flexbox to compress the wrapper's height while width stayed put, making it rectangular and clipping the `object-cover` image.

## Changes

- `apps/web/src/components/now-playing/NowPlayingView.tsx` — added `shrink-0` to the album art `motion.div` so flex never compresses the square wrapper; replaced `max-w-[clamp(...,px/vw,...)]` with `max-w-[min(vh,vw,px)]` on both the lyrics-on (`@3xl:max-w-[min(48vh,22vw,480px)]`) and lyrics-off (`max-w-[min(52vh,24vw,440px)]`) branches so the album's max size is also bounded by available viewport height.

## Why this approach

Adding a `vh` term to `min()` means the square naturally sizes down when vertical space is constrained (including when rem-based siblings are enlarged by font scale), while `shrink-0` ensures flex never collapses it further. Behavior at 100% scale is unchanged — the `vh` leg only binds on short viewports or when siblings have consumed more vertical space.

## Test plan

- [x] Open Now Playing (fullscreen) with UI scale set to 110% in Settings — album art should be square, not cropped
- [x] Toggle lyrics on/off at 110% scale — album art remains square in both states
- [x] Verify sidebar open vs collapsed — no album art jump (preserves #60 fix)
- [x] Verify at 80%, 90%, 100% scale — no regression
- [x] Resize window to ~800×600 — album art scales down cleanly via vh/vw legs