### PR TITLE
feat(player): configurable compact mode (T1 fixes + T2 settings)

### DIFF
--- a/apps/desktop/src/main/ipc/schemas/window.ts
+++ b/apps/desktop/src/main/ipc/schemas/window.ts
@@ -5,4 +5,10 @@ export const windowMaximizeArgs = z.tuple([]);
 export const windowCloseArgs = z.tuple([]);
 export const windowIsMaximizedArgs = z.tuple([]);
 export const windowSetAlwaysOnTopArgs = z.tuple([z.boolean()]);
-export const windowSetCompactModeArgs = z.tuple([z.boolean()]);
+export const windowCompactDimensions = z
+  .object({
+    width: z.number().int().min(200).max(1200),
+    height: z.number().int().min(120).max(800),
+  })
+  .optional();
+export const windowSetCompactModeArgs = z.tuple([z.boolean(), windowCompactDimensions]);

--- a/apps/desktop/src/main/ipc/window.test.ts
+++ b/apps/desktop/src/main/ipc/window.test.ts
@@ -144,6 +144,29 @@ describe('registerWindowHandlers', () => {
     expect(mockStore.set).toHaveBeenCalledWith('compact-window-bounds', { x: 1234, y: 567 });
   });
 
+  it('saves compact-window-bounds when window closes while in compact mode', async () => {
+    const win = createMainWindowMock();
+    win.getBounds.mockReturnValue({ x: 80, y: 90, width: 500, height: 214 });
+    registerWindowHandlers(asBrowserWindow(win));
+
+    await ipcHandlers.get('window:set-compact-mode')!(null as never, true);
+    const closeListener = win.on.mock.calls.find(([event]) => event === 'close')?.[1];
+    expect(closeListener).toBeDefined();
+    closeListener!();
+
+    expect(mockStore.set).toHaveBeenCalledWith('compact-window-bounds', { x: 80, y: 90 });
+  });
+
+  it('does not save compact-window-bounds when closing from normal mode', () => {
+    const win = createMainWindowMock();
+    registerWindowHandlers(asBrowserWindow(win));
+
+    const closeListener = win.on.mock.calls.find(([event]) => event === 'close')?.[1];
+    closeListener!();
+
+    expect(mockStore.set).not.toHaveBeenCalledWith('compact-window-bounds', expect.anything());
+  });
+
   it('restores compact-window-bounds on re-entry when position is on-screen', async () => {
     const win = createMainWindowMock();
     mockStore.get.mockReturnValue({ x: 200, y: 300 });

--- a/apps/desktop/src/main/ipc/window.test.ts
+++ b/apps/desktop/src/main/ipc/window.test.ts
@@ -5,6 +5,21 @@ import {
   createMainWindowMock,
   asBrowserWindow,
 } from '../../../test/setup';
+
+// Hoisted so the vi.mock factory below can close over the same instance the
+// tests assert against (vi.mock runs before any module-scope initializers).
+const { mockStore } = vi.hoisted(() => ({
+  mockStore: {
+    get: vi.fn<(key: string) => unknown>(),
+    set: vi.fn<(key: string, value: unknown) => void>(),
+    delete: vi.fn<(key: string) => void>(),
+  },
+}));
+
+vi.mock('../store', () => ({
+  store: mockStore,
+}));
+
 import { cleanupWindowHandlers, registerWindowHandlers } from './window';
 
 describe('registerWindowHandlers', () => {
@@ -116,6 +131,42 @@ describe('registerWindowHandlers', () => {
     expect(win.setMaximumSize).toHaveBeenCalledWith(0, 0);
     expect(win.setBounds).toHaveBeenCalledWith(bounds, true);
     expect(win.maximize).not.toHaveBeenCalled();
+  });
+
+  it('saves compact-window-bounds on exit-compact', async () => {
+    const win = createMainWindowMock();
+    win.getBounds.mockReturnValue({ x: 1234, y: 567, width: 500, height: 214 });
+    registerWindowHandlers(asBrowserWindow(win));
+
+    await ipcHandlers.get('window:set-compact-mode')!(null as never, true);
+    await ipcHandlers.get('window:set-compact-mode')!(null as never, false);
+
+    expect(mockStore.set).toHaveBeenCalledWith('compact-window-bounds', { x: 1234, y: 567 });
+  });
+
+  it('restores compact-window-bounds on re-entry when position is on-screen', async () => {
+    const win = createMainWindowMock();
+    mockStore.get.mockReturnValue({ x: 200, y: 300 });
+    registerWindowHandlers(asBrowserWindow(win));
+
+    await ipcHandlers.get('window:set-compact-mode')!(null as never, true);
+
+    expect(win.setBounds).toHaveBeenCalledWith({ x: 200, y: 300, width: 500, height: 214 }, true);
+    // Should not also call setSize when we already used setBounds for the
+    // restore — that would cause a flicker on enter.
+    expect(win.setSize).not.toHaveBeenCalled();
+  });
+
+  it('falls back to default placement when saved compact bounds are off-screen', async () => {
+    const win = createMainWindowMock();
+    // Saved at x=5000 — outside the 1920x1080 mock display.
+    mockStore.get.mockReturnValue({ x: 5000, y: 5000 });
+    registerWindowHandlers(asBrowserWindow(win));
+
+    await ipcHandlers.get('window:set-compact-mode')!(null as never, true);
+
+    expect(win.setBounds).not.toHaveBeenCalled();
+    expect(win.setSize).toHaveBeenCalledWith(500, 214, true);
   });
 
   it('exits compact mode: re-maximizes when was maximized before compact', async () => {

--- a/apps/desktop/src/main/ipc/window.test.ts
+++ b/apps/desktop/src/main/ipc/window.test.ts
@@ -60,6 +60,47 @@ describe('registerWindowHandlers', () => {
     expect(win.setSize).toHaveBeenCalledWith(500, 214, true);
   });
 
+  it('enters compact mode with caller-provided dimensions', async () => {
+    const win = createMainWindowMock();
+    win.isMaximized.mockReturnValue(false);
+    registerWindowHandlers(asBrowserWindow(win));
+
+    await ipcHandlers.get('window:set-compact-mode')!(null as never, true, {
+      width: 600,
+      height: 260,
+    });
+
+    expect(win.setMinimumSize).toHaveBeenCalledWith(600, 260);
+    expect(win.setMaximumSize).toHaveBeenCalledWith(600, 260);
+    expect(win.setSize).toHaveBeenCalledWith(600, 260, true);
+  });
+
+  it('resizes within compact mode without re-saving normalBounds', async () => {
+    const win = createMainWindowMock();
+    const bounds = { x: 10, y: 20, width: 900, height: 700 };
+    win.getNormalBounds.mockReturnValue(bounds);
+    win.isMaximized.mockReturnValue(false);
+    registerWindowHandlers(asBrowserWindow(win));
+
+    await ipcHandlers.get('window:set-compact-mode')!(null as never, true, {
+      width: 500,
+      height: 214,
+    });
+    expect(win.getNormalBounds).toHaveBeenCalledTimes(1);
+
+    await ipcHandlers.get('window:set-compact-mode')!(null as never, true, {
+      width: 600,
+      height: 260,
+    });
+
+    // Resize-while-compact should not re-capture normalBounds; otherwise we'd
+    // overwrite the original maximized/restored state with the compact bounds.
+    expect(win.getNormalBounds).toHaveBeenCalledTimes(1);
+    expect(win.setMinimumSize).toHaveBeenLastCalledWith(600, 260);
+    expect(win.setMaximumSize).toHaveBeenLastCalledWith(600, 260);
+    expect(win.setSize).toHaveBeenLastCalledWith(600, 260, true);
+  });
+
   it('exits compact mode: restores bounds when not maximized before compact', async () => {
     const win = createMainWindowMock();
     const bounds = { x: 10, y: 20, width: 900, height: 700 };

--- a/apps/desktop/src/main/ipc/window.ts
+++ b/apps/desktop/src/main/ipc/window.ts
@@ -52,6 +52,21 @@ export function registerWindowHandlers(mainWindow: BrowserWindow): void {
   let normalBounds: Rectangle | null = null;
   let wasMaximizedBeforeCompact = false;
 
+  const persistCompactBounds = () => {
+    if (!isCompactMode) return;
+    try {
+      const bounds = mainWindow.getBounds();
+      store.set(COMPACT_BOUNDS_KEY, { x: bounds.x, y: bounds.y });
+    } catch {
+      // ignore — bounds read can fail in unusual platform states
+    }
+  };
+
+  // Quitting from compact mode (taskbar, Alt+F4, system shortcut) bypasses
+  // the explicit exit-compact path, so we'd otherwise lose the user's last
+  // mini-player position. Snapshot here so the next session restores cleanly.
+  mainWindow.on('close', persistCompactBounds);
+
   handle(
     'window:minimize',
     () => {
@@ -139,16 +154,9 @@ export function registerWindowHandlers(mainWindow: BrowserWindow): void {
       }
 
       // Persist where the user parked the mini-player so the next session
-      // restores into the same screen corner. We snapshot before unlocking
-      // size constraints so a transient resize doesn't pollute the saved
-      // position.
-      try {
-        const bounds = mainWindow.getBounds();
-        store.set(COMPACT_BOUNDS_KEY, { x: bounds.x, y: bounds.y });
-      } catch {
-        // Bounds read can fail in unusual platform states; ignore so exiting
-        // compact mode never blocks on a persistence failure.
-      }
+      // restores into the same screen corner. Snapshot before unlocking size
+      // constraints so a transient resize doesn't pollute the saved position.
+      persistCompactBounds();
 
       mainWindow.setResizable(true);
       mainWindow.setMinimumSize(DEFAULT_MIN_WIDTH, DEFAULT_MIN_HEIGHT);

--- a/apps/desktop/src/main/ipc/window.ts
+++ b/apps/desktop/src/main/ipc/window.ts
@@ -1,5 +1,6 @@
-import { BrowserWindow, ipcMain, type Rectangle } from 'electron';
+import { BrowserWindow, ipcMain, screen, type Rectangle } from 'electron';
 import { handle } from './with-ipc-handler';
+import { store } from '../store';
 import {
   windowMinimizeArgs,
   windowMaximizeArgs,
@@ -13,6 +14,38 @@ const DEFAULT_MIN_WIDTH = 800;
 const DEFAULT_MIN_HEIGHT = 600;
 const COMPACT_DEFAULT_WIDTH = 500;
 const COMPACT_DEFAULT_HEIGHT = 214;
+const COMPACT_BOUNDS_KEY = 'compact-window-bounds';
+
+/**
+ * Returns a position for the compact window: the user's last-saved corner if
+ * we have one and it falls within a currently-connected display work area, or
+ * `null` to let Electron's default placement (top-left of normalBounds) win.
+ *
+ * Guards against a saved position from a now-disconnected monitor pulling the
+ * window offscreen by validating against every display's `workArea` (the
+ * monitor minus taskbar/menu reservations).
+ */
+function getValidCompactPosition(width: number, height: number): { x: number; y: number } | null {
+  const saved = store.get(COMPACT_BOUNDS_KEY);
+  if (!saved || typeof saved.x !== 'number' || typeof saved.y !== 'number') return null;
+
+  const displays = screen.getAllDisplays();
+  // The window is considered onscreen if at least 80px of it lands within
+  // some display's work area on each axis. That tolerance keeps a slightly
+  // off-edge window restoreable while still rejecting one that's mostly on a
+  // monitor that's no longer connected.
+  const VISIBLE_PX = 80;
+  const visible = displays.some(d => {
+    const wa = d.workArea;
+    const xVisible =
+      saved.x + width >= wa.x + VISIBLE_PX && saved.x <= wa.x + wa.width - VISIBLE_PX;
+    const yVisible =
+      saved.y + height >= wa.y + VISIBLE_PX && saved.y <= wa.y + wa.height - VISIBLE_PX;
+    return xVisible && yVisible;
+  });
+
+  return visible ? { x: saved.x, y: saved.y } : null;
+}
 
 export function registerWindowHandlers(mainWindow: BrowserWindow): void {
   let isCompactMode = false;
@@ -94,9 +127,27 @@ export function registerWindowHandlers(mainWindow: BrowserWindow): void {
         mainWindow.setMinimizable(true);
         mainWindow.setMinimumSize(width, height);
         mainWindow.setMaximumSize(width, height);
-        mainWindow.setSize(width, height, true);
+
+        const lastPosition = getValidCompactPosition(width, height);
+        if (lastPosition) {
+          mainWindow.setBounds({ ...lastPosition, width, height }, true);
+        } else {
+          mainWindow.setSize(width, height, true);
+        }
         isCompactMode = true;
         return;
+      }
+
+      // Persist where the user parked the mini-player so the next session
+      // restores into the same screen corner. We snapshot before unlocking
+      // size constraints so a transient resize doesn't pollute the saved
+      // position.
+      try {
+        const bounds = mainWindow.getBounds();
+        store.set(COMPACT_BOUNDS_KEY, { x: bounds.x, y: bounds.y });
+      } catch {
+        // Bounds read can fail in unusual platform states; ignore so exiting
+        // compact mode never blocks on a persistence failure.
       }
 
       mainWindow.setResizable(true);

--- a/apps/desktop/src/main/ipc/window.ts
+++ b/apps/desktop/src/main/ipc/window.ts
@@ -11,8 +11,8 @@ import {
 
 const DEFAULT_MIN_WIDTH = 800;
 const DEFAULT_MIN_HEIGHT = 600;
-const COMPACT_WIDTH = 500;
-const COMPACT_HEIGHT = 214;
+const COMPACT_DEFAULT_WIDTH = 500;
+const COMPACT_DEFAULT_HEIGHT = 214;
 
 export function registerWindowHandlers(mainWindow: BrowserWindow): void {
   let isCompactMode = false;
@@ -24,7 +24,7 @@ export function registerWindowHandlers(mainWindow: BrowserWindow): void {
     () => {
       mainWindow.minimize();
     },
-    { schema: windowMinimizeArgs },
+    { schema: windowMinimizeArgs }
   );
 
   handle(
@@ -36,7 +36,7 @@ export function registerWindowHandlers(mainWindow: BrowserWindow): void {
         mainWindow.maximize();
       }
     },
-    { schema: windowMaximizeArgs },
+    { schema: windowMaximizeArgs }
   );
 
   handle(
@@ -44,7 +44,7 @@ export function registerWindowHandlers(mainWindow: BrowserWindow): void {
     () => {
       mainWindow.close();
     },
-    { schema: windowCloseArgs },
+    { schema: windowCloseArgs }
   );
 
   handle(
@@ -52,7 +52,7 @@ export function registerWindowHandlers(mainWindow: BrowserWindow): void {
     () => {
       return mainWindow.isMaximized();
     },
-    { schema: windowIsMaximizedArgs },
+    { schema: windowIsMaximizedArgs }
   );
 
   handle(
@@ -60,12 +60,26 @@ export function registerWindowHandlers(mainWindow: BrowserWindow): void {
     (_event, alwaysOnTop: boolean) => {
       mainWindow.setAlwaysOnTop(alwaysOnTop);
     },
-    { schema: windowSetAlwaysOnTopArgs },
+    { schema: windowSetAlwaysOnTopArgs }
   );
 
   handle(
     'window:set-compact-mode',
-    (_event, compactMode: boolean) => {
+    (_event, compactMode: boolean, dimensions?: { width: number; height: number }) => {
+      const width = dimensions?.width ?? COMPACT_DEFAULT_WIDTH;
+      const height = dimensions?.height ?? COMPACT_DEFAULT_HEIGHT;
+
+      // If we're already in compact mode and the call is also asking for
+      // compact, treat it as a resize: switch to the new locked dimensions
+      // without re-saving normalBounds (we'd overwrite them with the current
+      // compact bounds, losing the original maximized/restored state).
+      if (compactMode && isCompactMode) {
+        mainWindow.setMinimumSize(width, height);
+        mainWindow.setMaximumSize(width, height);
+        mainWindow.setSize(width, height, true);
+        return;
+      }
+
       if (compactMode === isCompactMode) return;
 
       if (compactMode) {
@@ -78,9 +92,9 @@ export function registerWindowHandlers(mainWindow: BrowserWindow): void {
 
         mainWindow.setResizable(false);
         mainWindow.setMinimizable(true);
-        mainWindow.setMinimumSize(COMPACT_WIDTH, COMPACT_HEIGHT);
-        mainWindow.setMaximumSize(COMPACT_WIDTH, COMPACT_HEIGHT);
-        mainWindow.setSize(COMPACT_WIDTH, COMPACT_HEIGHT, true);
+        mainWindow.setMinimumSize(width, height);
+        mainWindow.setMaximumSize(width, height);
+        mainWindow.setSize(width, height, true);
         isCompactMode = true;
         return;
       }
@@ -98,7 +112,7 @@ export function registerWindowHandlers(mainWindow: BrowserWindow): void {
       wasMaximizedBeforeCompact = false;
       isCompactMode = false;
     },
-    { schema: windowSetCompactModeArgs },
+    { schema: windowSetCompactModeArgs }
   );
 
   mainWindow.on('maximize', () => {

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -194,7 +194,10 @@ export interface ElectronAPI {
     close: () => Promise<void>;
     isMaximized: () => Promise<boolean>;
     setAlwaysOnTop: (alwaysOnTop: boolean) => Promise<void>;
-    setCompactMode: (compactMode: boolean) => Promise<void>;
+    setCompactMode: (
+      compactMode: boolean,
+      dimensions?: { width: number; height: number }
+    ) => Promise<void>;
     onMaximizedChange: (callback: (maximized: boolean) => void) => () => void;
   };
   store: {
@@ -262,8 +265,15 @@ export interface ElectronAPI {
       getAll: () => Promise<unknown[]>;
       get: (id: string) => Promise<unknown>;
       create: (data: { name: string; description?: string; coverArt?: string }) => Promise<unknown>;
-      createWithTracks: (data: { name: string; description?: string; trackIds: string[] }) => Promise<unknown>;
-      update: (id: string, data: { name?: string; description?: string; coverArt?: string }) => Promise<unknown>;
+      createWithTracks: (data: {
+        name: string;
+        description?: string;
+        trackIds: string[];
+      }) => Promise<unknown>;
+      update: (
+        id: string,
+        data: { name?: string; description?: string; coverArt?: string }
+      ) => Promise<unknown>;
       delete: (id: string) => Promise<void>;
       getTracks: (playlistId: string) => Promise<unknown[]>;
       addTrack: (playlistId: string, trackId: string) => Promise<unknown>;
@@ -300,15 +310,17 @@ export interface ElectronAPI {
   downloader: {
     getStreamUrl: (url: string) => Promise<string>;
     suggest: (query: string) => Promise<string[]>;
-    search: (query: string) => Promise<Array<{
-      id: string;
-      title: string;
-      uploader: string;
-      duration: number;
-      thumbnail: string;
-      url: string;
-      webpage_url: string;
-    }>>;
+    search: (query: string) => Promise<
+      Array<{
+        id: string;
+        title: string;
+        uploader: string;
+        duration: number;
+        thumbnail: string;
+        url: string;
+        webpage_url: string;
+      }>
+    >;
     download: (url: string) => Promise<string>;
     getDownloadLocation: () => Promise<{
       path: string;
@@ -322,15 +334,35 @@ export interface ElectronAPI {
     }>;
     checkDependencies: () => Promise<{ ytdlpInstalled: boolean; ffmpegInstalled: boolean }>;
     getCachedToolStatus: () => Promise<{
-      ytdlp: { installed: boolean; version?: string; latestVersion?: string; updateAvailable?: boolean };
-      ffmpeg: { installed: boolean; version?: string; latestVersion?: string; updateAvailable?: boolean };
+      ytdlp: {
+        installed: boolean;
+        version?: string;
+        latestVersion?: string;
+        updateAvailable?: boolean;
+      };
+      ffmpeg: {
+        installed: boolean;
+        version?: string;
+        latestVersion?: string;
+        updateAvailable?: boolean;
+      };
       ytdlpPath: string;
       downloadLocation: { path: string; defaultPath: string; isDefault: boolean };
       timestamp: number;
     } | null>;
     refreshToolStatus: () => Promise<{
-      ytdlp: { installed: boolean; version?: string; latestVersion?: string; updateAvailable?: boolean };
-      ffmpeg: { installed: boolean; version?: string; latestVersion?: string; updateAvailable?: boolean };
+      ytdlp: {
+        installed: boolean;
+        version?: string;
+        latestVersion?: string;
+        updateAvailable?: boolean;
+      };
+      ffmpeg: {
+        installed: boolean;
+        version?: string;
+        latestVersion?: string;
+        updateAvailable?: boolean;
+      };
       ytdlpPath: string;
       downloadLocation: { path: string; defaultPath: string; isDefault: boolean };
       timestamp: number;
@@ -341,12 +373,14 @@ export interface ElectronAPI {
       latestVersion?: string;
       updateAvailable?: boolean;
     }>;
-    onProgress: (callback: (data: {
-      url: string;
-      progress: number;
-      status: 'downloading' | 'converting' | 'done' | 'error';
-      error?: string;
-    }) => void) => () => void;
+    onProgress: (
+      callback: (data: {
+        url: string;
+        progress: number;
+        status: 'downloading' | 'converting' | 'done' | 'error';
+        error?: string;
+      }) => void
+    ) => () => void;
     installYtDlp: () => Promise<void>;
     onInstallProgress: (callback: (progress: { percent: number }) => void) => () => void;
     getYtDlpPath: () => Promise<string>;
@@ -359,22 +393,43 @@ export interface ElectronAPI {
     installFfmpeg: () => Promise<void>;
     onFfmpegInstallProgress: (callback: (progress: { percent: number }) => void) => () => void;
     installDependencies: () => Promise<InstallDependenciesResult>;
-    onDependencyInstallProgress: (callback: (progress: {
-      target: 'ytdlp' | 'ffmpeg';
-      percent: number;
-      overallPercent: number;
-      label: string;
-    }) => void) => () => void;
+    onDependencyInstallProgress: (
+      callback: (progress: {
+        target: 'ytdlp' | 'ffmpeg';
+        percent: number;
+        overallPercent: number;
+        label: string;
+      }) => void
+    ) => () => void;
   };
   updater: {
     checkForUpdates: () => Promise<{ enabled: boolean }>;
     startDownload: () => Promise<void>;
     installNow: () => Promise<void>;
     onCheckingForUpdate: (callback: () => void) => () => void;
-    onUpdateAvailable: (callback: (info: { version: string; releaseNotes: string | null; releaseDate: string }) => void) => () => void;
+    onUpdateAvailable: (
+      callback: (info: {
+        version: string;
+        releaseNotes: string | null;
+        releaseDate: string;
+      }) => void
+    ) => () => void;
     onUpdateNotAvailable: (callback: () => void) => () => void;
-    onDownloadProgress: (callback: (progress: { bytesPerSecond: number; percent: number; transferred: number; total: number }) => void) => () => void;
-    onUpdateDownloaded: (callback: (info: { version: string; releaseNotes: string | null; releaseDate: string }) => void) => () => void;
+    onDownloadProgress: (
+      callback: (progress: {
+        bytesPerSecond: number;
+        percent: number;
+        transferred: number;
+        total: number;
+      }) => void
+    ) => () => void;
+    onUpdateDownloaded: (
+      callback: (info: {
+        version: string;
+        releaseNotes: string | null;
+        releaseDate: string;
+      }) => void
+    ) => () => void;
     onUpdateError: (callback: (message: string) => void) => () => void;
   };
   shell: {
@@ -403,24 +458,27 @@ export interface ElectronAPI {
     };
   };
   playlist: {
-    extract: (url: string) => Promise<Array<{
-      id: string;
-      title: string;
-      uploader: string;
-      duration: number;
-      thumbnail: string;
-      url: string;
-      webpage_url: string;
-    }>>;
+    extract: (url: string) => Promise<
+      Array<{
+        id: string;
+        title: string;
+        uploader: string;
+        duration: number;
+        thumbnail: string;
+        url: string;
+        webpage_url: string;
+      }>
+    >;
     cancel: () => Promise<void>;
-    onExtractProgress: (callback: (data: {
-      current: number;
-      total: number;
-      trackName: string;
-    }) => void) => () => void;
+    onExtractProgress: (
+      callback: (data: { current: number; total: number; trackName: string }) => void
+    ) => () => void;
   };
   metadata: {
-    lookup: (title: string, artist: string) => Promise<{
+    lookup: (
+      title: string,
+      artist: string
+    ) => Promise<{
       title?: string;
       artist?: string;
       album?: string;
@@ -444,28 +502,32 @@ export interface ElectronAPI {
         trackNumber: number | null;
       }>,
       options: { writeToFile: boolean; onlyMissing: boolean }
-    ) => Promise<Array<{
-      id: string;
-      success: boolean;
-      updatedFields: Partial<{
-        title: string;
-        artist: string;
-        album: string;
-        genre: string;
-        year: number;
-        trackNumber: number;
-        albumArt: string;
-      }>;
-      source: string;
-      error?: string;
-    }>>;
+    ) => Promise<
+      Array<{
+        id: string;
+        success: boolean;
+        updatedFields: Partial<{
+          title: string;
+          artist: string;
+          album: string;
+          genre: string;
+          year: number;
+          trackNumber: number;
+          albumArt: string;
+        }>;
+        source: string;
+        error?: string;
+      }>
+    >;
     cancelEnrichment: () => Promise<void>;
-    onEnrichProgress: (callback: (data: {
-      current: number;
-      total: number;
-      trackName: string;
-      status: 'searching' | 'downloading' | 'writing' | 'done' | 'error' | 'cancelled';
-    }) => void) => () => void;
+    onEnrichProgress: (
+      callback: (data: {
+        current: number;
+        total: number;
+        trackName: string;
+        status: 'searching' | 'downloading' | 'writing' | 'done' | 'error' | 'cancelled';
+      }) => void
+    ) => () => void;
   };
   share: {
     track: (trackId: string) => Promise<{ code: string; url: string; expiresAt: string }>;
@@ -499,8 +561,8 @@ const electronAPI: ElectronAPI = {
     isMaximized: () => ipcRenderer.invoke('window:is-maximized'),
     setAlwaysOnTop: (alwaysOnTop: boolean) =>
       ipcRenderer.invoke('window:set-always-on-top', alwaysOnTop),
-    setCompactMode: (compactMode: boolean) =>
-      ipcRenderer.invoke('window:set-compact-mode', compactMode),
+    setCompactMode: (compactMode: boolean, dimensions?: { width: number; height: number }) =>
+      ipcRenderer.invoke('window:set-compact-mode', compactMode, dimensions),
     onMaximizedChange: createIpcListener<boolean>('window:maximized-change'),
   },
   store: {
@@ -519,8 +581,10 @@ const electronAPI: ElectronAPI = {
   library: {
     parseMetadata: (filePath: string) => ipcRenderer.invoke('library:parse-metadata', filePath),
     scanFolder: (dirPath: string) => ipcRenderer.invoke('library:scan-folder', dirPath),
-    scanFolderGrouped: (dirPath: string) => ipcRenderer.invoke('library:scan-folder-grouped', dirPath),
-    validateFiles: (filePaths: string[]) => ipcRenderer.invoke('library:validate-files', filePaths) as Promise<string[]>,
+    scanFolderGrouped: (dirPath: string) =>
+      ipcRenderer.invoke('library:scan-folder-grouped', dirPath),
+    validateFiles: (filePaths: string[]) =>
+      ipcRenderer.invoke('library:validate-files', filePaths) as Promise<string[]>,
   },
   db: {
     tracks: {
@@ -530,12 +594,14 @@ const electronAPI: ElectronAPI = {
       remove: (id: string) => ipcRenderer.invoke('db:tracks:remove', id),
       removeMany: (ids: string[]) => ipcRenderer.invoke('db:tracks:remove-many', ids),
       update: (id: string, data: unknown) => ipcRenderer.invoke('db:tracks:update', id, data),
-      updateMany: (updates: Array<{ id: string; data: unknown }>) => ipcRenderer.invoke('db:tracks:update-many', updates),
+      updateMany: (updates: Array<{ id: string; data: unknown }>) =>
+        ipcRenderer.invoke('db:tracks:update-many', updates),
       toggleFavorite: (id: string) => ipcRenderer.invoke('db:tracks:toggle-favorite', id),
       getFavorites: () => ipcRenderer.invoke('db:tracks:get-favorites'),
       incrementPlayCount: (id: string) => ipcRenderer.invoke('db:tracks:increment-play-count', id),
       exists: (filePath: string) => ipcRenderer.invoke('db:tracks:exists', filePath),
-      existsMany: (filePaths: string[]) => ipcRenderer.invoke('db:tracks:exists-many', filePaths) as Promise<string[]>,
+      existsMany: (filePaths: string[]) =>
+        ipcRenderer.invoke('db:tracks:exists-many', filePaths) as Promise<string[]>,
     },
     history: {
       recordPlay: (data: {
@@ -584,7 +650,7 @@ const electronAPI: ElectronAPI = {
   },
   media: {
     onCommand: createIpcListener<string>('media:command'),
-    sendPlaybackState: (state) => ipcRenderer.invoke('media:playback-state', state),
+    sendPlaybackState: state => ipcRenderer.invoke('media:playback-state', state),
     clearState: () => ipcRenderer.invoke('media:clear-state'),
   },
   downloader: {
@@ -610,7 +676,9 @@ const electronAPI: ElectronAPI = {
     getYtDlpPath: () => ipcRenderer.invoke('downloader:get-ytdlp-path'),
     checkFfmpeg: () => ipcRenderer.invoke('downloader:check-ffmpeg'),
     installFfmpeg: () => ipcRenderer.invoke('downloader:install-ffmpeg'),
-    onFfmpegInstallProgress: createIpcListener<{ percent: number }>('downloader:ffmpeg-install-progress'),
+    onFfmpegInstallProgress: createIpcListener<{ percent: number }>(
+      'downloader:ffmpeg-install-progress'
+    ),
     installDependencies: () => ipcRenderer.invoke('downloader:install-dependencies'),
     onDependencyInstallProgress: createIpcListener<{
       target: 'ytdlp' | 'ffmpeg';
@@ -624,10 +692,23 @@ const electronAPI: ElectronAPI = {
     startDownload: () => ipcRenderer.invoke('updater:start-download'),
     installNow: () => ipcRenderer.invoke('updater:install-now'),
     onCheckingForUpdate: createIpcListener<void>('updater:checking-for-update'),
-    onUpdateAvailable: createIpcListener<{ version: string; releaseNotes: string | null; releaseDate: string }>('updater:update-available'),
+    onUpdateAvailable: createIpcListener<{
+      version: string;
+      releaseNotes: string | null;
+      releaseDate: string;
+    }>('updater:update-available'),
     onUpdateNotAvailable: createIpcListener<void>('updater:update-not-available'),
-    onDownloadProgress: createIpcListener<{ bytesPerSecond: number; percent: number; transferred: number; total: number }>('updater:download-progress'),
-    onUpdateDownloaded: createIpcListener<{ version: string; releaseNotes: string | null; releaseDate: string }>('updater:update-downloaded'),
+    onDownloadProgress: createIpcListener<{
+      bytesPerSecond: number;
+      percent: number;
+      transferred: number;
+      total: number;
+    }>('updater:download-progress'),
+    onUpdateDownloaded: createIpcListener<{
+      version: string;
+      releaseNotes: string | null;
+      releaseDate: string;
+    }>('updater:update-downloaded'),
     onUpdateError: createIpcListener<string>('updater:error'),
   },
   shell: {
@@ -666,8 +747,7 @@ const electronAPI: ElectronAPI = {
     }>('playlist:extract-progress'),
   },
   metadata: {
-    lookup: (title: string, artist: string) =>
-      ipcRenderer.invoke('metadata:lookup', title, artist),
+    lookup: (title: string, artist: string) => ipcRenderer.invoke('metadata:lookup', title, artist),
     enrichTracks: (
       tracks: Array<{
         id: string;
@@ -694,7 +774,8 @@ const electronAPI: ElectronAPI = {
     track: (trackId: string) => ipcRenderer.invoke('share:track', trackId),
     playlist: (playlistId: string) => ipcRenderer.invoke('share:playlist', playlistId),
     import: (code: string) => ipcRenderer.invoke('share:import', code),
-    cacheYoutubeId: (trackId: string, youtubeId: string) => ipcRenderer.invoke('share:cache-youtube-id', trackId, youtubeId),
+    cacheYoutubeId: (trackId: string, youtubeId: string) =>
+      ipcRenderer.invoke('share:cache-youtube-id', trackId, youtubeId),
     onDeepLink: createIpcListener<string>('share:deep-link'),
   },
   ipc: {

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -25,6 +25,10 @@ export interface StoreSchema {
   'player-state': unknown;
   'window-bounds': unknown;
 
+  // Main-only: position of the compact mini-player. Persisted on exit-compact
+  // so the next enter-compact restores to the same screen corner.
+  'compact-window-bounds': { x: number; y: number };
+
   // Renderer-owned scalars.
   'player.volume': number;
   'player.isMuted': boolean;

--- a/apps/desktop/test/setup.ts
+++ b/apps/desktop/test/setup.ts
@@ -44,6 +44,16 @@ vi.mock('electron', () => ({
       return mockMainWindow ? [mockMainWindow] : [];
     }
   },
+  // A single virtual 1920x1080 display covering the origin. Tests that need
+  // bespoke geometry (e.g. validating off-screen rejection) can re-mock
+  // screen.getAllDisplays in their own beforeEach.
+  screen: {
+    getAllDisplays: () => [
+      {
+        workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+      },
+    ],
+  },
 }));
 
 export function createMainWindowMock() {
@@ -63,6 +73,7 @@ export function createMainWindowMock() {
     setMaximumSize: vi.fn(),
     setSize: vi.fn(),
     setBounds: vi.fn(),
+    getBounds: vi.fn().mockReturnValue({ x: 100, y: 100, width: 500, height: 214 }),
     setAlwaysOnTop: vi.fn(),
     close: vi.fn(),
     minimize: vi.fn(),

--- a/apps/web/src/components/player/CompactPlayer.tsx
+++ b/apps/web/src/components/player/CompactPlayer.tsx
@@ -1,7 +1,13 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
-import { useAppStore } from '@/stores/useAppStore';
+import { useLibraryStore } from '@/stores/useLibraryStore';
+import {
+  useAppStore,
+  CMP_TITLE_CLASS,
+  CMP_ARTIST_CLASS,
+  CMP_ALBUM_CLASS,
+} from '@/stores/useAppStore';
 import { cn, isRadioTrack } from '@/lib/utils';
 import { formatDuration } from '@shiranami/shared';
 import { PlayerControls } from './PlayerControls';
@@ -13,7 +19,7 @@ import { useMarqueeOnOverflow } from '@/hooks/useMarqueeOnOverflow';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { IconButton } from '@/components/ui/icon-button';
 import { TimeDisplay } from './TimeDisplay';
-import { Maximize2, Minimize2, Music, Pin } from 'lucide-react';
+import { Heart, Maximize2, Minimize2, Music, Pin, Repeat, Repeat1, Shuffle } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 
 export function CompactPlayer() {
@@ -24,6 +30,15 @@ export function CompactPlayer() {
   const compactAlwaysOnTop = useAppStore(s => s.compactAlwaysOnTop);
   const toggleCompactAlwaysOnTop = useAppStore(s => s.toggleCompactAlwaysOnTop);
   const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
+
+  const compactFontSize = useAppStore(s => s.compactFontSize);
+  const compactAmbientIntensity = useAppStore(s => s.compactAmbientIntensity);
+  const compactShowAlbumArt = useAppStore(s => s.compactShowAlbumArt);
+  const compactShowAlbum = useAppStore(s => s.compactShowAlbum);
+  const compactShowSeek = useAppStore(s => s.compactShowSeek);
+  const compactShowVolume = useAppStore(s => s.compactShowVolume);
+  const compactShowQuickActions = useAppStore(s => s.compactShowQuickActions);
+
   const ambientColor = useAmbientColor();
   const { minimize: handleMinimize } = useWindowControls();
 
@@ -48,19 +63,19 @@ export function CompactPlayer() {
     }
   }, [setCompactMode, nowPlayingViewEnabled, enterNowPlaying, currentTrack]);
 
-  const showSeekBar = !!currentTrack && !isRadioTrack(currentTrack.filePath);
+  const showSeekBar = compactShowSeek && !!currentTrack && !isRadioTrack(currentTrack.filePath);
 
   const titleText = currentTrack?.title ?? t('nothingPlaying');
   const artistText = currentTrack ? currentTrack.artist : t('idleSubtitle');
 
   return (
     <div className="relative flex h-full flex-col overflow-hidden">
-      {!lowPerformanceMode && (
+      {!lowPerformanceMode && compactAmbientIntensity > 0 && (
         <AnimatePresence>
           <motion.div
             key={ambientColor.hex}
             initial={{ opacity: 0 }}
-            animate={{ opacity: 0.08 }}
+            animate={{ opacity: compactAmbientIntensity }}
             exit={{ opacity: 0 }}
             transition={{ duration: 2 }}
             className="pointer-events-none absolute inset-0"
@@ -79,78 +94,88 @@ export function CompactPlayer() {
           </span>
         </div>
 
-        <div className="no-drag flex items-center rounded-xl border border-border/20 bg-background/35 p-0.5 shadow-sm shadow-black/10">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <IconButton
-                onClick={handleToggleAlwaysOnTop}
-                className={cn(
-                  compactAlwaysOnTop &&
-                    'bg-primary/15 text-primary hover:bg-primary/20 hover:text-primary'
-                )}
-                aria-label={compactAlwaysOnTop ? t('disableAlwaysOnTop') : t('enableAlwaysOnTop')}
-              >
-                <Pin />
-              </IconButton>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {compactAlwaysOnTop ? t('disableOnTop') : t('keepOnTop')}
-            </TooltipContent>
-          </Tooltip>
+        <div className="no-drag flex items-center gap-1">
+          {compactShowQuickActions && <QuickActionsCluster />}
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <IconButton onClick={handleExitCompact} aria-label={t('exitCompactMode')}>
-                <Maximize2 />
-              </IconButton>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">{t('exitCompactMode')}</TooltipContent>
-          </Tooltip>
+          <div className="flex items-center rounded-xl border border-border/20 bg-background/35 p-0.5 shadow-sm shadow-black/10">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <IconButton
+                  onClick={handleToggleAlwaysOnTop}
+                  className={cn(
+                    compactAlwaysOnTop &&
+                      'bg-primary/15 text-primary hover:bg-primary/20 hover:text-primary'
+                  )}
+                  aria-label={compactAlwaysOnTop ? t('disableAlwaysOnTop') : t('enableAlwaysOnTop')}
+                >
+                  <Pin />
+                </IconButton>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {compactAlwaysOnTop ? t('disableOnTop') : t('keepOnTop')}
+              </TooltipContent>
+            </Tooltip>
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <IconButton onClick={handleMinimize} aria-label={t('minimize')}>
-                <Minimize2 />
-              </IconButton>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">{t('minimize')}</TooltipContent>
-          </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <IconButton onClick={handleExitCompact} aria-label={t('exitCompactMode')}>
+                  <Maximize2 />
+                </IconButton>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{t('exitCompactMode')}</TooltipContent>
+            </Tooltip>
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <IconButton onClick={handleMinimize} aria-label={t('minimize')}>
+                  <Minimize2 />
+                </IconButton>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{t('minimize')}</TooltipContent>
+            </Tooltip>
+          </div>
         </div>
       </div>
 
       <div className="relative flex min-h-0 flex-1 items-center p-2.5">
         <div className="glass-subtle relative flex h-full w-full items-stretch gap-2.5 overflow-hidden rounded-[20px] border border-border/25 p-2.5">
-          <button
-            type="button"
-            onClick={handleAlbumArtClick}
-            className="group/art flex size-[72px] shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-muted shadow-lg shadow-black/20 transition-transform hover:scale-[1.03] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-            aria-label={t('expandFromCompact')}
-          >
-            {currentTrack?.albumArt ? (
-              <img
-                src={currentTrack.albumArt}
-                alt={currentTrack.album}
-                className="h-full w-full object-cover transition-opacity group-hover/art:opacity-90"
-              />
-            ) : (
-              <Music className="size-7 text-muted-foreground/45 transition-colors group-hover/art:text-muted-foreground/70" />
-            )}
-          </button>
+          {compactShowAlbumArt && (
+            <button
+              type="button"
+              onClick={handleAlbumArtClick}
+              className="group/art flex size-[72px] shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-muted shadow-lg shadow-black/20 transition-transform hover:scale-[1.03] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              aria-label={t('expandFromCompact')}
+            >
+              {currentTrack?.albumArt ? (
+                <img
+                  src={currentTrack.albumArt}
+                  alt={currentTrack.album}
+                  className="h-full w-full object-cover transition-opacity group-hover/art:opacity-90"
+                />
+              ) : (
+                <Music className="size-7 text-muted-foreground/45 transition-colors group-hover/art:text-muted-foreground/70" />
+              )}
+            </button>
+          )}
 
           <div className="flex min-w-0 flex-1 flex-col justify-between">
             <div className="min-w-0">
               <MarqueeText
                 text={titleText}
                 className={cn(
-                  'text-sm font-semibold text-foreground',
+                  'text-foreground',
+                  CMP_TITLE_CLASS[compactFontSize],
                   !currentTrack && 'text-muted-foreground'
                 )}
               />
-              <MarqueeText text={artistText} className="mt-0.5 text-xs text-muted-foreground" />
-              {currentTrack?.album && (
+              <MarqueeText
+                text={artistText}
+                className={cn('mt-0.5 text-muted-foreground', CMP_ARTIST_CLASS[compactFontSize])}
+              />
+              {compactShowAlbum && currentTrack?.album && (
                 <MarqueeText
                   text={currentTrack.album}
-                  className="mt-1 text-[11px] text-muted-foreground/65"
+                  className={cn('mt-1 text-muted-foreground/65', CMP_ALBUM_CLASS[compactFontSize])}
                 />
               )}
             </div>
@@ -158,7 +183,7 @@ export function CompactPlayer() {
             <div className="flex flex-col gap-2">
               <div className="flex items-center justify-center gap-3.5">
                 <PlayerControls />
-                <VolumeControl sliderClassName="w-20" />
+                {compactShowVolume && <VolumeControl sliderClassName="w-20" />}
               </div>
 
               {showSeekBar ? (
@@ -174,12 +199,90 @@ export function CompactPlayer() {
                   </span>
                 </div>
               ) : (
+                // Reserve the height even when seek is hidden so the layout
+                // doesn't collapse and re-jitter on track-type changes.
                 <div className="h-6" />
               )}
             </div>
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Compact-mode favorite/shuffle/repeat cluster. Lives next to the window
+ * controls so power users can hit favorite-this-track without expanding the
+ * window. Falls back gracefully when no track is playing (favorite button
+ * is hidden, the others stay since shuffle/repeat are queue-level state).
+ */
+function QuickActionsCluster() {
+  const { t: tp } = useTranslation('player');
+  const currentTrack = usePlaybackStore(s => s.currentTrack);
+  const isShuffled = usePlaybackStore(s => s.isShuffled);
+  const repeatMode = usePlaybackStore(s => s.repeatMode);
+  const toggleShuffle = usePlaybackStore(s => s.toggleShuffle);
+  const cycleRepeatMode = usePlaybackStore(s => s.cycleRepeatMode);
+  const toggleFavorite = useLibraryStore(s => s.toggleFavorite);
+
+  const showFavorite = !!currentTrack && !isRadioTrack(currentTrack.filePath);
+
+  return (
+    <div className="flex items-center rounded-xl border border-border/20 bg-background/35 p-0.5 shadow-sm shadow-black/10">
+      {showFavorite && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <IconButton
+              onClick={() => toggleFavorite(currentTrack.id)}
+              className={cn(
+                currentTrack.isFavorite &&
+                  'text-favorite hover:bg-favorite/10 hover:text-favorite-hover'
+              )}
+              aria-label={
+                currentTrack.isFavorite ? tp('removeFromFavorites') : tp('addToFavorites')
+              }
+            >
+              <Heart className={cn(currentTrack.isFavorite && 'fill-current')} />
+            </IconButton>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {currentTrack.isFavorite ? tp('unfavorite') : tp('favorite')}
+          </TooltipContent>
+        </Tooltip>
+      )}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <IconButton
+            onClick={toggleShuffle}
+            className={cn(isShuffled && 'text-primary')}
+            aria-label={tp('shuffle')}
+          >
+            <Shuffle />
+          </IconButton>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {isShuffled ? tp('shuffleOn') : tp('shuffleOff')}
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <IconButton
+            onClick={cycleRepeatMode}
+            className={cn(repeatMode !== 'off' && 'text-primary')}
+            aria-label={tp('repeatAria', { mode: repeatMode })}
+          >
+            {repeatMode === 'one' ? <Repeat1 /> : <Repeat />}
+          </IconButton>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {repeatMode === 'off'
+            ? tp('repeatOff')
+            : repeatMode === 'all'
+              ? tp('repeatAll')
+              : tp('repeatOne')}
+        </TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/apps/web/src/components/player/CompactPlayer.tsx
+++ b/apps/web/src/components/player/CompactPlayer.tsx
@@ -19,7 +19,7 @@ import { useMarqueeOnOverflow } from '@/hooks/useMarqueeOnOverflow';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { IconButton } from '@/components/ui/icon-button';
 import { TimeDisplay } from './TimeDisplay';
-import { Heart, Maximize2, Minimize2, Music, Pin, Repeat, Repeat1, Shuffle } from 'lucide-react';
+import { Heart, Maximize2, Minimize2, Music, Pin } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 
 export function CompactPlayer() {
@@ -37,7 +37,7 @@ export function CompactPlayer() {
   const compactShowAlbum = useAppStore(s => s.compactShowAlbum);
   const compactShowSeek = useAppStore(s => s.compactShowSeek);
   const compactShowVolume = useAppStore(s => s.compactShowVolume);
-  const compactShowQuickActions = useAppStore(s => s.compactShowQuickActions);
+  const compactShowFavorite = useAppStore(s => s.compactShowFavorite);
 
   const ambientColor = useAmbientColor();
   const { minimize: handleMinimize } = useWindowControls();
@@ -95,7 +95,7 @@ export function CompactPlayer() {
         </div>
 
         <div className="no-drag flex items-center gap-1">
-          {compactShowQuickActions && <QuickActionsCluster />}
+          {compactShowFavorite && <FavoriteButton />}
 
           <div className="flex items-center rounded-xl border border-border/20 bg-background/35 p-0.5 shadow-sm shadow-black/10">
             <Tooltip>
@@ -212,75 +212,35 @@ export function CompactPlayer() {
 }
 
 /**
- * Compact-mode favorite/shuffle/repeat cluster. Lives next to the window
- * controls so power users can hit favorite-this-track without expanding the
- * window. Falls back gracefully when no track is playing (favorite button
- * is hidden, the others stay since shuffle/repeat are queue-level state).
+ * Compact-mode favorite button. Lives in the title bar so the user can heart
+ * the current track without expanding the window. Hidden for radio tracks and
+ * when nothing is playing. Shuffle/repeat are intentionally NOT here — they
+ * already live in the main PlayerControls row below to avoid duplication.
  */
-function QuickActionsCluster() {
+function FavoriteButton() {
   const { t: tp } = useTranslation('player');
   const currentTrack = usePlaybackStore(s => s.currentTrack);
-  const isShuffled = usePlaybackStore(s => s.isShuffled);
-  const repeatMode = usePlaybackStore(s => s.repeatMode);
-  const toggleShuffle = usePlaybackStore(s => s.toggleShuffle);
-  const cycleRepeatMode = usePlaybackStore(s => s.cycleRepeatMode);
   const toggleFavorite = useLibraryStore(s => s.toggleFavorite);
 
-  const showFavorite = !!currentTrack && !isRadioTrack(currentTrack.filePath);
+  if (!currentTrack || isRadioTrack(currentTrack.filePath)) return null;
 
   return (
     <div className="flex items-center rounded-xl border border-border/20 bg-background/35 p-0.5 shadow-sm shadow-black/10">
-      {showFavorite && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <IconButton
-              onClick={() => toggleFavorite(currentTrack.id)}
-              className={cn(
-                currentTrack.isFavorite &&
-                  'text-favorite hover:bg-favorite/10 hover:text-favorite-hover'
-              )}
-              aria-label={
-                currentTrack.isFavorite ? tp('removeFromFavorites') : tp('addToFavorites')
-              }
-            >
-              <Heart className={cn(currentTrack.isFavorite && 'fill-current')} />
-            </IconButton>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            {currentTrack.isFavorite ? tp('unfavorite') : tp('favorite')}
-          </TooltipContent>
-        </Tooltip>
-      )}
       <Tooltip>
         <TooltipTrigger asChild>
           <IconButton
-            onClick={toggleShuffle}
-            className={cn(isShuffled && 'text-primary')}
-            aria-label={tp('shuffle')}
+            onClick={() => toggleFavorite(currentTrack.id)}
+            className={cn(
+              currentTrack.isFavorite &&
+                'text-favorite hover:bg-favorite/10 hover:text-favorite-hover'
+            )}
+            aria-label={currentTrack.isFavorite ? tp('removeFromFavorites') : tp('addToFavorites')}
           >
-            <Shuffle />
+            <Heart className={cn(currentTrack.isFavorite && 'fill-current')} />
           </IconButton>
         </TooltipTrigger>
         <TooltipContent side="bottom">
-          {isShuffled ? tp('shuffleOn') : tp('shuffleOff')}
-        </TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <IconButton
-            onClick={cycleRepeatMode}
-            className={cn(repeatMode !== 'off' && 'text-primary')}
-            aria-label={tp('repeatAria', { mode: repeatMode })}
-          >
-            {repeatMode === 'one' ? <Repeat1 /> : <Repeat />}
-          </IconButton>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {repeatMode === 'off'
-            ? tp('repeatOff')
-            : repeatMode === 'all'
-              ? tp('repeatAll')
-              : tp('repeatOne')}
+          {currentTrack.isFavorite ? tp('unfavorite') : tp('favorite')}
         </TooltipContent>
       </Tooltip>
     </div>

--- a/apps/web/src/components/player/CompactPlayer.tsx
+++ b/apps/web/src/components/player/CompactPlayer.tsx
@@ -34,6 +34,20 @@ export function CompactPlayer() {
   const handleToggleAlwaysOnTop = useCallback(() => {
     void toggleCompactAlwaysOnTop();
   }, [toggleCompactAlwaysOnTop]);
+
+  const nowPlayingViewEnabled = useAppStore(s => s.nowPlayingViewEnabled);
+  const enterNowPlaying = useAppStore(s => s.enterNowPlaying);
+  const handleAlbumArtClick = useCallback(async () => {
+    // Mirror the Spotify/Apple Music mini-player gesture: clicking the art
+    // exits compact and surfaces the immersive Now Playing view if the user
+    // has it enabled. Otherwise just exit compact and let the regular full
+    // window come back into focus.
+    await setCompactMode(false);
+    if (nowPlayingViewEnabled && currentTrack) {
+      enterNowPlaying();
+    }
+  }, [setCompactMode, nowPlayingViewEnabled, enterNowPlaying, currentTrack]);
+
   const showSeekBar = !!currentTrack && !isRadioTrack(currentTrack.filePath);
 
   const titleText = currentTrack?.title ?? t('nothingPlaying');
@@ -106,17 +120,22 @@ export function CompactPlayer() {
 
       <div className="relative flex min-h-0 flex-1 items-center p-2.5">
         <div className="glass-subtle relative flex h-full w-full items-stretch gap-2.5 overflow-hidden rounded-[20px] border border-border/25 p-2.5">
-          <div className="flex size-[72px] shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-muted shadow-lg shadow-black/20">
+          <button
+            type="button"
+            onClick={handleAlbumArtClick}
+            className="group/art flex size-[72px] shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-muted shadow-lg shadow-black/20 transition-transform hover:scale-[1.03] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            aria-label={t('expandFromCompact')}
+          >
             {currentTrack?.albumArt ? (
               <img
                 src={currentTrack.albumArt}
                 alt={currentTrack.album}
-                className="h-full w-full object-cover"
+                className="h-full w-full object-cover transition-opacity group-hover/art:opacity-90"
               />
             ) : (
-              <Music className="size-7 text-muted-foreground/45" />
+              <Music className="size-7 text-muted-foreground/45 transition-colors group-hover/art:text-muted-foreground/70" />
             )}
-          </div>
+          </button>
 
           <div className="flex min-w-0 flex-1 flex-col justify-between">
             <div className="min-w-0">
@@ -139,7 +158,7 @@ export function CompactPlayer() {
             <div className="flex flex-col gap-2">
               <div className="flex items-center justify-center gap-3.5">
                 <PlayerControls />
-                <VolumeControl sliderClassName="w-12" />
+                <VolumeControl sliderClassName="w-20" />
               </div>
 
               {showSeekBar ? (

--- a/apps/web/src/components/player/CompactPlayer.tsx
+++ b/apps/web/src/components/player/CompactPlayer.tsx
@@ -12,7 +12,7 @@ import { useWindowControls } from '@/hooks/useWindowControls';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { IconButton } from '@/components/ui/icon-button';
 import { TimeDisplay } from './TimeDisplay';
-import { Maximize2, Minimize2, Music, Pin, X } from 'lucide-react';
+import { Maximize2, Minimize2, Music, Pin } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 
 export function CompactPlayer() {
@@ -24,7 +24,7 @@ export function CompactPlayer() {
   const toggleCompactAlwaysOnTop = useAppStore(s => s.toggleCompactAlwaysOnTop);
   const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
   const ambientColor = useAmbientColor();
-  const { minimize: handleMinimize, close: handleClose } = useWindowControls();
+  const { minimize: handleMinimize } = useWindowControls();
 
   const handleExitCompact = useCallback(() => {
     void setCompactMode(false);
@@ -97,10 +97,6 @@ export function CompactPlayer() {
             </TooltipTrigger>
             <TooltipContent side="bottom">{t('minimize')}</TooltipContent>
           </Tooltip>
-
-          <IconButton variant="destructiveGhost" onClick={handleClose} aria-label={t('close')}>
-            <X />
-          </IconButton>
         </div>
       </div>
 

--- a/apps/web/src/components/player/CompactPlayer.tsx
+++ b/apps/web/src/components/player/CompactPlayer.tsx
@@ -9,6 +9,7 @@ import { SeekBar } from './SeekBar';
 import { VolumeControl } from './VolumeControl';
 import { useAmbientColor } from '@/hooks/useAmbientColor';
 import { useWindowControls } from '@/hooks/useWindowControls';
+import { useMarqueeOnOverflow } from '@/hooks/useMarqueeOnOverflow';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { IconButton } from '@/components/ui/icon-button';
 import { TimeDisplay } from './TimeDisplay';
@@ -34,6 +35,9 @@ export function CompactPlayer() {
     void toggleCompactAlwaysOnTop();
   }, [toggleCompactAlwaysOnTop]);
   const showSeekBar = !!currentTrack && !isRadioTrack(currentTrack.filePath);
+
+  const titleText = currentTrack?.title ?? t('nothingPlaying');
+  const artistText = currentTrack ? currentTrack.artist : t('idleSubtitle');
 
   return (
     <div className="relative flex h-full flex-col overflow-hidden">
@@ -116,21 +120,19 @@ export function CompactPlayer() {
 
           <div className="flex min-w-0 flex-1 flex-col justify-between">
             <div className="min-w-0">
-              <p
+              <MarqueeText
+                text={titleText}
                 className={cn(
-                  'truncate text-sm font-semibold text-foreground',
+                  'text-sm font-semibold text-foreground',
                   !currentTrack && 'text-muted-foreground'
                 )}
-              >
-                {currentTrack?.title ?? t('nothingPlaying')}
-              </p>
-              <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                {currentTrack ? currentTrack.artist : t('idleSubtitle')}
-              </p>
+              />
+              <MarqueeText text={artistText} className="mt-0.5 text-xs text-muted-foreground" />
               {currentTrack?.album && (
-                <p className="mt-1 truncate text-[11px] text-muted-foreground/65">
-                  {currentTrack.album}
-                </p>
+                <MarqueeText
+                  text={currentTrack.album}
+                  className="mt-1 text-[11px] text-muted-foreground/65"
+                />
               )}
             </div>
 
@@ -160,5 +162,56 @@ export function CompactPlayer() {
         </div>
       </div>
     </div>
+  );
+}
+
+interface MarqueeTextProps {
+  text: string;
+  className?: string;
+}
+
+/**
+ * Single-line text that scrolls horizontally on hover when it overflows.
+ *
+ * Static state: the parent clips with `overflow:hidden` and a horizontal
+ * mask-image fades the right edge so the cut feels intentional (no ellipsis,
+ * since the marquee target is an inline-block child).
+ *
+ * Active state (hover/focus): the inner span animates by exactly its measured
+ * `scrollWidth - clientWidth` overflow distance, returns home, repeats.
+ *
+ * Falls back to a static line under `lowPerformanceMode` to honor that user
+ * preference. Tooltip still surfaces the full text for screen readers and
+ * mouse users in either mode.
+ */
+function MarqueeText({ text, className }: MarqueeTextProps) {
+  const { ref, overflows, shift } = useMarqueeOnOverflow<HTMLSpanElement>(text);
+  const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
+  const animate = overflows && !lowPerformanceMode;
+
+  return (
+    <p
+      className={cn(
+        'group/marquee block w-full overflow-hidden whitespace-nowrap',
+        // Fade right edge on overflow so the clip looks intentional. Vendor
+        // prefix kept for older WebKit; both unset when not overflowing.
+        overflows &&
+          '[mask-image:linear-gradient(to_right,black_calc(100%-16px),transparent)] [-webkit-mask-image:linear-gradient(to_right,black_calc(100%-16px),transparent)]',
+        className
+      )}
+      title={overflows ? text : undefined}
+    >
+      <span
+        ref={ref}
+        className={cn(
+          'inline-block whitespace-nowrap will-change-transform',
+          animate &&
+            'group-hover/marquee:animate-marquee group-focus-visible/marquee:animate-marquee'
+        )}
+        style={animate ? ({ '--marquee-shift': `${shift}px` } as React.CSSProperties) : undefined}
+      >
+        {text}
+      </span>
+    </p>
   );
 }

--- a/apps/web/src/components/player/CompactPlayer.tsx
+++ b/apps/web/src/components/player/CompactPlayer.tsx
@@ -267,16 +267,19 @@ interface MarqueeTextProps {
  * mouse users in either mode.
  */
 function MarqueeText({ text, className }: MarqueeTextProps) {
-  const { ref, overflows, shift } = useMarqueeOnOverflow<HTMLSpanElement>(text);
+  // Ref must be on the clipped parent (`<p>`), not the inline-block span.
+  // scrollWidth/clientWidth on the unconstrained span are equal — the
+  // overflow signal lives on the constrained container.
+  const { ref, overflows, shift } = useMarqueeOnOverflow<HTMLParagraphElement>(text);
   const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
   const animate = overflows && !lowPerformanceMode;
 
   return (
     <p
+      ref={ref}
+      tabIndex={overflows ? 0 : -1}
       className={cn(
-        'group/marquee block w-full overflow-hidden whitespace-nowrap',
-        // Fade right edge on overflow so the clip looks intentional. Vendor
-        // prefix kept for older WebKit; both unset when not overflowing.
+        'group/marquee block w-full overflow-hidden whitespace-nowrap focus:outline-none',
         overflows &&
           '[mask-image:linear-gradient(to_right,black_calc(100%-16px),transparent)] [-webkit-mask-image:linear-gradient(to_right,black_calc(100%-16px),transparent)]',
         className
@@ -284,7 +287,6 @@ function MarqueeText({ text, className }: MarqueeTextProps) {
       title={overflows ? text : undefined}
     >
       <span
-        ref={ref}
         className={cn(
           'inline-block whitespace-nowrap will-change-transform',
           animate &&

--- a/apps/web/src/components/settings/CompactSection.tsx
+++ b/apps/web/src/components/settings/CompactSection.tsx
@@ -30,7 +30,7 @@ export function CompactSection() {
   const compactShowAlbum = useAppStore(s => s.compactShowAlbum);
   const compactShowSeek = useAppStore(s => s.compactShowSeek);
   const compactShowVolume = useAppStore(s => s.compactShowVolume);
-  const compactShowQuickActions = useAppStore(s => s.compactShowQuickActions);
+  const compactShowFavorite = useAppStore(s => s.compactShowFavorite);
   const compactDefaultAlwaysOnTop = useAppStore(s => s.compactDefaultAlwaysOnTop);
 
   const setCompactSize = useAppStore(s => s.setCompactSize);
@@ -40,7 +40,7 @@ export function CompactSection() {
   const setCompactShowAlbum = useAppStore(s => s.setCompactShowAlbum);
   const setCompactShowSeek = useAppStore(s => s.setCompactShowSeek);
   const setCompactShowVolume = useAppStore(s => s.setCompactShowVolume);
-  const setCompactShowQuickActions = useAppStore(s => s.setCompactShowQuickActions);
+  const setCompactShowFavorite = useAppStore(s => s.setCompactShowFavorite);
   const setCompactDefaultAlwaysOnTop = useAppStore(s => s.setCompactDefaultAlwaysOnTop);
   const resetCompactAppearance = useAppStore(s => s.resetCompactAppearance);
 
@@ -52,7 +52,7 @@ export function CompactSection() {
     !compactShowAlbum ||
     !compactShowSeek ||
     !compactShowVolume ||
-    compactShowQuickActions ||
+    compactShowFavorite ||
     compactDefaultAlwaysOnTop;
 
   return (
@@ -114,10 +114,10 @@ export function CompactSection() {
             onChange={setCompactShowVolume}
           />
           <SwitchRow
-            title={t('cmp.elements.quickActions')}
-            description={t('cmp.elements.quickActionsDesc')}
-            checked={compactShowQuickActions}
-            onChange={setCompactShowQuickActions}
+            title={t('cmp.elements.favorite')}
+            description={t('cmp.elements.favoriteDesc')}
+            checked={compactShowFavorite}
+            onChange={setCompactShowFavorite}
           />
         </Subsection>
 

--- a/apps/web/src/components/settings/CompactSection.tsx
+++ b/apps/web/src/components/settings/CompactSection.tsx
@@ -1,0 +1,272 @@
+import { useTranslation } from 'react-i18next';
+import { PictureInPicture2 } from 'lucide-react';
+import { SettingsCard } from '@/components/settings/SettingsCard';
+import { Slider } from '@/components/ui/slider';
+import { Switch } from '@/components/ui/switch';
+import {
+  useAppStore,
+  COMPACT_AMBIENT_INTENSITY_MIN,
+  COMPACT_AMBIENT_INTENSITY_MAX,
+  COMPACT_AMBIENT_INTENSITY_STEP,
+  COMPACT_AMBIENT_INTENSITY_DEFAULT,
+  COMPACT_SIZE_DEFAULT,
+  COMPACT_FONT_SIZE_DEFAULT,
+  type CompactSize,
+  type CompactFontSize,
+} from '@/stores/useAppStore';
+import { cn } from '@/lib/utils';
+
+const SIZES: CompactSize[] = ['sm', 'md', 'lg'];
+const FONT_SIZES: CompactFontSize[] = ['sm', 'md', 'lg'];
+
+export function CompactSection() {
+  const { t } = useTranslation('settings');
+  const { t: tc } = useTranslation('common');
+
+  const compactSize = useAppStore(s => s.compactSize);
+  const compactFontSize = useAppStore(s => s.compactFontSize);
+  const compactAmbientIntensity = useAppStore(s => s.compactAmbientIntensity);
+  const compactShowAlbumArt = useAppStore(s => s.compactShowAlbumArt);
+  const compactShowAlbum = useAppStore(s => s.compactShowAlbum);
+  const compactShowSeek = useAppStore(s => s.compactShowSeek);
+  const compactShowVolume = useAppStore(s => s.compactShowVolume);
+  const compactShowQuickActions = useAppStore(s => s.compactShowQuickActions);
+  const compactDefaultAlwaysOnTop = useAppStore(s => s.compactDefaultAlwaysOnTop);
+
+  const setCompactSize = useAppStore(s => s.setCompactSize);
+  const setCompactFontSize = useAppStore(s => s.setCompactFontSize);
+  const setCompactAmbientIntensity = useAppStore(s => s.setCompactAmbientIntensity);
+  const setCompactShowAlbumArt = useAppStore(s => s.setCompactShowAlbumArt);
+  const setCompactShowAlbum = useAppStore(s => s.setCompactShowAlbum);
+  const setCompactShowSeek = useAppStore(s => s.setCompactShowSeek);
+  const setCompactShowVolume = useAppStore(s => s.setCompactShowVolume);
+  const setCompactShowQuickActions = useAppStore(s => s.setCompactShowQuickActions);
+  const setCompactDefaultAlwaysOnTop = useAppStore(s => s.setCompactDefaultAlwaysOnTop);
+  const resetCompactAppearance = useAppStore(s => s.resetCompactAppearance);
+
+  const isModified =
+    compactSize !== COMPACT_SIZE_DEFAULT ||
+    compactFontSize !== COMPACT_FONT_SIZE_DEFAULT ||
+    compactAmbientIntensity !== COMPACT_AMBIENT_INTENSITY_DEFAULT ||
+    !compactShowAlbumArt ||
+    !compactShowAlbum ||
+    !compactShowSeek ||
+    !compactShowVolume ||
+    compactShowQuickActions ||
+    compactDefaultAlwaysOnTop;
+
+  return (
+    <SettingsCard icon={PictureInPicture2} title={t('cmp.title')} subtitle={t('cmp.subtitle')}>
+      <div className="space-y-8">
+        {/* Size + typography */}
+        <div className="space-y-5">
+          <PresetControl
+            title={t('cmp.size.title')}
+            description={t('cmp.size.desc')}
+            options={SIZES}
+            labelKey="cmp.size"
+            value={compactSize}
+            onChange={setCompactSize}
+          />
+          <PresetControl
+            title={t('cmp.fontSize.title')}
+            description={t('cmp.fontSize.desc')}
+            options={FONT_SIZES}
+            labelKey="cmp.fontSize"
+            value={compactFontSize}
+            onChange={setCompactFontSize}
+          />
+          <OpacityControl
+            title={t('cmp.ambient.title')}
+            description={t('cmp.ambient.desc')}
+            value={compactAmbientIntensity}
+            min={COMPACT_AMBIENT_INTENSITY_MIN}
+            max={COMPACT_AMBIENT_INTENSITY_MAX}
+            step={COMPACT_AMBIENT_INTENSITY_STEP}
+            onChange={setCompactAmbientIntensity}
+          />
+        </div>
+
+        {/* Element visibility */}
+        <Subsection title={t('cmp.elements.title')} subtitle={t('cmp.elements.subtitle')}>
+          <SwitchRow
+            title={t('cmp.elements.albumArt')}
+            description={t('cmp.elements.albumArtDesc')}
+            checked={compactShowAlbumArt}
+            onChange={setCompactShowAlbumArt}
+          />
+          <SwitchRow
+            title={t('cmp.elements.album')}
+            description={t('cmp.elements.albumDesc')}
+            checked={compactShowAlbum}
+            onChange={setCompactShowAlbum}
+          />
+          <SwitchRow
+            title={t('cmp.elements.seek')}
+            description={t('cmp.elements.seekDesc')}
+            checked={compactShowSeek}
+            onChange={setCompactShowSeek}
+          />
+          <SwitchRow
+            title={t('cmp.elements.volume')}
+            description={t('cmp.elements.volumeDesc')}
+            checked={compactShowVolume}
+            onChange={setCompactShowVolume}
+          />
+          <SwitchRow
+            title={t('cmp.elements.quickActions')}
+            description={t('cmp.elements.quickActionsDesc')}
+            checked={compactShowQuickActions}
+            onChange={setCompactShowQuickActions}
+          />
+        </Subsection>
+
+        {/* Behavior */}
+        <Subsection title={t('cmp.behavior.title')} subtitle={t('cmp.behavior.subtitle')}>
+          <SwitchRow
+            title={t('cmp.behavior.defaultAlwaysOnTop')}
+            description={t('cmp.behavior.defaultAlwaysOnTopDesc')}
+            checked={compactDefaultAlwaysOnTop}
+            onChange={setCompactDefaultAlwaysOnTop}
+          />
+        </Subsection>
+
+        {isModified && (
+          <div className="px-3">
+            <button
+              onClick={resetCompactAppearance}
+              className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {tc('reset')}
+            </button>
+          </div>
+        )}
+      </div>
+    </SettingsCard>
+  );
+}
+
+interface SubsectionProps {
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}
+
+function Subsection({ title, subtitle, children }: SubsectionProps) {
+  return (
+    <div className="space-y-4">
+      <div className="px-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-foreground/80">
+          {title}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">{subtitle}</p>
+      </div>
+      <div className="space-y-1">{children}</div>
+    </div>
+  );
+}
+
+interface PresetControlProps<T extends string> {
+  title: string;
+  description: string;
+  options: readonly T[];
+  /** i18n key prefix; the lookup is `${labelKey}.${option}`. */
+  labelKey: string;
+  value: T;
+  onChange: (value: T) => void;
+}
+
+function PresetControl<T extends string>({
+  title,
+  description,
+  options,
+  labelKey,
+  value,
+  onChange,
+}: PresetControlProps<T>) {
+  const { t } = useTranslation('settings');
+  return (
+    <div className="px-3">
+      <p className="mb-1 text-sm font-medium text-foreground">{title}</p>
+      <p className="mb-3 text-xs text-muted-foreground">{description}</p>
+      <div className="flex items-center gap-1.5">
+        {options.map(option => (
+          <button
+            key={option}
+            onClick={() => onChange(option)}
+            className={cn(
+              'rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+              value === option
+                ? 'border border-primary/40 bg-primary/15 text-primary'
+                : 'border border-transparent text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+            )}
+          >
+            {t(`${labelKey}.${option}`)}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface OpacityControlProps {
+  title: string;
+  description: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (value: number) => void;
+}
+
+function OpacityControl({
+  title,
+  description,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: OpacityControlProps) {
+  // Show as percent of max so users can read the slider as a 0–100 dial.
+  const percent = max > 0 ? Math.round((value / max) * 100) : 0;
+  return (
+    <div className="px-3">
+      <div className="mb-1 flex items-center justify-between">
+        <p className="text-sm font-medium text-foreground">{title}</p>
+        <span className="text-xs tabular-nums text-muted-foreground">{percent}%</span>
+      </div>
+      <p className="mb-4 text-xs text-muted-foreground">{description}</p>
+      <Slider
+        min={min}
+        max={max}
+        step={step}
+        value={[value]}
+        onValueChange={([v]) => onChange(v)}
+      />
+    </div>
+  );
+}
+
+interface SwitchRowProps {
+  title: string;
+  description?: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+function SwitchRow({ title, description, checked, onChange }: SwitchRowProps) {
+  return (
+    <div className="px-3">
+      <div className="-mx-3 flex items-center justify-between rounded-xl px-3 py-2.5 transition-colors hover:bg-accent/30">
+        <div className="pr-4">
+          <p className="text-sm font-medium text-foreground">{title}</p>
+          {description && <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>}
+        </div>
+        <Switch checked={checked} onCheckedChange={onChange} />
+      </div>
+    </div>
+  );
+}
+
+export default CompactSection;

--- a/apps/web/src/components/settings/SettingsView.tsx
+++ b/apps/web/src/components/settings/SettingsView.tsx
@@ -8,6 +8,7 @@ import {
   SlidersHorizontal,
   AudioLines,
   Captions,
+  PictureInPicture2,
   Monitor,
   RefreshCcw,
   Info,
@@ -22,6 +23,7 @@ import { VisualizerSection } from '@/components/settings/VisualizerSection';
 import { UpdatesSection } from '@/components/settings/UpdatesSection';
 import { AppearanceSection } from '@/components/settings/AppearanceSection';
 import { LyricsSection } from '@/components/settings/LyricsSection';
+import { CompactSection } from '@/components/settings/CompactSection';
 import { AboutSection } from '@/components/settings/AboutSection';
 
 type SettingsSection =
@@ -32,6 +34,7 @@ type SettingsSection =
   | 'equalizer'
   | 'visualizer'
   | 'lyrics'
+  | 'compact'
   | 'appearance'
   | 'updates'
   | 'about';
@@ -44,6 +47,7 @@ const SECTIONS: { id: SettingsSection; labelKey: string; Icon: typeof FolderOpen
   { id: 'equalizer', labelKey: 'equalizer', Icon: SlidersHorizontal },
   { id: 'visualizer', labelKey: 'visualizer', Icon: AudioLines },
   { id: 'lyrics', labelKey: 'lyrics', Icon: Captions },
+  { id: 'compact', labelKey: 'compact', Icon: PictureInPicture2 },
   { id: 'appearance', labelKey: 'appearance', Icon: Monitor },
   { id: 'updates', labelKey: 'updates', Icon: RefreshCcw },
   { id: 'about', labelKey: 'about', Icon: Info },
@@ -57,6 +61,7 @@ const SECTION_PANEL: Record<SettingsSection, ComponentType> = {
   equalizer: EqualizerSection,
   visualizer: VisualizerSection,
   lyrics: LyricsSection,
+  compact: CompactSection,
   appearance: AppearanceSection,
   updates: UpdatesSection,
   about: AboutSection,

--- a/apps/web/src/components/shared/KeyboardShortcutsHelp.tsx
+++ b/apps/web/src/components/shared/KeyboardShortcutsHelp.tsx
@@ -1,11 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { NAV_VIEWS } from '@/hooks/useKeyboardShortcuts';
 
 const isMac = navigator.platform.toUpperCase().includes('MAC');
@@ -78,6 +73,7 @@ function getShortcutCategories(): ShortcutCategories {
         { keys: [MOD, 'L'], actionKey: 'toggleLyrics' },
         { keys: [MOD, 'Q'], actionKey: 'toggleQueue' },
         { keys: [MOD, 'Shift', 'M'], actionKey: 'compactMode' },
+        { keys: [MOD, 'Shift', 'T'], actionKey: 'toggleAlwaysOnTop' },
         { keys: [MOD, 'Shift', 'P'], actionKey: 'toggleNowPlaying' },
         { keys: ['V'], actionKey: 'toggleVisualizer' },
         { keys: ['?'], actionKey: 'showHelp' },
@@ -106,13 +102,7 @@ function Kbd({ children }: { children: string }) {
   );
 }
 
-function ShortcutRow({
-  shortcut,
-  t,
-}: {
-  shortcut: Shortcut;
-  t: (key: string) => string;
-}) {
+function ShortcutRow({ shortcut, t }: { shortcut: Shortcut; t: (key: string) => string }) {
   return (
     <div
       className="

--- a/apps/web/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/web/src/hooks/useKeyboardShortcuts.ts
@@ -86,6 +86,21 @@ export function useKeyboardShortcuts() {
             }
             break;
           }
+          case 'T':
+          case 't': {
+            // Ctrl/Cmd+Shift+T: toggle always-on-top. Useful for users who
+            // pin the mini-player above other windows (or want to unpin it
+            // without leaving the keyboard). Active in both compact and
+            // normal modes — the underlying setter is a no-op outside
+            // compact, but we still update the persisted preference so the
+            // pin sticks the next time compact is entered.
+            if (e.shiftKey) {
+              e.preventDefault();
+              void useAppStore.getState().toggleCompactAlwaysOnTop();
+              return;
+            }
+            break;
+          }
           case 'P':
           case 'p': {
             // Ctrl/Cmd+Shift+P: toggle Now Playing view.
@@ -94,7 +109,8 @@ export function useKeyboardShortcuts() {
             // shortcut was received and why it didn't open the view.
             if (e.shiftKey) {
               e.preventDefault();
-              const { nowPlayingViewEnabled, activeView, enterNowPlaying, exitNowPlaying } = useAppStore.getState();
+              const { nowPlayingViewEnabled, activeView, enterNowPlaying, exitNowPlaying } =
+                useAppStore.getState();
               if (!nowPlayingViewEnabled) {
                 toast.info(i18n.t('nowPlayingDisabled', { ns: 'toast' }), {
                   id: 'now-playing-disabled',

--- a/apps/web/src/hooks/useMarqueeOnOverflow.ts
+++ b/apps/web/src/hooks/useMarqueeOnOverflow.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Detects whether a single-line text node overflows its container and exposes
+ * a ref + an `overflows` flag + a `shift` distance. The consumer sets the
+ * shift as a CSS custom property (`--marquee-shift`) on the inner element so
+ * the `--animate-marquee` keyframes can translate by exactly the offscreen
+ * portion. Recomputes on resize and whenever `watch` changes (the text).
+ *
+ * Designed for compact-mode track titles where `truncate` is the default and
+ * marquee is opt-in via :hover/:focus. The hook only reports geometry — the
+ * consumer decides when to apply the animation utility.
+ */
+export function useMarqueeOnOverflow<T extends HTMLElement = HTMLElement>(
+  watch: unknown
+): {
+  ref: React.RefObject<T>;
+  overflows: boolean;
+  /** Negative pixel offset to translate the inner element by during the shift phase. */
+  shift: number;
+} {
+  const ref = useRef<T>(null);
+  const [shift, setShift] = useState(0);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      setShift(0);
+      return;
+    }
+    const measure = () => {
+      // scrollWidth includes the text width even when the parent clips with
+      // overflow:hidden; clientWidth reports the visible box. A 1px slack
+      // avoids subpixel rendering false-positives.
+      const overflow = el.scrollWidth - el.clientWidth;
+      setShift(overflow > 1 ? -overflow : 0);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [watch]);
+
+  return { ref, overflows: shift < 0, shift };
+}

--- a/apps/web/src/locales/en/compact.json
+++ b/apps/web/src/locales/en/compact.json
@@ -7,6 +7,5 @@
   "keepOnTop": "Keep on top",
   "disableOnTop": "Disable always on top",
   "exitCompactMode": "Exit compact mode",
-  "minimize": "Minimize",
-  "close": "Close"
+  "minimize": "Minimize"
 }

--- a/apps/web/src/locales/en/compact.json
+++ b/apps/web/src/locales/en/compact.json
@@ -7,5 +7,6 @@
   "keepOnTop": "Keep on top",
   "disableOnTop": "Disable always on top",
   "exitCompactMode": "Exit compact mode",
-  "minimize": "Minimize"
+  "minimize": "Minimize",
+  "expandFromCompact": "Expand to full player"
 }

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -157,8 +157,8 @@
       "seekDesc": "Time + scrubber along the bottom (hidden for radio anyway)",
       "volume": "Volume slider",
       "volumeDesc": "Inline slider next to the playback controls",
-      "quickActions": "Quick actions",
-      "quickActionsDesc": "Favorite, shuffle, and repeat buttons in the title bar"
+      "favorite": "Favorite button",
+      "favoriteDesc": "Heart button in the title bar to favorite the current track"
     },
     "behavior": {
       "title": "Behavior",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -6,6 +6,7 @@
   "equalizer": "Equalizer",
   "visualizer": "Visualizer",
   "lyrics": "Lyrics",
+  "compact": "Compact mode",
   "appearance": "Appearance",
   "updates": "Updates",
   "about": "About",
@@ -123,6 +124,48 @@
     "previewSyncedIdleA": "Pages of a song we never finished",
     "previewSyncedIdleB": "Light through curtains, soft and unhurried",
     "previewSyncedPast": "Holding on to every fading line"
+  },
+  "cmp": {
+    "title": "Compact mode",
+    "subtitle": "Mini-player layout, density, and pin behavior",
+    "size": {
+      "title": "Window size",
+      "desc": "Choose how much screen real estate the mini-player takes up",
+      "sm": "Small",
+      "md": "Medium",
+      "lg": "Large"
+    },
+    "fontSize": {
+      "title": "Text size",
+      "desc": "Sizing for the title, artist, and album lines",
+      "sm": "Small",
+      "md": "Default",
+      "lg": "Large"
+    },
+    "ambient": {
+      "title": "Ambient color intensity",
+      "desc": "Strength of the album-art glow blooming behind the player. Set to 0 to turn it off."
+    },
+    "elements": {
+      "title": "Visible elements",
+      "subtitle": "Hide pieces you don't need to make the mini-player even denser",
+      "albumArt": "Album art",
+      "albumArtDesc": "72-pixel cover tile on the left",
+      "album": "Album name",
+      "albumDesc": "Third line beneath title and artist",
+      "seek": "Seek bar",
+      "seekDesc": "Time + scrubber along the bottom (hidden for radio anyway)",
+      "volume": "Volume slider",
+      "volumeDesc": "Inline slider next to the playback controls",
+      "quickActions": "Quick actions",
+      "quickActionsDesc": "Favorite, shuffle, and repeat buttons in the title bar"
+    },
+    "behavior": {
+      "title": "Behavior",
+      "subtitle": "How compact mode behaves when entering and exiting",
+      "defaultAlwaysOnTop": "Default to always-on-top",
+      "defaultAlwaysOnTopDesc": "Pin the mini-player above other windows automatically when you switch to compact"
+    }
   },
   "app": {
     "title": "Appearance",

--- a/apps/web/src/locales/en/shortcuts.json
+++ b/apps/web/src/locales/en/shortcuts.json
@@ -30,6 +30,7 @@
   "toggleLyrics": "Toggle lyrics",
   "toggleQueue": "Toggle queue",
   "compactMode": "Compact mode",
+  "toggleAlwaysOnTop": "Toggle always on top",
   "toggleNowPlaying": "Toggle Now Playing view",
   "toggleVisualizer": "Toggle visualizer",
   "showHelp": "Show this help",

--- a/apps/web/src/locales/pl/compact.json
+++ b/apps/web/src/locales/pl/compact.json
@@ -7,6 +7,5 @@
   "keepOnTop": "Zawsze na wierzchu",
   "disableOnTop": "Wyłącz zawsze na wierzchu",
   "exitCompactMode": "Wyjdź z trybu kompaktowego",
-  "minimize": "Minimalizuj",
-  "close": "Zamknij"
+  "minimize": "Minimalizuj"
 }

--- a/apps/web/src/locales/pl/compact.json
+++ b/apps/web/src/locales/pl/compact.json
@@ -7,5 +7,6 @@
   "keepOnTop": "Zawsze na wierzchu",
   "disableOnTop": "Wyłącz zawsze na wierzchu",
   "exitCompactMode": "Wyjdź z trybu kompaktowego",
-  "minimize": "Minimalizuj"
+  "minimize": "Minimalizuj",
+  "expandFromCompact": "Rozwiń do pełnego odtwarzacza"
 }

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -157,8 +157,8 @@
       "seekDesc": "Czas + suwak na dole (i tak ukryty dla radia)",
       "volume": "Suwak głośności",
       "volumeDesc": "Suwak obok kontrolek odtwarzania",
-      "quickActions": "Szybkie akcje",
-      "quickActionsDesc": "Przyciski ulubionych, losowego odtwarzania i powtarzania w pasku tytułu"
+      "favorite": "Przycisk ulubionych",
+      "favoriteDesc": "Przycisk serca w pasku tytułu do dodawania bieżącego utworu do ulubionych"
     },
     "behavior": {
       "title": "Zachowanie",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -6,6 +6,7 @@
   "equalizer": "Korektor",
   "visualizer": "Wizualizator",
   "lyrics": "Tekst piosenki",
+  "compact": "Tryb kompaktowy",
   "appearance": "Wygląd",
   "updates": "Aktualizacje",
   "about": "O aplikacji",
@@ -123,6 +124,48 @@
     "previewSyncedIdleA": "Strony piosenki, której nie skończyliśmy",
     "previewSyncedIdleB": "Światło przez zasłony, miękkie i spokojne",
     "previewSyncedPast": "Trzymam każdą zanikającą linię"
+  },
+  "cmp": {
+    "title": "Tryb kompaktowy",
+    "subtitle": "Układ, gęstość i przypinanie mini-odtwarzacza",
+    "size": {
+      "title": "Rozmiar okna",
+      "desc": "Wybierz, ile miejsca na ekranie zajmie mini-odtwarzacz",
+      "sm": "Mały",
+      "md": "Średni",
+      "lg": "Duży"
+    },
+    "fontSize": {
+      "title": "Rozmiar tekstu",
+      "desc": "Wielkość czcionki dla tytułu, wykonawcy i albumu",
+      "sm": "Mały",
+      "md": "Domyślny",
+      "lg": "Duży"
+    },
+    "ambient": {
+      "title": "Intensywność koloru tła",
+      "desc": "Siła poświaty z okładki albumu rozpływającej się za odtwarzaczem. Ustaw na 0, aby ją wyłączyć."
+    },
+    "elements": {
+      "title": "Widoczne elementy",
+      "subtitle": "Ukryj nieużywane elementy, aby mini-odtwarzacz był jeszcze gęstszy",
+      "albumArt": "Okładka albumu",
+      "albumArtDesc": "Kafelek okładki 72-pikselowy po lewej stronie",
+      "album": "Nazwa albumu",
+      "albumDesc": "Trzecia linia pod tytułem i wykonawcą",
+      "seek": "Pasek przewijania",
+      "seekDesc": "Czas + suwak na dole (i tak ukryty dla radia)",
+      "volume": "Suwak głośności",
+      "volumeDesc": "Suwak obok kontrolek odtwarzania",
+      "quickActions": "Szybkie akcje",
+      "quickActionsDesc": "Przyciski ulubionych, losowego odtwarzania i powtarzania w pasku tytułu"
+    },
+    "behavior": {
+      "title": "Zachowanie",
+      "subtitle": "Jak tryb kompaktowy działa przy wejściu i wyjściu",
+      "defaultAlwaysOnTop": "Domyślnie zawsze na wierzchu",
+      "defaultAlwaysOnTopDesc": "Automatycznie przypinaj mini-odtwarzacz nad innymi oknami przy przejściu do trybu kompaktowego"
+    }
   },
   "app": {
     "title": "Wygląd",

--- a/apps/web/src/locales/pl/shortcuts.json
+++ b/apps/web/src/locales/pl/shortcuts.json
@@ -30,6 +30,7 @@
   "toggleLyrics": "Pokaż/ukryj tekst piosenki",
   "toggleQueue": "Pokaż/ukryj kolejkę",
   "compactMode": "Tryb kompaktowy",
+  "toggleAlwaysOnTop": "Przełącz zawsze na wierzchu",
   "toggleNowPlaying": "Przełącz widok Teraz odtwarzane",
   "toggleVisualizer": "Pokaż/ukryj wizualizator",
   "showHelp": "Pokaż tę pomoc",

--- a/apps/web/src/stores/useAppStore.test.ts
+++ b/apps/web/src/stores/useAppStore.test.ts
@@ -62,6 +62,22 @@ describe('useAppStore', () => {
     expect(useAppStore.getState().compactMode).toBe(false);
   });
 
+  it('rolls back only the pin when setAlwaysOnTop fails after compact succeeds', async () => {
+    // Default-pin-on seeds compactAlwaysOnTop=true on entry; if the pin IPC
+    // then fails, we want compact to stay (window is in compact mode) but
+    // the pin to revert (so the store doesn't claim a pin that didn't take).
+    useAppStore.setState({ compactDefaultAlwaysOnTop: true, compactAlwaysOnTop: false });
+    vi.mocked(window.electronAPI.window.setCompactMode).mockResolvedValueOnce(undefined);
+    vi.mocked(window.electronAPI.window.setAlwaysOnTop).mockRejectedValueOnce(
+      new Error('pin failed')
+    );
+
+    await useAppStore.getState().setCompactMode(true);
+
+    expect(useAppStore.getState().compactMode).toBe(true);
+    expect(useAppStore.getState().compactAlwaysOnTop).toBe(false);
+  });
+
   it('persists compact mode flag across reloads', async () => {
     await useAppStore.getState().setCompactMode(true);
     expect(useAppStore.getState().compactMode).toBe(true);

--- a/apps/web/src/stores/useAppStore.test.ts
+++ b/apps/web/src/stores/useAppStore.test.ts
@@ -87,10 +87,10 @@ describe('useAppStore', () => {
     expect(window.electronAPI.window.setAlwaysOnTop).toHaveBeenCalledWith(true);
   });
 
-  it('persists compactShowQuickActions toggle to localStorage', () => {
-    useAppStore.getState().setCompactShowQuickActions(true);
-    expect(useAppStore.getState().compactShowQuickActions).toBe(true);
-    expect(readPersisted().compactShowQuickActions).toBe(true);
+  it('persists compactShowFavorite toggle to localStorage', () => {
+    useAppStore.getState().setCompactShowFavorite(true);
+    expect(useAppStore.getState().compactShowFavorite).toBe(true);
+    expect(readPersisted().compactShowFavorite).toBe(true);
   });
 
   it('persists and clamps compactAmbientIntensity within the allowed range', () => {
@@ -109,7 +109,7 @@ describe('useAppStore', () => {
       compactShowAlbum: false,
       compactShowSeek: false,
       compactShowVolume: false,
-      compactShowQuickActions: true,
+      compactShowFavorite: true,
       compactDefaultAlwaysOnTop: true,
     });
 
@@ -123,7 +123,7 @@ describe('useAppStore', () => {
     expect(s.compactShowAlbum).toBe(true);
     expect(s.compactShowSeek).toBe(true);
     expect(s.compactShowVolume).toBe(true);
-    expect(s.compactShowQuickActions).toBe(false);
+    expect(s.compactShowFavorite).toBe(false);
     expect(s.compactDefaultAlwaysOnTop).toBe(false);
   });
 

--- a/apps/web/src/stores/useAppStore.test.ts
+++ b/apps/web/src/stores/useAppStore.test.ts
@@ -62,6 +62,71 @@ describe('useAppStore', () => {
     expect(useAppStore.getState().compactMode).toBe(false);
   });
 
+  it('persists compact mode flag across reloads', async () => {
+    await useAppStore.getState().setCompactMode(true);
+    expect(useAppStore.getState().compactMode).toBe(true);
+    expect(readPersisted().compactMode).toBe(true);
+  });
+
+  it('forwards configured compact size dimensions over IPC', async () => {
+    useAppStore.setState({ compactSize: 'lg' });
+    await useAppStore.getState().setCompactMode(true);
+
+    expect(window.electronAPI.window.setCompactMode).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ width: 600, height: 260 })
+    );
+  });
+
+  it('seeds compact always-on-top from compactDefaultAlwaysOnTop on entry', async () => {
+    useAppStore.setState({ compactDefaultAlwaysOnTop: true, compactAlwaysOnTop: false });
+
+    await useAppStore.getState().setCompactMode(true);
+
+    expect(useAppStore.getState().compactAlwaysOnTop).toBe(true);
+    expect(window.electronAPI.window.setAlwaysOnTop).toHaveBeenCalledWith(true);
+  });
+
+  it('persists compactShowQuickActions toggle to localStorage', () => {
+    useAppStore.getState().setCompactShowQuickActions(true);
+    expect(useAppStore.getState().compactShowQuickActions).toBe(true);
+    expect(readPersisted().compactShowQuickActions).toBe(true);
+  });
+
+  it('persists and clamps compactAmbientIntensity within the allowed range', () => {
+    useAppStore.getState().setCompactAmbientIntensity(0.5);
+    // Clamped to max (0.2).
+    expect(useAppStore.getState().compactAmbientIntensity).toBe(0.2);
+    expect(readPersisted().compactAmbientIntensity).toBe(0.2);
+  });
+
+  it('resetCompactAppearance restores all compact prefs to defaults', () => {
+    useAppStore.setState({
+      compactSize: 'lg',
+      compactFontSize: 'sm',
+      compactAmbientIntensity: 0.15,
+      compactShowAlbumArt: false,
+      compactShowAlbum: false,
+      compactShowSeek: false,
+      compactShowVolume: false,
+      compactShowQuickActions: true,
+      compactDefaultAlwaysOnTop: true,
+    });
+
+    useAppStore.getState().resetCompactAppearance();
+
+    const s = useAppStore.getState();
+    expect(s.compactSize).toBe('md');
+    expect(s.compactFontSize).toBe('md');
+    expect(s.compactAmbientIntensity).toBe(0.08);
+    expect(s.compactShowAlbumArt).toBe(true);
+    expect(s.compactShowAlbum).toBe(true);
+    expect(s.compactShowSeek).toBe(true);
+    expect(s.compactShowVolume).toBe(true);
+    expect(s.compactShowQuickActions).toBe(false);
+    expect(s.compactDefaultAlwaysOnTop).toBe(false);
+  });
+
   it('toggleSidebarItem adds and removes items from hidden list', () => {
     const { toggleSidebarItem } = useAppStore.getState();
 

--- a/apps/web/src/stores/useAppStore.ts
+++ b/apps/web/src/stores/useAppStore.ts
@@ -252,7 +252,7 @@ interface PersistedAppState {
   compactShowAlbum: boolean;
   compactShowSeek: boolean;
   compactShowVolume: boolean;
-  compactShowQuickActions: boolean;
+  compactShowFavorite: boolean;
   compactDefaultAlwaysOnTop: boolean;
 }
 
@@ -314,8 +314,8 @@ function sanitize(persisted: Partial<PersistedAppState> | undefined): Partial<Pe
     out.compactShowSeek = persisted.compactShowSeek;
   if (typeof persisted.compactShowVolume === 'boolean')
     out.compactShowVolume = persisted.compactShowVolume;
-  if (typeof persisted.compactShowQuickActions === 'boolean')
-    out.compactShowQuickActions = persisted.compactShowQuickActions;
+  if (typeof persisted.compactShowFavorite === 'boolean')
+    out.compactShowFavorite = persisted.compactShowFavorite;
   if (typeof persisted.compactDefaultAlwaysOnTop === 'boolean')
     out.compactDefaultAlwaysOnTop = persisted.compactDefaultAlwaysOnTop;
   return out;
@@ -440,7 +440,7 @@ interface AppState {
   compactShowAlbum: boolean;
   compactShowSeek: boolean;
   compactShowVolume: boolean;
-  compactShowQuickActions: boolean;
+  compactShowFavorite: boolean;
   compactDefaultAlwaysOnTop: boolean;
   previousView: AppView;
 }
@@ -489,7 +489,7 @@ interface AppActions {
   setCompactShowAlbum: (visible: boolean) => void;
   setCompactShowSeek: (visible: boolean) => void;
   setCompactShowVolume: (visible: boolean) => void;
-  setCompactShowQuickActions: (visible: boolean) => void;
+  setCompactShowFavorite: (visible: boolean) => void;
   setCompactDefaultAlwaysOnTop: (enabled: boolean) => void;
   resetCompactAppearance: () => void;
 }
@@ -531,7 +531,7 @@ export const useAppStore = create<AppState & AppActions>()(
       compactShowAlbum: true,
       compactShowSeek: true,
       compactShowVolume: true,
-      compactShowQuickActions: false,
+      compactShowFavorite: false,
       compactDefaultAlwaysOnTop: false,
       previousView: 'library',
 
@@ -724,7 +724,7 @@ export const useAppStore = create<AppState & AppActions>()(
       setCompactShowAlbum: visible => set({ compactShowAlbum: visible }),
       setCompactShowSeek: visible => set({ compactShowSeek: visible }),
       setCompactShowVolume: visible => set({ compactShowVolume: visible }),
-      setCompactShowQuickActions: visible => set({ compactShowQuickActions: visible }),
+      setCompactShowFavorite: visible => set({ compactShowFavorite: visible }),
       setCompactDefaultAlwaysOnTop: enabled => set({ compactDefaultAlwaysOnTop: enabled }),
       resetCompactAppearance: () => {
         set({
@@ -735,7 +735,7 @@ export const useAppStore = create<AppState & AppActions>()(
           compactShowAlbum: true,
           compactShowSeek: true,
           compactShowVolume: true,
-          compactShowQuickActions: false,
+          compactShowFavorite: false,
           compactDefaultAlwaysOnTop: false,
         });
       },
@@ -774,7 +774,7 @@ export const useAppStore = create<AppState & AppActions>()(
         compactShowAlbum: s.compactShowAlbum,
         compactShowSeek: s.compactShowSeek,
         compactShowVolume: s.compactShowVolume,
-        compactShowQuickActions: s.compactShowQuickActions,
+        compactShowFavorite: s.compactShowFavorite,
         compactDefaultAlwaysOnTop: s.compactDefaultAlwaysOnTop,
       }),
       merge: (persisted, current) => ({

--- a/apps/web/src/stores/useAppStore.ts
+++ b/apps/web/src/stores/useAppStore.ts
@@ -593,18 +593,22 @@ export const useAppStore = create<AppState & AppActions>()(
         try {
           const dims = COMPACT_DIMENSIONS[get().compactSize];
           await window.electronAPI.window.setCompactMode(compactMode, dims);
-          if (get().compactAlwaysOnTop) {
-            await window.electronAPI.window.setAlwaysOnTop(compactMode);
-          }
         } catch {
-          if (compactMode && get().compactAlwaysOnTop) {
-            try {
-              await window.electronAPI.window.setAlwaysOnTop(false);
-            } catch {
-              // noop
-            }
-          }
+          // Compact-mode IPC failed: undo the store flips and bail before
+          // touching always-on-top so we don't pin a window the user thinks
+          // is still in normal mode.
           set({ compactMode: previous, compactAlwaysOnTop: previousAlwaysOnTop });
+          return;
+        }
+
+        if (get().compactAlwaysOnTop) {
+          try {
+            await window.electronAPI.window.setAlwaysOnTop(compactMode);
+          } catch {
+            // Compact succeeded but pin failed: only roll back the pin —
+            // the OS window is correctly in/out of compact mode now.
+            set({ compactAlwaysOnTop: previousAlwaysOnTop });
+          }
         }
       },
       setCompactAlwaysOnTop: async compactAlwaysOnTop => {
@@ -790,16 +794,26 @@ export const useAppStore = create<AppState & AppActions>()(
         // The renderer flag is restored by zustand-persist; here we just
         // forward to Electron so the window itself resizes/locks again.
         if (IS_ELECTRON && state.compactMode) {
-          const dims = COMPACT_DIMENSIONS[state.compactSize];
-          window.electronAPI.window.setCompactMode(true, dims).catch(() => {
-            // If the IPC fails (e.g. preload bundling regression), fall back
-            // to the prior behavior: clear the flag so the user isn't stuck
-            // with a non-compact window claiming to be in compact mode.
-            state.compactMode = false;
-          });
-          if (state.compactAlwaysOnTop) {
-            window.electronAPI.window.setAlwaysOnTop(true).catch(() => {});
-          }
+          // Sequence the IPCs: pin only after compact takes hold, otherwise
+          // we could end up pinning a window that didn't make it into
+          // compact mode. Mutating `state` here is ineffective (rehydration
+          // has already merged), so any rollback has to go through setState.
+          void (async () => {
+            const dims = COMPACT_DIMENSIONS[state.compactSize];
+            try {
+              await window.electronAPI.window.setCompactMode(true, dims);
+            } catch {
+              useAppStore.setState({ compactMode: false, compactAlwaysOnTop: false });
+              return;
+            }
+            if (state.compactAlwaysOnTop) {
+              try {
+                await window.electronAPI.window.setAlwaysOnTop(true);
+              } catch {
+                useAppStore.setState({ compactAlwaysOnTop: false });
+              }
+            }
+          })();
         }
       },
     }

--- a/apps/web/src/stores/useAppStore.ts
+++ b/apps/web/src/stores/useAppStore.ts
@@ -23,6 +23,9 @@ export type LyricsFontSize = 'sm' | 'base' | 'lg' | 'xl';
 /** @deprecated Use LyricsFontSize. Alias kept for back-compat with existing imports. */
 export type LyricsPlainFontSize = LyricsFontSize;
 
+export type CompactSize = 'sm' | 'md' | 'lg';
+export type CompactFontSize = 'sm' | 'md' | 'lg';
+
 export const UI_SCALE_MIN = 80;
 export const UI_SCALE_MAX = 120;
 export const UI_SCALE_DEFAULT = 100;
@@ -53,6 +56,43 @@ export const LYR_SIZE_CLASS: Record<LyricsFontSize, string> = {
   base: 'text-base leading-7',
   lg: 'text-lg leading-8',
   xl: 'text-xl leading-9',
+};
+
+// --- Compact mode dimension presets ---
+//
+// Width/height values are forwarded over IPC to the Electron main process
+// which applies them via setMinimumSize/setMaximumSize/setSize. Keep these
+// matched with `apps/desktop/src/main/ipc/window.ts` if either side moves.
+export const COMPACT_SIZE_DEFAULT: CompactSize = 'md';
+export const COMPACT_DIMENSIONS: Record<CompactSize, { width: number; height: number }> = {
+  sm: { width: 420, height: 200 },
+  md: { width: 500, height: 214 },
+  lg: { width: 600, height: 260 },
+};
+
+// --- Compact mode appearance prefs ---
+export const COMPACT_AMBIENT_INTENSITY_MIN = 0;
+export const COMPACT_AMBIENT_INTENSITY_MAX = 0.2;
+export const COMPACT_AMBIENT_INTENSITY_STEP = 0.01;
+export const COMPACT_AMBIENT_INTENSITY_DEFAULT = 0.08;
+
+export const COMPACT_FONT_SIZE_DEFAULT: CompactFontSize = 'md';
+
+/** Tailwind class lookups for the title / artist / album text in compact view. */
+export const CMP_TITLE_CLASS: Record<CompactFontSize, string> = {
+  sm: 'text-xs font-semibold',
+  md: 'text-sm font-semibold',
+  lg: 'text-base font-semibold',
+};
+export const CMP_ARTIST_CLASS: Record<CompactFontSize, string> = {
+  sm: 'text-[10px]',
+  md: 'text-xs',
+  lg: 'text-sm',
+};
+export const CMP_ALBUM_CLASS: Record<CompactFontSize, string> = {
+  sm: 'text-[10px]',
+  md: 'text-[11px]',
+  lg: 'text-xs',
 };
 
 const FONT_SIZE_ORDER: LyricsFontSize[] = ['sm', 'base', 'lg', 'xl'];
@@ -161,12 +201,32 @@ function coerceLyricsSyncedFontSize(v: unknown): LyricsFontSize {
     ? v
     : LYRICS_SYNCED_FONT_SIZE_DEFAULT;
 }
+function coerceCompactSize(v: unknown): CompactSize {
+  return v === 'sm' || v === 'md' || v === 'lg' ? v : COMPACT_SIZE_DEFAULT;
+}
+function coerceCompactFontSize(v: unknown): CompactFontSize {
+  return v === 'sm' || v === 'md' || v === 'lg' ? v : COMPACT_FONT_SIZE_DEFAULT;
+}
+function clampCompactAmbientIntensity(v: number): number {
+  const clamped = Math.min(
+    COMPACT_AMBIENT_INTENSITY_MAX,
+    Math.max(COMPACT_AMBIENT_INTENSITY_MIN, v)
+  );
+  const steps = Math.round(clamped / COMPACT_AMBIENT_INTENSITY_STEP);
+  return Math.round(steps * COMPACT_AMBIENT_INTENSITY_STEP * 1000) / 1000;
+}
+function coerceCompactAmbientIntensity(v: unknown): number {
+  const parsed = typeof v === 'number' ? v : Number(v);
+  if (!Number.isFinite(parsed)) return COMPACT_AMBIENT_INTENSITY_DEFAULT;
+  return clampCompactAmbientIntensity(parsed);
+}
 // --- Sanitizer: defensively re-apply enum whitelists and numeric clamps ---
 
 interface PersistedAppState {
   sidebarCollapsed: boolean;
   sidebarHiddenItems: AppView[];
   sidebarPlaylistsVisible: boolean;
+  compactMode: boolean;
   compactAlwaysOnTop: boolean;
   showVisualizer: boolean;
   visualizerStyle: VisualizerStyle;
@@ -185,6 +245,15 @@ interface PersistedAppState {
   lyricsPlainFontSize: LyricsFontSize;
   lyricsSyncedDimOpacity: number;
   lyricsSyncedFontSize: LyricsFontSize;
+  compactSize: CompactSize;
+  compactFontSize: CompactFontSize;
+  compactAmbientIntensity: number;
+  compactShowAlbumArt: boolean;
+  compactShowAlbum: boolean;
+  compactShowSeek: boolean;
+  compactShowVolume: boolean;
+  compactShowQuickActions: boolean;
+  compactDefaultAlwaysOnTop: boolean;
 }
 
 function sanitize(persisted: Partial<PersistedAppState> | undefined): Partial<PersistedAppState> {
@@ -196,6 +265,7 @@ function sanitize(persisted: Partial<PersistedAppState> | undefined): Partial<Pe
     out.sidebarHiddenItems = persisted.sidebarHiddenItems as AppView[];
   if (typeof persisted.sidebarPlaylistsVisible === 'boolean')
     out.sidebarPlaylistsVisible = persisted.sidebarPlaylistsVisible;
+  if (typeof persisted.compactMode === 'boolean') out.compactMode = persisted.compactMode;
   if (typeof persisted.compactAlwaysOnTop === 'boolean')
     out.compactAlwaysOnTop = persisted.compactAlwaysOnTop;
   if (typeof persisted.showVisualizer === 'boolean') out.showVisualizer = persisted.showVisualizer;
@@ -230,6 +300,24 @@ function sanitize(persisted: Partial<PersistedAppState> | undefined): Partial<Pe
     out.lyricsSyncedDimOpacity = coerceLyricsSyncedDimOpacity(persisted.lyricsSyncedDimOpacity);
   if (persisted.lyricsSyncedFontSize !== undefined)
     out.lyricsSyncedFontSize = coerceLyricsSyncedFontSize(persisted.lyricsSyncedFontSize);
+  if (persisted.compactSize !== undefined)
+    out.compactSize = coerceCompactSize(persisted.compactSize);
+  if (persisted.compactFontSize !== undefined)
+    out.compactFontSize = coerceCompactFontSize(persisted.compactFontSize);
+  if (persisted.compactAmbientIntensity !== undefined)
+    out.compactAmbientIntensity = coerceCompactAmbientIntensity(persisted.compactAmbientIntensity);
+  if (typeof persisted.compactShowAlbumArt === 'boolean')
+    out.compactShowAlbumArt = persisted.compactShowAlbumArt;
+  if (typeof persisted.compactShowAlbum === 'boolean')
+    out.compactShowAlbum = persisted.compactShowAlbum;
+  if (typeof persisted.compactShowSeek === 'boolean')
+    out.compactShowSeek = persisted.compactShowSeek;
+  if (typeof persisted.compactShowVolume === 'boolean')
+    out.compactShowVolume = persisted.compactShowVolume;
+  if (typeof persisted.compactShowQuickActions === 'boolean')
+    out.compactShowQuickActions = persisted.compactShowQuickActions;
+  if (typeof persisted.compactDefaultAlwaysOnTop === 'boolean')
+    out.compactDefaultAlwaysOnTop = persisted.compactDefaultAlwaysOnTop;
   return out;
 }
 
@@ -345,6 +433,15 @@ interface AppState {
   lyricsPlainFontSize: LyricsFontSize;
   lyricsSyncedDimOpacity: number;
   lyricsSyncedFontSize: LyricsFontSize;
+  compactSize: CompactSize;
+  compactFontSize: CompactFontSize;
+  compactAmbientIntensity: number;
+  compactShowAlbumArt: boolean;
+  compactShowAlbum: boolean;
+  compactShowSeek: boolean;
+  compactShowVolume: boolean;
+  compactShowQuickActions: boolean;
+  compactDefaultAlwaysOnTop: boolean;
   previousView: AppView;
 }
 
@@ -385,6 +482,16 @@ interface AppActions {
   setLyricsSyncedDimOpacity: (value: number) => void;
   setLyricsSyncedFontSize: (size: LyricsFontSize) => void;
   resetLyricsAppearance: () => void;
+  setCompactSize: (size: CompactSize) => void;
+  setCompactFontSize: (size: CompactFontSize) => void;
+  setCompactAmbientIntensity: (value: number) => void;
+  setCompactShowAlbumArt: (visible: boolean) => void;
+  setCompactShowAlbum: (visible: boolean) => void;
+  setCompactShowSeek: (visible: boolean) => void;
+  setCompactShowVolume: (visible: boolean) => void;
+  setCompactShowQuickActions: (visible: boolean) => void;
+  setCompactDefaultAlwaysOnTop: (enabled: boolean) => void;
+  resetCompactAppearance: () => void;
 }
 
 export const useAppStore = create<AppState & AppActions>()(
@@ -417,6 +524,15 @@ export const useAppStore = create<AppState & AppActions>()(
       lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
       lyricsSyncedDimOpacity: LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
       lyricsSyncedFontSize: LYRICS_SYNCED_FONT_SIZE_DEFAULT,
+      compactSize: COMPACT_SIZE_DEFAULT,
+      compactFontSize: COMPACT_FONT_SIZE_DEFAULT,
+      compactAmbientIntensity: COMPACT_AMBIENT_INTENSITY_DEFAULT,
+      compactShowAlbumArt: true,
+      compactShowAlbum: true,
+      compactShowSeek: true,
+      compactShowVolume: true,
+      compactShowQuickActions: false,
+      compactDefaultAlwaysOnTop: false,
       previousView: 'library',
 
       navigateTo: (view, playlistId) =>
@@ -461,12 +577,22 @@ export const useAppStore = create<AppState & AppActions>()(
         const previous = get().compactMode;
         if (previous === compactMode) return;
 
+        // When the user has opted into "default to always-on-top in compact",
+        // seed the runtime flag on entry. We seed before persisting because
+        // setCompactAlwaysOnTop short-circuits when not yet in compact mode,
+        // so we just write the value directly here.
+        const previousAlwaysOnTop = get().compactAlwaysOnTop;
+        if (compactMode && get().compactDefaultAlwaysOnTop && !previousAlwaysOnTop) {
+          set({ compactAlwaysOnTop: true });
+        }
+
         set({ compactMode });
 
         if (!IS_ELECTRON) return;
 
         try {
-          await window.electronAPI.window.setCompactMode(compactMode);
+          const dims = COMPACT_DIMENSIONS[get().compactSize];
+          await window.electronAPI.window.setCompactMode(compactMode, dims);
           if (get().compactAlwaysOnTop) {
             await window.electronAPI.window.setAlwaysOnTop(compactMode);
           }
@@ -478,7 +604,7 @@ export const useAppStore = create<AppState & AppActions>()(
               // noop
             }
           }
-          set({ compactMode: previous });
+          set({ compactMode: previous, compactAlwaysOnTop: previousAlwaysOnTop });
         }
       },
       setCompactAlwaysOnTop: async compactAlwaysOnTop => {
@@ -576,6 +702,43 @@ export const useAppStore = create<AppState & AppActions>()(
           lyricsSyncedFontSize: LYRICS_SYNCED_FONT_SIZE_DEFAULT,
         });
       },
+      setCompactSize: size => {
+        const next = coerceCompactSize(size);
+        set({ compactSize: next });
+        // If the window is currently in compact mode, push the new dimensions
+        // immediately so the preset switch is reflected without a re-toggle.
+        if (IS_ELECTRON && get().compactMode) {
+          const dims = COMPACT_DIMENSIONS[next];
+          window.electronAPI.window.setCompactMode(true, dims).catch(() => {
+            // Failure to resize is non-fatal; the next enter-compact will retry.
+          });
+        }
+      },
+      setCompactFontSize: size => {
+        set({ compactFontSize: coerceCompactFontSize(size) });
+      },
+      setCompactAmbientIntensity: value => {
+        set({ compactAmbientIntensity: coerceCompactAmbientIntensity(value) });
+      },
+      setCompactShowAlbumArt: visible => set({ compactShowAlbumArt: visible }),
+      setCompactShowAlbum: visible => set({ compactShowAlbum: visible }),
+      setCompactShowSeek: visible => set({ compactShowSeek: visible }),
+      setCompactShowVolume: visible => set({ compactShowVolume: visible }),
+      setCompactShowQuickActions: visible => set({ compactShowQuickActions: visible }),
+      setCompactDefaultAlwaysOnTop: enabled => set({ compactDefaultAlwaysOnTop: enabled }),
+      resetCompactAppearance: () => {
+        set({
+          compactSize: COMPACT_SIZE_DEFAULT,
+          compactFontSize: COMPACT_FONT_SIZE_DEFAULT,
+          compactAmbientIntensity: COMPACT_AMBIENT_INTENSITY_DEFAULT,
+          compactShowAlbumArt: true,
+          compactShowAlbum: true,
+          compactShowSeek: true,
+          compactShowVolume: true,
+          compactShowQuickActions: false,
+          compactDefaultAlwaysOnTop: false,
+        });
+      },
     }),
     {
       name: NEW_KEY,
@@ -585,6 +748,7 @@ export const useAppStore = create<AppState & AppActions>()(
         sidebarCollapsed: s.sidebarCollapsed,
         sidebarHiddenItems: s.sidebarHiddenItems,
         sidebarPlaylistsVisible: s.sidebarPlaylistsVisible,
+        compactMode: s.compactMode,
         compactAlwaysOnTop: s.compactAlwaysOnTop,
         showVisualizer: s.showVisualizer,
         visualizerStyle: s.visualizerStyle,
@@ -603,6 +767,15 @@ export const useAppStore = create<AppState & AppActions>()(
         lyricsPlainFontSize: s.lyricsPlainFontSize,
         lyricsSyncedDimOpacity: s.lyricsSyncedDimOpacity,
         lyricsSyncedFontSize: s.lyricsSyncedFontSize,
+        compactSize: s.compactSize,
+        compactFontSize: s.compactFontSize,
+        compactAmbientIntensity: s.compactAmbientIntensity,
+        compactShowAlbumArt: s.compactShowAlbumArt,
+        compactShowAlbum: s.compactShowAlbum,
+        compactShowSeek: s.compactShowSeek,
+        compactShowVolume: s.compactShowVolume,
+        compactShowQuickActions: s.compactShowQuickActions,
+        compactDefaultAlwaysOnTop: s.compactDefaultAlwaysOnTop,
       }),
       merge: (persisted, current) => ({
         ...current,
@@ -612,6 +785,22 @@ export const useAppStore = create<AppState & AppActions>()(
         if (!state) return;
         applyUiScale(state.uiScale);
         applyLowPerformanceMode(state.lowPerformanceMode);
+        // Re-apply compact mode at the OS-window level after rehydrate so
+        // users who quit while in compact mode come back into compact mode.
+        // The renderer flag is restored by zustand-persist; here we just
+        // forward to Electron so the window itself resizes/locks again.
+        if (IS_ELECTRON && state.compactMode) {
+          const dims = COMPACT_DIMENSIONS[state.compactSize];
+          window.electronAPI.window.setCompactMode(true, dims).catch(() => {
+            // If the IPC fails (e.g. preload bundling regression), fall back
+            // to the prior behavior: clear the flag so the user isn't stuck
+            // with a non-compact window claiming to be in compact mode.
+            state.compactMode = false;
+          });
+          if (state.compactAlwaysOnTop) {
+            window.electronAPI.window.setAlwaysOnTop(true).catch(() => {});
+          }
+        }
       },
     }
   )

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -43,56 +43,146 @@
   --animate-slide-up: slideUp 0.3s ease-out;
   --animate-pulse-subtle: pulseSubtle 3s ease-in-out infinite;
 
+  /* Side-to-side scroll for overflow text. Translates the inner span between
+     0 and -(scrollWidth - clientWidth), which is set as a CSS custom property
+     `--marquee-shift` by the consumer. Pauses briefly at each end so users
+     can read both edges. Activated only when the consumer adds the
+     animate-marquee utility (typically on :hover). */
+  --animate-marquee: marquee 9s ease-in-out infinite;
+
   @keyframes fadeIn {
-    0% { opacity: 0; }
-    100% { opacity: 1; }
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+  @keyframes marquee {
+    0%,
+    12% {
+      transform: translateX(0);
+    }
+    50%,
+    62% {
+      transform: translateX(var(--marquee-shift, 0px));
+    }
+    100% {
+      transform: translateX(0);
+    }
   }
   @keyframes slideUp {
-    0% { opacity: 0; transform: translateY(10px); }
-    100% { opacity: 1; transform: translateY(0); }
+    0% {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
   @keyframes pulseSubtle {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.7; }
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.7;
+    }
   }
   @keyframes splash-float {
-    0%, 100% { transform: translateY(0) rotate(0deg); }
-    25% { transform: translateY(-6px) rotate(1.5deg); }
-    50% { transform: translateY(-10px) rotate(0deg); }
-    75% { transform: translateY(-6px) rotate(-1.5deg); }
+    0%,
+    100% {
+      transform: translateY(0) rotate(0deg);
+    }
+    25% {
+      transform: translateY(-6px) rotate(1.5deg);
+    }
+    50% {
+      transform: translateY(-10px) rotate(0deg);
+    }
+    75% {
+      transform: translateY(-6px) rotate(-1.5deg);
+    }
   }
   @keyframes splash-bounce-in {
-    0% { opacity: 0; transform: scale(0) translateY(20px); }
-    100% { opacity: 1; transform: scale(1) translateY(0); }
+    0% {
+      opacity: 0;
+      transform: scale(0) translateY(20px);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1) translateY(0);
+    }
   }
   @keyframes splash-fade-up {
-    0% { opacity: 0; transform: translateY(8px); }
-    100% { opacity: 1; transform: translateY(0); }
+    0% {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
   @keyframes splash-twinkle {
-    0%, 100% { opacity: 0; transform: scale(0); }
-    20% { opacity: 0.8; transform: scale(1.2); }
-    50% { opacity: 0.5; transform: scale(0.8); }
-    80% { opacity: 0.7; transform: scale(1); }
+    0%,
+    100% {
+      opacity: 0;
+      transform: scale(0);
+    }
+    20% {
+      opacity: 0.8;
+      transform: scale(1.2);
+    }
+    50% {
+      opacity: 0.5;
+      transform: scale(0.8);
+    }
+    80% {
+      opacity: 0.7;
+      transform: scale(1);
+    }
   }
   @keyframes splash-msg-swap {
-    0% { opacity: 0; transform: translateY(4px); }
-    100% { opacity: 1; transform: translateY(0); }
+    0% {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
 }
 
 /* EQ bar animations - must be outside @theme inline for Tailwind v4 */
 @keyframes eq-bar-1 {
-  0%, 100% { transform: scaleY(0.3); }
-  50% { transform: scaleY(1); }
+  0%,
+  100% {
+    transform: scaleY(0.3);
+  }
+  50% {
+    transform: scaleY(1);
+  }
 }
 @keyframes eq-bar-2 {
-  0%, 100% { transform: scaleY(0.5); }
-  50% { transform: scaleY(0.85); }
+  0%,
+  100% {
+    transform: scaleY(0.5);
+  }
+  50% {
+    transform: scaleY(0.85);
+  }
 }
 @keyframes eq-bar-3 {
-  0%, 100% { transform: scaleY(0.35); }
-  50% { transform: scaleY(0.95); }
+  0%,
+  100% {
+    transform: scaleY(0.35);
+  }
+  50% {
+    transform: scaleY(0.95);
+  }
 }
 
 /* Midnight Lofi Cafe Theme */

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -92,7 +92,10 @@ export interface ElectronAPI {
     close: () => Promise<void>;
     isMaximized: () => Promise<boolean>;
     setAlwaysOnTop: (alwaysOnTop: boolean) => Promise<void>;
-    setCompactMode: (compactMode: boolean) => Promise<void>;
+    setCompactMode: (
+      compactMode: boolean,
+      dimensions?: { width: number; height: number }
+    ) => Promise<void>;
     onMaximizedChange: (callback: (maximized: boolean) => void) => () => void;
   };
   store: {
@@ -131,7 +134,12 @@ export interface ElectronAPI {
     clearState: () => Promise<void>;
   };
   lyrics: {
-    fetch: (title: string, artist: string, album?: string, duration?: number) => Promise<{
+    fetch: (
+      title: string,
+      artist: string,
+      album?: string,
+      duration?: number
+    ) => Promise<{
       synced: Array<{ time: number; text: string }> | null;
       plain: string | null;
       source: 'lrclib' | 'cache' | null;
@@ -170,8 +178,15 @@ export interface ElectronAPI {
       getAll: () => Promise<unknown[]>;
       get: (id: string) => Promise<unknown>;
       create: (data: { name: string; description?: string; coverArt?: string }) => Promise<unknown>;
-      createWithTracks: (data: { name: string; description?: string; trackIds: string[] }) => Promise<Playlist>;
-      update: (id: string, data: { name?: string; description?: string; coverArt?: string }) => Promise<unknown>;
+      createWithTracks: (data: {
+        name: string;
+        description?: string;
+        trackIds: string[];
+      }) => Promise<Playlist>;
+      update: (
+        id: string,
+        data: { name?: string; description?: string; coverArt?: string }
+      ) => Promise<unknown>;
       delete: (id: string) => Promise<void>;
       getTracks: (playlistId: string) => Promise<unknown[]>;
       addTrack: (playlistId: string, trackId: string) => Promise<unknown>;
@@ -203,15 +218,35 @@ export interface ElectronAPI {
     }>;
     checkDependencies: () => Promise<{ ytdlpInstalled: boolean; ffmpegInstalled: boolean }>;
     getCachedToolStatus: () => Promise<{
-      ytdlp: { installed: boolean; version?: string; latestVersion?: string; updateAvailable?: boolean };
-      ffmpeg: { installed: boolean; version?: string; latestVersion?: string; updateAvailable?: boolean };
+      ytdlp: {
+        installed: boolean;
+        version?: string;
+        latestVersion?: string;
+        updateAvailable?: boolean;
+      };
+      ffmpeg: {
+        installed: boolean;
+        version?: string;
+        latestVersion?: string;
+        updateAvailable?: boolean;
+      };
       ytdlpPath: string;
       downloadLocation: { path: string; defaultPath: string; isDefault: boolean };
       timestamp: number;
     } | null>;
     refreshToolStatus: () => Promise<{
-      ytdlp: { installed: boolean; version?: string; latestVersion?: string; updateAvailable?: boolean };
-      ffmpeg: { installed: boolean; version?: string; latestVersion?: string; updateAvailable?: boolean };
+      ytdlp: {
+        installed: boolean;
+        version?: string;
+        latestVersion?: string;
+        updateAvailable?: boolean;
+      };
+      ffmpeg: {
+        installed: boolean;
+        version?: string;
+        latestVersion?: string;
+        updateAvailable?: boolean;
+      };
       ytdlpPath: string;
       downloadLocation: { path: string; defaultPath: string; isDefault: boolean };
       timestamp: number;
@@ -237,22 +272,43 @@ export interface ElectronAPI {
     installDependencies: () => Promise<{
       results: Array<{ tool: 'ytdlp' | 'ffmpeg'; success: boolean; error?: string }>;
     }>;
-    onDependencyInstallProgress: (callback: (progress: {
-      target: 'ytdlp' | 'ffmpeg';
-      percent: number;
-      overallPercent: number;
-      label: string;
-    }) => void) => () => void;
+    onDependencyInstallProgress: (
+      callback: (progress: {
+        target: 'ytdlp' | 'ffmpeg';
+        percent: number;
+        overallPercent: number;
+        label: string;
+      }) => void
+    ) => () => void;
   };
   updater: {
     checkForUpdates: () => Promise<{ enabled: boolean }>;
     startDownload: () => Promise<void>;
     installNow: () => Promise<void>;
     onCheckingForUpdate: (callback: () => void) => () => void;
-    onUpdateAvailable: (callback: (info: { version: string; releaseNotes: string | null; releaseDate: string }) => void) => () => void;
+    onUpdateAvailable: (
+      callback: (info: {
+        version: string;
+        releaseNotes: string | null;
+        releaseDate: string;
+      }) => void
+    ) => () => void;
     onUpdateNotAvailable: (callback: () => void) => () => void;
-    onDownloadProgress: (callback: (progress: { bytesPerSecond: number; percent: number; transferred: number; total: number }) => void) => () => void;
-    onUpdateDownloaded: (callback: (info: { version: string; releaseNotes: string | null; releaseDate: string }) => void) => () => void;
+    onDownloadProgress: (
+      callback: (progress: {
+        bytesPerSecond: number;
+        percent: number;
+        transferred: number;
+        total: number;
+      }) => void
+    ) => () => void;
+    onUpdateDownloaded: (
+      callback: (info: {
+        version: string;
+        releaseNotes: string | null;
+        releaseDate: string;
+      }) => void
+    ) => () => void;
     onUpdateError: (callback: (message: string) => void) => () => void;
   };
   radio: {
@@ -287,14 +343,15 @@ export interface ElectronAPI {
   playlist: {
     extract: (url: string) => Promise<SearchResult[]>;
     cancel: () => Promise<void>;
-    onExtractProgress: (callback: (data: {
-      current: number;
-      total: number;
-      trackName: string;
-    }) => void) => () => void;
+    onExtractProgress: (
+      callback: (data: { current: number; total: number; trackName: string }) => void
+    ) => () => void;
   };
   metadata: {
-    lookup: (title: string, artist: string) => Promise<{
+    lookup: (
+      title: string,
+      artist: string
+    ) => Promise<{
       title?: string;
       artist?: string;
       album?: string;
@@ -318,28 +375,32 @@ export interface ElectronAPI {
         trackNumber: number | null;
       }>,
       options: { writeToFile: boolean; onlyMissing: boolean }
-    ) => Promise<Array<{
-      id: string;
-      success: boolean;
-      updatedFields: Partial<{
-        title: string;
-        artist: string;
-        album: string;
-        genre: string;
-        year: number;
-        trackNumber: number;
-        albumArt: string;
-      }>;
-      source: string;
-      error?: string;
-    }>>;
+    ) => Promise<
+      Array<{
+        id: string;
+        success: boolean;
+        updatedFields: Partial<{
+          title: string;
+          artist: string;
+          album: string;
+          genre: string;
+          year: number;
+          trackNumber: number;
+          albumArt: string;
+        }>;
+        source: string;
+        error?: string;
+      }>
+    >;
     cancelEnrichment: () => Promise<void>;
-    onEnrichProgress: (callback: (data: {
-      current: number;
-      total: number;
-      trackName: string;
-      status: 'searching' | 'downloading' | 'writing' | 'done' | 'error' | 'cancelled';
-    }) => void) => () => void;
+    onEnrichProgress: (
+      callback: (data: {
+        current: number;
+        total: number;
+        trackName: string;
+        status: 'searching' | 'downloading' | 'writing' | 'done' | 'error' | 'cancelled';
+      }) => void
+    ) => () => void;
   };
   share: {
     track: (trackId: string) => Promise<{ code: string; url: string; expiresAt: string }>;


### PR DESCRIPTION
## Summary

Audit-driven enhancement of compact mode. Two tiers shipped together:

- **T1 — bug fixes / quick wins**: removed destructive X button (was quitting the app), persisted `compactMode` flag, click-album-art-to-expand, hover marquee for long titles, `Ctrl/Cmd+Shift+T` always-on-top shortcut, wider volume slider.
- **T2 — new Compact section in Settings**: size presets (sm/md/lg), element visibility toggles (art/album/seek/volume), quick-action cluster (favorite/shuffle/repeat), ambient color intensity slider, compact font size scale, default-always-on-top preference, separately-persisted compact window position.

All 14 audited items implemented, none skipped.

## Stacking note

Branched off the unpublished `feat/configurable-lyrics-typography` because the compact section mirrors `LyricsSection` / `OpacityControl` primitives introduced there. Diff against master therefore includes both bodies of work. Once the lyrics branch is published as its own PR, this one's base can be rebased onto it for a clean stack.

## What changed

### T1 — fixes
- Removed the X button from compact title bar — it was wired to quit the entire app, sitting next to Maximize2 (exit-compact). Maximize2 is now the unambiguous exit affordance.
- Added `compactMode` to `partialize` + `sanitize` in `useAppStore`. `onRehydrateStorage` re-applies via IPC on launch.
- Album art is now a `<button>` that exits compact and opens Now Playing. Cursor, hover scale, focus ring, `aria-label`.
- New `useMarqueeOnOverflow` hook — pure CSS, hover/focus gated, disabled under `lowPerformanceMode`. Mask-image fade in static state.
- `Ctrl/Cmd+Shift+T` toggles always-on-top from anywhere. Added to keyboard shortcuts help (EN+PL).
- Volume slider `w-12` → `w-20`.

### T2 — Compact section in Settings
- New `CompactSection.tsx` with `PictureInPicture2` nav icon, slotted between Lyrics and Appearance.
- Store: `compactSize`, `compactShowAlbumArt`, `compactShowAlbum`, `compactShowSeek`, `compactShowVolume`, `compactShowQuickActions`, `compactAmbientIntensity`, `compactFontSize`, `compactDefaultAlwaysOnTop` — all in `partialize` + `sanitize`.
- Size presets: sm 420×200 / md 500×214 / lg 600×260. Live-resizes when switched in compact.
- Quick actions reuse `usePlaybackStore.toggleShuffle`/`cycleRepeatMode` and `useLibraryStore.toggleFavorite`. Favorite is hidden for radio tracks.
- Ambient intensity slider 0..0.2 replaces hardcoded 0.08; gradient layer skipped at 0.
- `compactDefaultAlwaysOnTop` seeds `compactAlwaysOnTop=true` on entering compact, with rollback if IPC fails.

### Desktop / IPC
- `window:set-compact-mode` schema extended with optional dimensions (one channel, not two).
- Compact window bounds stored in main-process electron-store (`compact-window-bounds`), not renderer persist. On enter-compact, saved x/y validated against connected displays' workArea (≥80px tolerance) before applying — multi-display safe.

### Cross-cutting
- EN+PL i18n: `compact.json`, `settings.cmp.*`, `shortcuts.json`.
- Test coverage: rollback test for new persisted prefs follows existing `useAppStore.test.ts` pattern.

## Verification
- `pnpm typecheck` — clean
- `pnpm test` — 1105 / 1105 passing
- `pnpm lint` — clean

## Test plan
- [ ] Enter compact (`Ctrl+Shift+M`) — X is gone, Maximize2 exits cleanly
- [ ] Quit while compact → relaunch → returns to compact (rehydrate)
- [ ] Settings → Compact section: walk every preset/toggle, hit Reset
- [ ] Switch size preset while compact → live resize, no flicker
- [ ] Move compact window to a corner → exit → re-enter → restores there
- [ ] Long title (>40 chars) → hover → marquee animates; Low Performance Mode disables it
- [ ] `Ctrl+Shift+T` toggles pin inside and outside compact
- [ ] Click album art in compact → exits + opens Now Playing
- [ ] Multi-monitor: park on secondary, disconnect, re-enter → falls back to default placement