### PR TITLE
chore(deps): upgrade @vitejs/plugin-react to 6.0.1 (supersedes #131)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -52,7 +52,7 @@
     "@types/node": "^25.6.0",
     "@types/react": "^18.3.28",
     "@types/react-dom": "^18.3.7",
-    "@vitejs/plugin-react": "^5.2.0",
+    "@vitejs/plugin-react": "^6.0.1",
     "jsdom": "26.1.0",
     "tailwindcss": "^4.2.4",
     "tw-animate-css": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,8 +385,8 @@ importers:
         specifier: ^18.3.7
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
-        specifier: ^5.2.0
-        version: 5.2.0(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: ^6.0.1
+        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       jsdom:
         specifier: 26.1.0
         version: 26.1.0
@@ -4881,6 +4881,12 @@ packages:
         integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==,
       }
 
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution:
+      {
+        integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==,
+      }
+
   '@rollup/pluginutils@5.3.0':
     resolution:
       {
@@ -5978,6 +5984,22 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@vitejs/plugin-react@6.0.1':
+    resolution:
+      {
+        integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vitest/coverage-v8@4.1.5':
     resolution:
@@ -19229,6 +19251,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
+
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
     dependencies:
       '@types/estree': 1.0.8
@@ -19896,17 +19920,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.2.0(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.3
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.18.0
+      '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:


### PR DESCRIPTION
## Summary

Bumps \`@vitejs/plugin-react\` from \`^5.2.0\` to \`^6.0.1\` in \`apps/web\`. Supersedes #131 — re-baselined off current master so the lockfile diff is clean (no incidental \`lucide-react\` churn carried over from the Dependabot branch).

## What changed in v6

- **Babel → Oxc** for the JSX transformer and Fast Refresh path. Drop-in for our standard JSX/TSX usage.
- Vite 8 is now the supported floor — already satisfied (we're on 8.0.10).
- \`babel\` plugin option removed — we never passed options, so no migration needed.
- New optional \`reactCompilerPreset\` export available for opt-in React Compiler usage (out of scope for this PR).

## What changed in this repo

- \`apps/web/package.json\` — specifier bumped.
- \`pnpm-lock.yaml\` — small content delta (the apparent large initial diff was line-ending normalization). Verified that \`@vitejs/plugin-react@6.0.1\` resolves against \`vite@8.0.10\` and pulls in \`@rolldown/pluginutils\` for Rolldown integration. Astro's transitive v5 entry under Vite 7 in \`apps/landing\` continues to coexist via pnpm hoisting.
- \`apps/web/vite.config.ts\` and \`apps/web/vitest.config.ts\` — **untouched**. Both already use bare \`react()\` with no options, so no migration.

## Verification

- [x] \`pnpm install\` — clean
- [x] \`pnpm --filter @shiranami/web typecheck\` — clean
- [x] \`pnpm --filter @shiranami/web build\` — Rolldown build OK in ~530ms
- [x] \`pnpm test\` — 88/88 files, 1069/1069 tests pass

## Test plan

- [ ] CI green
- [ ] Manual \`pnpm dev:web\` smoke — Fast Refresh on a Zustand store edit (the Babel→Oxc swap is invisible in CI; only a dev-server smoke catches HMR regressions)
- [ ] Eyeball \`apps/web/dist\` chunk-size diff vs master (Oxc-emitted output may shift slightly)