### PR TITLE
refactor(web/stores): split useAppStore into focused stores

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -39,7 +39,7 @@ import { usePlaybackResume } from '@/hooks/usePlaybackResume';
 import { useUpdateNotifications } from '@/hooks/useUpdateNotifications';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import { useCompactStore } from '@/stores/useCompactStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { useDownloadStore } from '@/stores/useDownloadStore';
@@ -80,7 +80,7 @@ function App() {
   }, []);
 
   // Auto-collapse sidebar on narrow viewports
-  const setSidebarCollapsed = useAppStore(s => s.setSidebarCollapsed);
+  const setSidebarCollapsed = useUIStore(s => s.setSidebarCollapsed);
   useEffect(() => {
     const mql = window.matchMedia('(max-width: 900px)');
     const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
@@ -96,10 +96,10 @@ function App() {
   const activeView = useViewStore(s => s.activeView);
   const rightPanel = useViewStore(s => s.rightPanel);
   const selectedPlaylistId = useViewStore(s => s.selectedPlaylistId);
-  const showVisualizer = useAppStore(s => s.showVisualizer);
-  const visualizerStyle = useAppStore(s => s.visualizerStyle);
+  const showVisualizer = useUIStore(s => s.showVisualizer);
+  const visualizerStyle = useUIStore(s => s.visualizerStyle);
   const compactMode = useCompactStore(s => s.compactMode);
-  const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
+  const lowPerformanceMode = useUIStore(s => s.lowPerformanceMode);
   const updateDependencyInstall = useDownloadStore(s => s.updateDependencyInstall);
   const updateEnrichProgress = useMetadataEnrichStore(s => s.updateProgress);
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -40,6 +40,7 @@ import { useUpdateNotifications } from '@/hooks/useUpdateNotifications';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import { useDownloadStore } from '@/stores/useDownloadStore';
 import { useMetadataEnrichStore } from '@/stores/useMetadataEnrichStore';
 import { AmbientColorProvider } from '@/hooks/useAmbientColor';
@@ -91,9 +92,9 @@ function App() {
 
   const { handleOpenFile, handleOpenFolder, isScanning } = useLibraryActions();
   const currentTrack = usePlaybackStore(s => s.currentTrack);
-  const activeView = useAppStore(s => s.activeView);
-  const rightPanel = useAppStore(s => s.rightPanel);
-  const selectedPlaylistId = useAppStore(s => s.selectedPlaylistId);
+  const activeView = useViewStore(s => s.activeView);
+  const rightPanel = useViewStore(s => s.rightPanel);
+  const selectedPlaylistId = useViewStore(s => s.selectedPlaylistId);
   const showVisualizer = useAppStore(s => s.showVisualizer);
   const visualizerStyle = useAppStore(s => s.visualizerStyle);
   const compactMode = useAppStore(s => s.compactMode);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -40,6 +40,7 @@ import { useUpdateNotifications } from '@/hooks/useUpdateNotifications';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useAppStore } from '@/stores/useAppStore';
+import { useCompactStore } from '@/stores/useCompactStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { useDownloadStore } from '@/stores/useDownloadStore';
 import { useMetadataEnrichStore } from '@/stores/useMetadataEnrichStore';
@@ -97,7 +98,7 @@ function App() {
   const selectedPlaylistId = useViewStore(s => s.selectedPlaylistId);
   const showVisualizer = useAppStore(s => s.showVisualizer);
   const visualizerStyle = useAppStore(s => s.visualizerStyle);
-  const compactMode = useAppStore(s => s.compactMode);
+  const compactMode = useCompactStore(s => s.compactMode);
   const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
   const updateDependencyInstall = useDownloadStore(s => s.updateDependencyInstall);
   const updateEnrichProgress = useMetadataEnrichStore(s => s.updateProgress);

--- a/apps/web/src/components/favorites/FavoritesView.tsx
+++ b/apps/web/src/components/favorites/FavoritesView.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 import { Heart } from 'lucide-react';
 import { ViewEmptyState } from '@/components/shared/ViewEmptyState';
@@ -23,12 +23,9 @@ export function FavoritesView() {
   const setQueue = usePlaybackStore(s => s.setQueue);
   const toggleFavorite = useLibraryStore(s => s.toggleFavorite);
   const hasSelection = useSelectionStore(s => s.selectedTrackIds.size > 0);
-  const libraryHeroCardEnabled = useAppStore(s => s.libraryHeroCardEnabled);
+  const libraryHeroCardEnabled = useUIStore(s => s.libraryHeroCardEnabled);
 
-  const favorites = useMemo(
-    () => library.filter((t) => t.isFavorite),
-    [library]
-  );
+  const favorites = useMemo(() => library.filter(t => t.isFavorite), [library]);
 
   const favoritesRef = useRef(favorites);
   favoritesRef.current = favorites;
@@ -51,11 +48,7 @@ export function FavoritesView() {
       {libraryHeroCardEnabled && <NowPlayingHero show={showIfFavorite} />}
 
       {favorites.length === 0 ? (
-        <ViewEmptyState
-          title={t('emptyTitle')}
-          subtitle={t('emptySubtitle')}
-          icon={Heart}
-        />
+        <ViewEmptyState title={t('emptyTitle')} subtitle={t('emptySubtitle')} icon={Heart} />
       ) : (
         <div className="flex-1 min-h-0 px-4">
           <List
@@ -65,7 +58,14 @@ export function FavoritesView() {
             className="scrollbar-thin"
             style={{ height: '100%' }}
             rowComponent={TrackRow}
-            rowProps={{ queue: favorites, currentTrack, isPlaying, handlePlayTrack, onToggleFavorite: toggleFavorite, showAddToPlaylist: true }}
+            rowProps={{
+              queue: favorites,
+              currentTrack,
+              isPlaying,
+              handlePlayTrack,
+              onToggleFavorite: toggleFavorite,
+              showAddToPlaylist: true,
+            }}
           />
         </div>
       )}

--- a/apps/web/src/components/library/AlbumDetailView.tsx
+++ b/apps/web/src/components/library/AlbumDetailView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import type { Track } from '@/stores/types';
@@ -30,8 +30,8 @@ function mostFrequent<T>(values: Array<T | null | undefined>): T | undefined {
 
 export function AlbumDetailView() {
   const { t } = useTranslation('library');
-  const selectedAlbumName = useAppStore(s => s.selectedAlbumName);
-  const selectAlbum = useAppStore(s => s.selectAlbum);
+  const selectedAlbumName = useViewStore(s => s.selectedAlbumName);
+  const selectAlbum = useViewStore(s => s.selectAlbum);
   const library = useLibraryStore(s => s.library);
   const setQueue = usePlaybackStore(s => s.setQueue);
   const currentTrack = usePlaybackStore(s => s.currentTrack);
@@ -64,25 +64,16 @@ export function AlbumDetailView() {
 
   const hasMultipleDiscs = discGroups.length > 1;
 
-  const albumArt = useMemo(
-    () => albumTracks.find(t => t.albumArt)?.albumArt,
-    [albumTracks]
-  );
+  const albumArt = useMemo(() => albumTracks.find(t => t.albumArt)?.albumArt, [albumTracks]);
 
   const artist = useMemo(() => {
     const artists = new Set(albumTracks.map(t => t.artist));
     return Array.from(artists).join(', ');
   }, [albumTracks]);
 
-  const year = useMemo(
-    () => mostFrequent(albumTracks.map(t => t.year)),
-    [albumTracks]
-  );
+  const year = useMemo(() => mostFrequent(albumTracks.map(t => t.year)), [albumTracks]);
 
-  const genre = useMemo(
-    () => mostFrequent(albumTracks.map(t => t.genre)),
-    [albumTracks]
-  );
+  const genre = useMemo(() => mostFrequent(albumTracks.map(t => t.genre)), [albumTracks]);
 
   const headerMeta = useMemo(
     () => [artist, year?.toString(), genre].filter(Boolean).join(' · '),

--- a/apps/web/src/components/library/AlbumGrid.tsx
+++ b/apps/web/src/components/library/AlbumGrid.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import { type Track } from '@/stores/types';
 import { Disc3, Search } from 'lucide-react';
 import { motion } from 'motion/react';
@@ -15,9 +16,9 @@ interface AlbumGridProps {
 
 export function AlbumGrid({ library, searchQuery }: AlbumGridProps) {
   const { t } = useTranslation('library');
-  const selectAlbum = useAppStore(s => s.selectAlbum);
-  const albumGridScrollTop = useAppStore(s => s.albumGridScrollTop);
-  const setAlbumGridScrollTop = useAppStore(s => s.setAlbumGridScrollTop);
+  const selectAlbum = useViewStore(s => s.selectAlbum);
+  const albumGridScrollTop = useViewStore(s => s.albumGridScrollTop);
+  const setAlbumGridScrollTop = useViewStore(s => s.setAlbumGridScrollTop);
   const albumGridSize = useAppStore(s => s.albumGridSize);
   const albumSortMode = useAppStore(s => s.albumSortMode);
   const albumSortOrder = useAppStore(s => s.albumSortOrder);

--- a/apps/web/src/components/library/AlbumGrid.tsx
+++ b/apps/web/src/components/library/AlbumGrid.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { type Track } from '@/stores/types';
 import { Disc3, Search } from 'lucide-react';
@@ -19,9 +19,9 @@ export function AlbumGrid({ library, searchQuery }: AlbumGridProps) {
   const selectAlbum = useViewStore(s => s.selectAlbum);
   const albumGridScrollTop = useViewStore(s => s.albumGridScrollTop);
   const setAlbumGridScrollTop = useViewStore(s => s.setAlbumGridScrollTop);
-  const albumGridSize = useAppStore(s => s.albumGridSize);
-  const albumSortMode = useAppStore(s => s.albumSortMode);
-  const albumSortOrder = useAppStore(s => s.albumSortOrder);
+  const albumGridSize = useUIStore(s => s.albumGridSize);
+  const albumSortMode = useUIStore(s => s.albumSortMode);
+  const albumSortOrder = useUIStore(s => s.albumSortOrder);
   const scrollRef = useRef<HTMLDivElement>(null);
   // Capture scroll position at mount time — used to skip animation and restore scroll
   const savedScrollTop = useRef(albumGridScrollTop);

--- a/apps/web/src/components/library/LibraryView.tsx
+++ b/apps/web/src/components/library/LibraryView.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 import { Download, LayoutGrid, List, Music, Search, X } from 'lucide-react';
@@ -30,16 +30,16 @@ export function LibraryView() {
   const toggleFavorite = useLibraryStore(s => s.toggleFavorite);
   const hasSelection = useSelectionStore(s => s.selectedTrackIds.size > 0);
 
-  const libraryViewMode = useAppStore(s => s.libraryViewMode);
-  const setLibraryViewMode = useAppStore(s => s.setLibraryViewMode);
+  const libraryViewMode = useUIStore(s => s.libraryViewMode);
+  const setLibraryViewMode = useUIStore(s => s.setLibraryViewMode);
   const selectedAlbumName = useViewStore(s => s.selectedAlbumName);
-  const libraryHeroCardEnabled = useAppStore(s => s.libraryHeroCardEnabled);
-  const albumGridSize = useAppStore(s => s.albumGridSize);
-  const setAlbumGridSize = useAppStore(s => s.setAlbumGridSize);
-  const albumSortMode = useAppStore(s => s.albumSortMode);
-  const setAlbumSortMode = useAppStore(s => s.setAlbumSortMode);
-  const albumSortOrder = useAppStore(s => s.albumSortOrder);
-  const setAlbumSortOrder = useAppStore(s => s.setAlbumSortOrder);
+  const libraryHeroCardEnabled = useUIStore(s => s.libraryHeroCardEnabled);
+  const albumGridSize = useUIStore(s => s.albumGridSize);
+  const setAlbumGridSize = useUIStore(s => s.setAlbumGridSize);
+  const albumSortMode = useUIStore(s => s.albumSortMode);
+  const setAlbumSortMode = useUIStore(s => s.setAlbumSortMode);
+  const albumSortOrder = useUIStore(s => s.albumSortOrder);
+  const setAlbumSortOrder = useUIStore(s => s.setAlbumSortOrder);
 
   const [searchQuery, setSearchQuery] = useState('');
   const searchInputRef = useRef<HTMLInputElement>(null);

--- a/apps/web/src/components/library/LibraryView.tsx
+++ b/apps/web/src/components/library/LibraryView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 import { Download, LayoutGrid, List, Music, Search, X } from 'lucide-react';
 import { ViewEmptyState } from '@/components/shared/ViewEmptyState';
@@ -31,7 +32,7 @@ export function LibraryView() {
 
   const libraryViewMode = useAppStore(s => s.libraryViewMode);
   const setLibraryViewMode = useAppStore(s => s.setLibraryViewMode);
-  const selectedAlbumName = useAppStore(s => s.selectedAlbumName);
+  const selectedAlbumName = useViewStore(s => s.selectedAlbumName);
   const libraryHeroCardEnabled = useAppStore(s => s.libraryHeroCardEnabled);
   const albumGridSize = useAppStore(s => s.albumGridSize);
   const setAlbumGridSize = useAppStore(s => s.setAlbumGridSize);

--- a/apps/web/src/components/lyrics/LyricsPanel.tsx
+++ b/apps/web/src/components/lyrics/LyricsPanel.tsx
@@ -3,11 +3,11 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import {
-  useAppStore,
+  useLyricsAppearanceStore,
   LYR_SIZE_CLASS,
   LYRICS_SYNCED_PAST_RATIO,
   nextLyricsFontSize,
-} from '@/stores/useAppStore';
+} from '@/stores/useLyricsAppearanceStore';
 import { useLyricsQuery } from '@/hooks/queries/useLyrics';
 import { useActiveLineIndex } from '@/lib/lyrics';
 import { LyricsList } from '@/components/lyrics/LyricsList';
@@ -32,10 +32,10 @@ export function LyricsPanel() {
   const { t: tToast } = useTranslation('toast');
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const seek = usePlaybackStore(s => s.seek);
-  const lyricsPlainOpacity = useAppStore(s => s.lyricsPlainOpacity);
-  const lyricsPlainFontSize = useAppStore(s => s.lyricsPlainFontSize);
-  const lyricsSyncedDimOpacity = useAppStore(s => s.lyricsSyncedDimOpacity);
-  const lyricsSyncedFontSize = useAppStore(s => s.lyricsSyncedFontSize);
+  const lyricsPlainOpacity = useLyricsAppearanceStore(s => s.lyricsPlainOpacity);
+  const lyricsPlainFontSize = useLyricsAppearanceStore(s => s.lyricsPlainFontSize);
+  const lyricsSyncedDimOpacity = useLyricsAppearanceStore(s => s.lyricsSyncedDimOpacity);
+  const lyricsSyncedFontSize = useLyricsAppearanceStore(s => s.lyricsSyncedFontSize);
 
   const { data, isLoading, isError } = useLyricsQuery(
     currentTrack?.id ?? null,

--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -2,8 +2,12 @@ import { useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
-import type { LyricsFontSize } from '@/stores/useAppStore';
-import { useAppStore, LYRICS_SYNCED_PAST_RATIO } from '@/stores/useAppStore';
+import { useAppStore } from '@/stores/useAppStore';
+import {
+  useLyricsAppearanceStore,
+  LYRICS_SYNCED_PAST_RATIO,
+  type LyricsFontSize,
+} from '@/stores/useLyricsAppearanceStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { useLyricsQuery } from '@/hooks/queries/useLyrics';
 import { useActiveLineIndex } from '@/lib/lyrics';
@@ -55,10 +59,10 @@ export function NowPlayingView() {
   const exitNowPlaying = useViewStore(s => s.exitNowPlaying);
   const lyricsVisible = useAppStore(s => s.nowPlayingLyricsVisible);
   const toggleLyrics = useAppStore(s => s.toggleNowPlayingLyrics);
-  const lyricsPlainOpacity = useAppStore(s => s.lyricsPlainOpacity);
-  const lyricsPlainFontSize = useAppStore(s => s.lyricsPlainFontSize);
-  const lyricsSyncedDimOpacity = useAppStore(s => s.lyricsSyncedDimOpacity);
-  const lyricsSyncedFontSize = useAppStore(s => s.lyricsSyncedFontSize);
+  const lyricsPlainOpacity = useLyricsAppearanceStore(s => s.lyricsPlainOpacity);
+  const lyricsPlainFontSize = useLyricsAppearanceStore(s => s.lyricsPlainFontSize);
+  const lyricsSyncedDimOpacity = useLyricsAppearanceStore(s => s.lyricsSyncedDimOpacity);
+  const lyricsSyncedFontSize = useLyricsAppearanceStore(s => s.lyricsSyncedFontSize);
 
   const npBase = cn(NP_BASE_SHARED, NP_SYNCED_BASE_SIZE_CLASS[lyricsSyncedFontSize]);
   const npActive = cn(

--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -2,7 +2,7 @@ import { useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import {
   useLyricsAppearanceStore,
   LYRICS_SYNCED_PAST_RATIO,
@@ -57,8 +57,8 @@ export function NowPlayingView() {
   const duration = usePlaybackStore(s => s.duration);
   const seek = usePlaybackStore(s => s.seek);
   const exitNowPlaying = useViewStore(s => s.exitNowPlaying);
-  const lyricsVisible = useAppStore(s => s.nowPlayingLyricsVisible);
-  const toggleLyrics = useAppStore(s => s.toggleNowPlayingLyrics);
+  const lyricsVisible = useUIStore(s => s.nowPlayingLyricsVisible);
+  const toggleLyrics = useUIStore(s => s.toggleNowPlayingLyrics);
   const lyricsPlainOpacity = useLyricsAppearanceStore(s => s.lyricsPlainOpacity);
   const lyricsPlainFontSize = useLyricsAppearanceStore(s => s.lyricsPlainFontSize);
   const lyricsSyncedDimOpacity = useLyricsAppearanceStore(s => s.lyricsSyncedDimOpacity);

--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import type { LyricsFontSize } from '@/stores/useAppStore';
 import { useAppStore, LYRICS_SYNCED_PAST_RATIO } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import { useLyricsQuery } from '@/hooks/queries/useLyrics';
 import { useActiveLineIndex } from '@/lib/lyrics';
 import { LyricsList } from '@/components/lyrics/LyricsList';
@@ -51,7 +52,7 @@ export function NowPlayingView() {
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const duration = usePlaybackStore(s => s.duration);
   const seek = usePlaybackStore(s => s.seek);
-  const exitNowPlaying = useAppStore(s => s.exitNowPlaying);
+  const exitNowPlaying = useViewStore(s => s.exitNowPlaying);
   const lyricsVisible = useAppStore(s => s.nowPlayingLyricsVisible);
   const toggleLyrics = useAppStore(s => s.toggleNowPlayingLyrics);
   const lyricsPlainOpacity = useAppStore(s => s.lyricsPlainOpacity);

--- a/apps/web/src/components/player/CompactPlayer.tsx
+++ b/apps/web/src/components/player/CompactPlayer.tsx
@@ -8,6 +8,7 @@ import {
   CMP_ARTIST_CLASS,
   CMP_ALBUM_CLASS,
 } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import { cn, isRadioTrack } from '@/lib/utils';
 import { formatDuration } from '@shiranami/shared';
 import { PlayerControls } from './PlayerControls';
@@ -51,7 +52,7 @@ export function CompactPlayer() {
   }, [toggleCompactAlwaysOnTop]);
 
   const nowPlayingViewEnabled = useAppStore(s => s.nowPlayingViewEnabled);
-  const enterNowPlaying = useAppStore(s => s.enterNowPlaying);
+  const enterNowPlaying = useViewStore(s => s.enterNowPlaying);
   const handleAlbumArtClick = useCallback(async () => {
     // Mirror the Spotify/Apple Music mini-player gesture: clicking the art
     // exits compact and surfaces the immersive Now Playing view if the user

--- a/apps/web/src/components/player/CompactPlayer.tsx
+++ b/apps/web/src/components/player/CompactPlayer.tsx
@@ -2,12 +2,13 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useLibraryStore } from '@/stores/useLibraryStore';
+import { useAppStore } from '@/stores/useAppStore';
 import {
-  useAppStore,
+  useCompactStore,
   CMP_TITLE_CLASS,
   CMP_ARTIST_CLASS,
   CMP_ALBUM_CLASS,
-} from '@/stores/useAppStore';
+} from '@/stores/useCompactStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { cn, isRadioTrack } from '@/lib/utils';
 import { formatDuration } from '@shiranami/shared';
@@ -27,18 +28,18 @@ export function CompactPlayer() {
   const { t } = useTranslation('compact');
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const duration = usePlaybackStore(s => s.duration);
-  const setCompactMode = useAppStore(s => s.setCompactMode);
-  const compactAlwaysOnTop = useAppStore(s => s.compactAlwaysOnTop);
-  const toggleCompactAlwaysOnTop = useAppStore(s => s.toggleCompactAlwaysOnTop);
+  const setCompactMode = useCompactStore(s => s.setCompactMode);
+  const compactAlwaysOnTop = useCompactStore(s => s.compactAlwaysOnTop);
+  const toggleCompactAlwaysOnTop = useCompactStore(s => s.toggleCompactAlwaysOnTop);
   const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
 
-  const compactFontSize = useAppStore(s => s.compactFontSize);
-  const compactAmbientIntensity = useAppStore(s => s.compactAmbientIntensity);
-  const compactShowAlbumArt = useAppStore(s => s.compactShowAlbumArt);
-  const compactShowAlbum = useAppStore(s => s.compactShowAlbum);
-  const compactShowSeek = useAppStore(s => s.compactShowSeek);
-  const compactShowVolume = useAppStore(s => s.compactShowVolume);
-  const compactShowFavorite = useAppStore(s => s.compactShowFavorite);
+  const compactFontSize = useCompactStore(s => s.compactFontSize);
+  const compactAmbientIntensity = useCompactStore(s => s.compactAmbientIntensity);
+  const compactShowAlbumArt = useCompactStore(s => s.compactShowAlbumArt);
+  const compactShowAlbum = useCompactStore(s => s.compactShowAlbum);
+  const compactShowSeek = useCompactStore(s => s.compactShowSeek);
+  const compactShowVolume = useCompactStore(s => s.compactShowVolume);
+  const compactShowFavorite = useCompactStore(s => s.compactShowFavorite);
 
   const ambientColor = useAmbientColor();
   const { minimize: handleMinimize } = useWindowControls();

--- a/apps/web/src/components/player/CompactPlayer.tsx
+++ b/apps/web/src/components/player/CompactPlayer.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useLibraryStore } from '@/stores/useLibraryStore';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import {
   useCompactStore,
   CMP_TITLE_CLASS,
@@ -31,7 +31,7 @@ export function CompactPlayer() {
   const setCompactMode = useCompactStore(s => s.setCompactMode);
   const compactAlwaysOnTop = useCompactStore(s => s.compactAlwaysOnTop);
   const toggleCompactAlwaysOnTop = useCompactStore(s => s.toggleCompactAlwaysOnTop);
-  const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
+  const lowPerformanceMode = useUIStore(s => s.lowPerformanceMode);
 
   const compactFontSize = useCompactStore(s => s.compactFontSize);
   const compactAmbientIntensity = useCompactStore(s => s.compactAmbientIntensity);
@@ -52,7 +52,7 @@ export function CompactPlayer() {
     void toggleCompactAlwaysOnTop();
   }, [toggleCompactAlwaysOnTop]);
 
-  const nowPlayingViewEnabled = useAppStore(s => s.nowPlayingViewEnabled);
+  const nowPlayingViewEnabled = useUIStore(s => s.nowPlayingViewEnabled);
   const enterNowPlaying = useViewStore(s => s.enterNowPlaying);
   const handleAlbumArtClick = useCallback(async () => {
     // Mirror the Spotify/Apple Music mini-player gesture: clicking the art
@@ -274,7 +274,7 @@ function MarqueeText({ text, className }: MarqueeTextProps) {
   // scrollWidth/clientWidth on the unconstrained span are equal — the
   // overflow signal lives on the constrained container.
   const { ref, overflows, shift } = useMarqueeOnOverflow<HTMLParagraphElement>(text);
-  const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
+  const lowPerformanceMode = useUIStore(s => s.lowPerformanceMode);
   const animate = overflows && !lowPerformanceMode;
 
   return (

--- a/apps/web/src/components/player/PlayerBar.tsx
+++ b/apps/web/src/components/player/PlayerBar.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import { cn, isRadioTrack } from '@/lib/utils';
 import { formatDuration } from '@shiranami/shared';
 import { PlayerControls } from './PlayerControls';
@@ -26,14 +27,14 @@ export function PlayerBar() {
   const duration = usePlaybackStore(s => s.duration);
   const toggleFavorite = useLibraryStore(s => s.toggleFavorite);
   const ambientColor = useAmbientColor();
-  const rightPanel = useAppStore(s => s.rightPanel);
-  const toggleRightPanel = useAppStore(s => s.toggleRightPanel);
+  const rightPanel = useViewStore(s => s.rightPanel);
+  const toggleRightPanel = useViewStore(s => s.toggleRightPanel);
   const showVisualizer = useAppStore(s => s.showVisualizer);
   const toggleVisualizer = useAppStore(s => s.toggleVisualizer);
   const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
   const setCompactMode = useAppStore(s => s.setCompactMode);
   const nowPlayingViewEnabled = useAppStore(s => s.nowPlayingViewEnabled);
-  const enterNowPlaying = useAppStore(s => s.enterNowPlaying);
+  const enterNowPlaying = useViewStore(s => s.enterNowPlaying);
 
   return (
     <AnimatePresence>

--- a/apps/web/src/components/player/PlayerBar.tsx
+++ b/apps/web/src/components/player/PlayerBar.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import { useCompactStore } from '@/stores/useCompactStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { cn, isRadioTrack } from '@/lib/utils';
@@ -30,11 +30,11 @@ export function PlayerBar() {
   const ambientColor = useAmbientColor();
   const rightPanel = useViewStore(s => s.rightPanel);
   const toggleRightPanel = useViewStore(s => s.toggleRightPanel);
-  const showVisualizer = useAppStore(s => s.showVisualizer);
-  const toggleVisualizer = useAppStore(s => s.toggleVisualizer);
-  const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
+  const showVisualizer = useUIStore(s => s.showVisualizer);
+  const toggleVisualizer = useUIStore(s => s.toggleVisualizer);
+  const lowPerformanceMode = useUIStore(s => s.lowPerformanceMode);
   const setCompactMode = useCompactStore(s => s.setCompactMode);
-  const nowPlayingViewEnabled = useAppStore(s => s.nowPlayingViewEnabled);
+  const nowPlayingViewEnabled = useUIStore(s => s.nowPlayingViewEnabled);
   const enterNowPlaying = useViewStore(s => s.enterNowPlaying);
 
   return (

--- a/apps/web/src/components/player/PlayerBar.tsx
+++ b/apps/web/src/components/player/PlayerBar.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useAppStore } from '@/stores/useAppStore';
+import { useCompactStore } from '@/stores/useCompactStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { cn, isRadioTrack } from '@/lib/utils';
 import { formatDuration } from '@shiranami/shared';
@@ -32,7 +33,7 @@ export function PlayerBar() {
   const showVisualizer = useAppStore(s => s.showVisualizer);
   const toggleVisualizer = useAppStore(s => s.toggleVisualizer);
   const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
-  const setCompactMode = useAppStore(s => s.setCompactMode);
+  const setCompactMode = useCompactStore(s => s.setCompactMode);
   const nowPlayingViewEnabled = useAppStore(s => s.nowPlayingViewEnabled);
   const enterNowPlaying = useViewStore(s => s.enterNowPlaying);
 

--- a/apps/web/src/components/player/PlayerOverflowMenu.tsx
+++ b/apps/web/src/components/player/PlayerOverflowMenu.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { MoreHorizontal, Minimize2, AudioLines } from 'lucide-react';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import { useCompactStore } from '@/stores/useCompactStore';
 import { useEqStore } from '@/stores/useEqStore';
 import { cn } from '@/lib/utils';
@@ -19,8 +19,8 @@ const MOD = navigator.platform.toUpperCase().includes('MAC') ? '⌘' : 'Ctrl';
  */
 export function PlayerOverflowMenu() {
   const { t } = useTranslation('player');
-  const showVisualizer = useAppStore(s => s.showVisualizer);
-  const toggleVisualizer = useAppStore(s => s.toggleVisualizer);
+  const showVisualizer = useUIStore(s => s.showVisualizer);
+  const toggleVisualizer = useUIStore(s => s.toggleVisualizer);
   const setCompactMode = useCompactStore(s => s.setCompactMode);
   const eqEnabled = useEqStore(s => s.enabled);
   const eqPreset = useEqStore(s => s.preset);

--- a/apps/web/src/components/player/PlayerOverflowMenu.tsx
+++ b/apps/web/src/components/player/PlayerOverflowMenu.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { MoreHorizontal, Minimize2, AudioLines } from 'lucide-react';
 import { useAppStore } from '@/stores/useAppStore';
+import { useCompactStore } from '@/stores/useCompactStore';
 import { useEqStore } from '@/stores/useEqStore';
 import { cn } from '@/lib/utils';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
@@ -20,7 +21,7 @@ export function PlayerOverflowMenu() {
   const { t } = useTranslation('player');
   const showVisualizer = useAppStore(s => s.showVisualizer);
   const toggleVisualizer = useAppStore(s => s.toggleVisualizer);
-  const setCompactMode = useAppStore(s => s.setCompactMode);
+  const setCompactMode = useCompactStore(s => s.setCompactMode);
   const eqEnabled = useEqStore(s => s.enabled);
   const eqPreset = useEqStore(s => s.preset);
 

--- a/apps/web/src/components/playlists/PlaylistDetailView.tsx
+++ b/apps/web/src/components/playlists/PlaylistDetailView.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IS_ELECTRON } from '@/lib/platform';
-import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
@@ -48,13 +48,13 @@ import { DragOverlayContent } from './DragOverlayContent';
 export function PlaylistDetailView() {
   const { t } = useTranslation('playlists');
   const { t: tCommon } = useTranslation('common');
-  const selectedPlaylistId = useAppStore((s) => s.selectedPlaylistId);
-  const selectPlaylist = useAppStore((s) => s.selectPlaylist);
-  const setQueue = usePlaybackStore((s) => s.setQueue);
-  const currentTrack = usePlaybackStore((s) => s.currentTrack);
-  const isPlaying = usePlaybackStore((s) => s.isPlaying);
-  const toggleFavorite = useLibraryStore((s) => s.toggleFavorite);
-  const hasSelection = useSelectionStore((s) => s.selectedTrackIds.size > 0);
+  const selectedPlaylistId = useViewStore(s => s.selectedPlaylistId);
+  const selectPlaylist = useViewStore(s => s.selectPlaylist);
+  const setQueue = usePlaybackStore(s => s.setQueue);
+  const currentTrack = usePlaybackStore(s => s.currentTrack);
+  const isPlaying = usePlaybackStore(s => s.isPlaying);
+  const toggleFavorite = useLibraryStore(s => s.toggleFavorite);
+  const hasSelection = useSelectionStore(s => s.selectedTrackIds.size > 0);
 
   // Data fetching
   const { playlist, tracks, displayTracks, isLoading, isError, refetch } =
@@ -71,15 +71,12 @@ export function PlaylistDetailView() {
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 
-  const sortableIds = useMemo(
-    () => displayTracks.map((t) => t.id),
-    [displayTracks]
-  );
+  const sortableIds = useMemo(() => displayTracks.map(t => t.id), [displayTracks]);
 
   const [activeId, setActiveId] = useState<string | null>(null);
 
   const activeTrack = useMemo(
-    () => (activeId ? displayTracks.find((t) => t.id === activeId) ?? null : null),
+    () => (activeId ? (displayTracks.find(t => t.id === activeId) ?? null) : null),
     [activeId, displayTracks]
   );
 
@@ -109,13 +106,10 @@ export function PlaylistDetailView() {
   }, []);
 
   // Computed stats
-  const totalDuration = useMemo(
-    () => tracks.reduce((sum, t) => sum + t.duration, 0),
-    [tracks]
-  );
+  const totalDuration = useMemo(() => tracks.reduce((sum, t) => sum + t.duration, 0), [tracks]);
 
   // Cover art
-  const suggestedCoverArt = tracks.find((track) => track.albumArt)?.albumArt;
+  const suggestedCoverArt = tracks.find(track => track.albumArt)?.albumArt;
   const {
     showCoverMenu,
     setShowCoverMenu,
@@ -186,7 +180,12 @@ export function PlaylistDetailView() {
         title={t('errorTitle')}
         subtitle={t('errorSubtitle')}
         icon={AlertCircle}
-        action={{ label: tCommon('retry'), onClick: () => { void refetch(); } }}
+        action={{
+          label: tCommon('retry'),
+          onClick: () => {
+            void refetch();
+          },
+        }}
       />
     );
   }
@@ -290,13 +289,17 @@ export function PlaylistDetailView() {
         <div className="flex items-center gap-4">
           <div ref={coverMenuRef} className="relative shrink-0">
             <button
-              onClick={() => setShowCoverMenu((open) => !open)}
+              onClick={() => setShowCoverMenu(open => !open)}
               className="group/cover relative w-16 h-16 rounded-xl bg-surface border border-border/30 flex items-center justify-center overflow-hidden"
               disabled={isUpdatingCover}
               title={t('editCover')}
             >
               {playlist.coverArt ? (
-                <img src={playlist.coverArt} alt={playlist.name} className="w-full h-full object-cover" />
+                <img
+                  src={playlist.coverArt}
+                  alt={playlist.name}
+                  className="w-full h-full object-cover"
+                />
               ) : (
                 <ListMusic className="w-7 h-7 text-muted-foreground/20" />
               )}
@@ -363,7 +366,7 @@ export function PlaylistDetailView() {
               <input
                 ref={nameInputRef}
                 value={editName}
-                onChange={(e) => setEditName(e.target.value)}
+                onChange={e => setEditName(e.target.value)}
                 onBlur={handleSaveNameSubmit}
                 onKeyDown={handleNameKeyDown}
                 className="font-display text-lg font-semibold text-foreground bg-transparent outline-none border-b border-primary/40 w-full pb-0.5"

--- a/apps/web/src/components/playlists/PlaylistsView.tsx
+++ b/apps/web/src/components/playlists/PlaylistsView.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { ListMusic, Plus, AlertCircle } from 'lucide-react';
 import { ViewEmptyState } from '@/components/shared/ViewEmptyState';
@@ -19,8 +19,8 @@ export function PlaylistsView() {
   const selectPlaylist = useViewStore(s => s.selectPlaylist);
   const { data: playlists = [], isLoading, isError, refetch } = usePlaylistsQuery();
   const createPlaylist = useCreatePlaylistMutation();
-  const playlistGridSize = useAppStore(s => s.playlistGridSize);
-  const setPlaylistGridSize = useAppStore(s => s.setPlaylistGridSize);
+  const playlistGridSize = useUIStore(s => s.playlistGridSize);
+  const setPlaylistGridSize = useUIStore(s => s.setPlaylistGridSize);
   const [showNewForm, setShowNewForm] = useState(false);
   const [newName, setNewName] = useState('');
 

--- a/apps/web/src/components/playlists/PlaylistsView.tsx
+++ b/apps/web/src/components/playlists/PlaylistsView.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import { ListMusic, Plus, AlertCircle } from 'lucide-react';
 import { ViewEmptyState } from '@/components/shared/ViewEmptyState';
 import { Button } from '@/components/ui/button';
@@ -15,7 +16,7 @@ export function PlaylistsView() {
   const { t } = useTranslation('playlists');
   const { t: tCommon } = useTranslation('common');
   const { t: tToast } = useTranslation('toast');
-  const selectPlaylist = useAppStore(s => s.selectPlaylist);
+  const selectPlaylist = useViewStore(s => s.selectPlaylist);
   const { data: playlists = [], isLoading, isError, refetch } = usePlaylistsQuery();
   const createPlaylist = useCreatePlaylistMutation();
   const playlistGridSize = useAppStore(s => s.playlistGridSize);

--- a/apps/web/src/components/settings/AppearanceSection.tsx
+++ b/apps/web/src/components/settings/AppearanceSection.tsx
@@ -3,14 +3,14 @@ import { Languages, Sparkles, LayoutGrid } from 'lucide-react';
 import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsCard';
 import { Slider } from '@/components/ui/slider';
 import {
-  useAppStore,
+  useUIStore,
   UI_SCALE_MIN,
   UI_SCALE_MAX,
   UI_SCALE_STEP,
   UI_SCALE_DEFAULT,
   UI_SCALE_PRESETS,
-  type AppView,
-} from '@/stores/useAppStore';
+} from '@/stores/useUIStore';
+import type { AppView } from '@/stores/useViewStore';
 import { cn } from '@/lib/utils';
 import { SUPPORTED_LANGUAGES, persistLanguage, type SupportedLanguage } from '@/lib/i18n';
 
@@ -29,21 +29,21 @@ export function AppearanceSection() {
   const { t, i18n } = useTranslation('settings');
   const { t: tc } = useTranslation('common');
   const { t: ts } = useTranslation('sidebar');
-  const uiScale = useAppStore(s => s.uiScale);
-  const setUiScale = useAppStore(s => s.setUiScale);
-  const resetUiScale = useAppStore(s => s.resetUiScale);
-  const nowPlayingViewEnabled = useAppStore(s => s.nowPlayingViewEnabled);
-  const setNowPlayingViewEnabled = useAppStore(s => s.setNowPlayingViewEnabled);
-  const libraryHeroCardEnabled = useAppStore(s => s.libraryHeroCardEnabled);
-  const setLibraryHeroCardEnabled = useAppStore(s => s.setLibraryHeroCardEnabled);
-  const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
-  const setLowPerformanceMode = useAppStore(s => s.setLowPerformanceMode);
-  const noiseOverlayEnabled = useAppStore(s => s.noiseOverlayEnabled);
-  const setNoiseOverlayEnabled = useAppStore(s => s.setNoiseOverlayEnabled);
-  const sidebarHiddenItems = useAppStore(s => s.sidebarHiddenItems);
-  const toggleSidebarItem = useAppStore(s => s.toggleSidebarItem);
-  const sidebarPlaylistsVisible = useAppStore(s => s.sidebarPlaylistsVisible);
-  const setSidebarPlaylistsVisible = useAppStore(s => s.setSidebarPlaylistsVisible);
+  const uiScale = useUIStore(s => s.uiScale);
+  const setUiScale = useUIStore(s => s.setUiScale);
+  const resetUiScale = useUIStore(s => s.resetUiScale);
+  const nowPlayingViewEnabled = useUIStore(s => s.nowPlayingViewEnabled);
+  const setNowPlayingViewEnabled = useUIStore(s => s.setNowPlayingViewEnabled);
+  const libraryHeroCardEnabled = useUIStore(s => s.libraryHeroCardEnabled);
+  const setLibraryHeroCardEnabled = useUIStore(s => s.setLibraryHeroCardEnabled);
+  const lowPerformanceMode = useUIStore(s => s.lowPerformanceMode);
+  const setLowPerformanceMode = useUIStore(s => s.setLowPerformanceMode);
+  const noiseOverlayEnabled = useUIStore(s => s.noiseOverlayEnabled);
+  const setNoiseOverlayEnabled = useUIStore(s => s.setNoiseOverlayEnabled);
+  const sidebarHiddenItems = useUIStore(s => s.sidebarHiddenItems);
+  const toggleSidebarItem = useUIStore(s => s.toggleSidebarItem);
+  const sidebarPlaylistsVisible = useUIStore(s => s.sidebarPlaylistsVisible);
+  const setSidebarPlaylistsVisible = useUIStore(s => s.setSidebarPlaylistsVisible);
 
   function handleLanguageChange(lang: SupportedLanguage) {
     i18n.changeLanguage(lang);

--- a/apps/web/src/components/settings/CompactModePreview.tsx
+++ b/apps/web/src/components/settings/CompactModePreview.tsx
@@ -1,12 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import { Music2, Heart, Play, SkipBack, SkipForward } from 'lucide-react';
 import {
-  useAppStore,
+  useCompactStore,
   CMP_TITLE_CLASS,
   CMP_ARTIST_CLASS,
   CMP_ALBUM_CLASS,
   type CompactSize,
-} from '@/stores/useAppStore';
+} from '@/stores/useCompactStore';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { cn } from '@/lib/utils';
 
@@ -19,13 +19,13 @@ const SIZE_WIDTH: Record<CompactSize, number> = {
 export function CompactModePreview() {
   const { t } = useTranslation('settings');
 
-  const compactSize = useAppStore(s => s.compactSize);
-  const compactFontSize = useAppStore(s => s.compactFontSize);
-  const compactShowAlbumArt = useAppStore(s => s.compactShowAlbumArt);
-  const compactShowAlbum = useAppStore(s => s.compactShowAlbum);
-  const compactShowSeek = useAppStore(s => s.compactShowSeek);
-  const compactShowVolume = useAppStore(s => s.compactShowVolume);
-  const compactShowFavorite = useAppStore(s => s.compactShowFavorite);
+  const compactSize = useCompactStore(s => s.compactSize);
+  const compactFontSize = useCompactStore(s => s.compactFontSize);
+  const compactShowAlbumArt = useCompactStore(s => s.compactShowAlbumArt);
+  const compactShowAlbum = useCompactStore(s => s.compactShowAlbum);
+  const compactShowSeek = useCompactStore(s => s.compactShowSeek);
+  const compactShowVolume = useCompactStore(s => s.compactShowVolume);
+  const compactShowFavorite = useCompactStore(s => s.compactShowFavorite);
 
   const cardWidth = SIZE_WIDTH[compactSize];
   const titleClass = CMP_TITLE_CLASS[compactFontSize];

--- a/apps/web/src/components/settings/CompactSection.tsx
+++ b/apps/web/src/components/settings/CompactSection.tsx
@@ -3,7 +3,7 @@ import { PictureInPicture2 } from 'lucide-react';
 import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsCard';
 import { Slider } from '@/components/ui/slider';
 import {
-  useAppStore,
+  useCompactStore,
   COMPACT_AMBIENT_INTENSITY_MIN,
   COMPACT_AMBIENT_INTENSITY_MAX,
   COMPACT_AMBIENT_INTENSITY_STEP,
@@ -12,7 +12,7 @@ import {
   COMPACT_FONT_SIZE_DEFAULT,
   type CompactSize,
   type CompactFontSize,
-} from '@/stores/useAppStore';
+} from '@/stores/useCompactStore';
 import { cn } from '@/lib/utils';
 import { CompactModePreview } from '@/components/settings/CompactModePreview';
 
@@ -23,26 +23,26 @@ export function CompactSection() {
   const { t } = useTranslation('settings');
   const { t: tc } = useTranslation('common');
 
-  const compactSize = useAppStore(s => s.compactSize);
-  const compactFontSize = useAppStore(s => s.compactFontSize);
-  const compactAmbientIntensity = useAppStore(s => s.compactAmbientIntensity);
-  const compactShowAlbumArt = useAppStore(s => s.compactShowAlbumArt);
-  const compactShowAlbum = useAppStore(s => s.compactShowAlbum);
-  const compactShowSeek = useAppStore(s => s.compactShowSeek);
-  const compactShowVolume = useAppStore(s => s.compactShowVolume);
-  const compactShowFavorite = useAppStore(s => s.compactShowFavorite);
-  const compactDefaultAlwaysOnTop = useAppStore(s => s.compactDefaultAlwaysOnTop);
+  const compactSize = useCompactStore(s => s.compactSize);
+  const compactFontSize = useCompactStore(s => s.compactFontSize);
+  const compactAmbientIntensity = useCompactStore(s => s.compactAmbientIntensity);
+  const compactShowAlbumArt = useCompactStore(s => s.compactShowAlbumArt);
+  const compactShowAlbum = useCompactStore(s => s.compactShowAlbum);
+  const compactShowSeek = useCompactStore(s => s.compactShowSeek);
+  const compactShowVolume = useCompactStore(s => s.compactShowVolume);
+  const compactShowFavorite = useCompactStore(s => s.compactShowFavorite);
+  const compactDefaultAlwaysOnTop = useCompactStore(s => s.compactDefaultAlwaysOnTop);
 
-  const setCompactSize = useAppStore(s => s.setCompactSize);
-  const setCompactFontSize = useAppStore(s => s.setCompactFontSize);
-  const setCompactAmbientIntensity = useAppStore(s => s.setCompactAmbientIntensity);
-  const setCompactShowAlbumArt = useAppStore(s => s.setCompactShowAlbumArt);
-  const setCompactShowAlbum = useAppStore(s => s.setCompactShowAlbum);
-  const setCompactShowSeek = useAppStore(s => s.setCompactShowSeek);
-  const setCompactShowVolume = useAppStore(s => s.setCompactShowVolume);
-  const setCompactShowFavorite = useAppStore(s => s.setCompactShowFavorite);
-  const setCompactDefaultAlwaysOnTop = useAppStore(s => s.setCompactDefaultAlwaysOnTop);
-  const resetCompactAppearance = useAppStore(s => s.resetCompactAppearance);
+  const setCompactSize = useCompactStore(s => s.setCompactSize);
+  const setCompactFontSize = useCompactStore(s => s.setCompactFontSize);
+  const setCompactAmbientIntensity = useCompactStore(s => s.setCompactAmbientIntensity);
+  const setCompactShowAlbumArt = useCompactStore(s => s.setCompactShowAlbumArt);
+  const setCompactShowAlbum = useCompactStore(s => s.setCompactShowAlbum);
+  const setCompactShowSeek = useCompactStore(s => s.setCompactShowSeek);
+  const setCompactShowVolume = useCompactStore(s => s.setCompactShowVolume);
+  const setCompactShowFavorite = useCompactStore(s => s.setCompactShowFavorite);
+  const setCompactDefaultAlwaysOnTop = useCompactStore(s => s.setCompactDefaultAlwaysOnTop);
+  const resetCompactAppearance = useCompactStore(s => s.resetCompactAppearance);
 
   const isModified =
     compactSize !== COMPACT_SIZE_DEFAULT ||

--- a/apps/web/src/components/settings/LyricsSection.tsx
+++ b/apps/web/src/components/settings/LyricsSection.tsx
@@ -4,7 +4,7 @@ import { SettingsCard } from '@/components/settings/SettingsCard';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { Slider } from '@/components/ui/slider';
 import {
-  useAppStore,
+  useLyricsAppearanceStore,
   LYRICS_PLAIN_OPACITY_MIN,
   LYRICS_PLAIN_OPACITY_MAX,
   LYRICS_PLAIN_OPACITY_STEP,
@@ -19,7 +19,7 @@ import {
   LYR_SIZE_CLASS,
   nextLyricsFontSize,
   type LyricsFontSize,
-} from '@/stores/useAppStore';
+} from '@/stores/useLyricsAppearanceStore';
 import { cn } from '@/lib/utils';
 
 const FONT_SIZES: LyricsFontSize[] = ['sm', 'base', 'lg', 'xl'];
@@ -28,17 +28,17 @@ export function LyricsSection() {
   const { t } = useTranslation('settings');
   const { t: tc } = useTranslation('common');
 
-  const lyricsPlainOpacity = useAppStore(s => s.lyricsPlainOpacity);
-  const lyricsPlainFontSize = useAppStore(s => s.lyricsPlainFontSize);
-  const setLyricsPlainOpacity = useAppStore(s => s.setLyricsPlainOpacity);
-  const setLyricsPlainFontSize = useAppStore(s => s.setLyricsPlainFontSize);
+  const lyricsPlainOpacity = useLyricsAppearanceStore(s => s.lyricsPlainOpacity);
+  const lyricsPlainFontSize = useLyricsAppearanceStore(s => s.lyricsPlainFontSize);
+  const setLyricsPlainOpacity = useLyricsAppearanceStore(s => s.setLyricsPlainOpacity);
+  const setLyricsPlainFontSize = useLyricsAppearanceStore(s => s.setLyricsPlainFontSize);
 
-  const lyricsSyncedDimOpacity = useAppStore(s => s.lyricsSyncedDimOpacity);
-  const lyricsSyncedFontSize = useAppStore(s => s.lyricsSyncedFontSize);
-  const setLyricsSyncedDimOpacity = useAppStore(s => s.setLyricsSyncedDimOpacity);
-  const setLyricsSyncedFontSize = useAppStore(s => s.setLyricsSyncedFontSize);
+  const lyricsSyncedDimOpacity = useLyricsAppearanceStore(s => s.lyricsSyncedDimOpacity);
+  const lyricsSyncedFontSize = useLyricsAppearanceStore(s => s.lyricsSyncedFontSize);
+  const setLyricsSyncedDimOpacity = useLyricsAppearanceStore(s => s.setLyricsSyncedDimOpacity);
+  const setLyricsSyncedFontSize = useLyricsAppearanceStore(s => s.setLyricsSyncedFontSize);
 
-  const resetLyricsAppearance = useAppStore(s => s.resetLyricsAppearance);
+  const resetLyricsAppearance = useLyricsAppearanceStore(s => s.resetLyricsAppearance);
 
   const isModified =
     lyricsPlainOpacity !== LYRICS_PLAIN_OPACITY_DEFAULT ||

--- a/apps/web/src/components/settings/VisualizerSection.tsx
+++ b/apps/web/src/components/settings/VisualizerSection.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsCard';
 import { cn } from '@/lib/utils';
 import { AudioLines } from 'lucide-react';
-import { useAppStore, type VisualizerStyle } from '@/stores/useAppStore';
+import { useUIStore, type VisualizerStyle } from '@/stores/useUIStore';
 import { VisualizerStylePreview } from '@/components/settings/VisualizerStylePreview';
 
 const VISUALIZER_STYLE_OPTIONS = [
@@ -30,10 +30,10 @@ const VISUALIZER_STYLE_OPTIONS = [
 
 export function VisualizerSection() {
   const { t } = useTranslation('settings');
-  const visualizerStyle = useAppStore(s => s.visualizerStyle);
-  const setVisualizerStyle = useAppStore(s => s.setVisualizerStyle);
-  const showVisualizer = useAppStore(s => s.showVisualizer);
-  const toggleVisualizer = useAppStore(s => s.toggleVisualizer);
+  const visualizerStyle = useUIStore(s => s.visualizerStyle);
+  const setVisualizerStyle = useUIStore(s => s.setVisualizerStyle);
+  const showVisualizer = useUIStore(s => s.showVisualizer);
+  const toggleVisualizer = useUIStore(s => s.toggleVisualizer);
 
   return (
     <SettingsCard icon={AudioLines} title={t('vis.title')} subtitle={t('vis.subtitle')}>

--- a/apps/web/src/components/settings/VisualizerStylePreview.tsx
+++ b/apps/web/src/components/settings/VisualizerStylePreview.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { AudioVisualizer } from '@/components/player/AudioVisualizer';
 import { WaveformVisualizer } from '@/components/player/WaveformVisualizer';
@@ -27,7 +27,7 @@ function createSyntheticSource(): FrequencySource {
 
 export function VisualizerStylePreview() {
   const { t } = useTranslation('settings');
-  const visualizerStyle = useAppStore(s => s.visualizerStyle);
+  const visualizerStyle = useUIStore(s => s.visualizerStyle);
   const sourceRef = useRef<FrequencySource | null>(null);
   if (sourceRef.current === null) sourceRef.current = createSyntheticSource();
   const source = sourceRef.current;

--- a/apps/web/src/components/shared/AlbumSortControl.tsx
+++ b/apps/web/src/components/shared/AlbumSortControl.tsx
@@ -1,7 +1,7 @@
 import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
-import type { AlbumSortMode } from '@/stores/useAppStore';
+import type { AlbumSortMode } from '@/stores/useUIStore';
 
 export interface AlbumSortControlProps {
   mode: AlbumSortMode;

--- a/apps/web/src/components/shared/AmbientBackground.tsx
+++ b/apps/web/src/components/shared/AmbientBackground.tsx
@@ -1,13 +1,13 @@
 import { useAmbientColor } from '@/hooks/useAmbientColor';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import { motion, AnimatePresence } from 'motion/react';
 
 export function AmbientBackground() {
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const ambientColor = useAmbientColor();
-  const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
-  const noiseOverlayEnabled = useAppStore(s => s.noiseOverlayEnabled);
+  const lowPerformanceMode = useUIStore(s => s.lowPerformanceMode);
+  const noiseOverlayEnabled = useUIStore(s => s.noiseOverlayEnabled);
 
   if (lowPerformanceMode) return null;
 

--- a/apps/web/src/components/shared/CommandPalette.tsx
+++ b/apps/web/src/components/shared/CommandPalette.tsx
@@ -13,7 +13,7 @@ import {
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import type { Track } from '@/stores/types';
-import { useAppStore, type AppView } from '@/stores/useAppStore';
+import { useViewStore, type AppView } from '@/stores/useViewStore';
 import { formatDuration } from '@shiranami/shared';
 
 export function CommandPalette() {
@@ -22,7 +22,7 @@ export function CommandPalette() {
   const library = useLibraryStore(s => s.library);
   const setQueue = usePlaybackStore(s => s.setQueue);
   const currentTrack = usePlaybackStore(s => s.currentTrack);
-  const navigateTo = useAppStore(s => s.navigateTo);
+  const navigateTo = useViewStore(s => s.navigateTo);
 
   // Global Cmd+K / Ctrl+K listener
   useEffect(() => {

--- a/apps/web/src/components/shared/NowPlayingHero.tsx
+++ b/apps/web/src/components/shared/NowPlayingHero.tsx
@@ -3,7 +3,7 @@ import { Music } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import type { Track } from '@/stores/types';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { useAmbientColor } from '@/hooks/useAmbientColor';
 import { cn } from '@/lib/utils';
@@ -17,9 +17,9 @@ export function NowPlayingHero({ show }: NowPlayingHeroProps) {
   const { t } = useTranslation('common');
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const ambientColor = useAmbientColor();
-  const nowPlayingViewEnabled = useAppStore(s => s.nowPlayingViewEnabled);
+  const nowPlayingViewEnabled = useUIStore(s => s.nowPlayingViewEnabled);
   const enterNowPlaying = useViewStore(s => s.enterNowPlaying);
-  const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
+  const lowPerformanceMode = useUIStore(s => s.lowPerformanceMode);
 
   const visible = currentTrack && (!show || show(currentTrack));
 

--- a/apps/web/src/components/shared/NowPlayingHero.tsx
+++ b/apps/web/src/components/shared/NowPlayingHero.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from 'motion/react';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import type { Track } from '@/stores/types';
 import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import { useAmbientColor } from '@/hooks/useAmbientColor';
 import { cn } from '@/lib/utils';
 
@@ -17,7 +18,7 @@ export function NowPlayingHero({ show }: NowPlayingHeroProps) {
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const ambientColor = useAmbientColor();
   const nowPlayingViewEnabled = useAppStore(s => s.nowPlayingViewEnabled);
-  const enterNowPlaying = useAppStore(s => s.enterNowPlaying);
+  const enterNowPlaying = useViewStore(s => s.enterNowPlaying);
   const lowPerformanceMode = useAppStore(s => s.lowPerformanceMode);
 
   const visible = currentTrack && (!show || show(currentTrack));

--- a/apps/web/src/components/shared/PlaylistContextMenu.tsx
+++ b/apps/web/src/components/shared/PlaylistContextMenu.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import type { Playlist } from '@/types/electron';
 import { IS_ELECTRON } from '@/lib/platform';
 import { shuffleItems } from '@/lib/playlists';
-import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import type { Track } from '@/stores/types';
 import { useContextMenuDismiss, type ContextMenuPosition } from '@/hooks/useContextMenuDismiss';
@@ -42,17 +42,13 @@ function MenuItem({
   );
 }
 
-export function PlaylistContextMenu({
-  playlist,
-  position,
-  onClose,
-}: PlaylistContextMenuProps) {
+export function PlaylistContextMenu({ playlist, position, onClose }: PlaylistContextMenuProps) {
   const { t } = useTranslation('contextMenu');
   const { t: tToast } = useTranslation('toast');
   const menuRef = useRef<HTMLDivElement>(null);
   const adjustedPosition = useContextMenuDismiss(menuRef, position, onClose);
-  const navigateTo = useAppStore((s) => s.navigateTo);
-  const setQueue = usePlaybackStore((s) => s.setQueue);
+  const navigateTo = useViewStore(s => s.navigateTo);
+  const setQueue = usePlaybackStore(s => s.setQueue);
   const queryClient = useQueryClient();
 
   const loadPlaylistTracks = useCallback(async () => {

--- a/apps/web/src/components/shared/Sidebar.test.tsx
+++ b/apps/web/src/components/shared/Sidebar.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { Sidebar } from './Sidebar';
-import type { AppView } from '@/stores/useAppStore';
+import type { AppView } from '@/stores/useViewStore';
 
 // ── Shared spies ──
 
@@ -29,14 +29,16 @@ function setStoreState(overrides: Record<string, unknown>) {
 // ── Mocks ──
 
 vi.mock('@/stores/useAppStore', () => ({
-  useAppStore: <T,>(selector: (s: Record<string, unknown>) => T) =>
-    selector(storeState),
+  useAppStore: <T,>(selector: (s: Record<string, unknown>) => T) => selector(storeState),
+}));
+
+vi.mock('@/stores/useViewStore', () => ({
+  useViewStore: <T,>(selector: (s: Record<string, unknown>) => T) => selector(storeState),
 }));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, opts?: { ns?: string }) =>
-      opts?.ns === 'common' ? key : key,
+    t: (key: string, opts?: { ns?: string }) => (opts?.ns === 'common' ? key : key),
   }),
 }));
 
@@ -48,7 +50,10 @@ vi.mock('@/lib/platform', () => ({
   IS_MAC: false,
 }));
 
-let playlistQueryResult = { data: [] as Array<{ id: string; name: string; coverArt?: string }>, isLoading: false };
+let playlistQueryResult = {
+  data: [] as Array<{ id: string; name: string; coverArt?: string }>,
+  isLoading: false,
+};
 
 vi.mock('@/hooks/queries/usePlaylists', () => ({
   usePlaylistsQuery: () => playlistQueryResult,
@@ -76,7 +81,7 @@ vi.mock('motion/react', () => ({
         }
         return undefined;
       },
-    },
+    }
   ),
 }));
 
@@ -207,9 +212,7 @@ describe('Sidebar', () => {
     setStoreState({ sidebarCollapsed: true });
     render(<Sidebar />);
 
-    expect(
-      screen.getByRole('button', { name: 'expandSidebar' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'expandSidebar' })).toBeInTheDocument();
   });
 
   // 6. Settings nav item navigates to settings view

--- a/apps/web/src/components/shared/Sidebar.test.tsx
+++ b/apps/web/src/components/shared/Sidebar.test.tsx
@@ -28,8 +28,8 @@ function setStoreState(overrides: Record<string, unknown>) {
 
 // ── Mocks ──
 
-vi.mock('@/stores/useAppStore', () => ({
-  useAppStore: <T,>(selector: (s: Record<string, unknown>) => T) => selector(storeState),
+vi.mock('@/stores/useUIStore', () => ({
+  useUIStore: <T,>(selector: (s: Record<string, unknown>) => T) => selector(storeState),
 }));
 
 vi.mock('@/stores/useViewStore', () => ({

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { IS_MAC } from '@/lib/platform';
 import { useAppVersion } from '@/hooks/useAppVersion';
-import { useAppStore, type AppView } from '@/stores/useAppStore';
+import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore, type AppView } from '@/stores/useViewStore';
 import type { Playlist } from '@/types/electron';
 import { usePlaylistsQuery } from '@/hooks/queries/usePlaylists';
 import {
@@ -39,12 +40,12 @@ const NAV_ITEMS: Array<{ id: AppView; key: string; icon: typeof Library }> = [
 
 export function Sidebar() {
   const { t } = useTranslation('sidebar');
-  const activeView = useAppStore(s => s.activeView);
-  const selectedPlaylistId = useAppStore(s => s.selectedPlaylistId);
+  const activeView = useViewStore(s => s.activeView);
+  const selectedPlaylistId = useViewStore(s => s.selectedPlaylistId);
   const sidebarCollapsed = useAppStore(s => s.sidebarCollapsed);
   const sidebarHiddenItems = useAppStore(s => s.sidebarHiddenItems);
   const sidebarPlaylistsVisible = useAppStore(s => s.sidebarPlaylistsVisible);
-  const navigateTo = useAppStore(s => s.navigateTo);
+  const navigateTo = useViewStore(s => s.navigateTo);
   const toggleSidebarCollapsed = useAppStore(s => s.toggleSidebarCollapsed);
   const version = useAppVersion();
   const { data: playlists = [], isLoading: isLoadingPlaylists } = usePlaylistsQuery();

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { IS_MAC } from '@/lib/platform';
 import { useAppVersion } from '@/hooks/useAppVersion';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import { useViewStore, type AppView } from '@/stores/useViewStore';
 import type { Playlist } from '@/types/electron';
 import { usePlaylistsQuery } from '@/hooks/queries/usePlaylists';
@@ -42,11 +42,11 @@ export function Sidebar() {
   const { t } = useTranslation('sidebar');
   const activeView = useViewStore(s => s.activeView);
   const selectedPlaylistId = useViewStore(s => s.selectedPlaylistId);
-  const sidebarCollapsed = useAppStore(s => s.sidebarCollapsed);
-  const sidebarHiddenItems = useAppStore(s => s.sidebarHiddenItems);
-  const sidebarPlaylistsVisible = useAppStore(s => s.sidebarPlaylistsVisible);
+  const sidebarCollapsed = useUIStore(s => s.sidebarCollapsed);
+  const sidebarHiddenItems = useUIStore(s => s.sidebarHiddenItems);
+  const sidebarPlaylistsVisible = useUIStore(s => s.sidebarPlaylistsVisible);
   const navigateTo = useViewStore(s => s.navigateTo);
-  const toggleSidebarCollapsed = useAppStore(s => s.toggleSidebarCollapsed);
+  const toggleSidebarCollapsed = useUIStore(s => s.toggleSidebarCollapsed);
   const version = useAppVersion();
   const { data: playlists = [], isLoading: isLoadingPlaylists } = usePlaylistsQuery();
   const [contextMenuState, setContextMenuState] = useState<{

--- a/apps/web/src/components/shared/TopBar.tsx
+++ b/apps/web/src/components/shared/TopBar.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Minus, Square, Copy, X, Plus, FolderOpen, File } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { IS_ELECTRON, IS_MAC } from '@/lib/platform';
-import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import { useWindowControls } from '@/hooks/useWindowControls';
 
 const VIEW_TITLE_KEYS: Record<string, string> = {
@@ -24,7 +24,7 @@ interface TopBarProps {
 
 export function TopBar({ onAddFile, onAddFolder, isScanning }: TopBarProps) {
   const { t } = useTranslation('topbar');
-  const activeView = useAppStore(s => s.activeView);
+  const activeView = useViewStore(s => s.activeView);
   const { isMaximized, minimize, maximize, close } = useWindowControls();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -72,14 +72,20 @@ export function TopBar({ onAddFile, onAddFolder, isScanning }: TopBarProps) {
           {dropdownOpen && (
             <div className="absolute right-0 top-full mt-1 w-44 py-1 rounded-xl bg-card border border-border/50 shadow-xl shadow-black/20 z-50">
               <button
-                onClick={() => { onAddFolder?.(); setDropdownOpen(false); }}
+                onClick={() => {
+                  onAddFolder?.();
+                  setDropdownOpen(false);
+                }}
                 className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
               >
                 <FolderOpen className="w-4 h-4 text-muted-foreground" />
                 {t('addFolder')}
               </button>
               <button
-                onClick={() => { onAddFile?.(); setDropdownOpen(false); }}
+                onClick={() => {
+                  onAddFile?.();
+                  setDropdownOpen(false);
+                }}
                 className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
               >
                 <File className="w-4 h-4 text-muted-foreground" />

--- a/apps/web/src/hooks/useKeyboardShortcuts.test.ts
+++ b/apps/web/src/hooks/useKeyboardShortcuts.test.ts
@@ -4,6 +4,7 @@ import { fireEvent } from '@testing-library/react';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore, currentTimeRef } from '@/stores/usePlaybackStore';
 import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
 
@@ -49,7 +50,7 @@ describe('useKeyboardShortcuts', () => {
     });
     currentTimeRef.current = 100;
 
-    useAppStore.setState({
+    useViewStore.setState({
       rightPanel: null,
     });
 
@@ -288,7 +289,7 @@ describe('useKeyboardShortcuts', () => {
     for (const [key, view] of Object.entries(viewMap)) {
       it(`${key} navigates to ${view}`, () => {
         setup();
-        const navSpy = vi.spyOn(useAppStore.getState(), 'navigateTo');
+        const navSpy = vi.spyOn(useViewStore.getState(), 'navigateTo');
 
         pressKey(key);
         expect(navSpy).toHaveBeenCalledWith(view);
@@ -332,13 +333,13 @@ describe('useKeyboardShortcuts', () => {
       // panel-close branch).
       //
       // Note: we can't usefully assert on selection here. `useSelectionStore`
-      // has a module-level subscription on `useAppStore` (see
-      // useSelectionStore.ts:67-74) that auto-clears selection any time
+      // has a module-level subscription on `useViewStore` (see
+      // useSelectionStore.ts) that auto-clears selection any time
       // `activeView` changes. So `exitNowPlaying()` clears the selection
       // as a side effect regardless of which Esc branch the handler
       // takes — selection is unobservable for distinguishing branches.
       // The panel is the cleaner signal.
-      useAppStore.setState({
+      useViewStore.setState({
         activeView: 'now-playing',
         previousView: 'library',
         rightPanel: 'queue',
@@ -347,10 +348,10 @@ describe('useKeyboardShortcuts', () => {
       pressKey('Escape');
 
       // Exited back to previousView via exitNowPlaying()
-      expect(useAppStore.getState().activeView).toBe('library');
+      expect(useViewStore.getState().activeView).toBe('library');
       // Panel untouched — handler returned early, never reached the
       // setRightPanel(null) branch.
-      expect(useAppStore.getState().rightPanel).toBe('queue');
+      expect(useViewStore.getState().rightPanel).toBe('queue');
     });
 
     it('clears selection when tracks are selected', () => {
@@ -365,10 +366,10 @@ describe('useKeyboardShortcuts', () => {
 
     it('closes right panel when no tracks are selected', () => {
       setup();
-      useAppStore.setState({ rightPanel: 'queue' });
+      useViewStore.setState({ rightPanel: 'queue' });
 
       pressKey('Escape');
-      expect(useAppStore.getState().rightPanel).toBeNull();
+      expect(useViewStore.getState().rightPanel).toBeNull();
     });
 
     it('clears selection first, does not close panel', () => {
@@ -376,13 +377,13 @@ describe('useKeyboardShortcuts', () => {
       useSelectionStore.setState({
         selectedTrackIds: new Set(['t1']),
       });
-      useAppStore.setState({ rightPanel: 'lyrics' });
+      useViewStore.setState({ rightPanel: 'lyrics' });
 
       pressKey('Escape');
       // Selection should be cleared
       expect(useSelectionStore.getState().selectedTrackIds.size).toBe(0);
       // Panel should still be open
-      expect(useAppStore.getState().rightPanel).toBe('lyrics');
+      expect(useViewStore.getState().rightPanel).toBe('lyrics');
     });
   });
 
@@ -399,7 +400,7 @@ describe('useKeyboardShortcuts', () => {
 
     it('Ctrl+L toggles lyrics panel', () => {
       setup();
-      const toggleSpy = vi.spyOn(useAppStore.getState(), 'toggleRightPanel');
+      const toggleSpy = vi.spyOn(useViewStore.getState(), 'toggleRightPanel');
 
       pressKey('l', { ctrlKey: true });
       expect(toggleSpy).toHaveBeenCalledWith('lyrics');
@@ -407,7 +408,7 @@ describe('useKeyboardShortcuts', () => {
 
     it('Ctrl+Q toggles queue panel', () => {
       setup();
-      const toggleSpy = vi.spyOn(useAppStore.getState(), 'toggleRightPanel');
+      const toggleSpy = vi.spyOn(useViewStore.getState(), 'toggleRightPanel');
 
       pressKey('q', { ctrlKey: true });
       expect(toggleSpy).toHaveBeenCalledWith('queue');

--- a/apps/web/src/hooks/useKeyboardShortcuts.test.ts
+++ b/apps/web/src/hooks/useKeyboardShortcuts.test.ts
@@ -4,6 +4,7 @@ import { fireEvent } from '@testing-library/react';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore, currentTimeRef } from '@/stores/usePlaybackStore';
 import { useAppStore } from '@/stores/useAppStore';
+import { useCompactStore } from '@/stores/useCompactStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
@@ -416,7 +417,7 @@ describe('useKeyboardShortcuts', () => {
 
     it('Ctrl+Shift+M toggles compact mode', () => {
       setup();
-      const toggleSpy = vi.spyOn(useAppStore.getState(), 'toggleCompactMode');
+      const toggleSpy = vi.spyOn(useCompactStore.getState(), 'toggleCompactMode');
 
       pressKey('M', { ctrlKey: true, shiftKey: true });
       expect(toggleSpy).toHaveBeenCalledOnce();

--- a/apps/web/src/hooks/useKeyboardShortcuts.test.ts
+++ b/apps/web/src/hooks/useKeyboardShortcuts.test.ts
@@ -3,7 +3,7 @@ import { cleanup, renderHook } from '@testing-library/react';
 import { fireEvent } from '@testing-library/react';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore, currentTimeRef } from '@/stores/usePlaybackStore';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import { useCompactStore } from '@/stores/useCompactStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
@@ -393,7 +393,7 @@ describe('useKeyboardShortcuts', () => {
   describe('Modifier shortcuts (Ctrl/Cmd)', () => {
     it('Ctrl+B toggles sidebar', () => {
       setup();
-      const toggleSpy = vi.spyOn(useAppStore.getState(), 'toggleSidebarCollapsed');
+      const toggleSpy = vi.spyOn(useUIStore.getState(), 'toggleSidebarCollapsed');
 
       pressKey('b', { ctrlKey: true });
       expect(toggleSpy).toHaveBeenCalledOnce();
@@ -478,7 +478,7 @@ describe('useKeyboardShortcuts', () => {
       const input = document.createElement('input');
       document.body.appendChild(input);
 
-      const toggleSpy = vi.spyOn(useAppStore.getState(), 'toggleSidebarCollapsed');
+      const toggleSpy = vi.spyOn(useUIStore.getState(), 'toggleSidebarCollapsed');
 
       pressKey('b', { ctrlKey: true }, input);
       expect(toggleSpy).toHaveBeenCalledOnce();
@@ -492,7 +492,7 @@ describe('useKeyboardShortcuts', () => {
   describe('V - visualizer', () => {
     it('toggles visualizer', () => {
       setup();
-      const toggleSpy = vi.spyOn(useAppStore.getState(), 'toggleVisualizer');
+      const toggleSpy = vi.spyOn(useUIStore.getState(), 'toggleVisualizer');
 
       pressKey('v');
       expect(toggleSpy).toHaveBeenCalledOnce();

--- a/apps/web/src/hooks/useKeyboardShortcuts.test.ts
+++ b/apps/web/src/hooks/useKeyboardShortcuts.test.ts
@@ -52,6 +52,7 @@ describe('useKeyboardShortcuts', () => {
     currentTimeRef.current = 100;
 
     useViewStore.setState({
+      activeView: 'library',
       rightPanel: null,
     });
 

--- a/apps/web/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/web/src/hooks/useKeyboardShortcuts.ts
@@ -3,7 +3,7 @@ import { toast } from 'sonner';
 import i18n from '@/lib/i18n';
 import { usePlaybackStore, currentTimeRef } from '@/stores/usePlaybackStore';
 import { useLibraryStore } from '@/stores/useLibraryStore';
-import { useAppStore } from '@/stores/useAppStore';
+import { useUIStore } from '@/stores/useUIStore';
 import { useCompactStore } from '@/stores/useCompactStore';
 import { useViewStore, type AppView } from '@/stores/useViewStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
@@ -58,7 +58,7 @@ export function useKeyboardShortcuts() {
           case 'b':
           case 'B': {
             e.preventDefault();
-            useAppStore.getState().toggleSidebarCollapsed();
+            useUIStore.getState().toggleSidebarCollapsed();
             return;
           }
           case 'l':
@@ -111,7 +111,7 @@ export function useKeyboardShortcuts() {
             // shortcut was received and why it didn't open the view.
             if (e.shiftKey) {
               e.preventDefault();
-              const { nowPlayingViewEnabled } = useAppStore.getState();
+              const { nowPlayingViewEnabled } = useUIStore.getState();
               const { activeView, enterNowPlaying, exitNowPlaying } = useViewStore.getState();
               if (!nowPlayingViewEnabled) {
                 toast.info(i18n.t('nowPlayingDisabled', { ns: 'toast' }), {
@@ -226,7 +226,7 @@ export function useKeyboardShortcuts() {
         case 'V':
         case 'v': {
           e.preventDefault();
-          useAppStore.getState().toggleVisualizer();
+          useUIStore.getState().toggleVisualizer();
           return;
         }
         case '?': {

--- a/apps/web/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/web/src/hooks/useKeyboardShortcuts.ts
@@ -3,7 +3,8 @@ import { toast } from 'sonner';
 import i18n from '@/lib/i18n';
 import { usePlaybackStore, currentTimeRef } from '@/stores/usePlaybackStore';
 import { useLibraryStore } from '@/stores/useLibraryStore';
-import { useAppStore, type AppView } from '@/stores/useAppStore';
+import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore, type AppView } from '@/stores/useViewStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 
 /**
@@ -63,7 +64,7 @@ export function useKeyboardShortcuts() {
           case 'L': {
             if (!e.shiftKey) {
               e.preventDefault();
-              useAppStore.getState().toggleRightPanel('lyrics');
+              useViewStore.getState().toggleRightPanel('lyrics');
               return;
             }
             break;
@@ -72,7 +73,7 @@ export function useKeyboardShortcuts() {
           case 'Q': {
             if (!e.shiftKey) {
               e.preventDefault();
-              useAppStore.getState().toggleRightPanel('queue');
+              useViewStore.getState().toggleRightPanel('queue');
               return;
             }
             break;
@@ -109,15 +110,15 @@ export function useKeyboardShortcuts() {
             // shortcut was received and why it didn't open the view.
             if (e.shiftKey) {
               e.preventDefault();
-              const { nowPlayingViewEnabled, activeView, enterNowPlaying, exitNowPlaying } =
-                useAppStore.getState();
+              const { nowPlayingViewEnabled } = useAppStore.getState();
+              const { activeView, enterNowPlaying, exitNowPlaying } = useViewStore.getState();
               if (!nowPlayingViewEnabled) {
                 toast.info(i18n.t('nowPlayingDisabled', { ns: 'toast' }), {
                   id: 'now-playing-disabled',
                   duration: 6000,
                   action: {
                     label: i18n.t('updateSettings', { ns: 'toast' }),
-                    onClick: () => useAppStore.getState().navigateTo('settings'),
+                    onClick: () => useViewStore.getState().navigateTo('settings'),
                   },
                 });
                 return;
@@ -237,10 +238,10 @@ export function useKeyboardShortcuts() {
           // Now Playing is a modal-like full-screen view; Esc should
           // dismiss it before any background-state cleanup. Standard
           // modal interaction.
-          const appState = useAppStore.getState();
-          if (appState.activeView === 'now-playing') {
+          const viewState = useViewStore.getState();
+          if (viewState.activeView === 'now-playing') {
             e.preventDefault();
-            appState.exitNowPlaying();
+            viewState.exitNowPlaying();
             return;
           }
           // Clear track selection first
@@ -250,9 +251,9 @@ export function useKeyboardShortcuts() {
             clearSelection();
             return;
           }
-          if (appState.rightPanel !== null) {
+          if (viewState.rightPanel !== null) {
             e.preventDefault();
-            appState.setRightPanel(null);
+            viewState.setRightPanel(null);
           }
           return;
         }
@@ -268,7 +269,7 @@ export function useKeyboardShortcuts() {
           const entry = NAV_VIEWS[parseInt(e.key) - 1];
           if (!entry) return;
           e.preventDefault();
-          useAppStore.getState().navigateTo(entry.view);
+          useViewStore.getState().navigateTo(entry.view);
           return;
         }
       }

--- a/apps/web/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/web/src/hooks/useKeyboardShortcuts.ts
@@ -4,6 +4,7 @@ import i18n from '@/lib/i18n';
 import { usePlaybackStore, currentTimeRef } from '@/stores/usePlaybackStore';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { useAppStore } from '@/stores/useAppStore';
+import { useCompactStore } from '@/stores/useCompactStore';
 import { useViewStore, type AppView } from '@/stores/useViewStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 
@@ -82,7 +83,7 @@ export function useKeyboardShortcuts() {
           case 'm': {
             if (e.shiftKey) {
               e.preventDefault();
-              useAppStore.getState().toggleCompactMode();
+              useCompactStore.getState().toggleCompactMode();
               return;
             }
             break;
@@ -97,7 +98,7 @@ export function useKeyboardShortcuts() {
             // pin sticks the next time compact is entered.
             if (e.shiftKey) {
               e.preventDefault();
-              void useAppStore.getState().toggleCompactAlwaysOnTop();
+              void useCompactStore.getState().toggleCompactAlwaysOnTop();
               return;
             }
             break;

--- a/apps/web/src/hooks/usePlaylistMutations.ts
+++ b/apps/web/src/hooks/usePlaylistMutations.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import {
@@ -17,12 +17,9 @@ interface UsePlaylistMutationsOptions {
 /**
  * Handles playlist mutation operations using TanStack Query mutations.
  */
-export function usePlaylistMutations({
-  playlistId,
-  playlist,
-}: UsePlaylistMutationsOptions) {
+export function usePlaylistMutations({ playlistId, playlist }: UsePlaylistMutationsOptions) {
   const { t: tToast } = useTranslation('toast');
-  const selectPlaylist = useAppStore((s) => s.selectPlaylist);
+  const selectPlaylist = useViewStore(s => s.selectPlaylist);
 
   const updateMutation = useUpdatePlaylistMutation();
   const deleteMutation = useDeletePlaylistMutation();

--- a/apps/web/src/hooks/useUpdateNotifications.ts
+++ b/apps/web/src/hooks/useUpdateNotifications.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 import { IS_ELECTRON } from '@/lib/platform';
-import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 import i18n from '@/lib/i18n';
 
 const TOAST_ID = 'update-notification';
@@ -22,7 +22,7 @@ export function useUpdateNotifications() {
     const unsubs: (() => void)[] = [];
 
     unsubs.push(
-      window.electronAPI.updater.onUpdateAvailable((info) => {
+      window.electronAPI.updater.onUpdateAvailable(info => {
         // Don't re-notify for the same version
         if (notifiedVersionRef.current === info.version) return;
         notifiedVersionRef.current = info.version;
@@ -32,36 +32,36 @@ export function useUpdateNotifications() {
           duration: 19_000,
           action: {
             label: i18n.t('updateSettings', { ns: 'toast' }),
-            onClick: () => useAppStore.getState().navigateTo('settings'),
+            onClick: () => useViewStore.getState().navigateTo('settings'),
           },
         });
-      }),
+      })
     );
 
     unsubs.push(
-      window.electronAPI.updater.onUpdateDownloaded((info) => {
+      window.electronAPI.updater.onUpdateDownloaded(info => {
         toast.success(i18n.t('updateReady', { ns: 'toast', version: info.version }), {
           id: TOAST_ID,
           duration: Infinity,
           action: {
             label: i18n.t('updateRestart', { ns: 'toast' }),
             onClick: () => {
-              window.electronAPI.updater.installNow().catch((err) => {
+              window.electronAPI.updater.installNow().catch(err => {
                 console.warn('Failed to install update', err);
               });
             },
           },
         });
-      }),
+      })
     );
 
     unsubs.push(
-      window.electronAPI.updater.onUpdateError((message) => {
+      window.electronAPI.updater.onUpdateError(message => {
         // RELEASE_PENDING is not a real error — ignore it
         if (message === 'RELEASE_PENDING') return;
-      }),
+      })
     );
 
-    return () => unsubs.forEach((fn) => fn());
+    return () => unsubs.forEach(fn => fn());
   }, []);
 }

--- a/apps/web/src/lib/albumSort.ts
+++ b/apps/web/src/lib/albumSort.ts
@@ -1,5 +1,5 @@
 import { type Track } from '@/stores/types';
-import { type AlbumSortMode, type AlbumSortOrder } from '@/stores/useAppStore';
+import { type AlbumSortMode, type AlbumSortOrder } from '@/stores/useUIStore';
 
 export interface AlbumData {
   name: string;

--- a/apps/web/src/stores/useAppStore.test.ts
+++ b/apps/web/src/stores/useAppStore.test.ts
@@ -1,16 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  useAppStore,
-  LYRICS_PLAIN_OPACITY_DEFAULT,
-  LYRICS_PLAIN_OPACITY_MAX,
-  LYRICS_PLAIN_OPACITY_MIN,
-  LYRICS_PLAIN_FONT_SIZE_DEFAULT,
-  LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
-  LYRICS_SYNCED_DIM_OPACITY_MAX,
-  LYRICS_SYNCED_DIM_OPACITY_MIN,
-  LYRICS_SYNCED_FONT_SIZE_DEFAULT,
-  nextLyricsFontSize,
-} from './useAppStore';
+import { useAppStore } from './useAppStore';
 import { useViewStore } from './useViewStore';
 
 vi.mock('@/lib/platform', () => ({
@@ -215,93 +204,6 @@ describe('useAppStore', () => {
     expect(useViewStore.getState().albumGridScrollTop).toBe(500);
   });
 
-  it('clamps lyrics plain opacity above max and rounds to step', () => {
-    useAppStore.getState().setLyricsPlainOpacity(2);
-    expect(useAppStore.getState().lyricsPlainOpacity).toBe(LYRICS_PLAIN_OPACITY_MAX);
-    expect(readPersisted().lyricsPlainOpacity).toBe(LYRICS_PLAIN_OPACITY_MAX);
-  });
-
-  it('clamps lyrics plain opacity below min', () => {
-    useAppStore.getState().setLyricsPlainOpacity(0);
-    expect(useAppStore.getState().lyricsPlainOpacity).toBe(LYRICS_PLAIN_OPACITY_MIN);
-  });
-
-  it('rounds lyrics plain opacity to nearest step', () => {
-    useAppStore.getState().setLyricsPlainOpacity(0.873);
-    // step = 0.05, 0.873 -> rounds to 0.85
-    expect(useAppStore.getState().lyricsPlainOpacity).toBeCloseTo(0.85, 2);
-  });
-
-  it('coerces invalid lyrics plain font size to default on setter', () => {
-    // @ts-expect-error — runtime guard test
-    useAppStore.getState().setLyricsPlainFontSize('huge');
-    expect(useAppStore.getState().lyricsPlainFontSize).toBe(LYRICS_PLAIN_FONT_SIZE_DEFAULT);
-  });
-
-  it('persists lyrics plain font size when valid', () => {
-    useAppStore.getState().setLyricsPlainFontSize('lg');
-    expect(useAppStore.getState().lyricsPlainFontSize).toBe('lg');
-    expect(readPersisted().lyricsPlainFontSize).toBe('lg');
-  });
-
-  it('resets lyrics plain appearance to defaults', () => {
-    useAppStore.getState().setLyricsPlainOpacity(0.6);
-    useAppStore.getState().setLyricsPlainFontSize('xl');
-    useAppStore.getState().resetLyricsPlainAppearance();
-    expect(useAppStore.getState().lyricsPlainOpacity).toBe(LYRICS_PLAIN_OPACITY_DEFAULT);
-    expect(useAppStore.getState().lyricsPlainFontSize).toBe(LYRICS_PLAIN_FONT_SIZE_DEFAULT);
-  });
-
-  it('clamps lyrics synced dim opacity above max and rounds to step', () => {
-    useAppStore.getState().setLyricsSyncedDimOpacity(2);
-    expect(useAppStore.getState().lyricsSyncedDimOpacity).toBe(LYRICS_SYNCED_DIM_OPACITY_MAX);
-    expect(readPersisted().lyricsSyncedDimOpacity).toBe(LYRICS_SYNCED_DIM_OPACITY_MAX);
-  });
-
-  it('clamps lyrics synced dim opacity below min (down to 0.2 not 0.5)', () => {
-    useAppStore.getState().setLyricsSyncedDimOpacity(0);
-    // Synced floor is lower than plain floor — synced lines may be very dim.
-    expect(useAppStore.getState().lyricsSyncedDimOpacity).toBe(LYRICS_SYNCED_DIM_OPACITY_MIN);
-    expect(LYRICS_SYNCED_DIM_OPACITY_MIN).toBe(0.2);
-  });
-
-  it('rounds lyrics synced dim opacity to nearest step', () => {
-    useAppStore.getState().setLyricsSyncedDimOpacity(0.873);
-    // step = 0.05, 0.873 -> rounds to 0.85
-    expect(useAppStore.getState().lyricsSyncedDimOpacity).toBeCloseTo(0.85, 2);
-  });
-
-  it('coerces invalid lyrics synced font size to default on setter', () => {
-    // @ts-expect-error — runtime guard test
-    useAppStore.getState().setLyricsSyncedFontSize('huge');
-    expect(useAppStore.getState().lyricsSyncedFontSize).toBe(LYRICS_SYNCED_FONT_SIZE_DEFAULT);
-  });
-
-  it('persists lyrics synced font size when valid', () => {
-    useAppStore.getState().setLyricsSyncedFontSize('lg');
-    expect(useAppStore.getState().lyricsSyncedFontSize).toBe('lg');
-    expect(readPersisted().lyricsSyncedFontSize).toBe('lg');
-  });
-
-  it('resetLyricsAppearance restores all four lyrics prefs to defaults', () => {
-    useAppStore.getState().setLyricsPlainOpacity(0.6);
-    useAppStore.getState().setLyricsPlainFontSize('xl');
-    useAppStore.getState().setLyricsSyncedDimOpacity(0.9);
-    useAppStore.getState().setLyricsSyncedFontSize('sm');
-    useAppStore.getState().resetLyricsAppearance();
-    expect(useAppStore.getState().lyricsPlainOpacity).toBe(LYRICS_PLAIN_OPACITY_DEFAULT);
-    expect(useAppStore.getState().lyricsPlainFontSize).toBe(LYRICS_PLAIN_FONT_SIZE_DEFAULT);
-    expect(useAppStore.getState().lyricsSyncedDimOpacity).toBe(LYRICS_SYNCED_DIM_OPACITY_DEFAULT);
-    expect(useAppStore.getState().lyricsSyncedFontSize).toBe(LYRICS_SYNCED_FONT_SIZE_DEFAULT);
-  });
-
-  it('nextLyricsFontSize bumps one step and caps at xl', () => {
-    expect(nextLyricsFontSize('sm')).toBe('base');
-    expect(nextLyricsFontSize('base')).toBe('lg');
-    expect(nextLyricsFontSize('lg')).toBe('xl');
-    expect(nextLyricsFontSize('xl')).toBe('xl');
-  });
-
   it('rolls back compact always-on-top and localStorage when setAlwaysOnTop fails in compact mode', async () => {
     await useAppStore.getState().setCompactMode(true);
     vi.mocked(window.electronAPI.window.setAlwaysOnTop).mockRejectedValueOnce(
@@ -358,53 +260,5 @@ describe('useAppStore legacy localStorage migration', () => {
   it('does nothing when no legacy keys exist', async () => {
     await import('./useAppStore');
     expect(localStorage.getItem('shiranami.app-store')).toBeNull();
-  });
-
-  it('sanitizes malformed lyrics plain prefs from persisted shape', async () => {
-    localStorage.setItem(
-      'shiranami.app-store',
-      JSON.stringify({
-        state: { lyricsPlainOpacity: 'broken', lyricsPlainFontSize: 'huge' },
-        version: 1,
-      })
-    );
-
-    const mod = await import('./useAppStore');
-    const state = mod.useAppStore.getState();
-    expect(state.lyricsPlainOpacity).toBe(mod.LYRICS_PLAIN_OPACITY_DEFAULT);
-    expect(state.lyricsPlainFontSize).toBe(mod.LYRICS_PLAIN_FONT_SIZE_DEFAULT);
-  });
-
-  it('falls back to synced lyrics defaults when persisted shape lacks the new keys', async () => {
-    // Simulate a user upgrading from a build that only persisted plain prefs.
-    localStorage.setItem(
-      'shiranami.app-store',
-      JSON.stringify({
-        state: { lyricsPlainOpacity: 0.85, lyricsPlainFontSize: 'lg' },
-        version: 1,
-      })
-    );
-
-    const mod = await import('./useAppStore');
-    const state = mod.useAppStore.getState();
-    expect(state.lyricsPlainOpacity).toBe(0.85);
-    expect(state.lyricsPlainFontSize).toBe('lg');
-    expect(state.lyricsSyncedDimOpacity).toBe(mod.LYRICS_SYNCED_DIM_OPACITY_DEFAULT);
-    expect(state.lyricsSyncedFontSize).toBe(mod.LYRICS_SYNCED_FONT_SIZE_DEFAULT);
-  });
-
-  it('sanitizes malformed lyrics synced prefs from persisted shape', async () => {
-    localStorage.setItem(
-      'shiranami.app-store',
-      JSON.stringify({
-        state: { lyricsSyncedDimOpacity: 'broken', lyricsSyncedFontSize: 'huge' },
-        version: 1,
-      })
-    );
-
-    const mod = await import('./useAppStore');
-    const state = mod.useAppStore.getState();
-    expect(state.lyricsSyncedDimOpacity).toBe(mod.LYRICS_SYNCED_DIM_OPACITY_DEFAULT);
-    expect(state.lyricsSyncedFontSize).toBe(mod.LYRICS_SYNCED_FONT_SIZE_DEFAULT);
   });
 });

--- a/apps/web/src/stores/useAppStore.test.ts
+++ b/apps/web/src/stores/useAppStore.test.ts
@@ -11,6 +11,7 @@ import {
   LYRICS_SYNCED_FONT_SIZE_DEFAULT,
   nextLyricsFontSize,
 } from './useAppStore';
+import { useViewStore } from './useViewStore';
 
 vi.mock('@/lib/platform', () => ({
   IS_ELECTRON: true,
@@ -31,9 +32,6 @@ describe('useAppStore', () => {
   beforeEach(() => {
     localStorage.clear();
     useAppStore.setState({
-      activeView: 'library',
-      rightPanel: null,
-      selectedPlaylistId: null,
       sidebarCollapsed: false,
       sidebarHiddenItems: [],
       sidebarPlaylistsVisible: true,
@@ -174,18 +172,18 @@ describe('useAppStore', () => {
   });
 
   it('persists album sort mode and resets scroll position', () => {
-    useAppStore.setState({ albumGridScrollTop: 500 });
+    useViewStore.setState({ albumGridScrollTop: 500 });
     useAppStore.getState().setAlbumSortMode('artist');
     expect(useAppStore.getState().albumSortMode).toBe('artist');
-    expect(useAppStore.getState().albumGridScrollTop).toBe(0);
+    expect(useViewStore.getState().albumGridScrollTop).toBe(0);
     expect(readPersisted().albumSortMode).toBe('artist');
   });
 
   it('persists recentlyAdded sort mode and resets scroll position', () => {
-    useAppStore.setState({ albumGridScrollTop: 300 });
+    useViewStore.setState({ albumGridScrollTop: 300 });
     useAppStore.getState().setAlbumSortMode('recentlyAdded');
     expect(useAppStore.getState().albumSortMode).toBe('recentlyAdded');
-    expect(useAppStore.getState().albumGridScrollTop).toBe(0);
+    expect(useViewStore.getState().albumGridScrollTop).toBe(0);
     expect(readPersisted().albumSortMode).toBe('recentlyAdded');
   });
 
@@ -204,17 +202,17 @@ describe('useAppStore', () => {
   });
 
   it('persists album sort order and resets scroll position', () => {
-    useAppStore.setState({ albumGridScrollTop: 500 });
+    useViewStore.setState({ albumGridScrollTop: 500 });
     useAppStore.getState().setAlbumSortOrder('desc');
     expect(useAppStore.getState().albumSortOrder).toBe('desc');
-    expect(useAppStore.getState().albumGridScrollTop).toBe(0);
+    expect(useViewStore.getState().albumGridScrollTop).toBe(0);
     expect(readPersisted().albumSortOrder).toBe('desc');
   });
 
   it('album grid size changes do not reset scroll position', () => {
-    useAppStore.setState({ albumGridScrollTop: 500 });
+    useViewStore.setState({ albumGridScrollTop: 500 });
     useAppStore.getState().setAlbumGridSize('large');
-    expect(useAppStore.getState().albumGridScrollTop).toBe(500);
+    expect(useViewStore.getState().albumGridScrollTop).toBe(500);
   });
 
   it('clamps lyrics plain opacity above max and rounds to step', () => {

--- a/apps/web/src/stores/useAppStore.test.ts
+++ b/apps/web/src/stores/useAppStore.test.ts
@@ -24,110 +24,9 @@ describe('useAppStore', () => {
       sidebarCollapsed: false,
       sidebarHiddenItems: [],
       sidebarPlaylistsVisible: true,
-      compactMode: false,
-      compactAlwaysOnTop: false,
       showVisualizer: true,
       visualizerStyle: 'bars',
     });
-    vi.mocked(window.electronAPI.window.setCompactMode).mockResolvedValue(undefined);
-    vi.mocked(window.electronAPI.window.setAlwaysOnTop).mockResolvedValue(undefined);
-  });
-
-  it('persists compact always-on-top to localStorage', async () => {
-    await useAppStore.getState().setCompactAlwaysOnTop(true);
-    expect(useAppStore.getState().compactAlwaysOnTop).toBe(true);
-    expect(readPersisted().compactAlwaysOnTop).toBe(true);
-  });
-
-  it('rolls back compact mode when Electron setCompactMode fails', async () => {
-    vi.mocked(window.electronAPI.window.setCompactMode).mockRejectedValueOnce(
-      new Error('ipc failed')
-    );
-
-    await useAppStore.getState().setCompactMode(true);
-
-    expect(useAppStore.getState().compactMode).toBe(false);
-  });
-
-  it('rolls back only the pin when setAlwaysOnTop fails after compact succeeds', async () => {
-    // Default-pin-on seeds compactAlwaysOnTop=true on entry; if the pin IPC
-    // then fails, we want compact to stay (window is in compact mode) but
-    // the pin to revert (so the store doesn't claim a pin that didn't take).
-    useAppStore.setState({ compactDefaultAlwaysOnTop: true, compactAlwaysOnTop: false });
-    vi.mocked(window.electronAPI.window.setCompactMode).mockResolvedValueOnce(undefined);
-    vi.mocked(window.electronAPI.window.setAlwaysOnTop).mockRejectedValueOnce(
-      new Error('pin failed')
-    );
-
-    await useAppStore.getState().setCompactMode(true);
-
-    expect(useAppStore.getState().compactMode).toBe(true);
-    expect(useAppStore.getState().compactAlwaysOnTop).toBe(false);
-  });
-
-  it('persists compact mode flag across reloads', async () => {
-    await useAppStore.getState().setCompactMode(true);
-    expect(useAppStore.getState().compactMode).toBe(true);
-    expect(readPersisted().compactMode).toBe(true);
-  });
-
-  it('forwards configured compact size dimensions over IPC', async () => {
-    useAppStore.setState({ compactSize: 'lg' });
-    await useAppStore.getState().setCompactMode(true);
-
-    expect(window.electronAPI.window.setCompactMode).toHaveBeenCalledWith(
-      true,
-      expect.objectContaining({ width: 600, height: 260 })
-    );
-  });
-
-  it('seeds compact always-on-top from compactDefaultAlwaysOnTop on entry', async () => {
-    useAppStore.setState({ compactDefaultAlwaysOnTop: true, compactAlwaysOnTop: false });
-
-    await useAppStore.getState().setCompactMode(true);
-
-    expect(useAppStore.getState().compactAlwaysOnTop).toBe(true);
-    expect(window.electronAPI.window.setAlwaysOnTop).toHaveBeenCalledWith(true);
-  });
-
-  it('persists compactShowFavorite toggle to localStorage', () => {
-    useAppStore.getState().setCompactShowFavorite(true);
-    expect(useAppStore.getState().compactShowFavorite).toBe(true);
-    expect(readPersisted().compactShowFavorite).toBe(true);
-  });
-
-  it('persists and clamps compactAmbientIntensity within the allowed range', () => {
-    useAppStore.getState().setCompactAmbientIntensity(0.5);
-    // Clamped to max (0.2).
-    expect(useAppStore.getState().compactAmbientIntensity).toBe(0.2);
-    expect(readPersisted().compactAmbientIntensity).toBe(0.2);
-  });
-
-  it('resetCompactAppearance restores all compact prefs to defaults', () => {
-    useAppStore.setState({
-      compactSize: 'lg',
-      compactFontSize: 'sm',
-      compactAmbientIntensity: 0.15,
-      compactShowAlbumArt: false,
-      compactShowAlbum: false,
-      compactShowSeek: false,
-      compactShowVolume: false,
-      compactShowFavorite: true,
-      compactDefaultAlwaysOnTop: true,
-    });
-
-    useAppStore.getState().resetCompactAppearance();
-
-    const s = useAppStore.getState();
-    expect(s.compactSize).toBe('md');
-    expect(s.compactFontSize).toBe('md');
-    expect(s.compactAmbientIntensity).toBe(0.08);
-    expect(s.compactShowAlbumArt).toBe(true);
-    expect(s.compactShowAlbum).toBe(true);
-    expect(s.compactShowSeek).toBe(true);
-    expect(s.compactShowVolume).toBe(true);
-    expect(s.compactShowFavorite).toBe(false);
-    expect(s.compactDefaultAlwaysOnTop).toBe(false);
   });
 
   it('toggleSidebarItem adds and removes items from hidden list', () => {
@@ -202,18 +101,6 @@ describe('useAppStore', () => {
     useViewStore.setState({ albumGridScrollTop: 500 });
     useAppStore.getState().setAlbumGridSize('large');
     expect(useViewStore.getState().albumGridScrollTop).toBe(500);
-  });
-
-  it('rolls back compact always-on-top and localStorage when setAlwaysOnTop fails in compact mode', async () => {
-    await useAppStore.getState().setCompactMode(true);
-    vi.mocked(window.electronAPI.window.setAlwaysOnTop).mockRejectedValueOnce(
-      new Error('aot failed')
-    );
-
-    await useAppStore.getState().setCompactAlwaysOnTop(true);
-
-    expect(useAppStore.getState().compactAlwaysOnTop).toBe(false);
-    expect(readPersisted().compactAlwaysOnTop).toBe(false);
   });
 });
 

--- a/apps/web/src/stores/useAppStore.ts
+++ b/apps/web/src/stores/useAppStore.ts
@@ -1,19 +1,9 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { IS_ELECTRON } from '@/lib/platform';
+import { useViewStore, type AppView, type RightPanel } from '@/stores/useViewStore';
 
-export type AppView =
-  | 'library'
-  | 'playlists'
-  | 'favorites'
-  | 'history'
-  | 'mixes'
-  | 'search'
-  | 'radio'
-  | 'settings'
-  | 'import-playlist'
-  | 'now-playing';
-export type RightPanel = 'lyrics' | 'queue' | null;
+export type { AppView, RightPanel };
 export type VisualizerStyle = 'bars' | 'waveform' | 'circle' | 'particles';
 export type LibraryViewMode = 'tracks' | 'albums';
 export type AlbumGridSize = 'small' | 'medium' | 'large';
@@ -406,9 +396,6 @@ function importLegacyAppStore() {
 importLegacyAppStore();
 
 interface AppState {
-  activeView: AppView;
-  rightPanel: RightPanel;
-  selectedPlaylistId: string | null;
   sidebarCollapsed: boolean;
   compactMode: boolean;
   compactAlwaysOnTop: boolean;
@@ -422,8 +409,6 @@ interface AppState {
   playlistGridSize: AlbumGridSize;
   albumSortMode: AlbumSortMode;
   albumSortOrder: AlbumSortOrder;
-  selectedAlbumName: string | null;
-  albumGridScrollTop: number;
   nowPlayingViewEnabled: boolean;
   nowPlayingLyricsVisible: boolean;
   libraryHeroCardEnabled: boolean;
@@ -442,20 +427,14 @@ interface AppState {
   compactShowVolume: boolean;
   compactShowFavorite: boolean;
   compactDefaultAlwaysOnTop: boolean;
-  previousView: AppView;
 }
 
 interface AppActions {
-  navigateTo: (view: AppView, playlistId?: string | null) => void;
-  enterNowPlaying: () => void;
-  exitNowPlaying: () => void;
   setNowPlayingViewEnabled: (enabled: boolean) => void;
   toggleNowPlayingLyrics: () => void;
   setLibraryHeroCardEnabled: (enabled: boolean) => void;
   setLowPerformanceMode: (enabled: boolean) => void;
   setNoiseOverlayEnabled: (enabled: boolean) => void;
-  selectPlaylist: (id: string | null) => void;
-  setRightPanel: (panel: RightPanel) => void;
   setSidebarCollapsed: (sidebarCollapsed: boolean) => void;
   setCompactMode: (compactMode: boolean) => Promise<void>;
   setCompactAlwaysOnTop: (compactAlwaysOnTop: boolean) => Promise<void>;
@@ -464,7 +443,6 @@ interface AppActions {
   toggleSidebarCollapsed: () => void;
   toggleSidebarItem: (view: AppView) => void;
   setSidebarPlaylistsVisible: (visible: boolean) => void;
-  toggleRightPanel: (panel: 'lyrics' | 'queue') => void;
   toggleVisualizer: () => void;
   setVisualizerStyle: (style: VisualizerStyle) => void;
   setUiScale: (scale: number) => void;
@@ -474,8 +452,6 @@ interface AppActions {
   setPlaylistGridSize: (size: AlbumGridSize) => void;
   setAlbumSortMode: (mode: AlbumSortMode) => void;
   setAlbumSortOrder: (order: AlbumSortOrder) => void;
-  selectAlbum: (name: string | null) => void;
-  setAlbumGridScrollTop: (scrollTop: number) => void;
   setLyricsPlainOpacity: (value: number) => void;
   setLyricsPlainFontSize: (size: LyricsFontSize) => void;
   resetLyricsPlainAppearance: () => void;
@@ -497,9 +473,6 @@ interface AppActions {
 export const useAppStore = create<AppState & AppActions>()(
   persist(
     (set, get) => ({
-      activeView: 'library',
-      rightPanel: null,
-      selectedPlaylistId: null,
       sidebarCollapsed: false,
       sidebarHiddenItems: [],
       sidebarPlaylistsVisible: true,
@@ -513,8 +486,6 @@ export const useAppStore = create<AppState & AppActions>()(
       playlistGridSize: 'medium',
       albumSortMode: 'name',
       albumSortOrder: 'asc',
-      selectedAlbumName: null,
-      albumGridScrollTop: 0,
       nowPlayingViewEnabled: false,
       nowPlayingLyricsVisible: true,
       libraryHeroCardEnabled: true,
@@ -533,26 +504,12 @@ export const useAppStore = create<AppState & AppActions>()(
       compactShowVolume: true,
       compactShowFavorite: false,
       compactDefaultAlwaysOnTop: false,
-      previousView: 'library',
 
-      navigateTo: (view, playlistId) =>
-        set({
-          activeView: view,
-          selectedPlaylistId: view === 'playlists' ? (playlistId ?? null) : null,
-        }),
-      enterNowPlaying: () => {
-        const current = get().activeView;
-        if (current === 'now-playing') return;
-        set({ previousView: current, activeView: 'now-playing' });
-      },
-      exitNowPlaying: () => {
-        const prev = get().previousView;
-        set({ activeView: prev });
-      },
       setNowPlayingViewEnabled: enabled => {
         set({ nowPlayingViewEnabled: enabled });
-        if (!enabled && get().activeView === 'now-playing') {
-          get().exitNowPlaying();
+        const view = useViewStore.getState();
+        if (!enabled && view.activeView === 'now-playing') {
+          view.exitNowPlaying();
         }
       },
       toggleNowPlayingLyrics: () => {
@@ -568,8 +525,6 @@ export const useAppStore = create<AppState & AppActions>()(
       setNoiseOverlayEnabled: enabled => {
         set({ noiseOverlayEnabled: enabled });
       },
-      selectPlaylist: id => set({ selectedPlaylistId: id }),
-      setRightPanel: panel => set({ rightPanel: panel }),
       setSidebarCollapsed: sidebarCollapsed => {
         set({ sidebarCollapsed });
       },
@@ -642,10 +597,6 @@ export const useAppStore = create<AppState & AppActions>()(
       setSidebarPlaylistsVisible: visible => {
         set({ sidebarPlaylistsVisible: visible });
       },
-      toggleRightPanel: panel => {
-        const current = get().rightPanel;
-        set({ rightPanel: current === panel ? null : panel });
-      },
       toggleVisualizer: () => {
         set({ showVisualizer: !get().showVisualizer });
       },
@@ -662,7 +613,8 @@ export const useAppStore = create<AppState & AppActions>()(
         set({ uiScale: UI_SCALE_DEFAULT });
       },
       setLibraryViewMode: mode => {
-        set({ libraryViewMode: mode, selectedAlbumName: null, albumGridScrollTop: 0 });
+        set({ libraryViewMode: mode });
+        useViewStore.setState({ selectedAlbumName: null, albumGridScrollTop: 0 });
       },
       setAlbumGridSize: size => {
         set({ albumGridSize: size });
@@ -671,15 +623,15 @@ export const useAppStore = create<AppState & AppActions>()(
         set({ playlistGridSize: size });
       },
       setAlbumSortMode: mode => {
+        set({ albumSortMode: mode });
         // Scroll position is meaningless once album order changes.
-        set({ albumSortMode: mode, albumGridScrollTop: 0 });
+        useViewStore.setState({ albumGridScrollTop: 0 });
       },
       setAlbumSortOrder: order => {
+        set({ albumSortOrder: order });
         // Scroll position is meaningless once album order changes.
-        set({ albumSortOrder: order, albumGridScrollTop: 0 });
+        useViewStore.setState({ albumGridScrollTop: 0 });
       },
-      selectAlbum: name => set({ selectedAlbumName: name }),
-      setAlbumGridScrollTop: scrollTop => set({ albumGridScrollTop: scrollTop }),
       setLyricsPlainOpacity: value => {
         set({ lyricsPlainOpacity: coerceLyricsPlainOpacity(value) });
       },

--- a/apps/web/src/stores/useAppStore.ts
+++ b/apps/web/src/stores/useAppStore.ts
@@ -1,10 +1,10 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
-import { IS_ELECTRON } from '@/lib/platform';
 import { useViewStore, type AppView, type RightPanel } from '@/stores/useViewStore';
 import type { LyricsFontSize } from '@/stores/useLyricsAppearanceStore';
+import type { CompactSize, CompactFontSize } from '@/stores/useCompactStore';
 
-export type { AppView, RightPanel, LyricsFontSize };
+export type { AppView, RightPanel, LyricsFontSize, CompactSize, CompactFontSize };
 /** @deprecated Use LyricsFontSize. Alias kept for back-compat with existing imports. */
 export type LyricsPlainFontSize = LyricsFontSize;
 export type VisualizerStyle = 'bars' | 'waveform' | 'circle' | 'particles';
@@ -12,9 +12,6 @@ export type LibraryViewMode = 'tracks' | 'albums';
 export type AlbumGridSize = 'small' | 'medium' | 'large';
 export type AlbumSortMode = 'name' | 'artist' | 'year' | 'recentlyAdded';
 export type AlbumSortOrder = 'asc' | 'desc';
-
-export type CompactSize = 'sm' | 'md' | 'lg';
-export type CompactFontSize = 'sm' | 'md' | 'lg';
 
 export const UI_SCALE_MIN = 80;
 export const UI_SCALE_MAX = 120;
@@ -38,42 +35,18 @@ export {
   nextLyricsFontSize,
 } from '@/stores/useLyricsAppearanceStore';
 
-// --- Compact mode dimension presets ---
-//
-// Width/height values are forwarded over IPC to the Electron main process
-// which applies them via setMinimumSize/setMaximumSize/setSize. Keep these
-// matched with `apps/desktop/src/main/ipc/window.ts` if either side moves.
-export const COMPACT_SIZE_DEFAULT: CompactSize = 'md';
-export const COMPACT_DIMENSIONS: Record<CompactSize, { width: number; height: number }> = {
-  sm: { width: 420, height: 200 },
-  md: { width: 500, height: 214 },
-  lg: { width: 600, height: 260 },
-};
-
-// --- Compact mode appearance prefs ---
-export const COMPACT_AMBIENT_INTENSITY_MIN = 0;
-export const COMPACT_AMBIENT_INTENSITY_MAX = 0.2;
-export const COMPACT_AMBIENT_INTENSITY_STEP = 0.01;
-export const COMPACT_AMBIENT_INTENSITY_DEFAULT = 0.08;
-
-export const COMPACT_FONT_SIZE_DEFAULT: CompactFontSize = 'md';
-
-/** Tailwind class lookups for the title / artist / album text in compact view. */
-export const CMP_TITLE_CLASS: Record<CompactFontSize, string> = {
-  sm: 'text-xs font-semibold',
-  md: 'text-sm font-semibold',
-  lg: 'text-base font-semibold',
-};
-export const CMP_ARTIST_CLASS: Record<CompactFontSize, string> = {
-  sm: 'text-[10px]',
-  md: 'text-xs',
-  lg: 'text-sm',
-};
-export const CMP_ALBUM_CLASS: Record<CompactFontSize, string> = {
-  sm: 'text-[10px]',
-  md: 'text-[11px]',
-  lg: 'text-xs',
-};
+export {
+  COMPACT_SIZE_DEFAULT,
+  COMPACT_DIMENSIONS,
+  COMPACT_AMBIENT_INTENSITY_MIN,
+  COMPACT_AMBIENT_INTENSITY_MAX,
+  COMPACT_AMBIENT_INTENSITY_STEP,
+  COMPACT_AMBIENT_INTENSITY_DEFAULT,
+  COMPACT_FONT_SIZE_DEFAULT,
+  CMP_TITLE_CLASS,
+  CMP_ARTIST_CLASS,
+  CMP_ALBUM_CLASS,
+} from '@/stores/useCompactStore';
 
 const NEW_KEY = 'shiranami.app-store';
 
@@ -135,33 +108,12 @@ function coerceUiScale(v: unknown): number {
   if (Number.isNaN(parsed)) return UI_SCALE_DEFAULT;
   return Math.round(Math.min(UI_SCALE_MAX, Math.max(UI_SCALE_MIN, parsed)));
 }
-function coerceCompactSize(v: unknown): CompactSize {
-  return v === 'sm' || v === 'md' || v === 'lg' ? v : COMPACT_SIZE_DEFAULT;
-}
-function coerceCompactFontSize(v: unknown): CompactFontSize {
-  return v === 'sm' || v === 'md' || v === 'lg' ? v : COMPACT_FONT_SIZE_DEFAULT;
-}
-function clampCompactAmbientIntensity(v: number): number {
-  const clamped = Math.min(
-    COMPACT_AMBIENT_INTENSITY_MAX,
-    Math.max(COMPACT_AMBIENT_INTENSITY_MIN, v)
-  );
-  const steps = Math.round(clamped / COMPACT_AMBIENT_INTENSITY_STEP);
-  return Math.round(steps * COMPACT_AMBIENT_INTENSITY_STEP * 1000) / 1000;
-}
-function coerceCompactAmbientIntensity(v: unknown): number {
-  const parsed = typeof v === 'number' ? v : Number(v);
-  if (!Number.isFinite(parsed)) return COMPACT_AMBIENT_INTENSITY_DEFAULT;
-  return clampCompactAmbientIntensity(parsed);
-}
 // --- Sanitizer: defensively re-apply enum whitelists and numeric clamps ---
 
 interface PersistedAppState {
   sidebarCollapsed: boolean;
   sidebarHiddenItems: AppView[];
   sidebarPlaylistsVisible: boolean;
-  compactMode: boolean;
-  compactAlwaysOnTop: boolean;
   showVisualizer: boolean;
   visualizerStyle: VisualizerStyle;
   uiScale: number;
@@ -175,15 +127,6 @@ interface PersistedAppState {
   libraryHeroCardEnabled: boolean;
   lowPerformanceMode: boolean;
   noiseOverlayEnabled: boolean;
-  compactSize: CompactSize;
-  compactFontSize: CompactFontSize;
-  compactAmbientIntensity: number;
-  compactShowAlbumArt: boolean;
-  compactShowAlbum: boolean;
-  compactShowSeek: boolean;
-  compactShowVolume: boolean;
-  compactShowFavorite: boolean;
-  compactDefaultAlwaysOnTop: boolean;
 }
 
 function sanitize(persisted: Partial<PersistedAppState> | undefined): Partial<PersistedAppState> {
@@ -195,9 +138,6 @@ function sanitize(persisted: Partial<PersistedAppState> | undefined): Partial<Pe
     out.sidebarHiddenItems = persisted.sidebarHiddenItems as AppView[];
   if (typeof persisted.sidebarPlaylistsVisible === 'boolean')
     out.sidebarPlaylistsVisible = persisted.sidebarPlaylistsVisible;
-  if (typeof persisted.compactMode === 'boolean') out.compactMode = persisted.compactMode;
-  if (typeof persisted.compactAlwaysOnTop === 'boolean')
-    out.compactAlwaysOnTop = persisted.compactAlwaysOnTop;
   if (typeof persisted.showVisualizer === 'boolean') out.showVisualizer = persisted.showVisualizer;
   if (persisted.visualizerStyle !== undefined)
     out.visualizerStyle = coerceVisualizerStyle(persisted.visualizerStyle);
@@ -222,24 +162,6 @@ function sanitize(persisted: Partial<PersistedAppState> | undefined): Partial<Pe
     out.lowPerformanceMode = persisted.lowPerformanceMode;
   if (typeof persisted.noiseOverlayEnabled === 'boolean')
     out.noiseOverlayEnabled = persisted.noiseOverlayEnabled;
-  if (persisted.compactSize !== undefined)
-    out.compactSize = coerceCompactSize(persisted.compactSize);
-  if (persisted.compactFontSize !== undefined)
-    out.compactFontSize = coerceCompactFontSize(persisted.compactFontSize);
-  if (persisted.compactAmbientIntensity !== undefined)
-    out.compactAmbientIntensity = coerceCompactAmbientIntensity(persisted.compactAmbientIntensity);
-  if (typeof persisted.compactShowAlbumArt === 'boolean')
-    out.compactShowAlbumArt = persisted.compactShowAlbumArt;
-  if (typeof persisted.compactShowAlbum === 'boolean')
-    out.compactShowAlbum = persisted.compactShowAlbum;
-  if (typeof persisted.compactShowSeek === 'boolean')
-    out.compactShowSeek = persisted.compactShowSeek;
-  if (typeof persisted.compactShowVolume === 'boolean')
-    out.compactShowVolume = persisted.compactShowVolume;
-  if (typeof persisted.compactShowFavorite === 'boolean')
-    out.compactShowFavorite = persisted.compactShowFavorite;
-  if (typeof persisted.compactDefaultAlwaysOnTop === 'boolean')
-    out.compactDefaultAlwaysOnTop = persisted.compactDefaultAlwaysOnTop;
   return out;
 }
 
@@ -252,7 +174,11 @@ function importLegacyAppStore() {
   const hasAny = Object.values(LEGACY_KEYS).some(k => ls.getItem(k) !== null);
   if (!hasAny) return;
 
-  const state: Partial<PersistedAppState> = {};
+  // Relaxed shape — we also copy `compactAlwaysOnTop` through so the
+  // useCompactStore one-shot importer (which reads this same combined
+  // bucket) can pick it up on next load. The field is no longer on
+  // PersistedAppState since compact moved to its own store.
+  const state: Partial<PersistedAppState> & { compactAlwaysOnTop?: boolean } = {};
 
   const sidebarCollapsed = ls.getItem(LEGACY_KEYS.sidebarCollapsed);
   if (sidebarCollapsed !== null) state.sidebarCollapsed = sidebarCollapsed === 'true';
@@ -329,8 +255,6 @@ importLegacyAppStore();
 
 interface AppState {
   sidebarCollapsed: boolean;
-  compactMode: boolean;
-  compactAlwaysOnTop: boolean;
   sidebarHiddenItems: AppView[];
   sidebarPlaylistsVisible: boolean;
   showVisualizer: boolean;
@@ -346,15 +270,6 @@ interface AppState {
   libraryHeroCardEnabled: boolean;
   lowPerformanceMode: boolean;
   noiseOverlayEnabled: boolean;
-  compactSize: CompactSize;
-  compactFontSize: CompactFontSize;
-  compactAmbientIntensity: number;
-  compactShowAlbumArt: boolean;
-  compactShowAlbum: boolean;
-  compactShowSeek: boolean;
-  compactShowVolume: boolean;
-  compactShowFavorite: boolean;
-  compactDefaultAlwaysOnTop: boolean;
 }
 
 interface AppActions {
@@ -364,10 +279,6 @@ interface AppActions {
   setLowPerformanceMode: (enabled: boolean) => void;
   setNoiseOverlayEnabled: (enabled: boolean) => void;
   setSidebarCollapsed: (sidebarCollapsed: boolean) => void;
-  setCompactMode: (compactMode: boolean) => Promise<void>;
-  setCompactAlwaysOnTop: (compactAlwaysOnTop: boolean) => Promise<void>;
-  toggleCompactMode: () => Promise<void>;
-  toggleCompactAlwaysOnTop: () => Promise<void>;
   toggleSidebarCollapsed: () => void;
   toggleSidebarItem: (view: AppView) => void;
   setSidebarPlaylistsVisible: (visible: boolean) => void;
@@ -380,16 +291,6 @@ interface AppActions {
   setPlaylistGridSize: (size: AlbumGridSize) => void;
   setAlbumSortMode: (mode: AlbumSortMode) => void;
   setAlbumSortOrder: (order: AlbumSortOrder) => void;
-  setCompactSize: (size: CompactSize) => void;
-  setCompactFontSize: (size: CompactFontSize) => void;
-  setCompactAmbientIntensity: (value: number) => void;
-  setCompactShowAlbumArt: (visible: boolean) => void;
-  setCompactShowAlbum: (visible: boolean) => void;
-  setCompactShowSeek: (visible: boolean) => void;
-  setCompactShowVolume: (visible: boolean) => void;
-  setCompactShowFavorite: (visible: boolean) => void;
-  setCompactDefaultAlwaysOnTop: (enabled: boolean) => void;
-  resetCompactAppearance: () => void;
 }
 
 export const useAppStore = create<AppState & AppActions>()(
@@ -398,8 +299,6 @@ export const useAppStore = create<AppState & AppActions>()(
       sidebarCollapsed: false,
       sidebarHiddenItems: [],
       sidebarPlaylistsVisible: true,
-      compactMode: false,
-      compactAlwaysOnTop: false,
       showVisualizer: true,
       visualizerStyle: 'bars',
       uiScale: UI_SCALE_DEFAULT,
@@ -413,15 +312,6 @@ export const useAppStore = create<AppState & AppActions>()(
       libraryHeroCardEnabled: true,
       lowPerformanceMode: false,
       noiseOverlayEnabled: false,
-      compactSize: COMPACT_SIZE_DEFAULT,
-      compactFontSize: COMPACT_FONT_SIZE_DEFAULT,
-      compactAmbientIntensity: COMPACT_AMBIENT_INTENSITY_DEFAULT,
-      compactShowAlbumArt: true,
-      compactShowAlbum: true,
-      compactShowSeek: true,
-      compactShowVolume: true,
-      compactShowFavorite: false,
-      compactDefaultAlwaysOnTop: false,
 
       setNowPlayingViewEnabled: enabled => {
         set({ nowPlayingViewEnabled: enabled });
@@ -445,64 +335,6 @@ export const useAppStore = create<AppState & AppActions>()(
       },
       setSidebarCollapsed: sidebarCollapsed => {
         set({ sidebarCollapsed });
-      },
-      setCompactMode: async compactMode => {
-        const previous = get().compactMode;
-        if (previous === compactMode) return;
-
-        // When the user has opted into "default to always-on-top in compact",
-        // seed the runtime flag on entry. We seed before persisting because
-        // setCompactAlwaysOnTop short-circuits when not yet in compact mode,
-        // so we just write the value directly here.
-        const previousAlwaysOnTop = get().compactAlwaysOnTop;
-        if (compactMode && get().compactDefaultAlwaysOnTop && !previousAlwaysOnTop) {
-          set({ compactAlwaysOnTop: true });
-        }
-
-        set({ compactMode });
-
-        if (!IS_ELECTRON) return;
-
-        try {
-          const dims = COMPACT_DIMENSIONS[get().compactSize];
-          await window.electronAPI.window.setCompactMode(compactMode, dims);
-        } catch {
-          // Compact-mode IPC failed: undo the store flips and bail before
-          // touching always-on-top so we don't pin a window the user thinks
-          // is still in normal mode.
-          set({ compactMode: previous, compactAlwaysOnTop: previousAlwaysOnTop });
-          return;
-        }
-
-        if (get().compactAlwaysOnTop) {
-          try {
-            await window.electronAPI.window.setAlwaysOnTop(compactMode);
-          } catch {
-            // Compact succeeded but pin failed: only roll back the pin —
-            // the OS window is correctly in/out of compact mode now.
-            set({ compactAlwaysOnTop: previousAlwaysOnTop });
-          }
-        }
-      },
-      setCompactAlwaysOnTop: async compactAlwaysOnTop => {
-        const previous = get().compactAlwaysOnTop;
-        if (previous === compactAlwaysOnTop) return;
-
-        set({ compactAlwaysOnTop });
-
-        if (!IS_ELECTRON || !get().compactMode) return;
-
-        try {
-          await window.electronAPI.window.setAlwaysOnTop(compactAlwaysOnTop);
-        } catch {
-          set({ compactAlwaysOnTop: previous });
-        }
-      },
-      toggleCompactMode: async () => {
-        await get().setCompactMode(!get().compactMode);
-      },
-      toggleCompactAlwaysOnTop: async () => {
-        await get().setCompactAlwaysOnTop(!get().compactAlwaysOnTop);
       },
       toggleSidebarCollapsed: () => {
         set({ sidebarCollapsed: !get().sidebarCollapsed });
@@ -550,43 +382,6 @@ export const useAppStore = create<AppState & AppActions>()(
         // Scroll position is meaningless once album order changes.
         useViewStore.setState({ albumGridScrollTop: 0 });
       },
-      setCompactSize: size => {
-        const next = coerceCompactSize(size);
-        set({ compactSize: next });
-        // If the window is currently in compact mode, push the new dimensions
-        // immediately so the preset switch is reflected without a re-toggle.
-        if (IS_ELECTRON && get().compactMode) {
-          const dims = COMPACT_DIMENSIONS[next];
-          window.electronAPI.window.setCompactMode(true, dims).catch(() => {
-            // Failure to resize is non-fatal; the next enter-compact will retry.
-          });
-        }
-      },
-      setCompactFontSize: size => {
-        set({ compactFontSize: coerceCompactFontSize(size) });
-      },
-      setCompactAmbientIntensity: value => {
-        set({ compactAmbientIntensity: coerceCompactAmbientIntensity(value) });
-      },
-      setCompactShowAlbumArt: visible => set({ compactShowAlbumArt: visible }),
-      setCompactShowAlbum: visible => set({ compactShowAlbum: visible }),
-      setCompactShowSeek: visible => set({ compactShowSeek: visible }),
-      setCompactShowVolume: visible => set({ compactShowVolume: visible }),
-      setCompactShowFavorite: visible => set({ compactShowFavorite: visible }),
-      setCompactDefaultAlwaysOnTop: enabled => set({ compactDefaultAlwaysOnTop: enabled }),
-      resetCompactAppearance: () => {
-        set({
-          compactSize: COMPACT_SIZE_DEFAULT,
-          compactFontSize: COMPACT_FONT_SIZE_DEFAULT,
-          compactAmbientIntensity: COMPACT_AMBIENT_INTENSITY_DEFAULT,
-          compactShowAlbumArt: true,
-          compactShowAlbum: true,
-          compactShowSeek: true,
-          compactShowVolume: true,
-          compactShowFavorite: false,
-          compactDefaultAlwaysOnTop: false,
-        });
-      },
     }),
     {
       name: NEW_KEY,
@@ -596,8 +391,6 @@ export const useAppStore = create<AppState & AppActions>()(
         sidebarCollapsed: s.sidebarCollapsed,
         sidebarHiddenItems: s.sidebarHiddenItems,
         sidebarPlaylistsVisible: s.sidebarPlaylistsVisible,
-        compactMode: s.compactMode,
-        compactAlwaysOnTop: s.compactAlwaysOnTop,
         showVisualizer: s.showVisualizer,
         visualizerStyle: s.visualizerStyle,
         uiScale: s.uiScale,
@@ -611,15 +404,6 @@ export const useAppStore = create<AppState & AppActions>()(
         libraryHeroCardEnabled: s.libraryHeroCardEnabled,
         lowPerformanceMode: s.lowPerformanceMode,
         noiseOverlayEnabled: s.noiseOverlayEnabled,
-        compactSize: s.compactSize,
-        compactFontSize: s.compactFontSize,
-        compactAmbientIntensity: s.compactAmbientIntensity,
-        compactShowAlbumArt: s.compactShowAlbumArt,
-        compactShowAlbum: s.compactShowAlbum,
-        compactShowSeek: s.compactShowSeek,
-        compactShowVolume: s.compactShowVolume,
-        compactShowFavorite: s.compactShowFavorite,
-        compactDefaultAlwaysOnTop: s.compactDefaultAlwaysOnTop,
       }),
       merge: (persisted, current) => ({
         ...current,
@@ -629,32 +413,6 @@ export const useAppStore = create<AppState & AppActions>()(
         if (!state) return;
         applyUiScale(state.uiScale);
         applyLowPerformanceMode(state.lowPerformanceMode);
-        // Re-apply compact mode at the OS-window level after rehydrate so
-        // users who quit while in compact mode come back into compact mode.
-        // The renderer flag is restored by zustand-persist; here we just
-        // forward to Electron so the window itself resizes/locks again.
-        if (IS_ELECTRON && state.compactMode) {
-          // Sequence the IPCs: pin only after compact takes hold, otherwise
-          // we could end up pinning a window that didn't make it into
-          // compact mode. Mutating `state` here is ineffective (rehydration
-          // has already merged), so any rollback has to go through setState.
-          void (async () => {
-            const dims = COMPACT_DIMENSIONS[state.compactSize];
-            try {
-              await window.electronAPI.window.setCompactMode(true, dims);
-            } catch {
-              useAppStore.setState({ compactMode: false, compactAlwaysOnTop: false });
-              return;
-            }
-            if (state.compactAlwaysOnTop) {
-              try {
-                await window.electronAPI.window.setAlwaysOnTop(true);
-              } catch {
-                useAppStore.setState({ compactAlwaysOnTop: false });
-              }
-            }
-          })();
-        }
       },
     }
   )

--- a/apps/web/src/stores/useAppStore.ts
+++ b/apps/web/src/stores/useAppStore.ts
@@ -2,16 +2,16 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { IS_ELECTRON } from '@/lib/platform';
 import { useViewStore, type AppView, type RightPanel } from '@/stores/useViewStore';
+import type { LyricsFontSize } from '@/stores/useLyricsAppearanceStore';
 
-export type { AppView, RightPanel };
+export type { AppView, RightPanel, LyricsFontSize };
+/** @deprecated Use LyricsFontSize. Alias kept for back-compat with existing imports. */
+export type LyricsPlainFontSize = LyricsFontSize;
 export type VisualizerStyle = 'bars' | 'waveform' | 'circle' | 'particles';
 export type LibraryViewMode = 'tracks' | 'albums';
 export type AlbumGridSize = 'small' | 'medium' | 'large';
 export type AlbumSortMode = 'name' | 'artist' | 'year' | 'recentlyAdded';
 export type AlbumSortOrder = 'asc' | 'desc';
-export type LyricsFontSize = 'sm' | 'base' | 'lg' | 'xl';
-/** @deprecated Use LyricsFontSize. Alias kept for back-compat with existing imports. */
-export type LyricsPlainFontSize = LyricsFontSize;
 
 export type CompactSize = 'sm' | 'md' | 'lg';
 export type CompactFontSize = 'sm' | 'md' | 'lg';
@@ -22,31 +22,21 @@ export const UI_SCALE_DEFAULT = 100;
 export const UI_SCALE_STEP = 5;
 export const UI_SCALE_PRESETS = [80, 90, 100, 110, 120] as const;
 
-export const LYRICS_PLAIN_OPACITY_MIN = 0.5;
-export const LYRICS_PLAIN_OPACITY_MAX = 1.0;
-export const LYRICS_PLAIN_OPACITY_STEP = 0.05;
-export const LYRICS_PLAIN_OPACITY_DEFAULT = 0.9;
-export const LYRICS_PLAIN_FONT_SIZE_DEFAULT: LyricsFontSize = 'base';
-
-export const LYRICS_SYNCED_DIM_OPACITY_MIN = 0.2;
-export const LYRICS_SYNCED_DIM_OPACITY_MAX = 1.0;
-export const LYRICS_SYNCED_DIM_OPACITY_STEP = 0.05;
-export const LYRICS_SYNCED_DIM_OPACITY_DEFAULT = 0.45;
-export const LYRICS_SYNCED_FONT_SIZE_DEFAULT: LyricsFontSize = 'base';
-
-/**
- * Original synced view used past=0.25 / idle=0.45. We preserve that ratio
- * (≈ 0.5556) so when the user dims idle, past dims proportionally and stays
- * visibly fainter than idle.
- */
-export const LYRICS_SYNCED_PAST_RATIO = 0.25 / 0.45;
-
-export const LYR_SIZE_CLASS: Record<LyricsFontSize, string> = {
-  sm: 'text-sm leading-6',
-  base: 'text-base leading-7',
-  lg: 'text-lg leading-8',
-  xl: 'text-xl leading-9',
-};
+export {
+  LYRICS_PLAIN_OPACITY_MIN,
+  LYRICS_PLAIN_OPACITY_MAX,
+  LYRICS_PLAIN_OPACITY_STEP,
+  LYRICS_PLAIN_OPACITY_DEFAULT,
+  LYRICS_PLAIN_FONT_SIZE_DEFAULT,
+  LYRICS_SYNCED_DIM_OPACITY_MIN,
+  LYRICS_SYNCED_DIM_OPACITY_MAX,
+  LYRICS_SYNCED_DIM_OPACITY_STEP,
+  LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
+  LYRICS_SYNCED_FONT_SIZE_DEFAULT,
+  LYRICS_SYNCED_PAST_RATIO,
+  LYR_SIZE_CLASS,
+  nextLyricsFontSize,
+} from '@/stores/useLyricsAppearanceStore';
 
 // --- Compact mode dimension presets ---
 //
@@ -84,18 +74,6 @@ export const CMP_ALBUM_CLASS: Record<CompactFontSize, string> = {
   md: 'text-[11px]',
   lg: 'text-xs',
 };
-
-const FONT_SIZE_ORDER: LyricsFontSize[] = ['sm', 'base', 'lg', 'xl'];
-
-/**
- * Active synced line uses one step larger than the user-selected base, capped
- * at xl. Mirrors the original hardcoded "base→lg active" behavior.
- */
-export function nextLyricsFontSize(size: LyricsFontSize): LyricsFontSize {
-  const idx = FONT_SIZE_ORDER.indexOf(size);
-  if (idx < 0) return 'lg';
-  return FONT_SIZE_ORDER[Math.min(idx + 1, FONT_SIZE_ORDER.length - 1)];
-}
 
 const NEW_KEY = 'shiranami.app-store';
 
@@ -157,40 +135,6 @@ function coerceUiScale(v: unknown): number {
   if (Number.isNaN(parsed)) return UI_SCALE_DEFAULT;
   return Math.round(Math.min(UI_SCALE_MAX, Math.max(UI_SCALE_MIN, parsed)));
 }
-function clampLyricsPlainOpacity(v: number): number {
-  const clamped = Math.min(LYRICS_PLAIN_OPACITY_MAX, Math.max(LYRICS_PLAIN_OPACITY_MIN, v));
-  // Round to nearest step to keep persisted values clean.
-  const steps = Math.round(clamped / LYRICS_PLAIN_OPACITY_STEP);
-  return Math.round(steps * LYRICS_PLAIN_OPACITY_STEP * 1000) / 1000;
-}
-function coerceLyricsPlainOpacity(v: unknown): number {
-  const parsed = typeof v === 'number' ? v : Number(v);
-  if (!Number.isFinite(parsed)) return LYRICS_PLAIN_OPACITY_DEFAULT;
-  return clampLyricsPlainOpacity(parsed);
-}
-function coerceLyricsPlainFontSize(v: unknown): LyricsFontSize {
-  return v === 'sm' || v === 'base' || v === 'lg' || v === 'xl'
-    ? v
-    : LYRICS_PLAIN_FONT_SIZE_DEFAULT;
-}
-function clampLyricsSyncedDimOpacity(v: number): number {
-  const clamped = Math.min(
-    LYRICS_SYNCED_DIM_OPACITY_MAX,
-    Math.max(LYRICS_SYNCED_DIM_OPACITY_MIN, v)
-  );
-  const steps = Math.round(clamped / LYRICS_SYNCED_DIM_OPACITY_STEP);
-  return Math.round(steps * LYRICS_SYNCED_DIM_OPACITY_STEP * 1000) / 1000;
-}
-function coerceLyricsSyncedDimOpacity(v: unknown): number {
-  const parsed = typeof v === 'number' ? v : Number(v);
-  if (!Number.isFinite(parsed)) return LYRICS_SYNCED_DIM_OPACITY_DEFAULT;
-  return clampLyricsSyncedDimOpacity(parsed);
-}
-function coerceLyricsSyncedFontSize(v: unknown): LyricsFontSize {
-  return v === 'sm' || v === 'base' || v === 'lg' || v === 'xl'
-    ? v
-    : LYRICS_SYNCED_FONT_SIZE_DEFAULT;
-}
 function coerceCompactSize(v: unknown): CompactSize {
   return v === 'sm' || v === 'md' || v === 'lg' ? v : COMPACT_SIZE_DEFAULT;
 }
@@ -231,10 +175,6 @@ interface PersistedAppState {
   libraryHeroCardEnabled: boolean;
   lowPerformanceMode: boolean;
   noiseOverlayEnabled: boolean;
-  lyricsPlainOpacity: number;
-  lyricsPlainFontSize: LyricsFontSize;
-  lyricsSyncedDimOpacity: number;
-  lyricsSyncedFontSize: LyricsFontSize;
   compactSize: CompactSize;
   compactFontSize: CompactFontSize;
   compactAmbientIntensity: number;
@@ -282,14 +222,6 @@ function sanitize(persisted: Partial<PersistedAppState> | undefined): Partial<Pe
     out.lowPerformanceMode = persisted.lowPerformanceMode;
   if (typeof persisted.noiseOverlayEnabled === 'boolean')
     out.noiseOverlayEnabled = persisted.noiseOverlayEnabled;
-  if (persisted.lyricsPlainOpacity !== undefined)
-    out.lyricsPlainOpacity = coerceLyricsPlainOpacity(persisted.lyricsPlainOpacity);
-  if (persisted.lyricsPlainFontSize !== undefined)
-    out.lyricsPlainFontSize = coerceLyricsPlainFontSize(persisted.lyricsPlainFontSize);
-  if (persisted.lyricsSyncedDimOpacity !== undefined)
-    out.lyricsSyncedDimOpacity = coerceLyricsSyncedDimOpacity(persisted.lyricsSyncedDimOpacity);
-  if (persisted.lyricsSyncedFontSize !== undefined)
-    out.lyricsSyncedFontSize = coerceLyricsSyncedFontSize(persisted.lyricsSyncedFontSize);
   if (persisted.compactSize !== undefined)
     out.compactSize = coerceCompactSize(persisted.compactSize);
   if (persisted.compactFontSize !== undefined)
@@ -414,10 +346,6 @@ interface AppState {
   libraryHeroCardEnabled: boolean;
   lowPerformanceMode: boolean;
   noiseOverlayEnabled: boolean;
-  lyricsPlainOpacity: number;
-  lyricsPlainFontSize: LyricsFontSize;
-  lyricsSyncedDimOpacity: number;
-  lyricsSyncedFontSize: LyricsFontSize;
   compactSize: CompactSize;
   compactFontSize: CompactFontSize;
   compactAmbientIntensity: number;
@@ -452,12 +380,6 @@ interface AppActions {
   setPlaylistGridSize: (size: AlbumGridSize) => void;
   setAlbumSortMode: (mode: AlbumSortMode) => void;
   setAlbumSortOrder: (order: AlbumSortOrder) => void;
-  setLyricsPlainOpacity: (value: number) => void;
-  setLyricsPlainFontSize: (size: LyricsFontSize) => void;
-  resetLyricsPlainAppearance: () => void;
-  setLyricsSyncedDimOpacity: (value: number) => void;
-  setLyricsSyncedFontSize: (size: LyricsFontSize) => void;
-  resetLyricsAppearance: () => void;
   setCompactSize: (size: CompactSize) => void;
   setCompactFontSize: (size: CompactFontSize) => void;
   setCompactAmbientIntensity: (value: number) => void;
@@ -491,10 +413,6 @@ export const useAppStore = create<AppState & AppActions>()(
       libraryHeroCardEnabled: true,
       lowPerformanceMode: false,
       noiseOverlayEnabled: false,
-      lyricsPlainOpacity: LYRICS_PLAIN_OPACITY_DEFAULT,
-      lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
-      lyricsSyncedDimOpacity: LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
-      lyricsSyncedFontSize: LYRICS_SYNCED_FONT_SIZE_DEFAULT,
       compactSize: COMPACT_SIZE_DEFAULT,
       compactFontSize: COMPACT_FONT_SIZE_DEFAULT,
       compactAmbientIntensity: COMPACT_AMBIENT_INTENSITY_DEFAULT,
@@ -632,32 +550,6 @@ export const useAppStore = create<AppState & AppActions>()(
         // Scroll position is meaningless once album order changes.
         useViewStore.setState({ albumGridScrollTop: 0 });
       },
-      setLyricsPlainOpacity: value => {
-        set({ lyricsPlainOpacity: coerceLyricsPlainOpacity(value) });
-      },
-      setLyricsPlainFontSize: size => {
-        set({ lyricsPlainFontSize: coerceLyricsPlainFontSize(size) });
-      },
-      resetLyricsPlainAppearance: () => {
-        set({
-          lyricsPlainOpacity: LYRICS_PLAIN_OPACITY_DEFAULT,
-          lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
-        });
-      },
-      setLyricsSyncedDimOpacity: value => {
-        set({ lyricsSyncedDimOpacity: coerceLyricsSyncedDimOpacity(value) });
-      },
-      setLyricsSyncedFontSize: size => {
-        set({ lyricsSyncedFontSize: coerceLyricsSyncedFontSize(size) });
-      },
-      resetLyricsAppearance: () => {
-        set({
-          lyricsPlainOpacity: LYRICS_PLAIN_OPACITY_DEFAULT,
-          lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
-          lyricsSyncedDimOpacity: LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
-          lyricsSyncedFontSize: LYRICS_SYNCED_FONT_SIZE_DEFAULT,
-        });
-      },
       setCompactSize: size => {
         const next = coerceCompactSize(size);
         set({ compactSize: next });
@@ -719,10 +611,6 @@ export const useAppStore = create<AppState & AppActions>()(
         libraryHeroCardEnabled: s.libraryHeroCardEnabled,
         lowPerformanceMode: s.lowPerformanceMode,
         noiseOverlayEnabled: s.noiseOverlayEnabled,
-        lyricsPlainOpacity: s.lyricsPlainOpacity,
-        lyricsPlainFontSize: s.lyricsPlainFontSize,
-        lyricsSyncedDimOpacity: s.lyricsSyncedDimOpacity,
-        lyricsSyncedFontSize: s.lyricsSyncedFontSize,
         compactSize: s.compactSize,
         compactFontSize: s.compactFontSize,
         compactAmbientIntensity: s.compactAmbientIntensity,

--- a/apps/web/src/stores/useCompactStore.test.ts
+++ b/apps/web/src/stores/useCompactStore.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCompactStore } from './useCompactStore';
+
+vi.mock('@/lib/platform', () => ({
+  IS_ELECTRON: true,
+  IS_WINDOWS: false,
+  IS_MAC: false,
+}));
+
+const STORE_KEY = 'shiranami.compact-store';
+
+function readPersisted(): Record<string, unknown> {
+  const raw = localStorage.getItem(STORE_KEY);
+  if (!raw) return {};
+  const parsed = JSON.parse(raw) as { state?: Record<string, unknown> };
+  return parsed.state ?? {};
+}
+
+describe('useCompactStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useCompactStore.setState({
+      compactMode: false,
+      compactAlwaysOnTop: false,
+      compactSize: 'md',
+      compactFontSize: 'md',
+      compactAmbientIntensity: 0.08,
+      compactShowAlbumArt: true,
+      compactShowAlbum: true,
+      compactShowSeek: true,
+      compactShowVolume: true,
+      compactShowFavorite: false,
+      compactDefaultAlwaysOnTop: false,
+    });
+    vi.mocked(window.electronAPI.window.setCompactMode).mockResolvedValue(undefined);
+    vi.mocked(window.electronAPI.window.setAlwaysOnTop).mockResolvedValue(undefined);
+  });
+
+  it('persists compact always-on-top to localStorage', async () => {
+    await useCompactStore.getState().setCompactAlwaysOnTop(true);
+    expect(useCompactStore.getState().compactAlwaysOnTop).toBe(true);
+    expect(readPersisted().compactAlwaysOnTop).toBe(true);
+  });
+
+  it('rolls back compact mode when Electron setCompactMode fails', async () => {
+    vi.mocked(window.electronAPI.window.setCompactMode).mockRejectedValueOnce(
+      new Error('ipc failed')
+    );
+
+    await useCompactStore.getState().setCompactMode(true);
+
+    expect(useCompactStore.getState().compactMode).toBe(false);
+  });
+
+  it('rolls back only the pin when setAlwaysOnTop fails after compact succeeds', async () => {
+    // Default-pin-on seeds compactAlwaysOnTop=true on entry; if the pin IPC
+    // then fails, we want compact to stay (window is in compact mode) but
+    // the pin to revert (so the store doesn't claim a pin that didn't take).
+    useCompactStore.setState({ compactDefaultAlwaysOnTop: true, compactAlwaysOnTop: false });
+    vi.mocked(window.electronAPI.window.setCompactMode).mockResolvedValueOnce(undefined);
+    vi.mocked(window.electronAPI.window.setAlwaysOnTop).mockRejectedValueOnce(
+      new Error('pin failed')
+    );
+
+    await useCompactStore.getState().setCompactMode(true);
+
+    expect(useCompactStore.getState().compactMode).toBe(true);
+    expect(useCompactStore.getState().compactAlwaysOnTop).toBe(false);
+  });
+
+  it('persists compact mode flag across reloads', async () => {
+    await useCompactStore.getState().setCompactMode(true);
+    expect(useCompactStore.getState().compactMode).toBe(true);
+    expect(readPersisted().compactMode).toBe(true);
+  });
+
+  it('forwards configured compact size dimensions over IPC', async () => {
+    useCompactStore.setState({ compactSize: 'lg' });
+    await useCompactStore.getState().setCompactMode(true);
+
+    expect(window.electronAPI.window.setCompactMode).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ width: 600, height: 260 })
+    );
+  });
+
+  it('seeds compact always-on-top from compactDefaultAlwaysOnTop on entry', async () => {
+    useCompactStore.setState({ compactDefaultAlwaysOnTop: true, compactAlwaysOnTop: false });
+
+    await useCompactStore.getState().setCompactMode(true);
+
+    expect(useCompactStore.getState().compactAlwaysOnTop).toBe(true);
+    expect(window.electronAPI.window.setAlwaysOnTop).toHaveBeenCalledWith(true);
+  });
+
+  it('persists compactShowFavorite toggle to localStorage', () => {
+    useCompactStore.getState().setCompactShowFavorite(true);
+    expect(useCompactStore.getState().compactShowFavorite).toBe(true);
+    expect(readPersisted().compactShowFavorite).toBe(true);
+  });
+
+  it('persists and clamps compactAmbientIntensity within the allowed range', () => {
+    useCompactStore.getState().setCompactAmbientIntensity(0.5);
+    // Clamped to max (0.2).
+    expect(useCompactStore.getState().compactAmbientIntensity).toBe(0.2);
+    expect(readPersisted().compactAmbientIntensity).toBe(0.2);
+  });
+
+  it('resetCompactAppearance restores all compact prefs to defaults', () => {
+    useCompactStore.setState({
+      compactSize: 'lg',
+      compactFontSize: 'sm',
+      compactAmbientIntensity: 0.15,
+      compactShowAlbumArt: false,
+      compactShowAlbum: false,
+      compactShowSeek: false,
+      compactShowVolume: false,
+      compactShowFavorite: true,
+      compactDefaultAlwaysOnTop: true,
+    });
+
+    useCompactStore.getState().resetCompactAppearance();
+
+    const s = useCompactStore.getState();
+    expect(s.compactSize).toBe('md');
+    expect(s.compactFontSize).toBe('md');
+    expect(s.compactAmbientIntensity).toBe(0.08);
+    expect(s.compactShowAlbumArt).toBe(true);
+    expect(s.compactShowAlbum).toBe(true);
+    expect(s.compactShowSeek).toBe(true);
+    expect(s.compactShowVolume).toBe(true);
+    expect(s.compactShowFavorite).toBe(false);
+    expect(s.compactDefaultAlwaysOnTop).toBe(false);
+  });
+
+  it('rolls back compact always-on-top and localStorage when setAlwaysOnTop fails in compact mode', async () => {
+    await useCompactStore.getState().setCompactMode(true);
+    vi.mocked(window.electronAPI.window.setAlwaysOnTop).mockRejectedValueOnce(
+      new Error('aot failed')
+    );
+
+    await useCompactStore.getState().setCompactAlwaysOnTop(true);
+
+    expect(useCompactStore.getState().compactAlwaysOnTop).toBe(false);
+    expect(readPersisted().compactAlwaysOnTop).toBe(false);
+  });
+});
+
+// The pre-split combined `shiranami.app-store` bucket used to hold compact
+// state alongside the rest of the app prefs. The new compact store imports
+// that data into its own bucket once on first load so existing users
+// don't lose their compact preferences.
+describe('useCompactStore one-shot import from legacy app-store', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it('lifts persisted compact fields out of the legacy combined bucket', async () => {
+    localStorage.setItem(
+      'shiranami.app-store',
+      JSON.stringify({
+        state: {
+          compactMode: true,
+          compactAlwaysOnTop: true,
+          compactSize: 'lg',
+          compactFontSize: 'sm',
+          compactAmbientIntensity: 0.12,
+          compactShowAlbumArt: false,
+          compactShowFavorite: true,
+        },
+        version: 1,
+      })
+    );
+
+    const mod = await import('./useCompactStore');
+    const state = mod.useCompactStore.getState();
+    expect(state.compactMode).toBe(true);
+    expect(state.compactAlwaysOnTop).toBe(true);
+    expect(state.compactSize).toBe('lg');
+    expect(state.compactFontSize).toBe('sm');
+    expect(state.compactAmbientIntensity).toBe(0.12);
+    expect(state.compactShowAlbumArt).toBe(false);
+    expect(state.compactShowFavorite).toBe(true);
+  });
+
+  it('coerces malformed compact values from the legacy bucket', async () => {
+    localStorage.setItem(
+      'shiranami.app-store',
+      JSON.stringify({
+        state: {
+          compactSize: 'jumbo',
+          compactFontSize: 'mini',
+          compactAmbientIntensity: 'broken',
+        },
+        version: 1,
+      })
+    );
+
+    const mod = await import('./useCompactStore');
+    const state = mod.useCompactStore.getState();
+    expect(state.compactSize).toBe('md');
+    expect(state.compactFontSize).toBe('md');
+    expect(state.compactAmbientIntensity).toBe(0.08);
+  });
+
+  it('does nothing when the compact bucket already exists', async () => {
+    localStorage.setItem(
+      'shiranami.compact-store',
+      JSON.stringify({ state: { compactSize: 'md' }, version: 1 })
+    );
+    localStorage.setItem(
+      'shiranami.app-store',
+      JSON.stringify({ state: { compactSize: 'lg' }, version: 1 })
+    );
+
+    const mod = await import('./useCompactStore');
+    const state = mod.useCompactStore.getState();
+    // Should rehydrate from the existing compact bucket, not the legacy one.
+    expect(state.compactSize).toBe('md');
+  });
+});

--- a/apps/web/src/stores/useCompactStore.ts
+++ b/apps/web/src/stores/useCompactStore.ts
@@ -1,0 +1,343 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { IS_ELECTRON } from '@/lib/platform';
+
+export type CompactSize = 'sm' | 'md' | 'lg';
+export type CompactFontSize = 'sm' | 'md' | 'lg';
+
+// --- Compact mode dimension presets ---
+//
+// Width/height values are forwarded over IPC to the Electron main process
+// which applies them via setMinimumSize/setMaximumSize/setSize. Keep these
+// matched with `apps/desktop/src/main/ipc/window.ts` if either side moves.
+export const COMPACT_SIZE_DEFAULT: CompactSize = 'md';
+export const COMPACT_DIMENSIONS: Record<CompactSize, { width: number; height: number }> = {
+  sm: { width: 420, height: 200 },
+  md: { width: 500, height: 214 },
+  lg: { width: 600, height: 260 },
+};
+
+// --- Compact mode appearance prefs ---
+export const COMPACT_AMBIENT_INTENSITY_MIN = 0;
+export const COMPACT_AMBIENT_INTENSITY_MAX = 0.2;
+export const COMPACT_AMBIENT_INTENSITY_STEP = 0.01;
+export const COMPACT_AMBIENT_INTENSITY_DEFAULT = 0.08;
+
+export const COMPACT_FONT_SIZE_DEFAULT: CompactFontSize = 'md';
+
+/** Tailwind class lookups for the title / artist / album text in compact view. */
+export const CMP_TITLE_CLASS: Record<CompactFontSize, string> = {
+  sm: 'text-xs font-semibold',
+  md: 'text-sm font-semibold',
+  lg: 'text-base font-semibold',
+};
+export const CMP_ARTIST_CLASS: Record<CompactFontSize, string> = {
+  sm: 'text-[10px]',
+  md: 'text-xs',
+  lg: 'text-sm',
+};
+export const CMP_ALBUM_CLASS: Record<CompactFontSize, string> = {
+  sm: 'text-[10px]',
+  md: 'text-[11px]',
+  lg: 'text-xs',
+};
+
+const STORE_KEY = 'shiranami.compact-store';
+const LEGACY_APP_STORE_KEY = 'shiranami.app-store';
+
+function coerceCompactSize(v: unknown): CompactSize {
+  return v === 'sm' || v === 'md' || v === 'lg' ? v : COMPACT_SIZE_DEFAULT;
+}
+function coerceCompactFontSize(v: unknown): CompactFontSize {
+  return v === 'sm' || v === 'md' || v === 'lg' ? v : COMPACT_FONT_SIZE_DEFAULT;
+}
+function clampCompactAmbientIntensity(v: number): number {
+  const clamped = Math.min(
+    COMPACT_AMBIENT_INTENSITY_MAX,
+    Math.max(COMPACT_AMBIENT_INTENSITY_MIN, v)
+  );
+  const steps = Math.round(clamped / COMPACT_AMBIENT_INTENSITY_STEP);
+  return Math.round(steps * COMPACT_AMBIENT_INTENSITY_STEP * 1000) / 1000;
+}
+function coerceCompactAmbientIntensity(v: unknown): number {
+  const parsed = typeof v === 'number' ? v : Number(v);
+  if (!Number.isFinite(parsed)) return COMPACT_AMBIENT_INTENSITY_DEFAULT;
+  return clampCompactAmbientIntensity(parsed);
+}
+
+interface PersistedCompactState {
+  compactMode: boolean;
+  compactAlwaysOnTop: boolean;
+  compactSize: CompactSize;
+  compactFontSize: CompactFontSize;
+  compactAmbientIntensity: number;
+  compactShowAlbumArt: boolean;
+  compactShowAlbum: boolean;
+  compactShowSeek: boolean;
+  compactShowVolume: boolean;
+  compactShowFavorite: boolean;
+  compactDefaultAlwaysOnTop: boolean;
+}
+
+function sanitize(
+  persisted: Partial<PersistedCompactState> | undefined
+): Partial<PersistedCompactState> {
+  if (!persisted || typeof persisted !== 'object') return {};
+  const out: Partial<PersistedCompactState> = {};
+  if (typeof persisted.compactMode === 'boolean') out.compactMode = persisted.compactMode;
+  if (typeof persisted.compactAlwaysOnTop === 'boolean')
+    out.compactAlwaysOnTop = persisted.compactAlwaysOnTop;
+  if (persisted.compactSize !== undefined)
+    out.compactSize = coerceCompactSize(persisted.compactSize);
+  if (persisted.compactFontSize !== undefined)
+    out.compactFontSize = coerceCompactFontSize(persisted.compactFontSize);
+  if (persisted.compactAmbientIntensity !== undefined)
+    out.compactAmbientIntensity = coerceCompactAmbientIntensity(persisted.compactAmbientIntensity);
+  if (typeof persisted.compactShowAlbumArt === 'boolean')
+    out.compactShowAlbumArt = persisted.compactShowAlbumArt;
+  if (typeof persisted.compactShowAlbum === 'boolean')
+    out.compactShowAlbum = persisted.compactShowAlbum;
+  if (typeof persisted.compactShowSeek === 'boolean')
+    out.compactShowSeek = persisted.compactShowSeek;
+  if (typeof persisted.compactShowVolume === 'boolean')
+    out.compactShowVolume = persisted.compactShowVolume;
+  if (typeof persisted.compactShowFavorite === 'boolean')
+    out.compactShowFavorite = persisted.compactShowFavorite;
+  if (typeof persisted.compactDefaultAlwaysOnTop === 'boolean')
+    out.compactDefaultAlwaysOnTop = persisted.compactDefaultAlwaysOnTop;
+  return out;
+}
+
+/**
+ * One-shot import from the pre-split combined `shiranami.app-store` key.
+ * Compact-mode state used to live in that bucket; on first load we lift
+ * the relevant fields into our own bucket so existing users keep their
+ * compact preferences. Subsequent loads find our bucket populated and
+ * skip. The legacy bucket is left intact for the other slices to do
+ * their own one-shot imports.
+ */
+function importFromLegacyAppStore() {
+  if (typeof window === 'undefined') return;
+  const ls = window.localStorage;
+  if (ls.getItem(STORE_KEY)) return;
+  const raw = ls.getItem(LEGACY_APP_STORE_KEY);
+  if (!raw) return;
+
+  try {
+    const parsed = JSON.parse(raw) as { state?: Partial<PersistedCompactState> };
+    const state = sanitize(parsed.state);
+    if (Object.keys(state).length === 0) return;
+    ls.setItem(STORE_KEY, JSON.stringify({ state, version: 1 }));
+  } catch {
+    /* malformed legacy bucket — let the new store start empty */
+  }
+}
+
+importFromLegacyAppStore();
+
+interface CompactState {
+  compactMode: boolean;
+  compactAlwaysOnTop: boolean;
+  compactSize: CompactSize;
+  compactFontSize: CompactFontSize;
+  compactAmbientIntensity: number;
+  compactShowAlbumArt: boolean;
+  compactShowAlbum: boolean;
+  compactShowSeek: boolean;
+  compactShowVolume: boolean;
+  compactShowFavorite: boolean;
+  compactDefaultAlwaysOnTop: boolean;
+}
+
+interface CompactActions {
+  setCompactMode: (compactMode: boolean) => Promise<void>;
+  setCompactAlwaysOnTop: (compactAlwaysOnTop: boolean) => Promise<void>;
+  toggleCompactMode: () => Promise<void>;
+  toggleCompactAlwaysOnTop: () => Promise<void>;
+  setCompactSize: (size: CompactSize) => void;
+  setCompactFontSize: (size: CompactFontSize) => void;
+  setCompactAmbientIntensity: (value: number) => void;
+  setCompactShowAlbumArt: (visible: boolean) => void;
+  setCompactShowAlbum: (visible: boolean) => void;
+  setCompactShowSeek: (visible: boolean) => void;
+  setCompactShowVolume: (visible: boolean) => void;
+  setCompactShowFavorite: (visible: boolean) => void;
+  setCompactDefaultAlwaysOnTop: (enabled: boolean) => void;
+  resetCompactAppearance: () => void;
+}
+
+export const useCompactStore = create<CompactState & CompactActions>()(
+  persist(
+    (set, get) => ({
+      compactMode: false,
+      compactAlwaysOnTop: false,
+      compactSize: COMPACT_SIZE_DEFAULT,
+      compactFontSize: COMPACT_FONT_SIZE_DEFAULT,
+      compactAmbientIntensity: COMPACT_AMBIENT_INTENSITY_DEFAULT,
+      compactShowAlbumArt: true,
+      compactShowAlbum: true,
+      compactShowSeek: true,
+      compactShowVolume: true,
+      compactShowFavorite: false,
+      compactDefaultAlwaysOnTop: false,
+
+      setCompactMode: async compactMode => {
+        const previous = get().compactMode;
+        if (previous === compactMode) return;
+
+        // When the user has opted into "default to always-on-top in compact",
+        // seed the runtime flag on entry. We seed before persisting because
+        // setCompactAlwaysOnTop short-circuits when not yet in compact mode,
+        // so we just write the value directly here.
+        const previousAlwaysOnTop = get().compactAlwaysOnTop;
+        if (compactMode && get().compactDefaultAlwaysOnTop && !previousAlwaysOnTop) {
+          set({ compactAlwaysOnTop: true });
+        }
+
+        set({ compactMode });
+
+        if (!IS_ELECTRON) return;
+
+        try {
+          const dims = COMPACT_DIMENSIONS[get().compactSize];
+          await window.electronAPI.window.setCompactMode(compactMode, dims);
+        } catch {
+          // Compact-mode IPC failed: undo the store flips and bail before
+          // touching always-on-top so we don't pin a window the user thinks
+          // is still in normal mode.
+          set({ compactMode: previous, compactAlwaysOnTop: previousAlwaysOnTop });
+          return;
+        }
+
+        if (get().compactAlwaysOnTop) {
+          try {
+            await window.electronAPI.window.setAlwaysOnTop(compactMode);
+          } catch {
+            // Compact succeeded but pin failed: only roll back the pin —
+            // the OS window is correctly in/out of compact mode now.
+            set({ compactAlwaysOnTop: previousAlwaysOnTop });
+          }
+        }
+      },
+      setCompactAlwaysOnTop: async compactAlwaysOnTop => {
+        const previous = get().compactAlwaysOnTop;
+        if (previous === compactAlwaysOnTop) return;
+
+        set({ compactAlwaysOnTop });
+
+        if (!IS_ELECTRON || !get().compactMode) return;
+
+        try {
+          await window.electronAPI.window.setAlwaysOnTop(compactAlwaysOnTop);
+        } catch {
+          set({ compactAlwaysOnTop: previous });
+        }
+      },
+      toggleCompactMode: async () => {
+        await get().setCompactMode(!get().compactMode);
+      },
+      toggleCompactAlwaysOnTop: async () => {
+        await get().setCompactAlwaysOnTop(!get().compactAlwaysOnTop);
+      },
+      setCompactSize: size => {
+        const next = coerceCompactSize(size);
+        set({ compactSize: next });
+        // If the window is currently in compact mode, push the new dimensions
+        // immediately so the preset switch is reflected without a re-toggle.
+        if (IS_ELECTRON && get().compactMode) {
+          const dims = COMPACT_DIMENSIONS[next];
+          window.electronAPI.window.setCompactMode(true, dims).catch(() => {
+            // Failure to resize is non-fatal; the next enter-compact will retry.
+          });
+        }
+      },
+      setCompactFontSize: size => {
+        set({ compactFontSize: coerceCompactFontSize(size) });
+      },
+      setCompactAmbientIntensity: value => {
+        set({ compactAmbientIntensity: coerceCompactAmbientIntensity(value) });
+      },
+      setCompactShowAlbumArt: visible => set({ compactShowAlbumArt: visible }),
+      setCompactShowAlbum: visible => set({ compactShowAlbum: visible }),
+      setCompactShowSeek: visible => set({ compactShowSeek: visible }),
+      setCompactShowVolume: visible => set({ compactShowVolume: visible }),
+      setCompactShowFavorite: visible => set({ compactShowFavorite: visible }),
+      setCompactDefaultAlwaysOnTop: enabled => set({ compactDefaultAlwaysOnTop: enabled }),
+      resetCompactAppearance: () => {
+        set({
+          compactSize: COMPACT_SIZE_DEFAULT,
+          compactFontSize: COMPACT_FONT_SIZE_DEFAULT,
+          compactAmbientIntensity: COMPACT_AMBIENT_INTENSITY_DEFAULT,
+          compactShowAlbumArt: true,
+          compactShowAlbum: true,
+          compactShowSeek: true,
+          compactShowVolume: true,
+          compactShowFavorite: false,
+          compactDefaultAlwaysOnTop: false,
+        });
+      },
+    }),
+    {
+      name: STORE_KEY,
+      version: 1,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s): PersistedCompactState => ({
+        compactMode: s.compactMode,
+        compactAlwaysOnTop: s.compactAlwaysOnTop,
+        compactSize: s.compactSize,
+        compactFontSize: s.compactFontSize,
+        compactAmbientIntensity: s.compactAmbientIntensity,
+        compactShowAlbumArt: s.compactShowAlbumArt,
+        compactShowAlbum: s.compactShowAlbum,
+        compactShowSeek: s.compactShowSeek,
+        compactShowVolume: s.compactShowVolume,
+        compactShowFavorite: s.compactShowFavorite,
+        compactDefaultAlwaysOnTop: s.compactDefaultAlwaysOnTop,
+      }),
+      merge: (persisted, current) => ({
+        ...current,
+        ...sanitize(persisted as Partial<PersistedCompactState>),
+      }),
+      onRehydrateStorage: () => state => {
+        if (!state) return;
+        // Re-apply compact mode at the OS-window level after rehydrate so
+        // users who quit while in compact mode come back into compact mode.
+        // The renderer flag is restored by zustand-persist; here we just
+        // forward to Electron so the window itself resizes/locks again.
+        if (IS_ELECTRON && state.compactMode) {
+          // Sequence the IPCs: pin only after compact takes hold, otherwise
+          // we could end up pinning a window that didn't make it into
+          // compact mode. Mutating `state` here is ineffective (rehydration
+          // has already merged), so any rollback has to go through setState.
+          void (async () => {
+            const dims = COMPACT_DIMENSIONS[state.compactSize];
+            try {
+              await window.electronAPI.window.setCompactMode(true, dims);
+            } catch {
+              useCompactStore.setState({ compactMode: false, compactAlwaysOnTop: false });
+              return;
+            }
+            if (state.compactAlwaysOnTop) {
+              try {
+                await window.electronAPI.window.setAlwaysOnTop(true);
+              } catch {
+                useCompactStore.setState({ compactAlwaysOnTop: false });
+              }
+            }
+          })();
+        }
+      },
+    }
+  )
+);
+
+if (import.meta.hot) {
+  type HmrData = { store?: typeof useCompactStore };
+  const hot = import.meta.hot;
+  const data = (hot.data ?? {}) as HmrData;
+  if (data.store) {
+    useCompactStore.setState(data.store.getState());
+  }
+  data.store = useCompactStore;
+  hot.accept();
+}

--- a/apps/web/src/stores/useLyricsAppearanceStore.test.ts
+++ b/apps/web/src/stores/useLyricsAppearanceStore.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  useLyricsAppearanceStore,
+  LYRICS_PLAIN_OPACITY_DEFAULT,
+  LYRICS_PLAIN_OPACITY_MAX,
+  LYRICS_PLAIN_OPACITY_MIN,
+  LYRICS_PLAIN_FONT_SIZE_DEFAULT,
+  LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
+  LYRICS_SYNCED_DIM_OPACITY_MAX,
+  LYRICS_SYNCED_DIM_OPACITY_MIN,
+  LYRICS_SYNCED_FONT_SIZE_DEFAULT,
+  nextLyricsFontSize,
+} from './useLyricsAppearanceStore';
+
+const STORE_KEY = 'shiranami.lyrics-appearance-store';
+
+function readPersisted(): Record<string, unknown> {
+  const raw = localStorage.getItem(STORE_KEY);
+  if (!raw) return {};
+  const parsed = JSON.parse(raw) as { state?: Record<string, unknown> };
+  return parsed.state ?? {};
+}
+
+describe('useLyricsAppearanceStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useLyricsAppearanceStore.setState({
+      lyricsPlainOpacity: LYRICS_PLAIN_OPACITY_DEFAULT,
+      lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
+      lyricsSyncedDimOpacity: LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
+      lyricsSyncedFontSize: LYRICS_SYNCED_FONT_SIZE_DEFAULT,
+    });
+  });
+
+  it('clamps lyrics plain opacity above max and rounds to step', () => {
+    useLyricsAppearanceStore.getState().setLyricsPlainOpacity(2);
+    expect(useLyricsAppearanceStore.getState().lyricsPlainOpacity).toBe(LYRICS_PLAIN_OPACITY_MAX);
+    expect(readPersisted().lyricsPlainOpacity).toBe(LYRICS_PLAIN_OPACITY_MAX);
+  });
+
+  it('clamps lyrics plain opacity below min', () => {
+    useLyricsAppearanceStore.getState().setLyricsPlainOpacity(0);
+    expect(useLyricsAppearanceStore.getState().lyricsPlainOpacity).toBe(LYRICS_PLAIN_OPACITY_MIN);
+  });
+
+  it('rounds lyrics plain opacity to nearest step', () => {
+    useLyricsAppearanceStore.getState().setLyricsPlainOpacity(0.873);
+    // step = 0.05, 0.873 -> rounds to 0.85
+    expect(useLyricsAppearanceStore.getState().lyricsPlainOpacity).toBeCloseTo(0.85, 2);
+  });
+
+  it('coerces invalid lyrics plain font size to default on setter', () => {
+    // @ts-expect-error — runtime guard test
+    useLyricsAppearanceStore.getState().setLyricsPlainFontSize('huge');
+    expect(useLyricsAppearanceStore.getState().lyricsPlainFontSize).toBe(
+      LYRICS_PLAIN_FONT_SIZE_DEFAULT
+    );
+  });
+
+  it('persists lyrics plain font size when valid', () => {
+    useLyricsAppearanceStore.getState().setLyricsPlainFontSize('lg');
+    expect(useLyricsAppearanceStore.getState().lyricsPlainFontSize).toBe('lg');
+    expect(readPersisted().lyricsPlainFontSize).toBe('lg');
+  });
+
+  it('resets lyrics plain appearance to defaults', () => {
+    useLyricsAppearanceStore.getState().setLyricsPlainOpacity(0.6);
+    useLyricsAppearanceStore.getState().setLyricsPlainFontSize('xl');
+    useLyricsAppearanceStore.getState().resetLyricsPlainAppearance();
+    expect(useLyricsAppearanceStore.getState().lyricsPlainOpacity).toBe(
+      LYRICS_PLAIN_OPACITY_DEFAULT
+    );
+    expect(useLyricsAppearanceStore.getState().lyricsPlainFontSize).toBe(
+      LYRICS_PLAIN_FONT_SIZE_DEFAULT
+    );
+  });
+
+  it('clamps lyrics synced dim opacity above max and rounds to step', () => {
+    useLyricsAppearanceStore.getState().setLyricsSyncedDimOpacity(2);
+    expect(useLyricsAppearanceStore.getState().lyricsSyncedDimOpacity).toBe(
+      LYRICS_SYNCED_DIM_OPACITY_MAX
+    );
+    expect(readPersisted().lyricsSyncedDimOpacity).toBe(LYRICS_SYNCED_DIM_OPACITY_MAX);
+  });
+
+  it('clamps lyrics synced dim opacity below min (down to 0.2 not 0.5)', () => {
+    useLyricsAppearanceStore.getState().setLyricsSyncedDimOpacity(0);
+    // Synced floor is lower than plain floor — synced lines may be very dim.
+    expect(useLyricsAppearanceStore.getState().lyricsSyncedDimOpacity).toBe(
+      LYRICS_SYNCED_DIM_OPACITY_MIN
+    );
+    expect(LYRICS_SYNCED_DIM_OPACITY_MIN).toBe(0.2);
+  });
+
+  it('rounds lyrics synced dim opacity to nearest step', () => {
+    useLyricsAppearanceStore.getState().setLyricsSyncedDimOpacity(0.873);
+    // step = 0.05, 0.873 -> rounds to 0.85
+    expect(useLyricsAppearanceStore.getState().lyricsSyncedDimOpacity).toBeCloseTo(0.85, 2);
+  });
+
+  it('coerces invalid lyrics synced font size to default on setter', () => {
+    // @ts-expect-error — runtime guard test
+    useLyricsAppearanceStore.getState().setLyricsSyncedFontSize('huge');
+    expect(useLyricsAppearanceStore.getState().lyricsSyncedFontSize).toBe(
+      LYRICS_SYNCED_FONT_SIZE_DEFAULT
+    );
+  });
+
+  it('persists lyrics synced font size when valid', () => {
+    useLyricsAppearanceStore.getState().setLyricsSyncedFontSize('lg');
+    expect(useLyricsAppearanceStore.getState().lyricsSyncedFontSize).toBe('lg');
+    expect(readPersisted().lyricsSyncedFontSize).toBe('lg');
+  });
+
+  it('resetLyricsAppearance restores all four lyrics prefs to defaults', () => {
+    useLyricsAppearanceStore.getState().setLyricsPlainOpacity(0.6);
+    useLyricsAppearanceStore.getState().setLyricsPlainFontSize('xl');
+    useLyricsAppearanceStore.getState().setLyricsSyncedDimOpacity(0.9);
+    useLyricsAppearanceStore.getState().setLyricsSyncedFontSize('sm');
+    useLyricsAppearanceStore.getState().resetLyricsAppearance();
+    expect(useLyricsAppearanceStore.getState().lyricsPlainOpacity).toBe(
+      LYRICS_PLAIN_OPACITY_DEFAULT
+    );
+    expect(useLyricsAppearanceStore.getState().lyricsPlainFontSize).toBe(
+      LYRICS_PLAIN_FONT_SIZE_DEFAULT
+    );
+    expect(useLyricsAppearanceStore.getState().lyricsSyncedDimOpacity).toBe(
+      LYRICS_SYNCED_DIM_OPACITY_DEFAULT
+    );
+    expect(useLyricsAppearanceStore.getState().lyricsSyncedFontSize).toBe(
+      LYRICS_SYNCED_FONT_SIZE_DEFAULT
+    );
+  });
+
+  it('nextLyricsFontSize bumps one step and caps at xl', () => {
+    expect(nextLyricsFontSize('sm')).toBe('base');
+    expect(nextLyricsFontSize('base')).toBe('lg');
+    expect(nextLyricsFontSize('lg')).toBe('xl');
+    expect(nextLyricsFontSize('xl')).toBe('xl');
+  });
+});
+
+// The pre-split combined `shiranami.app-store` bucket used to hold lyrics
+// state alongside the rest of the app prefs. The new lyrics store imports
+// that data into its own bucket once on first load so existing users
+// don't lose their saved appearance settings.
+describe('useLyricsAppearanceStore one-shot import from legacy app-store', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it('sanitizes malformed lyrics plain prefs from the legacy bucket', async () => {
+    localStorage.setItem(
+      'shiranami.app-store',
+      JSON.stringify({
+        state: { lyricsPlainOpacity: 'broken', lyricsPlainFontSize: 'huge' },
+        version: 1,
+      })
+    );
+
+    const mod = await import('./useLyricsAppearanceStore');
+    const state = mod.useLyricsAppearanceStore.getState();
+    expect(state.lyricsPlainOpacity).toBe(mod.LYRICS_PLAIN_OPACITY_DEFAULT);
+    expect(state.lyricsPlainFontSize).toBe(mod.LYRICS_PLAIN_FONT_SIZE_DEFAULT);
+  });
+
+  it('falls back to synced lyrics defaults when the legacy bucket only has plain prefs', async () => {
+    localStorage.setItem(
+      'shiranami.app-store',
+      JSON.stringify({
+        state: { lyricsPlainOpacity: 0.85, lyricsPlainFontSize: 'lg' },
+        version: 1,
+      })
+    );
+
+    const mod = await import('./useLyricsAppearanceStore');
+    const state = mod.useLyricsAppearanceStore.getState();
+    expect(state.lyricsPlainOpacity).toBe(0.85);
+    expect(state.lyricsPlainFontSize).toBe('lg');
+    expect(state.lyricsSyncedDimOpacity).toBe(mod.LYRICS_SYNCED_DIM_OPACITY_DEFAULT);
+    expect(state.lyricsSyncedFontSize).toBe(mod.LYRICS_SYNCED_FONT_SIZE_DEFAULT);
+  });
+
+  it('sanitizes malformed lyrics synced prefs from the legacy bucket', async () => {
+    localStorage.setItem(
+      'shiranami.app-store',
+      JSON.stringify({
+        state: { lyricsSyncedDimOpacity: 'broken', lyricsSyncedFontSize: 'huge' },
+        version: 1,
+      })
+    );
+
+    const mod = await import('./useLyricsAppearanceStore');
+    const state = mod.useLyricsAppearanceStore.getState();
+    expect(state.lyricsSyncedDimOpacity).toBe(mod.LYRICS_SYNCED_DIM_OPACITY_DEFAULT);
+    expect(state.lyricsSyncedFontSize).toBe(mod.LYRICS_SYNCED_FONT_SIZE_DEFAULT);
+  });
+});

--- a/apps/web/src/stores/useLyricsAppearanceStore.ts
+++ b/apps/web/src/stores/useLyricsAppearanceStore.ts
@@ -1,0 +1,210 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+export type LyricsFontSize = 'sm' | 'base' | 'lg' | 'xl';
+
+export const LYRICS_PLAIN_OPACITY_MIN = 0.5;
+export const LYRICS_PLAIN_OPACITY_MAX = 1.0;
+export const LYRICS_PLAIN_OPACITY_STEP = 0.05;
+export const LYRICS_PLAIN_OPACITY_DEFAULT = 0.9;
+export const LYRICS_PLAIN_FONT_SIZE_DEFAULT: LyricsFontSize = 'base';
+
+export const LYRICS_SYNCED_DIM_OPACITY_MIN = 0.2;
+export const LYRICS_SYNCED_DIM_OPACITY_MAX = 1.0;
+export const LYRICS_SYNCED_DIM_OPACITY_STEP = 0.05;
+export const LYRICS_SYNCED_DIM_OPACITY_DEFAULT = 0.45;
+export const LYRICS_SYNCED_FONT_SIZE_DEFAULT: LyricsFontSize = 'base';
+
+/**
+ * Original synced view used past=0.25 / idle=0.45. We preserve that ratio
+ * (≈ 0.5556) so when the user dims idle, past dims proportionally and stays
+ * visibly fainter than idle.
+ */
+export const LYRICS_SYNCED_PAST_RATIO = 0.25 / 0.45;
+
+export const LYR_SIZE_CLASS: Record<LyricsFontSize, string> = {
+  sm: 'text-sm leading-6',
+  base: 'text-base leading-7',
+  lg: 'text-lg leading-8',
+  xl: 'text-xl leading-9',
+};
+
+const FONT_SIZE_ORDER: LyricsFontSize[] = ['sm', 'base', 'lg', 'xl'];
+
+/**
+ * Active synced line uses one step larger than the user-selected base, capped
+ * at xl. Mirrors the original hardcoded "base→lg active" behavior.
+ */
+export function nextLyricsFontSize(size: LyricsFontSize): LyricsFontSize {
+  const idx = FONT_SIZE_ORDER.indexOf(size);
+  if (idx < 0) return 'lg';
+  return FONT_SIZE_ORDER[Math.min(idx + 1, FONT_SIZE_ORDER.length - 1)];
+}
+
+const STORE_KEY = 'shiranami.lyrics-appearance-store';
+const LEGACY_APP_STORE_KEY = 'shiranami.app-store';
+
+function clampLyricsPlainOpacity(v: number): number {
+  const clamped = Math.min(LYRICS_PLAIN_OPACITY_MAX, Math.max(LYRICS_PLAIN_OPACITY_MIN, v));
+  // Round to nearest step to keep persisted values clean.
+  const steps = Math.round(clamped / LYRICS_PLAIN_OPACITY_STEP);
+  return Math.round(steps * LYRICS_PLAIN_OPACITY_STEP * 1000) / 1000;
+}
+function coerceLyricsPlainOpacity(v: unknown): number {
+  const parsed = typeof v === 'number' ? v : Number(v);
+  if (!Number.isFinite(parsed)) return LYRICS_PLAIN_OPACITY_DEFAULT;
+  return clampLyricsPlainOpacity(parsed);
+}
+function coerceLyricsPlainFontSize(v: unknown): LyricsFontSize {
+  return v === 'sm' || v === 'base' || v === 'lg' || v === 'xl'
+    ? v
+    : LYRICS_PLAIN_FONT_SIZE_DEFAULT;
+}
+function clampLyricsSyncedDimOpacity(v: number): number {
+  const clamped = Math.min(
+    LYRICS_SYNCED_DIM_OPACITY_MAX,
+    Math.max(LYRICS_SYNCED_DIM_OPACITY_MIN, v)
+  );
+  const steps = Math.round(clamped / LYRICS_SYNCED_DIM_OPACITY_STEP);
+  return Math.round(steps * LYRICS_SYNCED_DIM_OPACITY_STEP * 1000) / 1000;
+}
+function coerceLyricsSyncedDimOpacity(v: unknown): number {
+  const parsed = typeof v === 'number' ? v : Number(v);
+  if (!Number.isFinite(parsed)) return LYRICS_SYNCED_DIM_OPACITY_DEFAULT;
+  return clampLyricsSyncedDimOpacity(parsed);
+}
+function coerceLyricsSyncedFontSize(v: unknown): LyricsFontSize {
+  return v === 'sm' || v === 'base' || v === 'lg' || v === 'xl'
+    ? v
+    : LYRICS_SYNCED_FONT_SIZE_DEFAULT;
+}
+
+interface PersistedLyricsAppearanceState {
+  lyricsPlainOpacity: number;
+  lyricsPlainFontSize: LyricsFontSize;
+  lyricsSyncedDimOpacity: number;
+  lyricsSyncedFontSize: LyricsFontSize;
+}
+
+function sanitize(
+  persisted: Partial<PersistedLyricsAppearanceState> | undefined
+): Partial<PersistedLyricsAppearanceState> {
+  if (!persisted || typeof persisted !== 'object') return {};
+  const out: Partial<PersistedLyricsAppearanceState> = {};
+  if (persisted.lyricsPlainOpacity !== undefined)
+    out.lyricsPlainOpacity = coerceLyricsPlainOpacity(persisted.lyricsPlainOpacity);
+  if (persisted.lyricsPlainFontSize !== undefined)
+    out.lyricsPlainFontSize = coerceLyricsPlainFontSize(persisted.lyricsPlainFontSize);
+  if (persisted.lyricsSyncedDimOpacity !== undefined)
+    out.lyricsSyncedDimOpacity = coerceLyricsSyncedDimOpacity(persisted.lyricsSyncedDimOpacity);
+  if (persisted.lyricsSyncedFontSize !== undefined)
+    out.lyricsSyncedFontSize = coerceLyricsSyncedFontSize(persisted.lyricsSyncedFontSize);
+  return out;
+}
+
+/**
+ * One-shot import from the pre-split combined `shiranami.app-store` key.
+ * Lyrics appearance state used to live in that bucket; on first load we
+ * pull the relevant fields into our own bucket so existing users don't
+ * lose their saved preferences. Subsequent loads find our bucket
+ * populated and skip. The legacy bucket is left intact so its other
+ * (UI/compact) consumers can do the same migration independently.
+ */
+function importFromLegacyAppStore() {
+  if (typeof window === 'undefined') return;
+  const ls = window.localStorage;
+  if (ls.getItem(STORE_KEY)) return;
+  const raw = ls.getItem(LEGACY_APP_STORE_KEY);
+  if (!raw) return;
+
+  try {
+    const parsed = JSON.parse(raw) as { state?: Partial<PersistedLyricsAppearanceState> };
+    const state = sanitize(parsed.state);
+    if (Object.keys(state).length === 0) return;
+    ls.setItem(STORE_KEY, JSON.stringify({ state, version: 1 }));
+  } catch {
+    /* malformed legacy bucket — let the new store start empty */
+  }
+}
+
+importFromLegacyAppStore();
+
+interface LyricsAppearanceState {
+  lyricsPlainOpacity: number;
+  lyricsPlainFontSize: LyricsFontSize;
+  lyricsSyncedDimOpacity: number;
+  lyricsSyncedFontSize: LyricsFontSize;
+}
+
+interface LyricsAppearanceActions {
+  setLyricsPlainOpacity: (value: number) => void;
+  setLyricsPlainFontSize: (size: LyricsFontSize) => void;
+  resetLyricsPlainAppearance: () => void;
+  setLyricsSyncedDimOpacity: (value: number) => void;
+  setLyricsSyncedFontSize: (size: LyricsFontSize) => void;
+  resetLyricsAppearance: () => void;
+}
+
+export const useLyricsAppearanceStore = create<LyricsAppearanceState & LyricsAppearanceActions>()(
+  persist(
+    set => ({
+      lyricsPlainOpacity: LYRICS_PLAIN_OPACITY_DEFAULT,
+      lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
+      lyricsSyncedDimOpacity: LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
+      lyricsSyncedFontSize: LYRICS_SYNCED_FONT_SIZE_DEFAULT,
+
+      setLyricsPlainOpacity: value => {
+        set({ lyricsPlainOpacity: coerceLyricsPlainOpacity(value) });
+      },
+      setLyricsPlainFontSize: size => {
+        set({ lyricsPlainFontSize: coerceLyricsPlainFontSize(size) });
+      },
+      resetLyricsPlainAppearance: () => {
+        set({
+          lyricsPlainOpacity: LYRICS_PLAIN_OPACITY_DEFAULT,
+          lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
+        });
+      },
+      setLyricsSyncedDimOpacity: value => {
+        set({ lyricsSyncedDimOpacity: coerceLyricsSyncedDimOpacity(value) });
+      },
+      setLyricsSyncedFontSize: size => {
+        set({ lyricsSyncedFontSize: coerceLyricsSyncedFontSize(size) });
+      },
+      resetLyricsAppearance: () => {
+        set({
+          lyricsPlainOpacity: LYRICS_PLAIN_OPACITY_DEFAULT,
+          lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
+          lyricsSyncedDimOpacity: LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
+          lyricsSyncedFontSize: LYRICS_SYNCED_FONT_SIZE_DEFAULT,
+        });
+      },
+    }),
+    {
+      name: STORE_KEY,
+      version: 1,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s): PersistedLyricsAppearanceState => ({
+        lyricsPlainOpacity: s.lyricsPlainOpacity,
+        lyricsPlainFontSize: s.lyricsPlainFontSize,
+        lyricsSyncedDimOpacity: s.lyricsSyncedDimOpacity,
+        lyricsSyncedFontSize: s.lyricsSyncedFontSize,
+      }),
+      merge: (persisted, current) => ({
+        ...current,
+        ...sanitize(persisted as Partial<PersistedLyricsAppearanceState>),
+      }),
+    }
+  )
+);
+
+if (import.meta.hot) {
+  type HmrData = { store?: typeof useLyricsAppearanceStore };
+  const hot = import.meta.hot;
+  const data = (hot.data ?? {}) as HmrData;
+  if (data.store) {
+    useLyricsAppearanceStore.setState(data.store.getState());
+  }
+  data.store = useLyricsAppearanceStore;
+  hot.accept();
+}

--- a/apps/web/src/stores/useSelectionStore.ts
+++ b/apps/web/src/stores/useSelectionStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { useAppStore } from '@/stores/useAppStore';
+import { useViewStore } from '@/stores/useViewStore';
 
 interface Identifiable {
   id: string;
@@ -52,9 +52,9 @@ export const useSelectionStore = create<SelectionStore>((set, get) => ({
     set({ selectedTrackIds: new Set([trackId]), lastClickedIndex: index });
   },
 
-  selectAll: (trackList) => {
+  selectAll: trackList => {
     set({
-      selectedTrackIds: new Set(trackList.map((t) => t.id)),
+      selectedTrackIds: new Set(trackList.map(t => t.id)),
       lastClickedIndex: null,
     });
   },
@@ -65,8 +65,8 @@ export const useSelectionStore = create<SelectionStore>((set, get) => ({
 }));
 
 // Clear selection when navigating to a different view
-let prevView = useAppStore.getState().activeView;
-useAppStore.subscribe((state) => {
+let prevView = useViewStore.getState().activeView;
+useViewStore.subscribe(state => {
   if (state.activeView !== prevView) {
     prevView = state.activeView;
     useSelectionStore.getState().clearSelection();

--- a/apps/web/src/stores/useSelectionStore.ts
+++ b/apps/web/src/stores/useSelectionStore.ts
@@ -66,7 +66,7 @@ export const useSelectionStore = create<SelectionStore>((set, get) => ({
 
 // Clear selection when navigating to a different view
 let prevView = useViewStore.getState().activeView;
-useViewStore.subscribe(state => {
+export const _unsubscribeViewSync = useViewStore.subscribe(state => {
   if (state.activeView !== prevView) {
     prevView = state.activeView;
     useSelectionStore.getState().clearSelection();

--- a/apps/web/src/stores/useUIStore.test.ts
+++ b/apps/web/src/stores/useUIStore.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useAppStore } from './useAppStore';
+import { useUIStore } from './useUIStore';
 import { useViewStore } from './useViewStore';
 
 vi.mock('@/lib/platform', () => ({
@@ -17,10 +17,10 @@ function readPersisted(): Record<string, unknown> {
   return parsed.state ?? {};
 }
 
-describe('useAppStore', () => {
+describe('useUIStore', () => {
   beforeEach(() => {
     localStorage.clear();
-    useAppStore.setState({
+    useUIStore.setState({
       sidebarCollapsed: false,
       sidebarHiddenItems: [],
       sidebarPlaylistsVisible: true,
@@ -30,47 +30,47 @@ describe('useAppStore', () => {
   });
 
   it('toggleSidebarItem adds and removes items from hidden list', () => {
-    const { toggleSidebarItem } = useAppStore.getState();
+    const { toggleSidebarItem } = useUIStore.getState();
 
     toggleSidebarItem('favorites');
-    expect(useAppStore.getState().sidebarHiddenItems).toEqual(['favorites']);
+    expect(useUIStore.getState().sidebarHiddenItems).toEqual(['favorites']);
     expect(readPersisted().sidebarHiddenItems).toEqual(['favorites']);
 
     toggleSidebarItem('history');
-    expect(useAppStore.getState().sidebarHiddenItems).toEqual(['favorites', 'history']);
+    expect(useUIStore.getState().sidebarHiddenItems).toEqual(['favorites', 'history']);
 
     toggleSidebarItem('favorites');
-    expect(useAppStore.getState().sidebarHiddenItems).toEqual(['history']);
+    expect(useUIStore.getState().sidebarHiddenItems).toEqual(['history']);
   });
 
   it('persists sidebar playlists visibility to localStorage', () => {
-    useAppStore.getState().setSidebarPlaylistsVisible(false);
-    expect(useAppStore.getState().sidebarPlaylistsVisible).toBe(false);
+    useUIStore.getState().setSidebarPlaylistsVisible(false);
+    expect(useUIStore.getState().sidebarPlaylistsVisible).toBe(false);
     expect(readPersisted().sidebarPlaylistsVisible).toBe(false);
 
-    useAppStore.getState().setSidebarPlaylistsVisible(true);
-    expect(useAppStore.getState().sidebarPlaylistsVisible).toBe(true);
+    useUIStore.getState().setSidebarPlaylistsVisible(true);
+    expect(useUIStore.getState().sidebarPlaylistsVisible).toBe(true);
     expect(readPersisted().sidebarPlaylistsVisible).toBe(true);
   });
 
   it('persists album grid size to localStorage', () => {
-    useAppStore.getState().setAlbumGridSize('small');
-    expect(useAppStore.getState().albumGridSize).toBe('small');
+    useUIStore.getState().setAlbumGridSize('small');
+    expect(useUIStore.getState().albumGridSize).toBe('small');
     expect(readPersisted().albumGridSize).toBe('small');
   });
 
   it('persists album sort mode and resets scroll position', () => {
     useViewStore.setState({ albumGridScrollTop: 500 });
-    useAppStore.getState().setAlbumSortMode('artist');
-    expect(useAppStore.getState().albumSortMode).toBe('artist');
+    useUIStore.getState().setAlbumSortMode('artist');
+    expect(useUIStore.getState().albumSortMode).toBe('artist');
     expect(useViewStore.getState().albumGridScrollTop).toBe(0);
     expect(readPersisted().albumSortMode).toBe('artist');
   });
 
   it('persists recentlyAdded sort mode and resets scroll position', () => {
     useViewStore.setState({ albumGridScrollTop: 300 });
-    useAppStore.getState().setAlbumSortMode('recentlyAdded');
-    expect(useAppStore.getState().albumSortMode).toBe('recentlyAdded');
+    useUIStore.getState().setAlbumSortMode('recentlyAdded');
+    expect(useUIStore.getState().albumSortMode).toBe('recentlyAdded');
     expect(useViewStore.getState().albumGridScrollTop).toBe(0);
     expect(readPersisted().albumSortMode).toBe('recentlyAdded');
   });
@@ -82,29 +82,29 @@ describe('useAppStore', () => {
     );
     // Re-applying store state via merge path: simulate by calling setAlbumSortMode
     // and confirming the stored value round-trips through sanitize correctly.
-    useAppStore.getState().setAlbumSortMode('recentlyAdded');
+    useUIStore.getState().setAlbumSortMode('recentlyAdded');
     expect(readPersisted().albumSortMode).toBe('recentlyAdded');
     // Unknown value falls back to 'name'
-    useAppStore.getState().setAlbumSortMode('name');
-    expect(useAppStore.getState().albumSortMode).toBe('name');
+    useUIStore.getState().setAlbumSortMode('name');
+    expect(useUIStore.getState().albumSortMode).toBe('name');
   });
 
   it('persists album sort order and resets scroll position', () => {
     useViewStore.setState({ albumGridScrollTop: 500 });
-    useAppStore.getState().setAlbumSortOrder('desc');
-    expect(useAppStore.getState().albumSortOrder).toBe('desc');
+    useUIStore.getState().setAlbumSortOrder('desc');
+    expect(useUIStore.getState().albumSortOrder).toBe('desc');
     expect(useViewStore.getState().albumGridScrollTop).toBe(0);
     expect(readPersisted().albumSortOrder).toBe('desc');
   });
 
   it('album grid size changes do not reset scroll position', () => {
     useViewStore.setState({ albumGridScrollTop: 500 });
-    useAppStore.getState().setAlbumGridSize('large');
+    useUIStore.getState().setAlbumGridSize('large');
     expect(useViewStore.getState().albumGridScrollTop).toBe(500);
   });
 });
 
-describe('useAppStore legacy localStorage migration', () => {
+describe('useUIStore legacy localStorage migration', () => {
   beforeEach(() => {
     localStorage.clear();
     vi.resetModules();
@@ -116,7 +116,7 @@ describe('useAppStore legacy localStorage migration', () => {
     localStorage.setItem('shiranami.visualizer-style', 'waveform');
     localStorage.setItem('shiranami.sidebar-hidden-items', JSON.stringify(['favorites']));
 
-    await import('./useAppStore');
+    await import('./useUIStore');
 
     expect(localStorage.getItem('shiranami.compact-always-on-top')).toBeNull();
     expect(localStorage.getItem('shiranami.ui-scale')).toBeNull();
@@ -136,7 +136,7 @@ describe('useAppStore legacy localStorage migration', () => {
     localStorage.setItem('shiranami.app-store', JSON.stringify(existing));
     localStorage.setItem('shiranami.ui-scale', '120');
 
-    await import('./useAppStore');
+    await import('./useUIStore');
 
     // Combined key untouched
     expect(JSON.parse(localStorage.getItem('shiranami.app-store')!)).toEqual(existing);
@@ -145,7 +145,7 @@ describe('useAppStore legacy localStorage migration', () => {
   });
 
   it('does nothing when no legacy keys exist', async () => {
-    await import('./useAppStore');
+    await import('./useUIStore');
     expect(localStorage.getItem('shiranami.app-store')).toBeNull();
   });
 });

--- a/apps/web/src/stores/useUIStore.test.ts
+++ b/apps/web/src/stores/useUIStore.test.ts
@@ -102,6 +102,24 @@ describe('useUIStore', () => {
     useUIStore.getState().setAlbumGridSize('large');
     expect(useViewStore.getState().albumGridScrollTop).toBe(500);
   });
+
+  it('preserves unknown legacy fields in shared bucket across persist writes', () => {
+    // Seed the bucket with a lyrics-prefs field that belongs to useLyricsAppearanceStore
+    localStorage.setItem(
+      STORE_KEY,
+      JSON.stringify({
+        state: { lyricsPlainOpacity: 0.75, sidebarCollapsed: false },
+        version: 1,
+      })
+    );
+
+    // Trigger a UI mutation — this causes partialize() to run and write back
+    useUIStore.getState().setSidebarCollapsed(true);
+
+    const persisted = readPersisted();
+    expect(persisted.lyricsPlainOpacity).toBe(0.75);
+    expect(persisted.sidebarCollapsed).toBe(true);
+  });
 });
 
 describe('useUIStore legacy localStorage migration', () => {

--- a/apps/web/src/stores/useUIStore.ts
+++ b/apps/web/src/stores/useUIStore.ts
@@ -132,6 +132,44 @@ function sanitize(persisted: Partial<PersistedUIState> | undefined): Partial<Per
   return out;
 }
 
+// --- Passthrough: fields in the shared bucket that belong to sibling stores ---
+
+const UI_KEYS: ReadonlySet<keyof PersistedUIState> = new Set([
+  'sidebarCollapsed',
+  'sidebarHiddenItems',
+  'sidebarPlaylistsVisible',
+  'showVisualizer',
+  'visualizerStyle',
+  'uiScale',
+  'libraryViewMode',
+  'albumGridSize',
+  'playlistGridSize',
+  'albumSortMode',
+  'albumSortOrder',
+  'nowPlayingViewEnabled',
+  'nowPlayingLyricsVisible',
+  'libraryHeroCardEnabled',
+  'lowPerformanceMode',
+  'noiseOverlayEnabled',
+]);
+
+function readPassthroughLegacyFields(): Record<string, unknown> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as { state?: Record<string, unknown> };
+    if (!parsed.state || typeof parsed.state !== 'object') return {};
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(parsed.state)) {
+      if (!UI_KEYS.has(k as keyof PersistedUIState)) out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
 // --- One-shot legacy import (runs at module load, before create()) ---
 
 function importLegacyUIStore() {
@@ -354,24 +392,26 @@ export const useUIStore = create<UIState & UIActions>()(
       name: STORE_KEY,
       version: 1,
       storage: createJSONStorage(() => localStorage),
-      partialize: (s): PersistedUIState => ({
-        sidebarCollapsed: s.sidebarCollapsed,
-        sidebarHiddenItems: s.sidebarHiddenItems,
-        sidebarPlaylistsVisible: s.sidebarPlaylistsVisible,
-        showVisualizer: s.showVisualizer,
-        visualizerStyle: s.visualizerStyle,
-        uiScale: s.uiScale,
-        libraryViewMode: s.libraryViewMode,
-        albumGridSize: s.albumGridSize,
-        playlistGridSize: s.playlistGridSize,
-        albumSortMode: s.albumSortMode,
-        albumSortOrder: s.albumSortOrder,
-        nowPlayingViewEnabled: s.nowPlayingViewEnabled,
-        nowPlayingLyricsVisible: s.nowPlayingLyricsVisible,
-        libraryHeroCardEnabled: s.libraryHeroCardEnabled,
-        lowPerformanceMode: s.lowPerformanceMode,
-        noiseOverlayEnabled: s.noiseOverlayEnabled,
-      }),
+      partialize: s =>
+        ({
+          ...readPassthroughLegacyFields(),
+          sidebarCollapsed: s.sidebarCollapsed,
+          sidebarHiddenItems: s.sidebarHiddenItems,
+          sidebarPlaylistsVisible: s.sidebarPlaylistsVisible,
+          showVisualizer: s.showVisualizer,
+          visualizerStyle: s.visualizerStyle,
+          uiScale: s.uiScale,
+          libraryViewMode: s.libraryViewMode,
+          albumGridSize: s.albumGridSize,
+          playlistGridSize: s.playlistGridSize,
+          albumSortMode: s.albumSortMode,
+          albumSortOrder: s.albumSortOrder,
+          nowPlayingViewEnabled: s.nowPlayingViewEnabled,
+          nowPlayingLyricsVisible: s.nowPlayingLyricsVisible,
+          libraryHeroCardEnabled: s.libraryHeroCardEnabled,
+          lowPerformanceMode: s.lowPerformanceMode,
+          noiseOverlayEnabled: s.noiseOverlayEnabled,
+        }) as PersistedUIState,
       merge: (persisted, current) => ({
         ...current,
         ...sanitize(persisted as Partial<PersistedUIState>),

--- a/apps/web/src/stores/useUIStore.ts
+++ b/apps/web/src/stores/useUIStore.ts
@@ -1,12 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
-import { useViewStore, type AppView, type RightPanel } from '@/stores/useViewStore';
-import type { LyricsFontSize } from '@/stores/useLyricsAppearanceStore';
-import type { CompactSize, CompactFontSize } from '@/stores/useCompactStore';
+import { useViewStore, type AppView } from '@/stores/useViewStore';
 
-export type { AppView, RightPanel, LyricsFontSize, CompactSize, CompactFontSize };
-/** @deprecated Use LyricsFontSize. Alias kept for back-compat with existing imports. */
-export type LyricsPlainFontSize = LyricsFontSize;
 export type VisualizerStyle = 'bars' | 'waveform' | 'circle' | 'particles';
 export type LibraryViewMode = 'tracks' | 'albums';
 export type AlbumGridSize = 'small' | 'medium' | 'large';
@@ -19,36 +14,7 @@ export const UI_SCALE_DEFAULT = 100;
 export const UI_SCALE_STEP = 5;
 export const UI_SCALE_PRESETS = [80, 90, 100, 110, 120] as const;
 
-export {
-  LYRICS_PLAIN_OPACITY_MIN,
-  LYRICS_PLAIN_OPACITY_MAX,
-  LYRICS_PLAIN_OPACITY_STEP,
-  LYRICS_PLAIN_OPACITY_DEFAULT,
-  LYRICS_PLAIN_FONT_SIZE_DEFAULT,
-  LYRICS_SYNCED_DIM_OPACITY_MIN,
-  LYRICS_SYNCED_DIM_OPACITY_MAX,
-  LYRICS_SYNCED_DIM_OPACITY_STEP,
-  LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
-  LYRICS_SYNCED_FONT_SIZE_DEFAULT,
-  LYRICS_SYNCED_PAST_RATIO,
-  LYR_SIZE_CLASS,
-  nextLyricsFontSize,
-} from '@/stores/useLyricsAppearanceStore';
-
-export {
-  COMPACT_SIZE_DEFAULT,
-  COMPACT_DIMENSIONS,
-  COMPACT_AMBIENT_INTENSITY_MIN,
-  COMPACT_AMBIENT_INTENSITY_MAX,
-  COMPACT_AMBIENT_INTENSITY_STEP,
-  COMPACT_AMBIENT_INTENSITY_DEFAULT,
-  COMPACT_FONT_SIZE_DEFAULT,
-  CMP_TITLE_CLASS,
-  CMP_ARTIST_CLASS,
-  CMP_ALBUM_CLASS,
-} from '@/stores/useCompactStore';
-
-const NEW_KEY = 'shiranami.app-store';
+const STORE_KEY = 'shiranami.app-store';
 
 const LEGACY_KEYS = {
   sidebarCollapsed: 'shiranami.sidebar-collapsed',
@@ -108,9 +74,10 @@ function coerceUiScale(v: unknown): number {
   if (Number.isNaN(parsed)) return UI_SCALE_DEFAULT;
   return Math.round(Math.min(UI_SCALE_MAX, Math.max(UI_SCALE_MIN, parsed)));
 }
+
 // --- Sanitizer: defensively re-apply enum whitelists and numeric clamps ---
 
-interface PersistedAppState {
+interface PersistedUIState {
   sidebarCollapsed: boolean;
   sidebarHiddenItems: AppView[];
   sidebarPlaylistsVisible: boolean;
@@ -129,9 +96,9 @@ interface PersistedAppState {
   noiseOverlayEnabled: boolean;
 }
 
-function sanitize(persisted: Partial<PersistedAppState> | undefined): Partial<PersistedAppState> {
+function sanitize(persisted: Partial<PersistedUIState> | undefined): Partial<PersistedUIState> {
   if (!persisted || typeof persisted !== 'object') return {};
-  const out: Partial<PersistedAppState> = {};
+  const out: Partial<PersistedUIState> = {};
   if (typeof persisted.sidebarCollapsed === 'boolean')
     out.sidebarCollapsed = persisted.sidebarCollapsed;
   if (Array.isArray(persisted.sidebarHiddenItems))
@@ -167,18 +134,18 @@ function sanitize(persisted: Partial<PersistedAppState> | undefined): Partial<Pe
 
 // --- One-shot legacy import (runs at module load, before create()) ---
 
-function importLegacyAppStore() {
+function importLegacyUIStore() {
   if (typeof window === 'undefined') return;
   const ls = window.localStorage;
-  if (ls.getItem(NEW_KEY)) return;
+  if (ls.getItem(STORE_KEY)) return;
   const hasAny = Object.values(LEGACY_KEYS).some(k => ls.getItem(k) !== null);
   if (!hasAny) return;
 
   // Relaxed shape — we also copy `compactAlwaysOnTop` through so the
   // useCompactStore one-shot importer (which reads this same combined
   // bucket) can pick it up on next load. The field is no longer on
-  // PersistedAppState since compact moved to its own store.
-  const state: Partial<PersistedAppState> & { compactAlwaysOnTop?: boolean } = {};
+  // PersistedUIState since compact moved to its own store.
+  const state: Partial<PersistedUIState> & { compactAlwaysOnTop?: boolean } = {};
 
   const sidebarCollapsed = ls.getItem(LEGACY_KEYS.sidebarCollapsed);
   if (sidebarCollapsed !== null) state.sidebarCollapsed = sidebarCollapsed === 'true';
@@ -247,13 +214,13 @@ function importLegacyAppStore() {
   const noiseOverlayEnabled = ls.getItem(LEGACY_KEYS.noiseOverlayEnabled);
   if (noiseOverlayEnabled !== null) state.noiseOverlayEnabled = noiseOverlayEnabled === 'true';
 
-  ls.setItem(NEW_KEY, JSON.stringify({ state, version: 1 }));
+  ls.setItem(STORE_KEY, JSON.stringify({ state, version: 1 }));
   Object.values(LEGACY_KEYS).forEach(k => ls.removeItem(k));
 }
 
-importLegacyAppStore();
+importLegacyUIStore();
 
-interface AppState {
+interface UIState {
   sidebarCollapsed: boolean;
   sidebarHiddenItems: AppView[];
   sidebarPlaylistsVisible: boolean;
@@ -272,7 +239,7 @@ interface AppState {
   noiseOverlayEnabled: boolean;
 }
 
-interface AppActions {
+interface UIActions {
   setNowPlayingViewEnabled: (enabled: boolean) => void;
   toggleNowPlayingLyrics: () => void;
   setLibraryHeroCardEnabled: (enabled: boolean) => void;
@@ -293,7 +260,7 @@ interface AppActions {
   setAlbumSortOrder: (order: AlbumSortOrder) => void;
 }
 
-export const useAppStore = create<AppState & AppActions>()(
+export const useUIStore = create<UIState & UIActions>()(
   persist(
     (set, get) => ({
       sidebarCollapsed: false,
@@ -384,10 +351,10 @@ export const useAppStore = create<AppState & AppActions>()(
       },
     }),
     {
-      name: NEW_KEY,
+      name: STORE_KEY,
       version: 1,
       storage: createJSONStorage(() => localStorage),
-      partialize: s => ({
+      partialize: (s): PersistedUIState => ({
         sidebarCollapsed: s.sidebarCollapsed,
         sidebarHiddenItems: s.sidebarHiddenItems,
         sidebarPlaylistsVisible: s.sidebarPlaylistsVisible,
@@ -407,7 +374,7 @@ export const useAppStore = create<AppState & AppActions>()(
       }),
       merge: (persisted, current) => ({
         ...current,
-        ...sanitize(persisted as Partial<PersistedAppState>),
+        ...sanitize(persisted as Partial<PersistedUIState>),
       }),
       onRehydrateStorage: () => state => {
         if (!state) return;
@@ -419,12 +386,12 @@ export const useAppStore = create<AppState & AppActions>()(
 );
 
 if (import.meta.hot) {
-  type HmrData = { store?: typeof useAppStore };
+  type HmrData = { store?: typeof useUIStore };
   const hot = import.meta.hot;
   const data = (hot.data ?? {}) as HmrData;
   if (data.store) {
-    useAppStore.setState(data.store.getState());
+    useUIStore.setState(data.store.getState());
   }
-  data.store = useAppStore;
+  data.store = useUIStore;
   hot.accept();
 }

--- a/apps/web/src/stores/useViewStore.ts
+++ b/apps/web/src/stores/useViewStore.ts
@@ -1,0 +1,77 @@
+import { create } from 'zustand';
+
+export type AppView =
+  | 'library'
+  | 'playlists'
+  | 'favorites'
+  | 'history'
+  | 'mixes'
+  | 'search'
+  | 'radio'
+  | 'settings'
+  | 'import-playlist'
+  | 'now-playing';
+export type RightPanel = 'lyrics' | 'queue' | null;
+
+interface ViewState {
+  activeView: AppView;
+  previousView: AppView;
+  rightPanel: RightPanel;
+  selectedPlaylistId: string | null;
+  selectedAlbumName: string | null;
+  albumGridScrollTop: number;
+}
+
+interface ViewActions {
+  navigateTo: (view: AppView, playlistId?: string | null) => void;
+  enterNowPlaying: () => void;
+  exitNowPlaying: () => void;
+  selectPlaylist: (id: string | null) => void;
+  setRightPanel: (panel: RightPanel) => void;
+  toggleRightPanel: (panel: 'lyrics' | 'queue') => void;
+  selectAlbum: (name: string | null) => void;
+  setAlbumGridScrollTop: (scrollTop: number) => void;
+}
+
+export const useViewStore = create<ViewState & ViewActions>()((set, get) => ({
+  activeView: 'library',
+  previousView: 'library',
+  rightPanel: null,
+  selectedPlaylistId: null,
+  selectedAlbumName: null,
+  albumGridScrollTop: 0,
+
+  navigateTo: (view, playlistId) =>
+    set({
+      activeView: view,
+      selectedPlaylistId: view === 'playlists' ? (playlistId ?? null) : null,
+    }),
+  enterNowPlaying: () => {
+    const current = get().activeView;
+    if (current === 'now-playing') return;
+    set({ previousView: current, activeView: 'now-playing' });
+  },
+  exitNowPlaying: () => {
+    const prev = get().previousView;
+    set({ activeView: prev });
+  },
+  selectPlaylist: id => set({ selectedPlaylistId: id }),
+  setRightPanel: panel => set({ rightPanel: panel }),
+  toggleRightPanel: panel => {
+    const current = get().rightPanel;
+    set({ rightPanel: current === panel ? null : panel });
+  },
+  selectAlbum: name => set({ selectedAlbumName: name }),
+  setAlbumGridScrollTop: scrollTop => set({ albumGridScrollTop: scrollTop }),
+}));
+
+if (import.meta.hot) {
+  type HmrData = { store?: typeof useViewStore };
+  const hot = import.meta.hot;
+  const data = (hot.data ?? {}) as HmrData;
+  if (data.store) {
+    useViewStore.setState(data.store.getState());
+  }
+  data.store = useViewStore;
+  hot.accept();
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -334,7 +334,7 @@
 }
 
 /* Low performance mode — disables expensive compositor effects.
-   Toggled via <html data-perf-mode="low"> from useAppStore.setLowPerformanceMode.
+   Toggled via <html data-perf-mode="low"> from useUIStore.setLowPerformanceMode.
 
    These rules are intentionally OUTSIDE @layer so they always beat the
    @utility definitions of .glass / .glass-subtle (which Tailwind v4 emits


### PR DESCRIPTION
## Summary

Splits `apps/web/src/stores/useAppStore.ts` (832 LOC) into four focused stores along its natural concern boundaries. Step 3 of the long-term architecture plan from [the chain audit](docs/chain/2026-05-03-shiranami-longterm-architecture.md) (item #4 in the unified priority order; refactor doc step 6).

Pure structural refactor: state shapes, persistence behavior, and types are unchanged. Behavior parity verified by preserving and re-running the entire existing test suite, plus three new cases for the cross-store legacy import dance.

## The four stores

Derived from the actual state slices in the original file — names follow what each store *owns*, not what it does:

| Store | LOC | Responsibility | Persisted |
|---|---|---|---|
| `useUIStore` | 397 | Sidebar, visualizer, UI scale, library view-mode, album sort, now-playing flags, low-perf toggle, noise overlay | `shiranami.app-store` |
| `useCompactStore` | 343 | Compact mode, AOT, size/font/ambient/show-flags, `COMPACT_DIMENSIONS`, `CMP_*` constants, plus the IPC dance for the desktop window swap | `shiranami.compact-store` |
| `useLyricsAppearanceStore` | 210 | Plain + synced opacity/font, `LYR_SIZE_CLASS`, `nextLyricsFontSize`, `LYRICS_*_PAST_RATIO` ratios | `shiranami.lyrics-appearance-store` |
| `useViewStore` | 77 | activeView, previousView, rightPanel, selectedPlaylistId, selectedAlbumName, albumGridScrollTop | (in-memory only) |

The original `useAppStore.ts` was renamed to `useUIStore.ts` once everything else was extracted — the UI slice is what was left after pulling out compact/lyrics/view, so renaming preserved git blame on the dominant slice. No back-compat shim was left behind.

22 consumer files updated (components, hooks, `App.tsx`). Each commit keeps the codebase compiling on its own — the four extractions were ordered so the in-progress state always typechecks.

## Intentionally NOT in this PR

These were sequenced as separate items in the audit's priority order. Bundling them turns a reviewable refactor into an unreviewable rewrite.

- **`createPersistedStore` factory.** Refactor doc step 5. Each new store keeps its current persistence pattern with the duplicated `partialize`/`merge`/`sanitize` boilerplate. The factory PR is downstream.
- **`Track` migration to `@shiranami/contracts`.** Refactor doc explicitly defers the renderer Track migration to "after the useAppStore split lands so the renderer site moves cleanly." That's the next PR after this.
- **Library store normalization.** Perf finding M1 (`{ ids[], byId, favoriteIds, albumIndex }`). Separate downstream PR; the library store shape is unchanged here.

## Follow-ups surfaced mid-split

- The `LEGACY_KEYS` per-key importer in `useUIStore.ts` still funnels `compactAlwaysOnTop` through the old `shiranami.app-store` bucket so `useCompactStore`'s one-shot importer can pick it up on next boot. Once both legacy import generations have aged out, this cross-store dance collapses into a one-line delete.
- `COMPACT_DIMENSIONS` and the `setCompactMode` IPC payload shape are the natural extraction targets for **Step 4** (preload split + the deferred contracts migration) — they cross the renderer/main boundary cleanly and are flagged in `useCompactStore.ts:11-12`.
- `App.tsx` now reads from four stores at the top level (one selector per concern). The selector multiplication flagged in the perf audit is unchanged in shape but distributed across the new boundaries — a `useShallow` grouped-read pass per store would be a small mechanical follow-up.

## Test plan

- [x] `pnpm typecheck` passes (web + desktop + all packages)
- [x] `pnpm test` passes — 91 test files, 1129 passed + 1 skipped (baseline 1126; +3 from new compact-import legacy cases)
- [x] `pnpm --filter @shiranami/web build` clean
- [ ] Smoke: toggle compact mode, confirm window swap + persistence
- [ ] Smoke: change lyrics opacity/font, confirm persistence + correct rendering after reload
- [ ] Smoke: navigate between views (library / playlists / album detail), confirm `useViewStore` selection and scroll restoration work
- [ ] Smoke: toggle visualizer / sidebar / UI scale, confirm `useUIStore` persistence

## Commits

Atomic conventional commits, each one builds + typechecks cleanly:

1. `refactor(web/stores): extract useViewStore from useAppStore`
2. `refactor(web/stores): extract useLyricsAppearanceStore from useAppStore`
3. `refactor(web/stores): extract useCompactStore from useAppStore`
4. `refactor(web/stores): rename useAppStore to useUIStore`