### PR TITLE
test(web): fix spy state leakage in useKeyboardShortcuts tests

### DIFF
--- a/apps/web/src/hooks/useKeyboardShortcuts.test.ts
+++ b/apps/web/src/hooks/useKeyboardShortcuts.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, renderHook } from '@testing-library/react';
 import { fireEvent } from '@testing-library/react';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore, currentTimeRef } from '@/stores/usePlaybackStore';
@@ -15,7 +15,7 @@ vi.mock('@/lib/platform', () => ({
 // Use importOriginal so initReactI18next (and other exports) remain
 // available — @/lib/i18n.ts is now reachable from the hook via the
 // toast feedback path and needs the real plugin shape at module init.
-vi.mock('react-i18next', async (importOriginal) => {
+vi.mock('react-i18next', async importOriginal => {
   const actual = await importOriginal<typeof import('react-i18next')>();
   return {
     ...actual,
@@ -23,11 +23,7 @@ vi.mock('react-i18next', async (importOriginal) => {
   };
 });
 
-function pressKey(
-  key: string,
-  opts: Partial<KeyboardEventInit> = {},
-  target?: Element,
-) {
+function pressKey(key: string, opts: Partial<KeyboardEventInit> = {}, target?: Element) {
   const eventTarget = target ?? document;
   fireEvent.keyDown(eventTarget, { key, ...opts });
 }
@@ -61,6 +57,17 @@ describe('useKeyboardShortcuts', () => {
       selectedTrackIds: new Set(),
       lastClickedIndex: null,
     });
+  });
+
+  // Vitest 4 returns the same spy instance when vi.spyOn is called twice on
+  // the same target, and `restoreAllMocks` no longer clears spy call history
+  // — restore and clear are now independent. We need both: restore so the
+  // store method is back to its original, and clear so any spy that vitest
+  // still tracks for that target starts fresh.
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   function setup() {
@@ -384,10 +391,7 @@ describe('useKeyboardShortcuts', () => {
   describe('Modifier shortcuts (Ctrl/Cmd)', () => {
     it('Ctrl+B toggles sidebar', () => {
       setup();
-      const toggleSpy = vi.spyOn(
-        useAppStore.getState(),
-        'toggleSidebarCollapsed',
-      );
+      const toggleSpy = vi.spyOn(useAppStore.getState(), 'toggleSidebarCollapsed');
 
       pressKey('b', { ctrlKey: true });
       expect(toggleSpy).toHaveBeenCalledOnce();
@@ -472,10 +476,7 @@ describe('useKeyboardShortcuts', () => {
       const input = document.createElement('input');
       document.body.appendChild(input);
 
-      const toggleSpy = vi.spyOn(
-        useAppStore.getState(),
-        'toggleSidebarCollapsed',
-      );
+      const toggleSpy = vi.spyOn(useAppStore.getState(), 'toggleSidebarCollapsed');
 
       pressKey('b', { ctrlKey: true }, input);
       expect(toggleSpy).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

Three tests in `useKeyboardShortcuts.test.ts` were flagged as pre-existing failures in #134. Root cause is a vitest 4 behavior change: `vi.spyOn` now returns the same spy instance when called twice on the same target, and `vi.restoreAllMocks` no longer clears spy call history (restore and clear became independent in v4).

Several tests in this file respy store methods that earlier tests already spied (e.g. `toggleSidebarCollapsed`, `toggleShuffle`, `toggleFavorite`). In v3 the call history was wiped between tests; in v4 it leaks, producing assertions like "expected toggleShuffle not to be called, but was called 1 time" where the recorded call is from a previous test.

## Fix

`afterEach` that runs:

1. `cleanup()` from `@testing-library/react` — explicit RTL unmount.
2. `vi.restoreAllMocks()` — replaces store methods back with their originals.
3. `vi.clearAllMocks()` — zeroes out spy call history (the part `restoreAllMocks` no longer covers in v4).

Why all three: in v4 these are now strictly independent operations and only the combination gives each test a clean slate.

## Why scoped to this file

24 other test files use `vi.spyOn` but most spy 1–2 unique targets; this file has 17 spy sites and several hit the same store methods. They're the only ones bitten today. A repo-wide `restoreMocks: true` / `clearMocks: true` config flip is a reasonable hygiene follow-up but doesn't need to land with this fix.

## Verification

- `pnpm --filter @shiranami/web test` — 478/478 pass (was 475/478)
- `pnpm test` aggregate — 1062/1062 pass (was 1059/1062)

## Test plan

- [ ] CI green on this branch
- [ ] Spot-check that the diff is genuinely additive (only adds `afterEach`; doesn't change any test logic)