### PR TITLE
feat(lyrics): configurable typography for plain & synced views

### DIFF
--- a/apps/web/src/components/lyrics/LyricsPanel.tsx
+++ b/apps/web/src/components/lyrics/LyricsPanel.tsx
@@ -1,19 +1,31 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
-import { useAppStore, LYR_SIZE_CLASS } from '@/stores/useAppStore';
+import {
+  useAppStore,
+  LYR_SIZE_CLASS,
+  LYRICS_SYNCED_PAST_RATIO,
+  nextLyricsFontSize,
+} from '@/stores/useAppStore';
 import { useLyricsQuery } from '@/hooks/queries/useLyrics';
 import { useActiveLineIndex } from '@/lib/lyrics';
 import { LyricsList } from '@/components/lyrics/LyricsList';
 import { cn } from '@/lib/utils';
 import { Loader2, Music2 } from 'lucide-react';
 
-const PANEL_BASE =
-  'block w-full text-left text-base leading-relaxed font-medium cursor-pointer transition-all duration-500 rounded-md px-1 -mx-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40';
-const PANEL_ACTIVE = 'text-foreground text-lg font-semibold';
-const PANEL_PAST = 'text-muted-foreground/25';
-const PANEL_IDLE = 'text-muted-foreground/45 hover:text-muted-foreground/70';
+// Common per-line affordances. Size + opacity come from user prefs and are
+// composed below via LYR_SIZE_CLASS + CSS custom properties.
+const PANEL_BASE_AFFORDANCES =
+  'block w-full text-left leading-relaxed font-medium cursor-pointer transition-all duration-500 rounded-md px-1 -mx-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40';
+
+// Idle / past lines read their opacity from CSS vars set on the surrounding
+// container, so the values can change at runtime without re-tagging classes.
+// `hover:opacity-100` restores full contrast on pointer-over (the original
+// behavior used a hardcoded `hover:text-muted-foreground/70`).
+const PANEL_IDLE = 'text-foreground opacity-[var(--lyrics-idle-opacity)] hover:opacity-100';
+const PANEL_PAST = 'text-foreground opacity-[var(--lyrics-past-opacity)]';
+const PANEL_ACTIVE_AFFORDANCES = 'text-foreground font-semibold';
 
 export function LyricsPanel() {
   const { t } = useTranslation('lyrics');
@@ -22,6 +34,8 @@ export function LyricsPanel() {
   const seek = usePlaybackStore(s => s.seek);
   const lyricsPlainOpacity = useAppStore(s => s.lyricsPlainOpacity);
   const lyricsPlainFontSize = useAppStore(s => s.lyricsPlainFontSize);
+  const lyricsSyncedDimOpacity = useAppStore(s => s.lyricsSyncedDimOpacity);
+  const lyricsSyncedFontSize = useAppStore(s => s.lyricsSyncedFontSize);
 
   const { data, isLoading, isError } = useLyricsQuery(
     currentTrack?.id ?? null,
@@ -57,19 +71,30 @@ export function LyricsPanel() {
       </div>
     );
   } else if (synced && synced.length > 0) {
+    const baseSizeClass = LYR_SIZE_CLASS[lyricsSyncedFontSize];
+    const activeSizeClass = LYR_SIZE_CLASS[nextLyricsFontSize(lyricsSyncedFontSize)];
+    // CSS vars carry the dynamic opacity values; classes only ever reference
+    // them, so Tailwind's compile-time scanning still works.
+    const lyricsVars = {
+      '--lyrics-idle-opacity': String(lyricsSyncedDimOpacity),
+      '--lyrics-past-opacity': String(lyricsSyncedDimOpacity * LYRICS_SYNCED_PAST_RATIO),
+    } as CSSProperties;
+
     content = (
-      <LyricsList
-        lines={synced}
-        activeIndex={activeLine}
-        onLineClick={handleLineClick}
-        containerClassName="px-5 py-6"
-        spacingClassName="space-y-4"
-        bottomSpacerClassName="h-[50vh]"
-        baseClassName={PANEL_BASE}
-        activeClassName={PANEL_ACTIVE}
-        pastClassName={PANEL_PAST}
-        idleClassName={PANEL_IDLE}
-      />
+      <div className="flex-1 flex flex-col min-h-0" style={lyricsVars}>
+        <LyricsList
+          lines={synced}
+          activeIndex={activeLine}
+          onLineClick={handleLineClick}
+          containerClassName="px-5 py-6"
+          spacingClassName="space-y-4"
+          bottomSpacerClassName="h-[50vh]"
+          baseClassName={cn(PANEL_BASE_AFFORDANCES, baseSizeClass)}
+          activeClassName={cn(PANEL_ACTIVE_AFFORDANCES, activeSizeClass)}
+          pastClassName={PANEL_PAST}
+          idleClassName={PANEL_IDLE}
+        />
+      </div>
     );
   } else if (plain) {
     content = (

--- a/apps/web/src/components/lyrics/LyricsPanel.tsx
+++ b/apps/web/src/components/lyrics/LyricsPanel.tsx
@@ -2,9 +2,11 @@ import { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { useAppStore, LYR_SIZE_CLASS } from '@/stores/useAppStore';
 import { useLyricsQuery } from '@/hooks/queries/useLyrics';
 import { useActiveLineIndex } from '@/lib/lyrics';
 import { LyricsList } from '@/components/lyrics/LyricsList';
+import { cn } from '@/lib/utils';
 import { Loader2, Music2 } from 'lucide-react';
 
 const PANEL_BASE =
@@ -18,13 +20,15 @@ export function LyricsPanel() {
   const { t: tToast } = useTranslation('toast');
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const seek = usePlaybackStore(s => s.seek);
+  const lyricsPlainOpacity = useAppStore(s => s.lyricsPlainOpacity);
+  const lyricsPlainFontSize = useAppStore(s => s.lyricsPlainFontSize);
 
   const { data, isLoading, isError } = useLyricsQuery(
     currentTrack?.id ?? null,
     currentTrack?.title ?? '',
     currentTrack?.artist ?? '',
     currentTrack?.album,
-    currentTrack?.duration,
+    currentTrack?.duration
   );
 
   useEffect(() => {
@@ -70,7 +74,13 @@ export function LyricsPanel() {
   } else if (plain) {
     content = (
       <div className="flex-1 overflow-y-auto scrollbar-hide px-5 py-6">
-        <pre className="text-sm text-muted-foreground/50 whitespace-pre-wrap font-sans leading-relaxed">
+        <pre
+          className={cn(
+            'text-foreground whitespace-pre-wrap font-sans font-medium tracking-[0.005em]',
+            LYR_SIZE_CLASS[lyricsPlainFontSize]
+          )}
+          style={{ opacity: lyricsPlainOpacity }}
+        >
           {plain}
         </pre>
       </div>

--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -248,8 +248,10 @@ export function NowPlayingView() {
                 className="contents"
                 style={
                   {
-                    '--lyrics-idle-opacity': lyricsSyncedDimOpacity,
-                    '--lyrics-past-opacity': lyricsSyncedDimOpacity * LYRICS_SYNCED_PAST_RATIO,
+                    '--lyrics-idle-opacity': String(lyricsSyncedDimOpacity),
+                    '--lyrics-past-opacity': String(
+                      lyricsSyncedDimOpacity * LYRICS_SYNCED_PAST_RATIO
+                    ),
                   } as React.CSSProperties
                 }
               >

--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -2,7 +2,8 @@ import { useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
-import { useAppStore } from '@/stores/useAppStore';
+import type { LyricsFontSize } from '@/stores/useAppStore';
+import { useAppStore, LYRICS_SYNCED_PAST_RATIO } from '@/stores/useAppStore';
 import { useLyricsQuery } from '@/hooks/queries/useLyrics';
 import { useActiveLineIndex } from '@/lib/lyrics';
 import { LyricsList } from '@/components/lyrics/LyricsList';
@@ -17,11 +18,29 @@ import { motion, AnimatePresence } from 'motion/react';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { IconButton } from '@/components/ui/icon-button';
 
-const NP_BASE =
-  'block w-full text-left leading-relaxed font-medium cursor-pointer transition-all duration-500 rounded-md px-1 -mx-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40 text-base @5xl:text-lg @7xl:text-xl';
-const NP_ACTIVE = 'text-foreground text-xl @5xl:!text-2xl @7xl:!text-3xl font-semibold';
-const NP_PAST = 'text-muted-foreground/20';
-const NP_IDLE = 'text-muted-foreground/40 hover:text-muted-foreground/65';
+const NP_PLAIN_SIZE_CLASS: Record<LyricsFontSize, string> = {
+  sm: 'text-xs @5xl:text-sm @7xl:text-base',
+  base: 'text-sm @5xl:text-base @7xl:text-lg',
+  lg: 'text-base @5xl:text-lg @7xl:text-xl',
+  xl: 'text-lg @5xl:text-xl @7xl:text-2xl',
+};
+
+const NP_SYNCED_BASE_SIZE_CLASS: Record<LyricsFontSize, string> = {
+  sm: 'text-sm @5xl:text-base @7xl:text-lg',
+  base: 'text-base @5xl:text-lg @7xl:text-xl',
+  lg: 'text-lg @5xl:text-xl @7xl:text-2xl',
+  xl: 'text-xl @5xl:text-2xl @7xl:text-3xl',
+};
+
+const NP_SYNCED_ACTIVE_SIZE_CLASS: Record<LyricsFontSize, string> = {
+  sm: 'text-lg @5xl:!text-xl @7xl:!text-2xl',
+  base: 'text-xl @5xl:!text-2xl @7xl:!text-3xl',
+  lg: 'text-2xl @5xl:!text-3xl @7xl:!text-4xl',
+  xl: 'text-3xl @5xl:!text-4xl @7xl:!text-4xl',
+};
+
+const NP_BASE_SHARED =
+  'block w-full text-left leading-relaxed font-medium cursor-pointer transition-all duration-500 rounded-md px-1 -mx-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40';
 
 export function NowPlayingView() {
   const { t } = useTranslation('nowPlaying');
@@ -32,6 +51,19 @@ export function NowPlayingView() {
   const exitNowPlaying = useAppStore(s => s.exitNowPlaying);
   const lyricsVisible = useAppStore(s => s.nowPlayingLyricsVisible);
   const toggleLyrics = useAppStore(s => s.toggleNowPlayingLyrics);
+  const lyricsPlainOpacity = useAppStore(s => s.lyricsPlainOpacity);
+  const lyricsPlainFontSize = useAppStore(s => s.lyricsPlainFontSize);
+  const lyricsSyncedDimOpacity = useAppStore(s => s.lyricsSyncedDimOpacity);
+  const lyricsSyncedFontSize = useAppStore(s => s.lyricsSyncedFontSize);
+
+  const npBase = cn(NP_BASE_SHARED, NP_SYNCED_BASE_SIZE_CLASS[lyricsSyncedFontSize]);
+  const npActive = cn(
+    'text-foreground font-semibold',
+    NP_SYNCED_ACTIVE_SIZE_CLASS[lyricsSyncedFontSize]
+  );
+  const npIdle =
+    'text-foreground opacity-[var(--lyrics-idle-opacity)] hover:opacity-100 transition-opacity';
+  const npPast = 'text-foreground opacity-[var(--lyrics-past-opacity)]';
 
   const {
     data,
@@ -212,21 +244,37 @@ export function NowPlayingView() {
                 </div>
               </div>
             ) : synced && synced.length > 0 ? (
-              <LyricsList
-                lines={synced}
-                activeIndex={activeLine}
-                onLineClick={handleLineClick}
-                containerClassName="pr-2 @3xl:pr-4"
-                spacingClassName="space-y-4 @5xl:space-y-5 @7xl:space-y-6"
-                bottomSpacerClassName="h-[40vh]"
-                baseClassName={NP_BASE}
-                activeClassName={NP_ACTIVE}
-                pastClassName={NP_PAST}
-                idleClassName={NP_IDLE}
-              />
+              <div
+                className="contents"
+                style={
+                  {
+                    '--lyrics-idle-opacity': lyricsSyncedDimOpacity,
+                    '--lyrics-past-opacity': lyricsSyncedDimOpacity * LYRICS_SYNCED_PAST_RATIO,
+                  } as React.CSSProperties
+                }
+              >
+                <LyricsList
+                  lines={synced}
+                  activeIndex={activeLine}
+                  onLineClick={handleLineClick}
+                  containerClassName="pr-2 @3xl:pr-4"
+                  spacingClassName="space-y-4 @5xl:space-y-5 @7xl:space-y-6"
+                  bottomSpacerClassName="h-[40vh]"
+                  baseClassName={npBase}
+                  activeClassName={npActive}
+                  pastClassName={npPast}
+                  idleClassName={npIdle}
+                />
+              </div>
             ) : plain ? (
               <div className="flex-1 overflow-y-auto scrollbar-hide pr-2 @3xl:pr-4">
-                <pre className="text-sm @5xl:text-base @7xl:text-lg text-muted-foreground/45 whitespace-pre-wrap font-sans leading-relaxed">
+                <pre
+                  className={cn(
+                    'text-foreground whitespace-pre-wrap font-sans font-medium tracking-[0.005em] leading-relaxed',
+                    NP_PLAIN_SIZE_CLASS[lyricsPlainFontSize]
+                  )}
+                  style={{ opacity: lyricsPlainOpacity }}
+                >
                   {plain}
                 </pre>
               </div>

--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -42,6 +42,9 @@ const NP_SYNCED_ACTIVE_SIZE_CLASS: Record<LyricsFontSize, string> = {
 const NP_BASE_SHARED =
   'block w-full text-left leading-relaxed font-medium cursor-pointer transition-all duration-500 rounded-md px-1 -mx-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40';
 
+const NP_IDLE = 'text-foreground opacity-[var(--lyrics-idle-opacity)] hover:opacity-100';
+const NP_PAST = 'text-foreground opacity-[var(--lyrics-past-opacity)]';
+
 export function NowPlayingView() {
   const { t } = useTranslation('nowPlaying');
   const { t: tToast } = useTranslation('toast');
@@ -61,9 +64,6 @@ export function NowPlayingView() {
     'text-foreground font-semibold',
     NP_SYNCED_ACTIVE_SIZE_CLASS[lyricsSyncedFontSize]
   );
-  const npIdle =
-    'text-foreground opacity-[var(--lyrics-idle-opacity)] hover:opacity-100 transition-opacity';
-  const npPast = 'text-foreground opacity-[var(--lyrics-past-opacity)]';
 
   const {
     data,
@@ -262,8 +262,8 @@ export function NowPlayingView() {
                   bottomSpacerClassName="h-[40vh]"
                   baseClassName={npBase}
                   activeClassName={npActive}
-                  pastClassName={npPast}
-                  idleClassName={npIdle}
+                  pastClassName={NP_PAST}
+                  idleClassName={NP_IDLE}
                 />
               </div>
             ) : plain ? (

--- a/apps/web/src/components/settings/LyricsSection.tsx
+++ b/apps/web/src/components/settings/LyricsSection.tsx
@@ -37,10 +37,10 @@ export function LyricsSection() {
         {/* Opacity */}
         <div className="px-3">
           <div className="flex items-center justify-between mb-1">
-            <p className="text-sm font-medium text-foreground">{t('lyr.opacityTitle')}</p>
+            <p className="text-sm font-medium text-foreground">{t('lyr.plain.opacityTitle')}</p>
             <span className="text-xs tabular-nums text-muted-foreground">{opacityPercent}%</span>
           </div>
-          <p className="text-xs text-muted-foreground mb-4">{t('lyr.opacityDesc')}</p>
+          <p className="text-xs text-muted-foreground mb-4">{t('lyr.plain.opacityDesc')}</p>
 
           <Slider
             min={LYRICS_PLAIN_OPACITY_MIN}
@@ -53,8 +53,8 @@ export function LyricsSection() {
 
         {/* Font size */}
         <div className="px-3">
-          <p className="text-sm font-medium text-foreground mb-1">{t('lyr.fontSizeTitle')}</p>
-          <p className="text-xs text-muted-foreground mb-3">{t('lyr.fontSizeDesc')}</p>
+          <p className="text-sm font-medium text-foreground mb-1">{t('lyr.plain.fontSizeTitle')}</p>
+          <p className="text-xs text-muted-foreground mb-3">{t('lyr.plain.fontSizeDesc')}</p>
           <div className="flex items-center gap-1.5">
             {FONT_SIZES.map(size => (
               <button

--- a/apps/web/src/components/settings/LyricsSection.tsx
+++ b/apps/web/src/components/settings/LyricsSection.tsx
@@ -1,0 +1,122 @@
+import { useTranslation } from 'react-i18next';
+import { Captions } from 'lucide-react';
+import { SettingsCard } from '@/components/settings/SettingsCard';
+import { Slider } from '@/components/ui/slider';
+import {
+  useAppStore,
+  LYRICS_PLAIN_OPACITY_MIN,
+  LYRICS_PLAIN_OPACITY_MAX,
+  LYRICS_PLAIN_OPACITY_STEP,
+  LYRICS_PLAIN_OPACITY_DEFAULT,
+  LYRICS_PLAIN_FONT_SIZE_DEFAULT,
+  LYR_SIZE_CLASS,
+  type LyricsPlainFontSize,
+} from '@/stores/useAppStore';
+import { cn } from '@/lib/utils';
+
+const FONT_SIZES: LyricsPlainFontSize[] = ['sm', 'base', 'lg', 'xl'];
+
+export function LyricsSection() {
+  const { t } = useTranslation('settings');
+  const { t: tc } = useTranslation('common');
+  const lyricsPlainOpacity = useAppStore(s => s.lyricsPlainOpacity);
+  const lyricsPlainFontSize = useAppStore(s => s.lyricsPlainFontSize);
+  const setLyricsPlainOpacity = useAppStore(s => s.setLyricsPlainOpacity);
+  const setLyricsPlainFontSize = useAppStore(s => s.setLyricsPlainFontSize);
+  const resetLyricsPlainAppearance = useAppStore(s => s.resetLyricsPlainAppearance);
+
+  const isModified =
+    lyricsPlainOpacity !== LYRICS_PLAIN_OPACITY_DEFAULT ||
+    lyricsPlainFontSize !== LYRICS_PLAIN_FONT_SIZE_DEFAULT;
+
+  const opacityPercent = Math.round(lyricsPlainOpacity * 100);
+
+  return (
+    <SettingsCard icon={Captions} title={t('lyr.title')} subtitle={t('lyr.subtitle')}>
+      <div className="space-y-6">
+        {/* Opacity */}
+        <div className="px-3">
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-sm font-medium text-foreground">{t('lyr.opacityTitle')}</p>
+            <span className="text-xs tabular-nums text-muted-foreground">{opacityPercent}%</span>
+          </div>
+          <p className="text-xs text-muted-foreground mb-4">{t('lyr.opacityDesc')}</p>
+
+          <Slider
+            min={LYRICS_PLAIN_OPACITY_MIN}
+            max={LYRICS_PLAIN_OPACITY_MAX}
+            step={LYRICS_PLAIN_OPACITY_STEP}
+            value={[lyricsPlainOpacity]}
+            onValueChange={([v]) => setLyricsPlainOpacity(v)}
+          />
+        </div>
+
+        {/* Font size */}
+        <div className="px-3">
+          <p className="text-sm font-medium text-foreground mb-1">{t('lyr.fontSizeTitle')}</p>
+          <p className="text-xs text-muted-foreground mb-3">{t('lyr.fontSizeDesc')}</p>
+          <div className="flex items-center gap-1.5">
+            {FONT_SIZES.map(size => (
+              <button
+                key={size}
+                onClick={() => setLyricsPlainFontSize(size)}
+                className={cn(
+                  'px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
+                  lyricsPlainFontSize === size
+                    ? 'bg-primary/15 text-primary border border-primary/40'
+                    : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground border border-transparent'
+                )}
+              >
+                {t(`lyr.size.${size}`)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Reset */}
+        {isModified && (
+          <div className="px-3 -mt-2">
+            <button
+              onClick={resetLyricsPlainAppearance}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {tc('reset')}
+            </button>
+          </div>
+        )}
+
+        {/* Preview */}
+        <div className="px-3">
+          <p className="text-xs font-medium uppercase tracking-[0.1em] text-muted-foreground/60 mb-2">
+            {t('lyr.previewTitle')}
+          </p>
+          <LyricsPreview opacity={lyricsPlainOpacity} fontSize={lyricsPlainFontSize} />
+        </div>
+      </div>
+    </SettingsCard>
+  );
+}
+
+interface LyricsPreviewProps {
+  opacity: number;
+  fontSize: LyricsPlainFontSize;
+}
+
+function LyricsPreview({ opacity, fontSize }: LyricsPreviewProps) {
+  const { t } = useTranslation('settings');
+  return (
+    <div className="bg-surface/40 border border-border/30 rounded-xl px-4 py-4">
+      <pre
+        className={cn(
+          'text-foreground whitespace-pre-wrap font-sans font-medium tracking-[0.005em]',
+          LYR_SIZE_CLASS[fontSize]
+        )}
+        style={{ opacity }}
+      >
+        {`${t('lyr.previewLine1')}\n${t('lyr.previewLine2')}\n${t('lyr.previewLine3')}\n${t('lyr.previewLine4')}`}
+      </pre>
+    </div>
+  );
+}
+
+export default LyricsSection;

--- a/apps/web/src/components/settings/LyricsSection.tsx
+++ b/apps/web/src/components/settings/LyricsSection.tsx
@@ -156,6 +156,7 @@ function OpacityControl({
       </div>
       <p className="text-xs text-muted-foreground mb-4">{description}</p>
       <Slider
+        aria-label={title}
         min={min}
         max={max}
         step={step}
@@ -179,10 +180,13 @@ function FontSizeControl({ title, description, value, onChange }: FontSizeContro
     <div className="px-3">
       <p className="text-sm font-medium text-foreground mb-1">{title}</p>
       <p className="text-xs text-muted-foreground mb-3">{description}</p>
-      <div className="flex items-center gap-1.5">
+      <div className="flex items-center gap-1.5" role="radiogroup" aria-label={title}>
         {FONT_SIZES.map(size => (
           <button
             key={size}
+            type="button"
+            role="radio"
+            aria-checked={value === size}
             onClick={() => onChange(size)}
             className={cn(
               'px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',

--- a/apps/web/src/components/settings/LyricsSection.tsx
+++ b/apps/web/src/components/settings/LyricsSection.tsx
@@ -9,100 +9,218 @@ import {
   LYRICS_PLAIN_OPACITY_STEP,
   LYRICS_PLAIN_OPACITY_DEFAULT,
   LYRICS_PLAIN_FONT_SIZE_DEFAULT,
+  LYRICS_SYNCED_DIM_OPACITY_MIN,
+  LYRICS_SYNCED_DIM_OPACITY_MAX,
+  LYRICS_SYNCED_DIM_OPACITY_STEP,
+  LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
+  LYRICS_SYNCED_FONT_SIZE_DEFAULT,
+  LYRICS_SYNCED_PAST_RATIO,
   LYR_SIZE_CLASS,
-  type LyricsPlainFontSize,
+  nextLyricsFontSize,
+  type LyricsFontSize,
 } from '@/stores/useAppStore';
 import { cn } from '@/lib/utils';
 
-const FONT_SIZES: LyricsPlainFontSize[] = ['sm', 'base', 'lg', 'xl'];
+const FONT_SIZES: LyricsFontSize[] = ['sm', 'base', 'lg', 'xl'];
 
 export function LyricsSection() {
   const { t } = useTranslation('settings');
   const { t: tc } = useTranslation('common');
+
   const lyricsPlainOpacity = useAppStore(s => s.lyricsPlainOpacity);
   const lyricsPlainFontSize = useAppStore(s => s.lyricsPlainFontSize);
   const setLyricsPlainOpacity = useAppStore(s => s.setLyricsPlainOpacity);
   const setLyricsPlainFontSize = useAppStore(s => s.setLyricsPlainFontSize);
-  const resetLyricsPlainAppearance = useAppStore(s => s.resetLyricsPlainAppearance);
+
+  const lyricsSyncedDimOpacity = useAppStore(s => s.lyricsSyncedDimOpacity);
+  const lyricsSyncedFontSize = useAppStore(s => s.lyricsSyncedFontSize);
+  const setLyricsSyncedDimOpacity = useAppStore(s => s.setLyricsSyncedDimOpacity);
+  const setLyricsSyncedFontSize = useAppStore(s => s.setLyricsSyncedFontSize);
+
+  const resetLyricsAppearance = useAppStore(s => s.resetLyricsAppearance);
 
   const isModified =
     lyricsPlainOpacity !== LYRICS_PLAIN_OPACITY_DEFAULT ||
-    lyricsPlainFontSize !== LYRICS_PLAIN_FONT_SIZE_DEFAULT;
-
-  const opacityPercent = Math.round(lyricsPlainOpacity * 100);
+    lyricsPlainFontSize !== LYRICS_PLAIN_FONT_SIZE_DEFAULT ||
+    lyricsSyncedDimOpacity !== LYRICS_SYNCED_DIM_OPACITY_DEFAULT ||
+    lyricsSyncedFontSize !== LYRICS_SYNCED_FONT_SIZE_DEFAULT;
 
   return (
     <SettingsCard icon={Captions} title={t('lyr.title')} subtitle={t('lyr.subtitle')}>
-      <div className="space-y-6">
-        {/* Opacity */}
-        <div className="px-3">
-          <div className="flex items-center justify-between mb-1">
-            <p className="text-sm font-medium text-foreground">{t('lyr.plain.opacityTitle')}</p>
-            <span className="text-xs tabular-nums text-muted-foreground">{opacityPercent}%</span>
-          </div>
-          <p className="text-xs text-muted-foreground mb-4">{t('lyr.plain.opacityDesc')}</p>
-
-          <Slider
+      <div className="space-y-8">
+        {/* Plain text subsection */}
+        <Subsection title={t('lyr.plain.title')} subtitle={t('lyr.plain.subtitle')}>
+          <OpacityControl
+            title={t('lyr.plain.opacityTitle')}
+            description={t('lyr.plain.opacityDesc')}
+            value={lyricsPlainOpacity}
             min={LYRICS_PLAIN_OPACITY_MIN}
             max={LYRICS_PLAIN_OPACITY_MAX}
             step={LYRICS_PLAIN_OPACITY_STEP}
-            value={[lyricsPlainOpacity]}
-            onValueChange={([v]) => setLyricsPlainOpacity(v)}
+            onChange={setLyricsPlainOpacity}
           />
-        </div>
+          <FontSizeControl
+            title={t('lyr.plain.fontSizeTitle')}
+            description={t('lyr.plain.fontSizeDesc')}
+            value={lyricsPlainFontSize}
+            onChange={setLyricsPlainFontSize}
+          />
+          <PreviewSlot title={t('lyr.previewTitle')}>
+            <PlainPreview opacity={lyricsPlainOpacity} fontSize={lyricsPlainFontSize} />
+          </PreviewSlot>
+        </Subsection>
 
-        {/* Font size */}
-        <div className="px-3">
-          <p className="text-sm font-medium text-foreground mb-1">{t('lyr.plain.fontSizeTitle')}</p>
-          <p className="text-xs text-muted-foreground mb-3">{t('lyr.plain.fontSizeDesc')}</p>
-          <div className="flex items-center gap-1.5">
-            {FONT_SIZES.map(size => (
-              <button
-                key={size}
-                onClick={() => setLyricsPlainFontSize(size)}
-                className={cn(
-                  'px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
-                  lyricsPlainFontSize === size
-                    ? 'bg-primary/15 text-primary border border-primary/40'
-                    : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground border border-transparent'
-                )}
-              >
-                {t(`lyr.size.${size}`)}
-              </button>
-            ))}
-          </div>
-        </div>
+        {/* Synced lyrics subsection */}
+        <Subsection title={t('lyr.synced.title')} subtitle={t('lyr.synced.subtitle')}>
+          <OpacityControl
+            title={t('lyr.synced.opacityTitle')}
+            description={t('lyr.synced.opacityDesc')}
+            value={lyricsSyncedDimOpacity}
+            min={LYRICS_SYNCED_DIM_OPACITY_MIN}
+            max={LYRICS_SYNCED_DIM_OPACITY_MAX}
+            step={LYRICS_SYNCED_DIM_OPACITY_STEP}
+            onChange={setLyricsSyncedDimOpacity}
+          />
+          <FontSizeControl
+            title={t('lyr.synced.fontSizeTitle')}
+            description={t('lyr.synced.fontSizeDesc')}
+            value={lyricsSyncedFontSize}
+            onChange={setLyricsSyncedFontSize}
+          />
+          <PreviewSlot title={t('lyr.previewTitle')}>
+            <SyncedPreview dimOpacity={lyricsSyncedDimOpacity} fontSize={lyricsSyncedFontSize} />
+          </PreviewSlot>
+        </Subsection>
 
-        {/* Reset */}
+        {/* Unified reset — restores all four lyrics prefs */}
         {isModified && (
-          <div className="px-3 -mt-2">
+          <div className="px-3">
             <button
-              onClick={resetLyricsPlainAppearance}
+              onClick={resetLyricsAppearance}
               className="text-xs text-muted-foreground hover:text-foreground transition-colors"
             >
               {tc('reset')}
             </button>
           </div>
         )}
-
-        {/* Preview */}
-        <div className="px-3">
-          <p className="text-xs font-medium uppercase tracking-[0.1em] text-muted-foreground/60 mb-2">
-            {t('lyr.previewTitle')}
-          </p>
-          <LyricsPreview opacity={lyricsPlainOpacity} fontSize={lyricsPlainFontSize} />
-        </div>
       </div>
     </SettingsCard>
   );
 }
 
-interface LyricsPreviewProps {
-  opacity: number;
-  fontSize: LyricsPlainFontSize;
+interface SubsectionProps {
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
 }
 
-function LyricsPreview({ opacity, fontSize }: LyricsPreviewProps) {
+function Subsection({ title, subtitle, children }: SubsectionProps) {
+  return (
+    <div className="space-y-5">
+      <div className="px-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-foreground/80">
+          {title}
+        </p>
+        <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
+      </div>
+      <div className="space-y-5">{children}</div>
+    </div>
+  );
+}
+
+interface OpacityControlProps {
+  title: string;
+  description: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (value: number) => void;
+}
+
+function OpacityControl({
+  title,
+  description,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: OpacityControlProps) {
+  const percent = Math.round(value * 100);
+  return (
+    <div className="px-3">
+      <div className="flex items-center justify-between mb-1">
+        <p className="text-sm font-medium text-foreground">{title}</p>
+        <span className="text-xs tabular-nums text-muted-foreground">{percent}%</span>
+      </div>
+      <p className="text-xs text-muted-foreground mb-4">{description}</p>
+      <Slider
+        min={min}
+        max={max}
+        step={step}
+        value={[value]}
+        onValueChange={([v]) => onChange(v)}
+      />
+    </div>
+  );
+}
+
+interface FontSizeControlProps {
+  title: string;
+  description: string;
+  value: LyricsFontSize;
+  onChange: (size: LyricsFontSize) => void;
+}
+
+function FontSizeControl({ title, description, value, onChange }: FontSizeControlProps) {
+  const { t } = useTranslation('settings');
+  return (
+    <div className="px-3">
+      <p className="text-sm font-medium text-foreground mb-1">{title}</p>
+      <p className="text-xs text-muted-foreground mb-3">{description}</p>
+      <div className="flex items-center gap-1.5">
+        {FONT_SIZES.map(size => (
+          <button
+            key={size}
+            onClick={() => onChange(size)}
+            className={cn(
+              'px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
+              value === size
+                ? 'bg-primary/15 text-primary border border-primary/40'
+                : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground border border-transparent'
+            )}
+          >
+            {t(`lyr.size.${size}`)}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface PreviewSlotProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function PreviewSlot({ title, children }: PreviewSlotProps) {
+  return (
+    <div className="px-3">
+      <p className="text-xs font-medium uppercase tracking-[0.1em] text-muted-foreground/60 mb-2">
+        {title}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+interface PlainPreviewProps {
+  opacity: number;
+  fontSize: LyricsFontSize;
+}
+
+function PlainPreview({ opacity, fontSize }: PlainPreviewProps) {
   const { t } = useTranslation('settings');
   return (
     <div className="bg-surface/40 border border-border/30 rounded-xl px-4 py-4">
@@ -115,6 +233,45 @@ function LyricsPreview({ opacity, fontSize }: LyricsPreviewProps) {
       >
         {`${t('lyr.previewLine1')}\n${t('lyr.previewLine2')}\n${t('lyr.previewLine3')}\n${t('lyr.previewLine4')}`}
       </pre>
+    </div>
+  );
+}
+
+interface SyncedPreviewProps {
+  dimOpacity: number;
+  fontSize: LyricsFontSize;
+}
+
+function SyncedPreview({ dimOpacity, fontSize }: SyncedPreviewProps) {
+  const { t } = useTranslation('settings');
+  const baseClass = LYR_SIZE_CLASS[fontSize];
+  const activeClass = LYR_SIZE_CLASS[nextLyricsFontSize(fontSize)];
+  // Mirror the runtime ratio so preview past-line dimness tracks the panel.
+  const pastOpacity = dimOpacity * LYRICS_SYNCED_PAST_RATIO;
+
+  return (
+    <div className="bg-surface/40 border border-border/30 rounded-xl px-4 py-4 space-y-3">
+      <p
+        className={cn('text-foreground font-medium leading-relaxed', baseClass)}
+        style={{ opacity: pastOpacity }}
+      >
+        {t('lyr.previewSyncedPast')}
+      </p>
+      <p
+        className={cn('text-foreground font-medium leading-relaxed', baseClass)}
+        style={{ opacity: dimOpacity }}
+      >
+        {t('lyr.previewSyncedIdleA')}
+      </p>
+      <p className={cn('text-foreground font-semibold leading-relaxed', activeClass)}>
+        {t('lyr.previewSyncedActive')}
+      </p>
+      <p
+        className={cn('text-foreground font-medium leading-relaxed', baseClass)}
+        style={{ opacity: dimOpacity }}
+      >
+        {t('lyr.previewSyncedIdleB')}
+      </p>
     </div>
   );
 }

--- a/apps/web/src/components/settings/SettingsView.tsx
+++ b/apps/web/src/components/settings/SettingsView.tsx
@@ -7,6 +7,7 @@ import {
   Settings2,
   SlidersHorizontal,
   AudioLines,
+  Captions,
   Monitor,
   RefreshCcw,
   Info,
@@ -20,6 +21,7 @@ import { EqualizerSection } from '@/components/settings/EqualizerSection';
 import { VisualizerSection } from '@/components/settings/VisualizerSection';
 import { UpdatesSection } from '@/components/settings/UpdatesSection';
 import { AppearanceSection } from '@/components/settings/AppearanceSection';
+import { LyricsSection } from '@/components/settings/LyricsSection';
 import { AboutSection } from '@/components/settings/AboutSection';
 
 type SettingsSection =
@@ -29,6 +31,7 @@ type SettingsSection =
   | 'playback'
   | 'equalizer'
   | 'visualizer'
+  | 'lyrics'
   | 'appearance'
   | 'updates'
   | 'about';
@@ -40,6 +43,7 @@ const SECTIONS: { id: SettingsSection; labelKey: string; Icon: typeof FolderOpen
   { id: 'playback', labelKey: 'playback', Icon: Settings2 },
   { id: 'equalizer', labelKey: 'equalizer', Icon: SlidersHorizontal },
   { id: 'visualizer', labelKey: 'visualizer', Icon: AudioLines },
+  { id: 'lyrics', labelKey: 'lyrics', Icon: Captions },
   { id: 'appearance', labelKey: 'appearance', Icon: Monitor },
   { id: 'updates', labelKey: 'updates', Icon: RefreshCcw },
   { id: 'about', labelKey: 'about', Icon: Info },
@@ -52,6 +56,7 @@ const SECTION_PANEL: Record<SettingsSection, ComponentType> = {
   playback: PlaybackSection,
   equalizer: EqualizerSection,
   visualizer: VisualizerSection,
+  lyrics: LyricsSection,
   appearance: AppearanceSection,
   updates: UpdatesSection,
   about: AboutSection,
@@ -70,7 +75,7 @@ export function SettingsView() {
         role="tablist"
         aria-label="Settings sections"
       >
-        {SECTIONS.map((section) => (
+        {SECTIONS.map(section => (
           <button
             key={section.id}
             role="tab"
@@ -82,7 +87,7 @@ export function SettingsView() {
               'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
               activeSection === section.id
                 ? 'bg-primary/15 text-primary font-medium'
-                : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground/80',
+                : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground/80'
             )}
           >
             <section.Icon className="w-4 h-4 shrink-0" />

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -91,11 +91,23 @@
   },
   "lyr": {
     "title": "Lyrics",
-    "subtitle": "Appearance of plain-text lyrics in the lyrics panel",
-    "opacityTitle": "Text opacity",
-    "opacityDesc": "How prominent the lyric text is against the background",
-    "fontSizeTitle": "Font size",
-    "fontSizeDesc": "Reading size for plain-text lyrics. Synced lyrics keep their own sizing.",
+    "subtitle": "Appearance of lyrics in the lyrics panel",
+    "plain": {
+      "title": "Plain text",
+      "subtitle": "Lyrics shown when no synced timing is available",
+      "opacityTitle": "Text opacity",
+      "opacityDesc": "How prominent the lyric text is against the background",
+      "fontSizeTitle": "Font size",
+      "fontSizeDesc": "Reading size for plain-text lyrics"
+    },
+    "synced": {
+      "title": "Synced lyrics",
+      "subtitle": "Per-line timed lyrics with the active line highlighted",
+      "opacityTitle": "Dim opacity",
+      "opacityDesc": "How visible non-active lines are. The current line stays at full contrast.",
+      "fontSizeTitle": "Font size",
+      "fontSizeDesc": "Reading size for synced lyrics. The active line scales up automatically."
+    },
     "size": {
       "sm": "Small",
       "base": "Default",
@@ -106,7 +118,11 @@
     "previewLine1": "Whispered hopes inside a quiet morning",
     "previewLine2": "Pages of a song we never finished",
     "previewLine3": "Light through curtains, soft and unhurried",
-    "previewLine4": "Holding on to every fading line"
+    "previewLine4": "Holding on to every fading line",
+    "previewSyncedActive": "Whispered hopes inside a quiet morning",
+    "previewSyncedIdleA": "Pages of a song we never finished",
+    "previewSyncedIdleB": "Light through curtains, soft and unhurried",
+    "previewSyncedPast": "Holding on to every fading line"
   },
   "app": {
     "title": "Appearance",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -5,6 +5,7 @@
   "playback": "Playback",
   "equalizer": "Equalizer",
   "visualizer": "Visualizer",
+  "lyrics": "Lyrics",
   "appearance": "Appearance",
   "updates": "Updates",
   "about": "About",
@@ -87,6 +88,25 @@
     "circleDesc": "Radial frequency arc",
     "particles": "Wave",
     "particlesDesc": "Smooth flowing gradient wave"
+  },
+  "lyr": {
+    "title": "Lyrics",
+    "subtitle": "Appearance of plain-text lyrics in the lyrics panel",
+    "opacityTitle": "Text opacity",
+    "opacityDesc": "How prominent the lyric text is against the background",
+    "fontSizeTitle": "Font size",
+    "fontSizeDesc": "Reading size for plain-text lyrics. Synced lyrics keep their own sizing.",
+    "size": {
+      "sm": "Small",
+      "base": "Default",
+      "lg": "Large",
+      "xl": "Extra large"
+    },
+    "previewTitle": "Preview",
+    "previewLine1": "Whispered hopes inside a quiet morning",
+    "previewLine2": "Pages of a song we never finished",
+    "previewLine3": "Light through curtains, soft and unhurried",
+    "previewLine4": "Holding on to every fading line"
   },
   "app": {
     "title": "Appearance",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -91,7 +91,7 @@
   },
   "lyr": {
     "title": "Tekst piosenki",
-    "subtitle": "Wygląd tekstu piosenki w panelu lyrics",
+    "subtitle": "Wygląd tekstu piosenki w panelu",
     "plain": {
       "title": "Tekst zwykły",
       "subtitle": "Tekst pokazywany, gdy brak zsynchronizowanego timingu",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -5,6 +5,7 @@
   "playback": "Odtwarzanie",
   "equalizer": "Korektor",
   "visualizer": "Wizualizator",
+  "lyrics": "Tekst piosenki",
   "appearance": "Wygląd",
   "updates": "Aktualizacje",
   "about": "O aplikacji",
@@ -87,6 +88,25 @@
     "circleDesc": "Promieniowy łuk częstotliwości",
     "particles": "Fala gradientowa",
     "particlesDesc": "Płynna fala z wypełnieniem gradientowym"
+  },
+  "lyr": {
+    "title": "Tekst piosenki",
+    "subtitle": "Wygląd tekstu piosenki w panelu lyrics",
+    "opacityTitle": "Przezroczystość tekstu",
+    "opacityDesc": "Jak wyraźny jest tekst na tle aplikacji",
+    "fontSizeTitle": "Rozmiar czcionki",
+    "fontSizeDesc": "Rozmiar czytania tekstu piosenki. Zsynchronizowany tekst zachowuje własne rozmiary.",
+    "size": {
+      "sm": "Mały",
+      "base": "Domyślny",
+      "lg": "Duży",
+      "xl": "Bardzo duży"
+    },
+    "previewTitle": "Podgląd",
+    "previewLine1": "Szeptane nadzieje w cichy poranek",
+    "previewLine2": "Strony piosenki, której nie skończyliśmy",
+    "previewLine3": "Światło przez zasłony, miękkie i spokojne",
+    "previewLine4": "Trzymam każdą zanikającą linię"
   },
   "app": {
     "title": "Wygląd",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -92,10 +92,22 @@
   "lyr": {
     "title": "Tekst piosenki",
     "subtitle": "Wygląd tekstu piosenki w panelu lyrics",
-    "opacityTitle": "Przezroczystość tekstu",
-    "opacityDesc": "Jak wyraźny jest tekst na tle aplikacji",
-    "fontSizeTitle": "Rozmiar czcionki",
-    "fontSizeDesc": "Rozmiar czytania tekstu piosenki. Zsynchronizowany tekst zachowuje własne rozmiary.",
+    "plain": {
+      "title": "Tekst zwykły",
+      "subtitle": "Tekst pokazywany, gdy brak zsynchronizowanego timingu",
+      "opacityTitle": "Przezroczystość tekstu",
+      "opacityDesc": "Jak wyraźny jest tekst na tle aplikacji",
+      "fontSizeTitle": "Rozmiar czcionki",
+      "fontSizeDesc": "Rozmiar czytania zwykłego tekstu piosenki"
+    },
+    "synced": {
+      "title": "Zsynchronizowany tekst",
+      "subtitle": "Tekst z czasem dla każdej linii i podświetloną aktywną linią",
+      "opacityTitle": "Przezroczystość przyciemnienia",
+      "opacityDesc": "Jak widoczne są nieaktywne linie. Bieżąca linia pozostaje w pełnym kontraście.",
+      "fontSizeTitle": "Rozmiar czcionki",
+      "fontSizeDesc": "Rozmiar czytania zsynchronizowanego tekstu. Aktywna linia powiększa się automatycznie."
+    },
     "size": {
       "sm": "Mały",
       "base": "Domyślny",
@@ -106,7 +118,11 @@
     "previewLine1": "Szeptane nadzieje w cichy poranek",
     "previewLine2": "Strony piosenki, której nie skończyliśmy",
     "previewLine3": "Światło przez zasłony, miękkie i spokojne",
-    "previewLine4": "Trzymam każdą zanikającą linię"
+    "previewLine4": "Trzymam każdą zanikającą linię",
+    "previewSyncedActive": "Szeptane nadzieje w cichy poranek",
+    "previewSyncedIdleA": "Strony piosenki, której nie skończyliśmy",
+    "previewSyncedIdleB": "Światło przez zasłony, miękkie i spokojne",
+    "previewSyncedPast": "Trzymam każdą zanikającą linię"
   },
   "app": {
     "title": "Wygląd",

--- a/apps/web/src/stores/useAppStore.test.ts
+++ b/apps/web/src/stores/useAppStore.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useAppStore } from './useAppStore';
+import {
+  useAppStore,
+  LYRICS_PLAIN_OPACITY_DEFAULT,
+  LYRICS_PLAIN_OPACITY_MAX,
+  LYRICS_PLAIN_OPACITY_MIN,
+  LYRICS_PLAIN_FONT_SIZE_DEFAULT,
+} from './useAppStore';
 
 vi.mock('@/lib/platform', () => ({
   IS_ELECTRON: true,
@@ -125,6 +131,43 @@ describe('useAppStore', () => {
     expect(useAppStore.getState().albumGridScrollTop).toBe(500);
   });
 
+  it('clamps lyrics plain opacity above max and rounds to step', () => {
+    useAppStore.getState().setLyricsPlainOpacity(2);
+    expect(useAppStore.getState().lyricsPlainOpacity).toBe(LYRICS_PLAIN_OPACITY_MAX);
+    expect(readPersisted().lyricsPlainOpacity).toBe(LYRICS_PLAIN_OPACITY_MAX);
+  });
+
+  it('clamps lyrics plain opacity below min', () => {
+    useAppStore.getState().setLyricsPlainOpacity(0);
+    expect(useAppStore.getState().lyricsPlainOpacity).toBe(LYRICS_PLAIN_OPACITY_MIN);
+  });
+
+  it('rounds lyrics plain opacity to nearest step', () => {
+    useAppStore.getState().setLyricsPlainOpacity(0.873);
+    // step = 0.05, 0.873 -> rounds to 0.85
+    expect(useAppStore.getState().lyricsPlainOpacity).toBeCloseTo(0.85, 2);
+  });
+
+  it('coerces invalid lyrics plain font size to default on setter', () => {
+    // @ts-expect-error — runtime guard test
+    useAppStore.getState().setLyricsPlainFontSize('huge');
+    expect(useAppStore.getState().lyricsPlainFontSize).toBe(LYRICS_PLAIN_FONT_SIZE_DEFAULT);
+  });
+
+  it('persists lyrics plain font size when valid', () => {
+    useAppStore.getState().setLyricsPlainFontSize('lg');
+    expect(useAppStore.getState().lyricsPlainFontSize).toBe('lg');
+    expect(readPersisted().lyricsPlainFontSize).toBe('lg');
+  });
+
+  it('resets lyrics plain appearance to defaults', () => {
+    useAppStore.getState().setLyricsPlainOpacity(0.6);
+    useAppStore.getState().setLyricsPlainFontSize('xl');
+    useAppStore.getState().resetLyricsPlainAppearance();
+    expect(useAppStore.getState().lyricsPlainOpacity).toBe(LYRICS_PLAIN_OPACITY_DEFAULT);
+    expect(useAppStore.getState().lyricsPlainFontSize).toBe(LYRICS_PLAIN_FONT_SIZE_DEFAULT);
+  });
+
   it('rolls back compact always-on-top and localStorage when setAlwaysOnTop fails in compact mode', async () => {
     await useAppStore.getState().setCompactMode(true);
     vi.mocked(window.electronAPI.window.setAlwaysOnTop).mockRejectedValueOnce(
@@ -181,5 +224,20 @@ describe('useAppStore legacy localStorage migration', () => {
   it('does nothing when no legacy keys exist', async () => {
     await import('./useAppStore');
     expect(localStorage.getItem('shiranami.app-store')).toBeNull();
+  });
+
+  it('sanitizes malformed lyrics plain prefs from persisted shape', async () => {
+    localStorage.setItem(
+      'shiranami.app-store',
+      JSON.stringify({
+        state: { lyricsPlainOpacity: 'broken', lyricsPlainFontSize: 'huge' },
+        version: 1,
+      })
+    );
+
+    const mod = await import('./useAppStore');
+    const state = mod.useAppStore.getState();
+    expect(state.lyricsPlainOpacity).toBe(mod.LYRICS_PLAIN_OPACITY_DEFAULT);
+    expect(state.lyricsPlainFontSize).toBe(mod.LYRICS_PLAIN_FONT_SIZE_DEFAULT);
   });
 });

--- a/apps/web/src/stores/useAppStore.test.ts
+++ b/apps/web/src/stores/useAppStore.test.ts
@@ -5,6 +5,11 @@ import {
   LYRICS_PLAIN_OPACITY_MAX,
   LYRICS_PLAIN_OPACITY_MIN,
   LYRICS_PLAIN_FONT_SIZE_DEFAULT,
+  LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
+  LYRICS_SYNCED_DIM_OPACITY_MAX,
+  LYRICS_SYNCED_DIM_OPACITY_MIN,
+  LYRICS_SYNCED_FONT_SIZE_DEFAULT,
+  nextLyricsFontSize,
 } from './useAppStore';
 
 vi.mock('@/lib/platform', () => ({
@@ -168,6 +173,56 @@ describe('useAppStore', () => {
     expect(useAppStore.getState().lyricsPlainFontSize).toBe(LYRICS_PLAIN_FONT_SIZE_DEFAULT);
   });
 
+  it('clamps lyrics synced dim opacity above max and rounds to step', () => {
+    useAppStore.getState().setLyricsSyncedDimOpacity(2);
+    expect(useAppStore.getState().lyricsSyncedDimOpacity).toBe(LYRICS_SYNCED_DIM_OPACITY_MAX);
+    expect(readPersisted().lyricsSyncedDimOpacity).toBe(LYRICS_SYNCED_DIM_OPACITY_MAX);
+  });
+
+  it('clamps lyrics synced dim opacity below min (down to 0.2 not 0.5)', () => {
+    useAppStore.getState().setLyricsSyncedDimOpacity(0);
+    // Synced floor is lower than plain floor — synced lines may be very dim.
+    expect(useAppStore.getState().lyricsSyncedDimOpacity).toBe(LYRICS_SYNCED_DIM_OPACITY_MIN);
+    expect(LYRICS_SYNCED_DIM_OPACITY_MIN).toBe(0.2);
+  });
+
+  it('rounds lyrics synced dim opacity to nearest step', () => {
+    useAppStore.getState().setLyricsSyncedDimOpacity(0.873);
+    // step = 0.05, 0.873 -> rounds to 0.85
+    expect(useAppStore.getState().lyricsSyncedDimOpacity).toBeCloseTo(0.85, 2);
+  });
+
+  it('coerces invalid lyrics synced font size to default on setter', () => {
+    // @ts-expect-error — runtime guard test
+    useAppStore.getState().setLyricsSyncedFontSize('huge');
+    expect(useAppStore.getState().lyricsSyncedFontSize).toBe(LYRICS_SYNCED_FONT_SIZE_DEFAULT);
+  });
+
+  it('persists lyrics synced font size when valid', () => {
+    useAppStore.getState().setLyricsSyncedFontSize('lg');
+    expect(useAppStore.getState().lyricsSyncedFontSize).toBe('lg');
+    expect(readPersisted().lyricsSyncedFontSize).toBe('lg');
+  });
+
+  it('resetLyricsAppearance restores all four lyrics prefs to defaults', () => {
+    useAppStore.getState().setLyricsPlainOpacity(0.6);
+    useAppStore.getState().setLyricsPlainFontSize('xl');
+    useAppStore.getState().setLyricsSyncedDimOpacity(0.9);
+    useAppStore.getState().setLyricsSyncedFontSize('sm');
+    useAppStore.getState().resetLyricsAppearance();
+    expect(useAppStore.getState().lyricsPlainOpacity).toBe(LYRICS_PLAIN_OPACITY_DEFAULT);
+    expect(useAppStore.getState().lyricsPlainFontSize).toBe(LYRICS_PLAIN_FONT_SIZE_DEFAULT);
+    expect(useAppStore.getState().lyricsSyncedDimOpacity).toBe(LYRICS_SYNCED_DIM_OPACITY_DEFAULT);
+    expect(useAppStore.getState().lyricsSyncedFontSize).toBe(LYRICS_SYNCED_FONT_SIZE_DEFAULT);
+  });
+
+  it('nextLyricsFontSize bumps one step and caps at xl', () => {
+    expect(nextLyricsFontSize('sm')).toBe('base');
+    expect(nextLyricsFontSize('base')).toBe('lg');
+    expect(nextLyricsFontSize('lg')).toBe('xl');
+    expect(nextLyricsFontSize('xl')).toBe('xl');
+  });
+
   it('rolls back compact always-on-top and localStorage when setAlwaysOnTop fails in compact mode', async () => {
     await useAppStore.getState().setCompactMode(true);
     vi.mocked(window.electronAPI.window.setAlwaysOnTop).mockRejectedValueOnce(
@@ -239,5 +294,38 @@ describe('useAppStore legacy localStorage migration', () => {
     const state = mod.useAppStore.getState();
     expect(state.lyricsPlainOpacity).toBe(mod.LYRICS_PLAIN_OPACITY_DEFAULT);
     expect(state.lyricsPlainFontSize).toBe(mod.LYRICS_PLAIN_FONT_SIZE_DEFAULT);
+  });
+
+  it('falls back to synced lyrics defaults when persisted shape lacks the new keys', async () => {
+    // Simulate a user upgrading from a build that only persisted plain prefs.
+    localStorage.setItem(
+      'shiranami.app-store',
+      JSON.stringify({
+        state: { lyricsPlainOpacity: 0.85, lyricsPlainFontSize: 'lg' },
+        version: 1,
+      })
+    );
+
+    const mod = await import('./useAppStore');
+    const state = mod.useAppStore.getState();
+    expect(state.lyricsPlainOpacity).toBe(0.85);
+    expect(state.lyricsPlainFontSize).toBe('lg');
+    expect(state.lyricsSyncedDimOpacity).toBe(mod.LYRICS_SYNCED_DIM_OPACITY_DEFAULT);
+    expect(state.lyricsSyncedFontSize).toBe(mod.LYRICS_SYNCED_FONT_SIZE_DEFAULT);
+  });
+
+  it('sanitizes malformed lyrics synced prefs from persisted shape', async () => {
+    localStorage.setItem(
+      'shiranami.app-store',
+      JSON.stringify({
+        state: { lyricsSyncedDimOpacity: 'broken', lyricsSyncedFontSize: 'huge' },
+        version: 1,
+      })
+    );
+
+    const mod = await import('./useAppStore');
+    const state = mod.useAppStore.getState();
+    expect(state.lyricsSyncedDimOpacity).toBe(mod.LYRICS_SYNCED_DIM_OPACITY_DEFAULT);
+    expect(state.lyricsSyncedFontSize).toBe(mod.LYRICS_SYNCED_FONT_SIZE_DEFAULT);
   });
 });

--- a/apps/web/src/stores/useAppStore.ts
+++ b/apps/web/src/stores/useAppStore.ts
@@ -19,7 +19,9 @@ export type LibraryViewMode = 'tracks' | 'albums';
 export type AlbumGridSize = 'small' | 'medium' | 'large';
 export type AlbumSortMode = 'name' | 'artist' | 'year' | 'recentlyAdded';
 export type AlbumSortOrder = 'asc' | 'desc';
-export type LyricsPlainFontSize = 'sm' | 'base' | 'lg' | 'xl';
+export type LyricsFontSize = 'sm' | 'base' | 'lg' | 'xl';
+/** @deprecated Use LyricsFontSize. Alias kept for back-compat with existing imports. */
+export type LyricsPlainFontSize = LyricsFontSize;
 
 export const UI_SCALE_MIN = 80;
 export const UI_SCALE_MAX = 120;
@@ -31,14 +33,39 @@ export const LYRICS_PLAIN_OPACITY_MIN = 0.5;
 export const LYRICS_PLAIN_OPACITY_MAX = 1.0;
 export const LYRICS_PLAIN_OPACITY_STEP = 0.05;
 export const LYRICS_PLAIN_OPACITY_DEFAULT = 0.9;
-export const LYRICS_PLAIN_FONT_SIZE_DEFAULT: LyricsPlainFontSize = 'base';
+export const LYRICS_PLAIN_FONT_SIZE_DEFAULT: LyricsFontSize = 'base';
 
-export const LYR_SIZE_CLASS: Record<LyricsPlainFontSize, string> = {
+export const LYRICS_SYNCED_DIM_OPACITY_MIN = 0.2;
+export const LYRICS_SYNCED_DIM_OPACITY_MAX = 1.0;
+export const LYRICS_SYNCED_DIM_OPACITY_STEP = 0.05;
+export const LYRICS_SYNCED_DIM_OPACITY_DEFAULT = 0.45;
+export const LYRICS_SYNCED_FONT_SIZE_DEFAULT: LyricsFontSize = 'base';
+
+/**
+ * Original synced view used past=0.25 / idle=0.45. We preserve that ratio
+ * (≈ 0.5556) so when the user dims idle, past dims proportionally and stays
+ * visibly fainter than idle.
+ */
+export const LYRICS_SYNCED_PAST_RATIO = 0.25 / 0.45;
+
+export const LYR_SIZE_CLASS: Record<LyricsFontSize, string> = {
   sm: 'text-sm leading-6',
   base: 'text-base leading-7',
   lg: 'text-lg leading-8',
   xl: 'text-xl leading-9',
 };
+
+const FONT_SIZE_ORDER: LyricsFontSize[] = ['sm', 'base', 'lg', 'xl'];
+
+/**
+ * Active synced line uses one step larger than the user-selected base, capped
+ * at xl. Mirrors the original hardcoded "base→lg active" behavior.
+ */
+export function nextLyricsFontSize(size: LyricsFontSize): LyricsFontSize {
+  const idx = FONT_SIZE_ORDER.indexOf(size);
+  if (idx < 0) return 'lg';
+  return FONT_SIZE_ORDER[Math.min(idx + 1, FONT_SIZE_ORDER.length - 1)];
+}
 
 const NEW_KEY = 'shiranami.app-store';
 
@@ -111,10 +138,28 @@ function coerceLyricsPlainOpacity(v: unknown): number {
   if (!Number.isFinite(parsed)) return LYRICS_PLAIN_OPACITY_DEFAULT;
   return clampLyricsPlainOpacity(parsed);
 }
-function coerceLyricsPlainFontSize(v: unknown): LyricsPlainFontSize {
+function coerceLyricsPlainFontSize(v: unknown): LyricsFontSize {
   return v === 'sm' || v === 'base' || v === 'lg' || v === 'xl'
     ? v
     : LYRICS_PLAIN_FONT_SIZE_DEFAULT;
+}
+function clampLyricsSyncedDimOpacity(v: number): number {
+  const clamped = Math.min(
+    LYRICS_SYNCED_DIM_OPACITY_MAX,
+    Math.max(LYRICS_SYNCED_DIM_OPACITY_MIN, v)
+  );
+  const steps = Math.round(clamped / LYRICS_SYNCED_DIM_OPACITY_STEP);
+  return Math.round(steps * LYRICS_SYNCED_DIM_OPACITY_STEP * 1000) / 1000;
+}
+function coerceLyricsSyncedDimOpacity(v: unknown): number {
+  const parsed = typeof v === 'number' ? v : Number(v);
+  if (!Number.isFinite(parsed)) return LYRICS_SYNCED_DIM_OPACITY_DEFAULT;
+  return clampLyricsSyncedDimOpacity(parsed);
+}
+function coerceLyricsSyncedFontSize(v: unknown): LyricsFontSize {
+  return v === 'sm' || v === 'base' || v === 'lg' || v === 'xl'
+    ? v
+    : LYRICS_SYNCED_FONT_SIZE_DEFAULT;
 }
 // --- Sanitizer: defensively re-apply enum whitelists and numeric clamps ---
 
@@ -137,7 +182,9 @@ interface PersistedAppState {
   lowPerformanceMode: boolean;
   noiseOverlayEnabled: boolean;
   lyricsPlainOpacity: number;
-  lyricsPlainFontSize: LyricsPlainFontSize;
+  lyricsPlainFontSize: LyricsFontSize;
+  lyricsSyncedDimOpacity: number;
+  lyricsSyncedFontSize: LyricsFontSize;
 }
 
 function sanitize(persisted: Partial<PersistedAppState> | undefined): Partial<PersistedAppState> {
@@ -179,6 +226,10 @@ function sanitize(persisted: Partial<PersistedAppState> | undefined): Partial<Pe
     out.lyricsPlainOpacity = coerceLyricsPlainOpacity(persisted.lyricsPlainOpacity);
   if (persisted.lyricsPlainFontSize !== undefined)
     out.lyricsPlainFontSize = coerceLyricsPlainFontSize(persisted.lyricsPlainFontSize);
+  if (persisted.lyricsSyncedDimOpacity !== undefined)
+    out.lyricsSyncedDimOpacity = coerceLyricsSyncedDimOpacity(persisted.lyricsSyncedDimOpacity);
+  if (persisted.lyricsSyncedFontSize !== undefined)
+    out.lyricsSyncedFontSize = coerceLyricsSyncedFontSize(persisted.lyricsSyncedFontSize);
   return out;
 }
 
@@ -291,7 +342,9 @@ interface AppState {
   lowPerformanceMode: boolean;
   noiseOverlayEnabled: boolean;
   lyricsPlainOpacity: number;
-  lyricsPlainFontSize: LyricsPlainFontSize;
+  lyricsPlainFontSize: LyricsFontSize;
+  lyricsSyncedDimOpacity: number;
+  lyricsSyncedFontSize: LyricsFontSize;
   previousView: AppView;
 }
 
@@ -327,8 +380,11 @@ interface AppActions {
   selectAlbum: (name: string | null) => void;
   setAlbumGridScrollTop: (scrollTop: number) => void;
   setLyricsPlainOpacity: (value: number) => void;
-  setLyricsPlainFontSize: (size: LyricsPlainFontSize) => void;
+  setLyricsPlainFontSize: (size: LyricsFontSize) => void;
   resetLyricsPlainAppearance: () => void;
+  setLyricsSyncedDimOpacity: (value: number) => void;
+  setLyricsSyncedFontSize: (size: LyricsFontSize) => void;
+  resetLyricsAppearance: () => void;
 }
 
 export const useAppStore = create<AppState & AppActions>()(
@@ -359,6 +415,8 @@ export const useAppStore = create<AppState & AppActions>()(
       noiseOverlayEnabled: false,
       lyricsPlainOpacity: LYRICS_PLAIN_OPACITY_DEFAULT,
       lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
+      lyricsSyncedDimOpacity: LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
+      lyricsSyncedFontSize: LYRICS_SYNCED_FONT_SIZE_DEFAULT,
       previousView: 'library',
 
       navigateTo: (view, playlistId) =>
@@ -504,6 +562,20 @@ export const useAppStore = create<AppState & AppActions>()(
           lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
         });
       },
+      setLyricsSyncedDimOpacity: value => {
+        set({ lyricsSyncedDimOpacity: coerceLyricsSyncedDimOpacity(value) });
+      },
+      setLyricsSyncedFontSize: size => {
+        set({ lyricsSyncedFontSize: coerceLyricsSyncedFontSize(size) });
+      },
+      resetLyricsAppearance: () => {
+        set({
+          lyricsPlainOpacity: LYRICS_PLAIN_OPACITY_DEFAULT,
+          lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
+          lyricsSyncedDimOpacity: LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
+          lyricsSyncedFontSize: LYRICS_SYNCED_FONT_SIZE_DEFAULT,
+        });
+      },
     }),
     {
       name: NEW_KEY,
@@ -529,6 +601,8 @@ export const useAppStore = create<AppState & AppActions>()(
         noiseOverlayEnabled: s.noiseOverlayEnabled,
         lyricsPlainOpacity: s.lyricsPlainOpacity,
         lyricsPlainFontSize: s.lyricsPlainFontSize,
+        lyricsSyncedDimOpacity: s.lyricsSyncedDimOpacity,
+        lyricsSyncedFontSize: s.lyricsSyncedFontSize,
       }),
       merge: (persisted, current) => ({
         ...current,

--- a/apps/web/src/stores/useAppStore.ts
+++ b/apps/web/src/stores/useAppStore.ts
@@ -19,12 +19,26 @@ export type LibraryViewMode = 'tracks' | 'albums';
 export type AlbumGridSize = 'small' | 'medium' | 'large';
 export type AlbumSortMode = 'name' | 'artist' | 'year' | 'recentlyAdded';
 export type AlbumSortOrder = 'asc' | 'desc';
+export type LyricsPlainFontSize = 'sm' | 'base' | 'lg' | 'xl';
 
 export const UI_SCALE_MIN = 80;
 export const UI_SCALE_MAX = 120;
 export const UI_SCALE_DEFAULT = 100;
 export const UI_SCALE_STEP = 5;
 export const UI_SCALE_PRESETS = [80, 90, 100, 110, 120] as const;
+
+export const LYRICS_PLAIN_OPACITY_MIN = 0.5;
+export const LYRICS_PLAIN_OPACITY_MAX = 1.0;
+export const LYRICS_PLAIN_OPACITY_STEP = 0.05;
+export const LYRICS_PLAIN_OPACITY_DEFAULT = 0.9;
+export const LYRICS_PLAIN_FONT_SIZE_DEFAULT: LyricsPlainFontSize = 'base';
+
+export const LYR_SIZE_CLASS: Record<LyricsPlainFontSize, string> = {
+  sm: 'text-sm leading-6',
+  base: 'text-base leading-7',
+  lg: 'text-lg leading-8',
+  xl: 'text-xl leading-9',
+};
 
 const NEW_KEY = 'shiranami.app-store';
 
@@ -86,6 +100,22 @@ function coerceUiScale(v: unknown): number {
   if (Number.isNaN(parsed)) return UI_SCALE_DEFAULT;
   return Math.round(Math.min(UI_SCALE_MAX, Math.max(UI_SCALE_MIN, parsed)));
 }
+function clampLyricsPlainOpacity(v: number): number {
+  const clamped = Math.min(LYRICS_PLAIN_OPACITY_MAX, Math.max(LYRICS_PLAIN_OPACITY_MIN, v));
+  // Round to nearest step to keep persisted values clean.
+  const steps = Math.round(clamped / LYRICS_PLAIN_OPACITY_STEP);
+  return Math.round(steps * LYRICS_PLAIN_OPACITY_STEP * 1000) / 1000;
+}
+function coerceLyricsPlainOpacity(v: unknown): number {
+  const parsed = typeof v === 'number' ? v : Number(v);
+  if (!Number.isFinite(parsed)) return LYRICS_PLAIN_OPACITY_DEFAULT;
+  return clampLyricsPlainOpacity(parsed);
+}
+function coerceLyricsPlainFontSize(v: unknown): LyricsPlainFontSize {
+  return v === 'sm' || v === 'base' || v === 'lg' || v === 'xl'
+    ? v
+    : LYRICS_PLAIN_FONT_SIZE_DEFAULT;
+}
 // --- Sanitizer: defensively re-apply enum whitelists and numeric clamps ---
 
 interface PersistedAppState {
@@ -106,6 +136,8 @@ interface PersistedAppState {
   libraryHeroCardEnabled: boolean;
   lowPerformanceMode: boolean;
   noiseOverlayEnabled: boolean;
+  lyricsPlainOpacity: number;
+  lyricsPlainFontSize: LyricsPlainFontSize;
 }
 
 function sanitize(persisted: Partial<PersistedAppState> | undefined): Partial<PersistedAppState> {
@@ -143,6 +175,10 @@ function sanitize(persisted: Partial<PersistedAppState> | undefined): Partial<Pe
     out.lowPerformanceMode = persisted.lowPerformanceMode;
   if (typeof persisted.noiseOverlayEnabled === 'boolean')
     out.noiseOverlayEnabled = persisted.noiseOverlayEnabled;
+  if (persisted.lyricsPlainOpacity !== undefined)
+    out.lyricsPlainOpacity = coerceLyricsPlainOpacity(persisted.lyricsPlainOpacity);
+  if (persisted.lyricsPlainFontSize !== undefined)
+    out.lyricsPlainFontSize = coerceLyricsPlainFontSize(persisted.lyricsPlainFontSize);
   return out;
 }
 
@@ -254,6 +290,8 @@ interface AppState {
   libraryHeroCardEnabled: boolean;
   lowPerformanceMode: boolean;
   noiseOverlayEnabled: boolean;
+  lyricsPlainOpacity: number;
+  lyricsPlainFontSize: LyricsPlainFontSize;
   previousView: AppView;
 }
 
@@ -288,6 +326,9 @@ interface AppActions {
   setAlbumSortOrder: (order: AlbumSortOrder) => void;
   selectAlbum: (name: string | null) => void;
   setAlbumGridScrollTop: (scrollTop: number) => void;
+  setLyricsPlainOpacity: (value: number) => void;
+  setLyricsPlainFontSize: (size: LyricsPlainFontSize) => void;
+  resetLyricsPlainAppearance: () => void;
 }
 
 export const useAppStore = create<AppState & AppActions>()(
@@ -316,6 +357,8 @@ export const useAppStore = create<AppState & AppActions>()(
       libraryHeroCardEnabled: true,
       lowPerformanceMode: false,
       noiseOverlayEnabled: false,
+      lyricsPlainOpacity: LYRICS_PLAIN_OPACITY_DEFAULT,
+      lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
       previousView: 'library',
 
       navigateTo: (view, playlistId) =>
@@ -449,6 +492,18 @@ export const useAppStore = create<AppState & AppActions>()(
       },
       selectAlbum: name => set({ selectedAlbumName: name }),
       setAlbumGridScrollTop: scrollTop => set({ albumGridScrollTop: scrollTop }),
+      setLyricsPlainOpacity: value => {
+        set({ lyricsPlainOpacity: coerceLyricsPlainOpacity(value) });
+      },
+      setLyricsPlainFontSize: size => {
+        set({ lyricsPlainFontSize: coerceLyricsPlainFontSize(size) });
+      },
+      resetLyricsPlainAppearance: () => {
+        set({
+          lyricsPlainOpacity: LYRICS_PLAIN_OPACITY_DEFAULT,
+          lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
+        });
+      },
     }),
     {
       name: NEW_KEY,
@@ -472,6 +527,8 @@ export const useAppStore = create<AppState & AppActions>()(
         libraryHeroCardEnabled: s.libraryHeroCardEnabled,
         lowPerformanceMode: s.lowPerformanceMode,
         noiseOverlayEnabled: s.noiseOverlayEnabled,
+        lyricsPlainOpacity: s.lyricsPlainOpacity,
+        lyricsPlainFontSize: s.lyricsPlainFontSize,
       }),
       merge: (persisted, current) => ({
         ...current,


### PR DESCRIPTION
Closes #144

## Summary

User reported plain-text lyrics in the lyrics panel were too small and too grey to read comfortably. Fixed the immediate readability problem, then extended the surface into a configurable Settings → Lyrics section so users can tune both **plain-text** and **synced** lyrics typography to taste — opacity + font size, with live previews. The original readability fix's values become the new defaults.

10 commits, +758 / -42 across 8 files. No regressions — typecheck clean, all 510 tests pass.

## What changed

### Phase 1 — Plain-text typography (5 commits)
- `useAppStore`: new `lyricsPlainOpacity` (default `0.9`, range `0.5–1.0`, step `0.05`) and `lyricsPlainFontSize` (`'sm' | 'base' | 'lg' | 'xl'`, default `'base'`) with clamp / step-rounding / coerce / reset + sanitize fallback for older persisted shapes.
- `settings.json` (EN + PL): full `lyr.*` block (later restructured in Phase 2).
- `LyricsSection.tsx` (new): `SettingsCard` with slider + segmented size picker + co-located `LyricsPreview`.
- `SettingsView.tsx`: new "Lyrics" section between Visualizer and Appearance, `Captions` icon.
- `LyricsPanel.tsx`: hardcoded plain-text `<pre>` className replaced with `cn(LYR_SIZE_CLASS[...])` + `style.opacity`.

Defaults preserve the issue #144 fix: `text-foreground` at 0.9 opacity, `text-base` + `leading-7`, `font-medium`, `tracking-[0.005em]`.

### Phase 2 — Synced typography (4 commits)
- i18n restructured: `lyr.*` flat keys → `lyr.plain.*` + `lyr.synced.*` with shared `lyr.size.*` / `lyr.preview*`. Translation parity in PL.
- `useAppStore`: new `lyricsSyncedDimOpacity` (default `0.45`, range `0.2–1.0`) + `lyricsSyncedFontSize`. Past lines derive at `dimOpacity × LYRICS_SYNCED_PAST_RATIO` (≈ `× 0.556`) preserving the original past:idle visual ratio. Active line stays pinned at full contrast and one size step larger than base.
- `LyricsSection.tsx`: split into "Plain text" + "Synced lyrics" subsections, each with its own controls and preview (synced preview shows past + idle + active + idle sample lines).
- `LyricsPanel.tsx`: switched synced idle/past lines from `text-muted-foreground/{X}` tokens to `text-foreground` + `opacity-[var(--lyrics-{idle,past}-opacity)]`. CSS custom properties set on the `LyricsList` parent — bridges Tailwind 4's compile-time class generation with runtime numeric values.

### Phase 3 — Now Playing parity (1 commit)
- `NowPlayingView.tsx`: applied the same prefs to the immersive lyrics block, preserving the existing container-query scaling (`@5xl:`, `@7xl:`) and the NP-specific +2-step active emphasis. Three local `Record<LyricsFontSize, string>` tables (`NP_PLAIN_SIZE_CLASS`, `NP_SYNCED_BASE_SIZE_CLASS`, `NP_SYNCED_ACTIVE_SIZE_CLASS`) keep the responsive class strings static while the user's enum picks the row. CSS-var pattern reused for synced opacities.

## Architectural notes
- Persistence via the existing Zustand `persist` → `localStorage` pattern, matching every other renderer UI preference (`uiScale`, `noiseOverlayEnabled`, sidebar prefs, EQ, visualizer style). No new IPC, no electron-store changes.
- `LyricsList.tsx` (the per-line renderer) is **not modified** — all dynamic styling threads through props or CSS vars on its parent. `git diff master -- apps/web/src/components/lyrics/LyricsList.tsx` is empty.
- `LYR_SIZE_CLASS` exported from `useAppStore` as the single source of truth, consumed by `LyricsPanel` + `LyricsSection`'s preview.
- `LYRICS_SYNCED_PAST_RATIO` exported as a named constant — used in both runtime CSS var math and section preview, guaranteeing they stay in sync.
- Floating-point clamp uses `Math.round(steps × step × 1000) / 1000` to keep persisted values stable (no `0.55000000000001` drift through JSON round-trips).

## Test plan
- [ ] Open Settings → **Lyrics**; both "Plain text" and "Synced lyrics" subsections render with working sliders + segmented size pickers.
- [ ] Each subsection's live preview updates synchronously as controls change.
- [ ] Single "Reset to defaults" link appears only when any of the four lyrics prefs differs from defaults; clicking it resets all four.
- [ ] Play a track with no synced lyrics → side-panel plain-text view renders larger and at higher contrast than before; opacity slider visibly tunes it.
- [ ] Play a track with synced lyrics → side-panel synced view renders identically to before at default settings; dim opacity slider lifts idle and past lines while the active highlight stays at full contrast.
- [ ] Synced font size enum scales all synced lines, with the active line consistently one step larger than the rest.
- [ ] Switch to **Now Playing** immersive view → prefs apply there too; container-query scaling at wide widths is preserved; active line emphasis remains visibly larger than base.
- [ ] Reload the renderer → all four prefs are restored from persistence.
- [ ] Switch language to Polish → all new `lyr.*` strings render without overflow at the smallest panel size.
- [ ] No console errors when rehydrating persisted state from a build that predates the synced prefs (sanitize fallback applies defaults).