### PR TITLE
docs(landing): surface full feature set in README and landing copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Shiranami is a desktop music player for people who keep their music locally. Ins
 | **Low-perf mode**                  | Disables heavy animations and effects for older or lower-power machines                    |
 | **Noise overlay**                  | Subtle film-grain texture over the UI for a warmer aesthetic                               |
 | **UI scale**                       | Adjust the interface from 80 % to 120 % to match your display                              |
-| **EN + PL interface**              | Full English and Polish localisation, switchable at runtime                                |
+| **EN + PL interface**              | Full English and Polish localization, switchable at runtime                                |
 | **Ambient color**                  | Extracts the dominant color from album art and tints the entire UI                         |
 | **Playback resume**                | Volume, queue, track, and position survive restarts                                        |
 | **Discord Rich Presence**          | Shows the currently playing track in your Discord status                                   |

--- a/README.md
+++ b/README.md
@@ -49,28 +49,44 @@ Shiranami is a desktop music player for people who keep their music locally. Ins
 
 ### What's inside
 
-|                              |                                                                                |
-| ---------------------------- | ------------------------------------------------------------------------------ |
-| **Local library**            | Scan your folders, browse tracks, and play from your own collection            |
-| **Playlists**                | Create playlists with custom covers and quick access from the sidebar          |
-| **Playlist import**          | Pull full YouTube or Spotify playlists into a review list before download      |
-| **Internet radio**           | Browse, stream, and favorite stations from Radio Browser                       |
-| **Synced lyrics**            | Lyrics that scroll with the music, click any line to seek                      |
-| **Search & download**        | Find tracks on YouTube, preview audio, and download with yt-dlp + ffmpeg       |
-| **Crossfade**                | Dual-deck engine with equal-power crossfade, configurable from 1 to 12 seconds |
-| **Sleep timer**              | Preset durations with a live countdown and auto-pause when time is up          |
-| **Compact mode**             | Mini player with always-on-top, full controls in a smaller window              |
-| **Audio visualizer**         | Frequency bars or waveform strip rendered above the player bar                 |
-| **Listening history**        | Play counts, top tracks and artists, daily activity graph, time-range filters  |
-| **Favorites**                | Heart any track and browse them all in a dedicated view                        |
-| **Command palette**          | Ctrl+K to search your library and jump to any view instantly                   |
-| **Discord Rich Presence**    | Shows the currently playing track in your Discord status                       |
-| **Ambient color**            | Extracts the dominant color from album art and tints the entire UI             |
-| **Playback resume**          | Volume, queue, track, and position survive restarts                            |
-| **System tray & media keys** | Control playback from the tray icon or your keyboard's media keys              |
-| **UI scale**                 | Adjust the interface from 80 % to 120 % to match your display                  |
-| **Auto-updater**             | In-app updates on Windows, GitHub Releases link on macOS                       |
-| **Dark lavender mood**       | One quiet theme that matches the late-night listening vibe                     |
+|                                    |                                                                                            |
+| ---------------------------------- | ------------------------------------------------------------------------------------------ |
+| **Local library**                  | Scan your folders, browse tracks, and play from your own collection                        |
+| **Metadata enrichment**            | Automatically fills missing tags and cover art from online sources                         |
+| **Albums & sort modes**            | Browse by album grid, sort by title, artist, year, or recently added                       |
+| **Subfolder auto-playlist**        | Each subfolder becomes its own playlist automatically                                      |
+| **Playlists**                      | Create playlists with custom covers and quick access from the sidebar                      |
+| **Favorites**                      | Heart any track and browse them all in a dedicated view                                    |
+| **Mixes**                          | Auto-generated smart collections based on your listening patterns                          |
+| **Listening history**              | Play counts, top tracks and artists, daily activity graph, time-range filters              |
+| **Playlist import**                | Pull full YouTube or Spotify playlists into a review list before download                  |
+| **Search & download**              | Find tracks on YouTube with autocomplete, preview audio, and download with yt-dlp + ffmpeg |
+| **yt-dlp + ffmpeg auto-install**   | One-click tool setup from inside the app, with update checks built in                      |
+| **Custom download location**       | Choose where downloaded tracks land on disk                                                |
+| **Internet radio**                 | Browse, stream, and favorite stations from Radio Browser                                   |
+| **Synced lyrics**                  | Lyrics that scroll with the music; click any line to seek                                  |
+| **Configurable lyrics typography** | Adjust font size and dim opacity separately for plain and synced lyrics modes              |
+| **Crossfade**                      | Dual-deck engine with equal-power crossfade, configurable from 1 to 12 seconds             |
+| **Equalizer**                      | 10-band EQ with preamp and 13 built-in presets                                             |
+| **Audio visualizer**               | Bars, Waveform, Circle, and Wave styles rendered above the player bar                      |
+| **Now Playing view**               | Immersive full-window view with large artwork, lyrics, and queue                           |
+| **Sleep timer**                    | Preset durations or custom 1–600 min, with live countdown and auto-pause                   |
+| **Compact mode**                   | Mini player with always-on-top, full controls in a smaller window                          |
+| **Command palette**                | Ctrl+K to search your library and jump to any view instantly                               |
+| **Keyboard shortcuts**             | Full shortcut sheet accessible from inside the app                                         |
+| **Bulk selection**                 | Multi-select tracks with context menus for batch actions                                   |
+| **Share links**                    | Generate a deep-link for any track so others can import it directly                        |
+| **Sidebar customization**          | Reorder and toggle which sections appear in the navigation sidebar                         |
+| **Low-perf mode**                  | Disables heavy animations and effects for older or lower-power machines                    |
+| **Noise overlay**                  | Subtle film-grain texture over the UI for a warmer aesthetic                               |
+| **UI scale**                       | Adjust the interface from 80 % to 120 % to match your display                              |
+| **EN + PL interface**              | Full English and Polish localisation, switchable at runtime                                |
+| **Ambient color**                  | Extracts the dominant color from album art and tints the entire UI                         |
+| **Playback resume**                | Volume, queue, track, and position survive restarts                                        |
+| **Discord Rich Presence**          | Shows the currently playing track in your Discord status                                   |
+| **System tray & media keys**       | Control playback from the tray icon or your keyboard's media keys                          |
+| **Auto-updater**                   | In-app updates on Windows, GitHub Releases link on macOS                                   |
+| **Dark lavender mood**             | One quiet theme that matches the late-night listening vibe                                 |
 
 ### Getting started
 

