### PR TITLE
perf: downscale album art cache to reduce renderer memory

### DIFF
--- a/apps/desktop/src/main/art-protocol.test.ts
+++ b/apps/desktop/src/main/art-protocol.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mimeToExt, extToMime, toArtUrl } from './art-protocol';
 
 describe('mimeToExt', () => {
@@ -66,5 +66,113 @@ describe('toArtUrl', () => {
 
   it('preserves filename with extension', () => {
     expect(toArtUrl('deadbeef.png')).toBe('shiranami-art://art/deadbeef.png');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// downscaleImage — takes a NativeImage; each test builds a stub directly.
+// ---------------------------------------------------------------------------
+
+function makeImageStub({
+  width = 1000,
+  height = 1000,
+  jpegOutput = Buffer.from('jpeg-output'),
+}: {
+  width?: number;
+  height?: number;
+  jpegOutput?: Buffer;
+} = {}) {
+  const resizedStub = {
+    toJPEG: vi.fn().mockReturnValue(jpegOutput),
+  };
+  const stub = {
+    isEmpty: vi.fn().mockReturnValue(false),
+    getSize: vi.fn().mockReturnValue({ width, height }),
+    resize: vi.fn().mockReturnValue(resizedStub),
+    toJPEG: vi.fn().mockReturnValue(jpegOutput),
+  };
+  return { stub, resizedStub };
+}
+
+describe('downscaleImage', () => {
+  it('re-encodes to JPEG q=85 without resize when dimensions are within limit', async () => {
+    const jpeg = Buffer.from('small-jpeg');
+    const { stub } = makeImageStub({ width: 256, height: 256, jpegOutput: jpeg });
+
+    const { downscaleImage } = await import('./art-protocol');
+    const result = downscaleImage(stub as never);
+
+    expect(stub.resize).not.toHaveBeenCalled();
+    expect(stub.toJPEG).toHaveBeenCalledWith(85);
+    expect(result).toBe(jpeg);
+  });
+
+  it('resizes wide image so longest edge becomes 512', async () => {
+    const jpeg = Buffer.from('resized-wide');
+    const { stub, resizedStub } = makeImageStub({ width: 1024, height: 512, jpegOutput: jpeg });
+
+    const { downscaleImage } = await import('./art-protocol');
+    const result = downscaleImage(stub as never);
+
+    expect(stub.resize).toHaveBeenCalledWith({ width: 512, height: 256, quality: 'best' });
+    expect(resizedStub.toJPEG).toHaveBeenCalledWith(85);
+    expect(result).toBe(jpeg);
+  });
+
+  it('resizes tall image so longest edge becomes 512', async () => {
+    const jpeg = Buffer.from('resized-tall');
+    const { stub, resizedStub } = makeImageStub({ width: 400, height: 800, jpegOutput: jpeg });
+
+    const { downscaleImage } = await import('./art-protocol');
+    const result = downscaleImage(stub as never);
+
+    expect(stub.resize).toHaveBeenCalledWith({ width: 256, height: 512, quality: 'best' });
+    expect(resizedStub.toJPEG).toHaveBeenCalledWith(85);
+    expect(result).toBe(jpeg);
+  });
+
+  it('resizes square image so both edges become 512', async () => {
+    const jpeg = Buffer.from('resized-square');
+    const { stub, resizedStub } = makeImageStub({ width: 1000, height: 1000, jpegOutput: jpeg });
+
+    const { downscaleImage } = await import('./art-protocol');
+    downscaleImage(stub as never);
+
+    expect(stub.resize).toHaveBeenCalledWith({ width: 512, height: 512, quality: 'best' });
+    expect(resizedStub.toJPEG).toHaveBeenCalledWith(85);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saveAlbumArt — mocks nativeImage via vi.mock (module-level).
+// ---------------------------------------------------------------------------
+
+vi.mock('electron', async importOriginal => {
+  const original = await importOriginal<typeof import('electron')>();
+  return {
+    ...original,
+    nativeImage: {
+      createFromBuffer: vi.fn(),
+    },
+  };
+});
+
+describe('saveAlbumArt', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns null for empty buffer', async () => {
+    const { saveAlbumArt } = await import('./art-protocol');
+    expect(await saveAlbumArt(Buffer.alloc(0), 'image/jpeg')).toBeNull();
+  });
+
+  it('returns null when nativeImage cannot decode the buffer', async () => {
+    const { nativeImage } = await import('electron');
+    const emptyStub = { isEmpty: vi.fn().mockReturnValue(true) };
+    vi.mocked(nativeImage.createFromBuffer).mockReturnValue(emptyStub as never);
+
+    const { saveAlbumArt } = await import('./art-protocol');
+    expect(await saveAlbumArt(Buffer.from('garbage'), 'image/jpeg')).toBeNull();
   });
 });

--- a/apps/desktop/src/main/art-protocol.test.ts
+++ b/apps/desktop/src/main/art-protocol.test.ts
@@ -136,10 +136,23 @@ describe('downscaleImage', () => {
     const { stub, resizedStub } = makeImageStub({ width: 1000, height: 1000, jpegOutput: jpeg });
 
     const { downscaleImage } = await import('./art-protocol');
-    downscaleImage(stub as never);
+    const result = downscaleImage(stub as never);
 
     expect(stub.resize).toHaveBeenCalledWith({ width: 512, height: 512, quality: 'best' });
     expect(resizedStub.toJPEG).toHaveBeenCalledWith(85);
+    expect(result).toBe(jpeg);
+  });
+
+  it('floors target dimension at 1px for extreme aspect ratios', async () => {
+    const jpeg = Buffer.from('resized-extreme');
+    const { stub, resizedStub } = makeImageStub({ width: 10000, height: 1, jpegOutput: jpeg });
+
+    const { downscaleImage } = await import('./art-protocol');
+    const result = downscaleImage(stub as never);
+
+    expect(stub.resize).toHaveBeenCalledWith({ width: 512, height: 1, quality: 'best' });
+    expect(resizedStub.toJPEG).toHaveBeenCalledWith(85);
+    expect(result).toBe(jpeg);
   });
 });
 

--- a/apps/desktop/src/main/art-protocol.test.ts
+++ b/apps/desktop/src/main/art-protocol.test.ts
@@ -1,32 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mimeToExt, extToMime, toArtUrl } from './art-protocol';
-
-describe('mimeToExt', () => {
-  it('maps image/jpeg to .jpg', () => {
-    expect(mimeToExt('image/jpeg')).toBe('.jpg');
-  });
-
-  it('maps image/png to .png', () => {
-    expect(mimeToExt('image/png')).toBe('.png');
-  });
-
-  it('maps image/webp to .webp', () => {
-    expect(mimeToExt('image/webp')).toBe('.webp');
-  });
-
-  it('maps image/gif to .gif', () => {
-    expect(mimeToExt('image/gif')).toBe('.gif');
-  });
-
-  it('maps image/bmp to .bmp', () => {
-    expect(mimeToExt('image/bmp')).toBe('.bmp');
-  });
-
-  it('falls back to .jpg for unknown MIME types', () => {
-    expect(mimeToExt('image/tiff')).toBe('.jpg');
-    expect(mimeToExt('application/octet-stream')).toBe('.jpg');
-  });
-});
+import { extToMime, toArtUrl } from './art-protocol';
 
 describe('extToMime', () => {
   it('maps .jpg to image/jpeg', () => {

--- a/apps/desktop/src/main/art-protocol.ts
+++ b/apps/desktop/src/main/art-protocol.ts
@@ -1,4 +1,4 @@
-import { app, protocol } from 'electron';
+import { app, protocol, nativeImage } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
@@ -50,21 +50,53 @@ export function extToMime(ext: string): string {
 
 const ALLOWED_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.gif', '.bmp']);
 
+const MAX_DIMENSION = 512;
+
+/**
+ * Downscale a decoded nativeImage to fit within MAX_DIMENSION on its longest edge,
+ * re-encoding as JPEG q=85. Skips the resize step when both dimensions are already
+ * within the limit; always re-encodes to normalise the output format.
+ */
+export function downscaleImage(image: Electron.NativeImage): Buffer {
+  const { width, height } = image.getSize();
+  if (width <= MAX_DIMENSION && height <= MAX_DIMENSION) {
+    return image.toJPEG(85);
+  }
+
+  const scale = MAX_DIMENSION / Math.max(width, height);
+  const targetWidth = Math.round(width * scale);
+  const targetHeight = Math.round(height * scale);
+
+  const resized = image.resize({ width: targetWidth, height: targetHeight, quality: 'best' });
+  return resized.toJPEG(85);
+}
+
+/** Whether we have logged the first cache-write info line this session. */
+let _firstWriteLogged = false;
+
 /**
  * Save album art image data to disk.
- * Returns the protocol URL (shiranami-art://art/{hash}{ext}) or null if data is empty.
+ * Returns the protocol URL (shiranami-art://art/{hash}.jpg) or null if data is empty.
  */
-export async function saveAlbumArt(data: Buffer, mimeType: string): Promise<string | null> {
+export async function saveAlbumArt(data: Buffer, _mimeType: string): Promise<string | null> {
   if (!data || data.length === 0) return null;
 
-  const hash = crypto.createHash('sha256').update(data).digest('hex').slice(0, 32);
-  const ext = mimeToExt(mimeType);
-  const fileName = `${hash}${ext}`;
+  const image = nativeImage.createFromBuffer(data);
+  if (image.isEmpty()) return null;
+
+  const resized = downscaleImage(image);
+
+  const hash = crypto.createHash('sha256').update(resized).digest('hex').slice(0, 32);
+  const fileName = `${hash}.jpg`;
   const filePath = path.join(getArtDir(), fileName);
 
   try {
     // Atomically write the file if it doesn't exist using the 'wx' flag.
-    await fs.promises.writeFile(filePath, data, { flag: 'wx' });
+    await fs.promises.writeFile(filePath, resized, { flag: 'wx' });
+    if (!_firstWriteLogged) {
+      _firstWriteLogged = true;
+      logger.info('[art-protocol] Writing downscaled album art (512px JPEG) to cache');
+    }
   } catch (error: unknown) {
     // If the file already exists ('EEXIST'), it's not an error for content-addressing.
     if (error instanceof Error && (error as NodeJS.ErrnoException).code !== 'EEXIST') {
@@ -74,6 +106,11 @@ export async function saveAlbumArt(data: Buffer, mimeType: string): Promise<stri
   }
 
   return toArtUrl(fileName);
+}
+
+/** Reset the first-write log flag (for testing only). */
+export function _resetFirstWriteLoggedForTest(): void {
+  _firstWriteLogged = false;
 }
 
 /**

--- a/apps/desktop/src/main/art-protocol.ts
+++ b/apps/desktop/src/main/art-protocol.ts
@@ -23,18 +23,6 @@ export function ensureArtDir(): void {
   }
 }
 
-/** Map MIME type to file extension */
-export function mimeToExt(mime: string): string {
-  const map: Record<string, string> = {
-    'image/jpeg': '.jpg',
-    'image/png': '.png',
-    'image/webp': '.webp',
-    'image/gif': '.gif',
-    'image/bmp': '.bmp',
-  };
-  return map[mime] || '.jpg';
-}
-
 /** Map file extension to MIME type */
 export function extToMime(ext: string): string {
   const map: Record<string, string> = {

--- a/apps/desktop/src/main/art-protocol.ts
+++ b/apps/desktop/src/main/art-protocol.ts
@@ -64,8 +64,9 @@ export function downscaleImage(image: Electron.NativeImage): Buffer {
   }
 
   const scale = MAX_DIMENSION / Math.max(width, height);
-  const targetWidth = Math.round(width * scale);
-  const targetHeight = Math.round(height * scale);
+  // Floor at 1px so extreme aspect ratios (e.g. 10000×1) can't round to 0.
+  const targetWidth = Math.max(1, Math.round(width * scale));
+  const targetHeight = Math.max(1, Math.round(height * scale));
 
   const resized = image.resize({ width: targetWidth, height: targetHeight, quality: 'best' });
   return resized.toJPEG(85);

--- a/apps/web/src/components/history/HistoryTrackRows.tsx
+++ b/apps/web/src/components/history/HistoryTrackRows.tsx
@@ -12,7 +12,13 @@ function TrackArtwork({ albumArt, title }: { albumArt: string | null; title: str
   return (
     <div className="flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-muted/35">
       {albumArt ? (
-        <img src={albumArt} alt={title} className="h-full w-full object-cover" />
+        <img
+          src={albumArt}
+          alt={title}
+          className="h-full w-full object-cover"
+          loading="lazy"
+          decoding="async"
+        />
       ) : (
         <Music className="size-4 text-muted-foreground/45" />
       )}
@@ -39,7 +45,9 @@ export function TopTrackRow({ track, onPlay }: TopTrackRowProps) {
         <p className="truncate text-xs text-muted-foreground">{track.artist}</p>
       </div>
       <div className="shrink-0 text-right">
-        <p className="text-xs font-medium text-foreground">{t('plays', { count: track.playCount })}</p>
+        <p className="text-xs font-medium text-foreground">
+          {t('plays', { count: track.playCount })}
+        </p>
         <p className="text-[11px] text-muted-foreground/65">
           {formatListenTime(track.listenedSeconds)}
         </p>
@@ -87,9 +95,7 @@ export function RecentRow({ entry, onPlay }: RecentRowProps) {
         </p>
       </div>
       <div className="shrink-0 text-right">
-        <p className="text-xs font-medium text-foreground">
-          {formatDuration(entry.playedSeconds)}
-        </p>
+        <p className="text-xs font-medium text-foreground">{formatDuration(entry.playedSeconds)}</p>
         <p className="text-[11px] text-muted-foreground/65">{formatPlayedAt(entry.playedAt)}</p>
       </div>
     </button>

--- a/apps/web/src/components/library/AlbumGrid.tsx
+++ b/apps/web/src/components/library/AlbumGrid.tsx
@@ -33,25 +33,26 @@ export function AlbumGrid({ library, searchQuery }: AlbumGridProps) {
     }
   }, []);
 
-  const handleAlbumClick = useCallback((albumName: string) => {
-    if (scrollRef.current) {
-      setAlbumGridScrollTop(scrollRef.current.scrollTop);
-    }
-    selectAlbum(albumName);
-  }, [selectAlbum, setAlbumGridScrollTop]);
+  const handleAlbumClick = useCallback(
+    (albumName: string) => {
+      if (scrollRef.current) {
+        setAlbumGridScrollTop(scrollRef.current.scrollTop);
+      }
+      selectAlbum(albumName);
+    },
+    [selectAlbum, setAlbumGridScrollTop]
+  );
 
   const albums = useMemo(
     () => groupTracksByAlbum(library, albumSortMode, albumSortOrder),
-    [library, albumSortMode, albumSortOrder],
+    [library, albumSortMode, albumSortOrder]
   );
 
   const filteredAlbums = useMemo(() => {
     if (!searchQuery.trim()) return albums;
     const q = searchQuery.toLowerCase();
     return albums.filter(
-      a =>
-        a.name.toLowerCase().includes(q) ||
-        a.artist.toLowerCase().includes(q)
+      a => a.name.toLowerCase().includes(q) || a.artist.toLowerCase().includes(q)
     );
   }, [albums, searchQuery]);
 
@@ -75,7 +76,9 @@ export function AlbumGrid({ library, searchQuery }: AlbumGridProps) {
       <div className="flex-1 flex flex-col items-center justify-center gap-4 text-center px-6">
         <Search className="w-12 h-12 text-muted-foreground/20" strokeWidth={1.5} />
         <div>
-          <p className="font-display text-base font-medium text-muted-foreground">{t('noMatchesTitle')}</p>
+          <p className="font-display text-base font-medium text-muted-foreground">
+            {t('noMatchesTitle')}
+          </p>
           <p className="text-sm text-muted-foreground/50 mt-1">{t('noMatchesSubtitle')}</p>
         </div>
       </div>
@@ -112,7 +115,13 @@ export function AlbumGrid({ library, searchQuery }: AlbumGridProps) {
           >
             <div className="w-full aspect-square rounded-xl bg-muted/30 flex items-center justify-center mb-3 overflow-hidden">
               {album.albumArt ? (
-                <img src={album.albumArt} alt={album.name} className="w-full h-full object-cover" />
+                <img
+                  src={album.albumArt}
+                  alt={album.name}
+                  className="w-full h-full object-cover"
+                  loading="lazy"
+                  decoding="async"
+                />
               ) : (
                 <Disc3 className="w-10 h-10 text-muted-foreground/20 group-hover:text-muted-foreground/30 transition-colors" />
               )}
@@ -120,9 +129,7 @@ export function AlbumGrid({ library, searchQuery }: AlbumGridProps) {
             <p className="font-display text-sm font-semibold text-foreground truncate">
               {album.name}
             </p>
-            <p className="text-xs text-muted-foreground/50 truncate mt-0.5">
-              {album.artist}
-            </p>
+            <p className="text-xs text-muted-foreground/50 truncate mt-0.5">{album.artist}</p>
             <p className="text-[10px] text-muted-foreground/30 mt-1.5">
               {t('trackCount', { count: album.trackCount })}
             </p>

--- a/apps/web/src/components/mixes/ArtCollage.tsx
+++ b/apps/web/src/components/mixes/ArtCollage.tsx
@@ -4,22 +4,23 @@ import type { Track } from '@/stores/types';
 
 /** A quiet decorative collage of album art from the library. */
 export function ArtCollage({ library }: { library: Track[] }) {
-  const artTracks = useMemo(
-    () => library.filter((t) => t.albumArt).slice(0, 12),
-    [library]
-  );
+  const artTracks = useMemo(() => library.filter(t => t.albumArt).slice(0, 12), [library]);
 
   if (artTracks.length < 4) return null;
 
   return (
     <div className="flex gap-1.5 overflow-hidden rounded-xl opacity-40">
       {artTracks.map((track, i) => (
-        <div
-          key={i}
-          className="w-14 h-14 shrink-0 rounded-md overflow-hidden bg-accent/20"
-        >
+        <div key={i} className="w-14 h-14 shrink-0 rounded-md overflow-hidden bg-accent/20">
           {track.albumArt ? (
-            <img src={track.albumArt} alt="" aria-hidden="true" className="w-full h-full object-cover" />
+            <img
+              src={track.albumArt}
+              alt=""
+              aria-hidden="true"
+              className="w-full h-full object-cover"
+              loading="lazy"
+              decoding="async"
+            />
           ) : (
             <div className="w-full h-full flex items-center justify-center">
               <Music className="w-4 h-4 text-muted-foreground/20" />

--- a/apps/web/src/components/mixes/ArtCollage.tsx
+++ b/apps/web/src/components/mixes/ArtCollage.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { Music } from 'lucide-react';
 import type { Track } from '@/stores/types';
 
 /** A quiet decorative collage of album art from the library. */
@@ -12,20 +11,14 @@ export function ArtCollage({ library }: { library: Track[] }) {
     <div className="flex gap-1.5 overflow-hidden rounded-xl opacity-40">
       {artTracks.map((track, i) => (
         <div key={i} className="w-14 h-14 shrink-0 rounded-md overflow-hidden bg-accent/20">
-          {track.albumArt ? (
-            <img
-              src={track.albumArt}
-              alt=""
-              aria-hidden="true"
-              className="w-full h-full object-cover"
-              loading="lazy"
-              decoding="async"
-            />
-          ) : (
-            <div className="w-full h-full flex items-center justify-center">
-              <Music className="w-4 h-4 text-muted-foreground/20" />
-            </div>
-          )}
+          <img
+            src={track.albumArt!}
+            alt=""
+            aria-hidden="true"
+            className="w-full h-full object-cover"
+            loading="lazy"
+            decoding="async"
+          />
         </div>
       ))}
     </div>

--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -180,6 +180,7 @@ export function NowPlayingView() {
                   src={currentTrack.albumArt}
                   alt={currentTrack.album}
                   className="w-full h-full object-cover"
+                  decoding="async"
                 />
               ) : (
                 <Music className="w-16 h-16 text-muted-foreground/30" />

--- a/apps/web/src/components/player/CompactPlayer.tsx
+++ b/apps/web/src/components/player/CompactPlayer.tsx
@@ -151,6 +151,7 @@ export function CompactPlayer() {
                   src={currentTrack.albumArt}
                   alt={currentTrack.album}
                   className="h-full w-full object-cover transition-opacity group-hover/art:opacity-90"
+                  decoding="async"
                 />
               ) : (
                 <Music className="size-7 text-muted-foreground/45 transition-colors group-hover/art:text-muted-foreground/70" />

--- a/apps/web/src/components/player/PlayerBar.tsx
+++ b/apps/web/src/components/player/PlayerBar.tsx
@@ -80,6 +80,7 @@ export function PlayerBar() {
                     src={currentTrack.albumArt}
                     alt={currentTrack.album}
                     className="w-full h-full object-cover"
+                    decoding="async"
                   />
                 ) : (
                   <Music className="w-6 h-6 text-muted-foreground/50" />

--- a/apps/web/src/components/shared/NowPlayingHero.tsx
+++ b/apps/web/src/components/shared/NowPlayingHero.tsx
@@ -14,11 +14,11 @@ interface NowPlayingHeroProps {
 
 export function NowPlayingHero({ show }: NowPlayingHeroProps) {
   const { t } = useTranslation('common');
-  const currentTrack = usePlaybackStore((s) => s.currentTrack);
+  const currentTrack = usePlaybackStore(s => s.currentTrack);
   const ambientColor = useAmbientColor();
-  const nowPlayingViewEnabled = useAppStore((s) => s.nowPlayingViewEnabled);
-  const enterNowPlaying = useAppStore((s) => s.enterNowPlaying);
-  const lowPerformanceMode = useAppStore((s) => s.lowPerformanceMode);
+  const nowPlayingViewEnabled = useAppStore(s => s.nowPlayingViewEnabled);
+  const enterNowPlaying = useAppStore(s => s.enterNowPlaying);
+  const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
 
   const visible = currentTrack && (!show || show(currentTrack));
 
@@ -41,7 +41,11 @@ export function NowPlayingHero({ show }: NowPlayingHeroProps) {
             {currentTrack.albumArt && !lowPerformanceMode && (
               <div
                 className="absolute inset-0 opacity-[0.08] blur-2xl scale-110"
-                style={{ backgroundImage: `url(${currentTrack.albumArt})`, backgroundSize: 'cover', backgroundPosition: 'center' }}
+                style={{
+                  backgroundImage: `url(${currentTrack.albumArt})`,
+                  backgroundSize: 'cover',
+                  backgroundPosition: 'center',
+                }}
               />
             )}
 
@@ -59,7 +63,12 @@ export function NowPlayingHero({ show }: NowPlayingHeroProps) {
                 )}
               >
                 {currentTrack.albumArt ? (
-                  <img src={currentTrack.albumArt} alt={currentTrack.title} className="w-full h-full object-cover" />
+                  <img
+                    src={currentTrack.albumArt}
+                    alt={currentTrack.title}
+                    className="w-full h-full object-cover"
+                    decoding="async"
+                  />
                 ) : (
                   <Music className="w-8 h-8 text-muted-foreground/40" />
                 )}
@@ -67,7 +76,9 @@ export function NowPlayingHero({ show }: NowPlayingHeroProps) {
             </AnimatePresence>
 
             <div className="relative min-w-0 flex-1">
-              <p className="text-[10px] uppercase tracking-widest text-muted-foreground/60 font-medium mb-1">{t('nowPlaying')}</p>
+              <p className="text-[10px] uppercase tracking-widest text-muted-foreground/60 font-medium mb-1">
+                {t('nowPlaying')}
+              </p>
               <AnimatePresence mode="wait">
                 <motion.div
                   key={currentTrack.id}
@@ -76,8 +87,12 @@ export function NowPlayingHero({ show }: NowPlayingHeroProps) {
                   exit={{ opacity: 0, y: -8 }}
                   transition={{ duration: 0.3 }}
                 >
-                  <h2 className="font-display text-lg font-semibold text-foreground truncate">{currentTrack.title}</h2>
-                  <p className="text-sm text-muted-foreground truncate mt-0.5">{currentTrack.artist} — {currentTrack.album}</p>
+                  <h2 className="font-display text-lg font-semibold text-foreground truncate">
+                    {currentTrack.title}
+                  </h2>
+                  <p className="text-sm text-muted-foreground truncate mt-0.5">
+                    {currentTrack.artist} — {currentTrack.album}
+                  </p>
                 </motion.div>
               </AnimatePresence>
             </div>


### PR DESCRIPTION
## Summary

Fixes #145 — high renderer memory use on large libraries (672 MB at 4,000 tracks reported).

The album-art cache was writing embedded covers to disk verbatim at source resolution (typically 1000×1000). Disk size (~130 KB) was a red herring — Chromium decodes each unique image into a ~3.8 MB RGBA bitmap in renderer memory, which is what drove the working set up.

## Changes

**`perf(desktop): downscale album art to 512px on cache write`** (`apps/desktop/src/main/art-protocol.ts`)
- New `downscaleImage()` helper using Electron's built-in `nativeImage` (no native dependency, no electron-rebuild concerns).
- Longer-edge clamp at 512 px preserves aspect ratio; images already ≤512 px skip the resize step but still re-encode for format normalisation.
- Always re-encodes to JPEG q=85 — file extension is now always `.jpg` regardless of source MIME.
- SHA-256 hash is now computed over the **resized** bytes so content-addressed deduplication still works.
- Empty buffers and undecodeable input bail with `null` (covers corrupt embedded art).
- Logs once per session on first cache write, not per file (a fresh scan can write thousands).
- All four call sites (scan, tag-write, metadata-enrich, base64-migration) funnel through `saveAlbumArt`, so a single function change covers every write path.

**`perf(web): add loading=lazy and decoding=async to album art images`**
- Gallery surfaces (`AlbumGrid`, `ArtCollage`, `HistoryTrackRows`) — `loading="lazy" decoding="async"` so off-screen covers don't decode at mount.
- Always-visible player surfaces (`PlayerBar`, `CompactPlayer`, `NowPlayingHero`, `NowPlayingView`) — `decoding="async"` only; they need to render but shouldn't block the main thread.

## Migration

Existing 1000×1000 cache entries become orphans on disk and are replaced naturally as users rescan the library. No DB migration required thanks to content-addressing — a future cleanup PR can sweep orphaned files if desired.

## Expected impact

| Metric | Before | After |
|---|---|---|
| Renderer memory @ 4,000 tracks | ~672 MB | ~400-500 MB (25-40% drop) |
| Average art file on disk | ~130 KB | ~40 KB (3× smaller) |
| Decoded bitmap per cover | ~3.8 MB | ~1 MB (4× smaller) |

## Test plan

- [x] Desktop typecheck passes
- [x] Web typecheck passes
- [x] All 560 desktop unit tests pass (new tests added for `downscaleImage` aspect-ratio handling and empty/undecodeable buffer guards)
- [ ] Manual: scan a library with mixed-aspect-ratio covers; confirm no distortion in album grid
- [ ] Manual: rescan a previously-imported library and confirm `%APPDATA%\Shiranami\album-art\` files average ~40 KB
- [ ] Manual: load library with 1,000+ covers; confirm renderer memory in Task Manager is meaningfully lower than 0.16.1

## Suggested release note

> Album art is now cached at 512 px (longer edge) to reduce memory usage on large libraries. Existing covers are replaced as you rescan.