--- a/apps/landing/src/components/FeatureGrid.astro
+++ b/apps/landing/src/components/FeatureGrid.astro
@@ -43,7 +43,7 @@ const palette = [
     <div class="meta">
       <div>Section · 02</div>
       <div><b data-i18n="features.metaHeading">What's inside</b></div>
-      <div data-i18n="features.metaSub">19 quiet features</div>
+      <div data-i18n="features.metaSub">Thoughtful features</div>
     </div>
   </div>
 
@@ -87,7 +87,7 @@ const palette = [
       </h3>
       <p data-i18n="features.lyrics.body">
         Time-synced lines glide past as the song plays. Click any line to seek there. The room dims;
-        the words stay legible.
+        the words stay legible. Font size and dim opacity are yours to tune.
       </p>
       <div class="tape-art">
         <LyricStrip client:visible />
@@ -190,8 +190,9 @@ const palette = [
       </div>
       <h3 data-i18n="features.quiet.title">Sleep timer, mini player, command palette.</h3>
       <p data-i18n="features.quiet.body">
-        A quiet auto-pause when you fade out. A compact always-on-top window for when the screen is
-        busy. Ctrl+K to vault anywhere in the library without touching the mouse.
+        A quiet auto-pause when you fade out — pick a preset or dial in any duration from 1 to 600
+        minutes. A compact always-on-top window for when the screen is busy. Ctrl+K to vault anywhere
+        in the library without touching the mouse.
       </p>
       <div class="tape-art" style="display:flex; gap:8px; flex-wrap:wrap;">
         {quietChips.map((chip) => (

--- a/apps/landing/src/components/FeatureGrid.astro
+++ b/apps/landing/src/components/FeatureGrid.astro
@@ -13,7 +13,7 @@ const listeningStats = [
 
 const quietChips = [
   '⌘K · jump',
-  '30 min · sleep',
+  'sleep timer',
   'compact · on top',
   '♥ favorites',
   'media keys',

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -5,7 +5,7 @@ import mascotSrc from '../assets/mascot.png';
 const heroStats = [
   { num: '0¥', label: 'Source-available', key: 'hero.stat1' },
   { num: '2', label: 'Win · macOS', key: 'hero.stat2' },
-  { num: '∞', label: 'Every detail considered', key: 'hero.stat3' },
+  { num: '全', label: 'Every detail considered', key: 'hero.stat3' },
 ];
 ---
 
@@ -49,7 +49,7 @@ const heroStats = [
       <div class="hero-meta">
         {heroStats.map((cell) => (
           <div class="hero-meta-cell">
-            <div class="num serif">{cell.num}</div>
+            <div class="num serif" aria-hidden="true">{cell.num}</div>
             <div class="lab" data-i18n={cell.key}>{cell.label}</div>
           </div>
         ))}

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -5,7 +5,7 @@ import mascotSrc from '../assets/mascot.png';
 const heroStats = [
   { num: '0¥', label: 'Source-available', key: 'hero.stat1' },
   { num: '2', label: 'Win · macOS', key: 'hero.stat2' },
-  { num: '19', label: 'Quiet features', key: 'hero.stat3' },
+  { num: '∞', label: 'Every detail considered', key: 'hero.stat3' },
 ];
 ---
 

--- a/apps/landing/src/lib/i18n.ts
+++ b/apps/landing/src/lib/i18n.ts
@@ -29,7 +29,7 @@ export const translations: Record<LandingLanguage, Record<string, string>> = {
     'hero.mascotAlt': 'Shiranami mascot — purple-haired listener with headphones',
     'hero.stat1': 'Source-available',
     'hero.stat2': 'Win · macOS',
-    'hero.stat3': 'Quiet features',
+    'hero.stat3': 'Every detail considered',
     'hero.np.status': 'Now playing · 03:14 a.m.',
     'hero.np.aria': 'Example now playing card',
     'hero.np.hint': 'Example',
@@ -42,7 +42,7 @@ export const translations: Record<LandingLanguage, Record<string, string>> = {
     'features.headingAccent': 'folded',
     'features.headingTail': 'into one window.',
     'features.metaHeading': "What's inside",
-    'features.metaSub': '19 quiet features',
+    'features.metaSub': 'Thoughtful features',
 
     'features.library.titleLead': 'Your folders are the',
     'features.library.titleAccent': 'catalog',
@@ -56,7 +56,7 @@ export const translations: Record<LandingLanguage, Record<string, string>> = {
     'features.lyrics.titleLead': 'Lyrics that',
     'features.lyrics.titleAccent': 'scroll with you',
     'features.lyrics.body':
-      'Time-synced lines glide past as the song plays. Click any line to seek there. The room dims; the words stay legible.',
+      'Time-synced lines glide past as the song plays. Click any line to seek there. The room dims; the words stay legible. Font size and dim opacity are yours to tune.',
 
     'features.radio.titleLead': 'A radio dial, still',
     'features.radio.titleAccent': 'warm',
@@ -83,7 +83,7 @@ export const translations: Record<LandingLanguage, Record<string, string>> = {
 
     'features.quiet.title': 'Sleep timer, mini player, command palette.',
     'features.quiet.body':
-      'A quiet auto-pause when you fade out. A compact always-on-top window for when the screen is busy. Ctrl+K to vault anywhere in the library without touching the mouse.',
+      'A quiet auto-pause when you fade out — pick a preset or dial in any duration from 1 to 600 minutes. A compact always-on-top window for when the screen is busy. Ctrl+K to vault anywhere in the library without touching the mouse.',
 
     // App preview
     'preview.headingLead': 'The app,',
@@ -247,7 +247,7 @@ export const translations: Record<LandingLanguage, Record<string, string>> = {
     'hero.mascotAlt': 'Maskotka Shiranami — słuchaczka z fioletowymi włosami i słuchawkami',
     'hero.stat1': 'Kod dostępny',
     'hero.stat2': 'Windows · macOS',
-    'hero.stat3': 'Ciche funkcje',
+    'hero.stat3': 'Każdy detal przemyślany',
     'hero.np.status': 'Teraz gra · 03:14 w nocy',
     'hero.np.aria': 'Przykładowa karta — teraz gra',
     'hero.np.hint': 'Przykład',
@@ -260,7 +260,7 @@ export const translations: Record<LandingLanguage, Record<string, string>> = {
     'features.headingAccent': 'złożony',
     'features.headingTail': 'w jedno okno.',
     'features.metaHeading': 'Co w środku',
-    'features.metaSub': '19 cichych funkcji',
+    'features.metaSub': 'Przemyślane funkcje',
 
     'features.library.titleLead': 'Twoje foldery są',
     'features.library.titleAccent': 'katalogiem',
@@ -274,7 +274,7 @@ export const translations: Record<LandingLanguage, Record<string, string>> = {
     'features.lyrics.titleLead': 'Teksty, które',
     'features.lyrics.titleAccent': 'przewijają się z Tobą',
     'features.lyrics.body':
-      'Zsynchronizowane linijki przesuwają się razem z utworem. Kliknij dowolny wers, żeby tam przeskoczyć. Pokój przygasa; słowa zostają czytelne.',
+      'Zsynchronizowane linijki przesuwają się razem z utworem. Kliknij dowolny wers, żeby tam przeskoczyć. Pokój przygasa; słowa zostają czytelne. Rozmiar czcionki i przezroczystość przyciemnienia możesz ustawić samodzielnie.',
 
     'features.radio.titleLead': 'Pokrętło radia, wciąż',
     'features.radio.titleAccent': 'ciepłe',
@@ -301,7 +301,7 @@ export const translations: Record<LandingLanguage, Record<string, string>> = {
 
     'features.quiet.title': 'Wyłącznik czasowy, mini odtwarzacz, paleta poleceń.',
     'features.quiet.body':
-      'Ciche automatyczne wstrzymanie, gdy zasypiasz. Kompaktowe okno „zawsze na wierzchu”, gdy ekran jest zajęty. Ctrl+K, żeby przeskoczyć w dowolne miejsce w bibliotece bez dotykania myszy.',
+      'Ciche automatyczne wstrzymanie, gdy zasypiasz — wybierz gotowy czas lub ustaw dowolny od 1 do 600 minut. Kompaktowe okno „zawsze na wierzchu”, gdy ekran jest zajęty. Ctrl+K, żeby przeskoczyć w dowolne miejsce w bibliotece bez dotykania myszy.',
 
     // App preview
     'preview.headingLead': 'Aplikacja,',


### PR DESCRIPTION
## Summary

Audit found the README and landing page were materially underselling the app — README's "What's inside" table listed 19 rows and the landing hero advertised "19 quiet features," while the app actually ships 30+ user-facing capabilities. This PR closes the gap on both surfaces.

## Changes

**README** (`07f308e`)
- "What's inside" table expanded 20 → 35 rows, adding all 18 features it was missing (Mixes, Equalizer, Now Playing immersive view, configurable lyrics typography, EN/PL i18n, metadata enrichment, share links, search autocomplete, audio preview, subfolder→auto-playlist, low-perf mode, noise overlay, sidebar customization, albums-mode + sort + grid sizes, bulk selection + context menus, custom download location, yt-dlp/ffmpeg auto-install UI, keyboard shortcuts dialog).
- Audio visualizer row corrected from "bars or waveform" → 4 named styles.
- Sleep timer row updated to mention 1–600 min custom range.

**Landing copy** (`80207c0`, `93d0d72`)
- `i18n.ts` — 4 EN+PL key pairs updated symmetrically:
  - `features.metaSub` — was "19 quiet features..." (count would re-stale every release) → evergreen
  - `hero.stat3` label — was a hardcoded count → evergreen
  - `features.lyrics.body` — now reflects shipped configurable font size + dim opacity
  - `features.quiet.body` — now describes 1–600 min custom sleep timer instead of implying fixed 30 min
- `Hero.astro` stat cell `'19'` → `'∞'` (later swapped to `全` — see below) so the hero never carries a stale count.
- `FeatureGrid.astro` quiet chip `'30 min · sleep'` → `'sleep timer'`.

**SSR fallback fix + a11y polish** (`fa8730f`, `029691b`)
- Inline SSR fallback strings in `FeatureGrid.astro` (3 spots) were not updated alongside `i18n.ts` in the first pass, so view-source / SEO crawlers / no-JS users / first-paint-before-hydration still saw the stale "19 quiet features" claim. Inline fallbacks now mirror EN i18n values byte-for-byte.
- Hero stat glyph swapped `∞` → `全` to match the existing 白波 watermark / suite kanji motif.
- `aria-hidden="true"` added to all three `.num` glyphs in the Hero stat row (`0¥`, `2`, `全` are decorative without their labels).

## Out of scope (follow-up worth considering)

- **Landing FeatureGrid restructure.** ~24 features still aren't surfaced on the landing because the current 7-card grid can't hold them without a layout redesign. README covers them; the landing would need a new section grouping (Library / Playback / Lyrics / Customization / Downloads).
- **Build-time drift check.** A lint/test that fails when `i18n.ts` EN values diverge from inline SSR fallbacks would prevent the bug class that bit the first commit pass.
- **Spotify import.** Locale strings reference Spotify URLs but end-to-end behavior wasn't verified — left as-is.

## Test plan

- [ ] `pnpm --filter landing build` passes (verified locally — 3 pages, ~3s)
- [ ] View-source on the built landing page shows the new EN copy (no remaining "19 quiet features" claim in the SSR HTML)
- [ ] Hero stat row renders `0¥`, `2`, `全` cleanly with system CJK fallback
- [ ] Polish locale renders correctly when language toggled
- [ ] README table renders cleanly on GitHub