### PR TITLE
refactor(desktop/preload): split per namespace and derive allowlist from contracts

### DIFF
--- a/apps/desktop/src/main/ipc/downloader.ts
+++ b/apps/desktop/src/main/ipc/downloader.ts
@@ -67,15 +67,9 @@ interface DependencyInstallProgress {
   label: string;
 }
 
-export interface ToolInstallResult {
-  tool: 'ytdlp' | 'ffmpeg';
-  success: boolean;
-  error?: string;
-}
+import type { ToolInstallResult, InstallDependenciesResult } from '../preload/types';
 
-export interface InstallDependenciesResult {
-  results: ToolInstallResult[];
-}
+export type { ToolInstallResult, InstallDependenciesResult };
 
 export interface DownloadLocationState {
   path: string;

--- a/apps/desktop/src/main/preload.test.ts
+++ b/apps/desktop/src/main/preload.test.ts
@@ -1,23 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /**
- * The preload module calls `contextBridge.exposeInMainWorld` at import time,
- * so we mock Electron's preload APIs and then import the module to exercise
- * the channel allowlist (assertAllowedChannel) and invokeWithTimeout logic
- * embedded inside the exposed `electronAPI` object.
+ * Unit tests for the preload context-bridge utilities: the channel allowlist
+ * (assertAllowedChannel) and invokeWithTimeout. These are tested directly
+ * against context-bridge.ts rather than through the renderer surface, since
+ * the ipc.invokeWithTimeout escape hatch was removed from the exposed API.
  */
 
 const mockInvoke = vi.fn();
 const mockSend = vi.fn();
 const mockOn = vi.fn();
 const mockRemoveListener = vi.fn();
-let exposedAPI: Record<string, unknown> | null = null;
 
 vi.mock('electron', () => ({
   contextBridge: {
-    exposeInMainWorld(_key: string, api: Record<string, unknown>) {
-      exposedAPI = api;
-    },
+    exposeInMainWorld(_key: string, _api: Record<string, unknown>) {},
   },
   ipcRenderer: {
     invoke: (...args: unknown[]) => mockInvoke(...args),
@@ -27,20 +24,15 @@ vi.mock('electron', () => ({
   },
 }));
 
-// Import the preload module; this triggers `contextBridge.exposeInMainWorld`
-// and captures the API object via our mock.
+let invokeWithTimeout: (channel: string, timeoutMs: number, ...args: unknown[]) => Promise<unknown>;
+
 beforeEach(async () => {
   vi.clearAllMocks();
-  exposedAPI = null;
-  // Re-import to capture the API fresh
   vi.resetModules();
 
-  // Re-apply the electron mock after resetModules
   vi.doMock('electron', () => ({
     contextBridge: {
-      exposeInMainWorld(_key: string, api: Record<string, unknown>) {
-        exposedAPI = api;
-      },
+      exposeInMainWorld(_key: string, _api: Record<string, unknown>) {},
     },
     ipcRenderer: {
       invoke: (...args: unknown[]) => mockInvoke(...args),
@@ -50,55 +42,38 @@ beforeEach(async () => {
     },
   }));
 
-  await import('./preload');
+  const mod = await import('./main/preload/context-bridge');
+  invokeWithTimeout = mod.invokeWithTimeout;
 });
-
-function getAPI() {
-  if (!exposedAPI) throw new Error('electronAPI was not exposed');
-  return exposedAPI as {
-    ipc: {
-      invokeWithTimeout: <T>(channel: string, timeout: number, ...args: unknown[]) => Promise<T>;
-    };
-    store: {
-      get: (key: string) => Promise<unknown>;
-    };
-  };
-}
 
 describe('preload assertAllowedChannel', () => {
   it('invokeWithTimeout resolves for an allowed channel', async () => {
     mockInvoke.mockResolvedValue('ok');
-    const api = getAPI();
 
-    const result = await api.ipc.invokeWithTimeout('store:get', 5000, 'theme');
+    const result = await invokeWithTimeout('store:get', 5000, 'theme');
     expect(result).toBe('ok');
     expect(mockInvoke).toHaveBeenCalledWith('store:get', 'theme');
   });
 
   it('invokeWithTimeout throws synchronously for a disallowed channel', () => {
-    const api = getAPI();
-
-    expect(() => api.ipc.invokeWithTimeout('evil:channel', 5000)).toThrow(
-      'IPC channel not allowed: "evil:channel"',
+    expect(() => invokeWithTimeout('evil:channel', 5000)).toThrow(
+      'IPC channel not allowed: "evil:channel"'
     );
     expect(mockInvoke).not.toHaveBeenCalled();
   });
 
   it('invokeWithTimeout rejects after timeout when invoke hangs', async () => {
-    // Simulate an invoke that never resolves
     mockInvoke.mockReturnValue(new Promise(() => {}));
-    const api = getAPI();
 
-    await expect(
-      api.ipc.invokeWithTimeout('store:get', 50, 'theme'),
-    ).rejects.toThrow('IPC timeout: "store:get" did not respond within 50ms');
+    await expect(invokeWithTimeout('store:get', 50, 'theme')).rejects.toThrow(
+      'IPC timeout: "store:get" did not respond within 50ms'
+    );
   });
 
   it('invokeWithTimeout resolves before timeout for fast responses', async () => {
     mockInvoke.mockResolvedValue(42);
-    const api = getAPI();
 
-    const result = await api.ipc.invokeWithTimeout('store:get', 5000, 'settings');
+    const result = await invokeWithTimeout('store:get', 5000, 'settings');
     expect(result).toBe(42);
   });
 });

--- a/apps/desktop/src/main/preload.test.ts
+++ b/apps/desktop/src/main/preload.test.ts
@@ -42,7 +42,7 @@ beforeEach(async () => {
     },
   }));
 
-  const mod = await import('./main/preload/context-bridge');
+  const mod = await import('./preload/context-bridge');
   invokeWithTimeout = mod.invokeWithTimeout;
 });
 

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -5,10 +5,11 @@ import {
   PLAYLIST_ERROR_CODES,
   VALIDATION_ERROR_CODES,
 } from './ipc/errors';
-import type { InstallDependenciesResult } from './ipc/downloader';
 import { createIpcListener } from './preload/ipc-listener';
 import { appApi, type AppApi } from './preload/api/app';
+import { dbApi, type DbApi } from './preload/api/db';
 import { dialogApi, type DialogApi } from './preload/api/dialog';
+import { downloaderApi, type DownloaderApi } from './preload/api/downloader';
 import { libraryApi, type LibraryApi } from './preload/api/library';
 import { lyricsApi, type LyricsApi } from './preload/api/lyrics';
 import { mediaApi, type MediaApi } from './preload/api/media';
@@ -126,8 +127,6 @@ function invokeWithTimeout<T>(channel: string, timeout: number, ...args: unknown
   return Promise.race([invokePromise.finally(() => clearTimeout(timer)), timeoutPromise]);
 }
 
-import { dbApi, type DbApi } from './preload/api/db';
-
 export interface ElectronAPI {
   window: WindowApi;
   store: StoreApi;
@@ -137,101 +136,7 @@ export interface ElectronAPI {
   db: DbApi;
   lyrics: LyricsApi;
   media: MediaApi;
-  downloader: {
-    getStreamUrl: (url: string) => Promise<string>;
-    suggest: (query: string) => Promise<string[]>;
-    search: (query: string) => Promise<
-      Array<{
-        id: string;
-        title: string;
-        uploader: string;
-        duration: number;
-        thumbnail: string;
-        url: string;
-        webpage_url: string;
-      }>
-    >;
-    download: (url: string) => Promise<string>;
-    getDownloadLocation: () => Promise<{
-      path: string;
-      defaultPath: string;
-      isDefault: boolean;
-    }>;
-    setDownloadLocation: (path: string | null) => Promise<{
-      path: string;
-      defaultPath: string;
-      isDefault: boolean;
-    }>;
-    checkDependencies: () => Promise<{ ytdlpInstalled: boolean; ffmpegInstalled: boolean }>;
-    getCachedToolStatus: () => Promise<{
-      ytdlp: {
-        installed: boolean;
-        version?: string;
-        latestVersion?: string;
-        updateAvailable?: boolean;
-      };
-      ffmpeg: {
-        installed: boolean;
-        version?: string;
-        latestVersion?: string;
-        updateAvailable?: boolean;
-      };
-      ytdlpPath: string;
-      downloadLocation: { path: string; defaultPath: string; isDefault: boolean };
-      timestamp: number;
-    } | null>;
-    refreshToolStatus: () => Promise<{
-      ytdlp: {
-        installed: boolean;
-        version?: string;
-        latestVersion?: string;
-        updateAvailable?: boolean;
-      };
-      ffmpeg: {
-        installed: boolean;
-        version?: string;
-        latestVersion?: string;
-        updateAvailable?: boolean;
-      };
-      ytdlpPath: string;
-      downloadLocation: { path: string; defaultPath: string; isDefault: boolean };
-      timestamp: number;
-    } | null>;
-    check: () => Promise<{
-      installed: boolean;
-      version?: string;
-      latestVersion?: string;
-      updateAvailable?: boolean;
-    }>;
-    onProgress: (
-      callback: (data: {
-        url: string;
-        progress: number;
-        status: 'downloading' | 'converting' | 'done' | 'error';
-        error?: string;
-      }) => void
-    ) => () => void;
-    installYtDlp: () => Promise<void>;
-    onInstallProgress: (callback: (progress: { percent: number }) => void) => () => void;
-    getYtDlpPath: () => Promise<string>;
-    checkFfmpeg: () => Promise<{
-      installed: boolean;
-      version?: string;
-      latestVersion?: string;
-      updateAvailable?: boolean;
-    }>;
-    installFfmpeg: () => Promise<void>;
-    onFfmpegInstallProgress: (callback: (progress: { percent: number }) => void) => () => void;
-    installDependencies: () => Promise<InstallDependenciesResult>;
-    onDependencyInstallProgress: (
-      callback: (progress: {
-        target: 'ytdlp' | 'ffmpeg';
-        percent: number;
-        overallPercent: number;
-        label: string;
-      }) => void
-    ) => () => void;
-  };
+  downloader: DownloaderApi;
   updater: {
     checkForUpdates: () => Promise<{ enabled: boolean }>;
     startDownload: () => Promise<void>;
@@ -389,40 +294,7 @@ const electronAPI: ElectronAPI = {
   db: dbApi,
   lyrics: lyricsApi,
   media: mediaApi,
-  downloader: {
-    suggest: (query: string) => ipcRenderer.invoke('downloader:suggest', query),
-    search: (query: string) => ipcRenderer.invoke('downloader:search', query),
-    getStreamUrl: (url: string) => ipcRenderer.invoke('downloader:get-stream-url', url),
-    download: (url: string) => ipcRenderer.invoke('downloader:download', { url }),
-    getDownloadLocation: () => ipcRenderer.invoke('downloader:get-download-location'),
-    setDownloadLocation: (downloadPath: string | null) =>
-      ipcRenderer.invoke('downloader:set-download-location', downloadPath),
-    checkDependencies: () => ipcRenderer.invoke('downloader:check-dependencies'),
-    getCachedToolStatus: () => ipcRenderer.invoke('downloader:get-cached-tool-status'),
-    refreshToolStatus: () => ipcRenderer.invoke('downloader:refresh-tool-status'),
-    check: () => ipcRenderer.invoke('downloader:check'),
-    onProgress: createIpcListener<{
-      url: string;
-      progress: number;
-      status: 'downloading' | 'converting' | 'done' | 'error';
-      error?: string;
-    }>('downloader:progress'),
-    installYtDlp: () => ipcRenderer.invoke('downloader:install-ytdlp'),
-    onInstallProgress: createIpcListener<{ percent: number }>('downloader:install-progress'),
-    getYtDlpPath: () => ipcRenderer.invoke('downloader:get-ytdlp-path'),
-    checkFfmpeg: () => ipcRenderer.invoke('downloader:check-ffmpeg'),
-    installFfmpeg: () => ipcRenderer.invoke('downloader:install-ffmpeg'),
-    onFfmpegInstallProgress: createIpcListener<{ percent: number }>(
-      'downloader:ffmpeg-install-progress'
-    ),
-    installDependencies: () => ipcRenderer.invoke('downloader:install-dependencies'),
-    onDependencyInstallProgress: createIpcListener<{
-      target: 'ytdlp' | 'ffmpeg';
-      percent: number;
-      overallPercent: number;
-      label: string;
-    }>('downloader:dependency-install-progress'),
-  },
+  downloader: downloaderApi,
   updater: {
     checkForUpdates: () => ipcRenderer.invoke('updater:check-for-updates'),
     startDownload: () => ipcRenderer.invoke('updater:start-download'),

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
 import {
   isIpcError,
   SHARE_ERROR_CODES,
@@ -6,16 +6,15 @@ import {
   VALIDATION_ERROR_CODES,
 } from './ipc/errors';
 import type { InstallDependenciesResult } from './ipc/downloader';
-
-function createIpcListener<T>(channel: string): (callback: (data: T) => void) => () => void {
-  return (callback: (data: T) => void) => {
-    const handler = (_event: IpcRendererEvent, data: T) => callback(data);
-    ipcRenderer.on(channel, handler);
-    return () => {
-      ipcRenderer.removeListener(channel, handler);
-    };
-  };
-}
+import { createIpcListener } from './preload/ipc-listener';
+import { appApi, type AppApi } from './preload/api/app';
+import { dialogApi, type DialogApi } from './preload/api/dialog';
+import { libraryApi, type LibraryApi } from './preload/api/library';
+import { lyricsApi, type LyricsApi } from './preload/api/lyrics';
+import { mediaApi, type MediaApi } from './preload/api/media';
+import { shellApi, type ShellApi } from './preload/api/shell';
+import { storeApi, type StoreApi } from './preload/api/store';
+import { windowApi, type WindowApi } from './preload/api/window';
 
 const UPDATER_IPC_CHANNELS = new Set([
   'updater:check-for-updates',
@@ -127,105 +126,18 @@ function invokeWithTimeout<T>(channel: string, timeout: number, ...args: unknown
   return Promise.race([invokePromise.finally(() => clearTimeout(timer)), timeoutPromise]);
 }
 
-interface TrackMetadata {
-  title: string;
-  artist: string;
-  album: string;
-  duration: number;
-  genre: string;
-  year: number | null;
-  trackNumber: number | null;
-  discNumber: number | null;
-  albumArt: string | null;
-}
-
-interface ListeningHistoryEntry {
-  id: string;
-  trackId: string;
-  title: string;
-  artist: string;
-  album: string;
-  albumArt: string | null;
-  duration: number | null;
-  playedAt: string;
-  playedSeconds: number;
-  completionRatio: number;
-  completed: boolean;
-  source: string;
-}
-
-interface ListeningStatsTrack {
-  trackId: string;
-  title: string;
-  artist: string;
-  album: string;
-  albumArt: string | null;
-  playCount: number;
-  listenedSeconds: number;
-  lastPlayedAt: string;
-}
-
-interface ListeningStatsArtist {
-  artist: string;
-  playCount: number;
-  listenedSeconds: number;
-}
-
-interface ListeningStatsSummary {
-  totalPlays: number;
-  totalMinutes: number;
-  uniqueTracks: number;
-  uniqueArtists: number;
-  completedPlays: number;
-  topTracks: ListeningStatsTrack[];
-  topArtists: ListeningStatsArtist[];
-}
-
-interface ListeningActivityPoint {
-  date: string;
-  playCount: number;
-  listenedMinutes: number;
-}
+import type {
+  ListeningActivityPoint,
+  ListeningHistoryEntry,
+  ListeningStatsSummary,
+} from './preload/types';
 
 export interface ElectronAPI {
-  window: {
-    minimize: () => Promise<void>;
-    maximize: () => Promise<void>;
-    close: () => Promise<void>;
-    isMaximized: () => Promise<boolean>;
-    setAlwaysOnTop: (alwaysOnTop: boolean) => Promise<void>;
-    setCompactMode: (
-      compactMode: boolean,
-      dimensions?: { width: number; height: number }
-    ) => Promise<void>;
-    onMaximizedChange: (callback: (maximized: boolean) => void) => () => void;
-  };
-  store: {
-    get: <T>(key: string) => Promise<T | undefined>;
-    set: <T>(key: string, value: T) => Promise<void>;
-    delete: (key: string) => Promise<void>;
-  };
-  dialog: {
-    openDirectory: () => Promise<string | null>;
-    openFile: (options?: unknown) => Promise<string | null>;
-  };
-  app: {
-    getVersion: () => Promise<string>;
-    openLogsFolder: () => Promise<void>;
-  };
-  library: {
-    parseMetadata: (filePath: string) => Promise<{ filePath: string; metadata: TrackMetadata }>;
-    scanFolder: (dirPath: string) => Promise<Array<{ filePath: string; metadata: TrackMetadata }>>;
-    scanFolderGrouped: (dirPath: string) => Promise<{
-      rootTracks: Array<{ filePath: string; metadata: TrackMetadata }>;
-      subfolders: Array<{
-        name: string;
-        path: string;
-        tracks: Array<{ filePath: string; metadata: TrackMetadata }>;
-      }>;
-    }>;
-    validateFiles: (filePaths: string[]) => Promise<string[]>;
-  };
+  window: WindowApi;
+  store: StoreApi;
+  dialog: DialogApi;
+  app: AppApi;
+  library: LibraryApi;
   db: {
     tracks: {
       getAll: () => Promise<unknown[]>;
@@ -282,31 +194,8 @@ export interface ElectronAPI {
       reorder: (playlistId: string, trackIds: string[]) => Promise<void>;
     };
   };
-  lyrics: {
-    fetch: (
-      title: string,
-      artist: string,
-      album?: string,
-      duration?: number
-    ) => Promise<{
-      synced: Array<{ time: number; text: string }> | null;
-      plain: string | null;
-      source: 'lrclib' | 'cache' | null;
-    }>;
-  };
-  media: {
-    onCommand: (callback: (command: string) => void) => () => void;
-    sendPlaybackState: (state: {
-      isPlaying: boolean;
-      title: string;
-      artist: string;
-      album: string;
-      duration: number;
-      currentTime: number;
-      albumArt: string | null;
-    }) => Promise<void>;
-    clearState: () => Promise<void>;
-  };
+  lyrics: LyricsApi;
+  media: MediaApi;
   downloader: {
     getStreamUrl: (url: string) => Promise<string>;
     suggest: (query: string) => Promise<string[]>;
@@ -432,10 +321,7 @@ export interface ElectronAPI {
     ) => () => void;
     onUpdateError: (callback: (message: string) => void) => () => void;
   };
-  shell: {
-    showInFolder: (filePath: string) => Promise<void>;
-    trashFile: (filePath: string) => Promise<void>;
-  };
+  shell: ShellApi;
   radio: {
     favorites: {
       getAll: () => Promise<unknown[]>;
@@ -554,38 +440,11 @@ export interface ElectronAPI {
 }
 
 const electronAPI: ElectronAPI = {
-  window: {
-    minimize: () => ipcRenderer.invoke('window:minimize'),
-    maximize: () => ipcRenderer.invoke('window:maximize'),
-    close: () => ipcRenderer.invoke('window:close'),
-    isMaximized: () => ipcRenderer.invoke('window:is-maximized'),
-    setAlwaysOnTop: (alwaysOnTop: boolean) =>
-      ipcRenderer.invoke('window:set-always-on-top', alwaysOnTop),
-    setCompactMode: (compactMode: boolean, dimensions?: { width: number; height: number }) =>
-      ipcRenderer.invoke('window:set-compact-mode', compactMode, dimensions),
-    onMaximizedChange: createIpcListener<boolean>('window:maximized-change'),
-  },
-  store: {
-    get: <T>(key: string) => ipcRenderer.invoke('store:get', key) as Promise<T | undefined>,
-    set: <T>(key: string, value: T) => ipcRenderer.invoke('store:set', key, value),
-    delete: (key: string) => ipcRenderer.invoke('store:delete', key),
-  },
-  dialog: {
-    openDirectory: () => ipcRenderer.invoke('dialog:open-directory'),
-    openFile: (options?: unknown) => ipcRenderer.invoke('dialog:open-file', options),
-  },
-  app: {
-    getVersion: () => ipcRenderer.invoke('app:get-version'),
-    openLogsFolder: () => ipcRenderer.invoke('app:open-logs-folder'),
-  },
-  library: {
-    parseMetadata: (filePath: string) => ipcRenderer.invoke('library:parse-metadata', filePath),
-    scanFolder: (dirPath: string) => ipcRenderer.invoke('library:scan-folder', dirPath),
-    scanFolderGrouped: (dirPath: string) =>
-      ipcRenderer.invoke('library:scan-folder-grouped', dirPath),
-    validateFiles: (filePaths: string[]) =>
-      ipcRenderer.invoke('library:validate-files', filePaths) as Promise<string[]>,
-  },
+  window: windowApi,
+  store: storeApi,
+  dialog: dialogApi,
+  app: appApi,
+  library: libraryApi,
   db: {
     tracks: {
       getAll: () => ipcRenderer.invoke('db:tracks:get-all'),
@@ -644,15 +503,8 @@ const electronAPI: ElectronAPI = {
         ipcRenderer.invoke('db:playlists:reorder', { playlistId, trackIds }),
     },
   },
-  lyrics: {
-    fetch: (title: string, artist: string, album?: string, duration?: number) =>
-      ipcRenderer.invoke('lyrics:fetch', title, artist, album, duration),
-  },
-  media: {
-    onCommand: createIpcListener<string>('media:command'),
-    sendPlaybackState: state => ipcRenderer.invoke('media:playback-state', state),
-    clearState: () => ipcRenderer.invoke('media:clear-state'),
-  },
+  lyrics: lyricsApi,
+  media: mediaApi,
   downloader: {
     suggest: (query: string) => ipcRenderer.invoke('downloader:suggest', query),
     search: (query: string) => ipcRenderer.invoke('downloader:search', query),
@@ -711,10 +563,7 @@ const electronAPI: ElectronAPI = {
     }>('updater:update-downloaded'),
     onUpdateError: createIpcListener<string>('updater:error'),
   },
-  shell: {
-    showInFolder: (filePath: string) => ipcRenderer.invoke('shell:show-in-folder', filePath),
-    trashFile: (filePath: string) => ipcRenderer.invoke('shell:trash-file', filePath),
-  },
+  shell: shellApi,
   radio: {
     favorites: {
       getAll: () => ipcRenderer.invoke('radio:favorites:get-all'),

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -5,7 +5,6 @@ import {
   PLAYLIST_ERROR_CODES,
   VALIDATION_ERROR_CODES,
 } from './ipc/errors';
-import { createIpcListener } from './preload/ipc-listener';
 import { appApi, type AppApi } from './preload/api/app';
 import { dbApi, type DbApi } from './preload/api/db';
 import { dialogApi, type DialogApi } from './preload/api/dialog';
@@ -13,8 +12,13 @@ import { downloaderApi, type DownloaderApi } from './preload/api/downloader';
 import { libraryApi, type LibraryApi } from './preload/api/library';
 import { lyricsApi, type LyricsApi } from './preload/api/lyrics';
 import { mediaApi, type MediaApi } from './preload/api/media';
+import { metadataApi, type MetadataApi } from './preload/api/metadata';
+import { playlistApi, type PlaylistApi } from './preload/api/playlist';
+import { radioApi, type RadioApi } from './preload/api/radio';
+import { shareApi, type ShareApi } from './preload/api/share';
 import { shellApi, type ShellApi } from './preload/api/shell';
 import { storeApi, type StoreApi } from './preload/api/store';
+import { updaterApi, type UpdaterApi } from './preload/api/updater';
 import { windowApi, type WindowApi } from './preload/api/window';
 
 const UPDATER_IPC_CHANNELS = new Set([
@@ -137,142 +141,12 @@ export interface ElectronAPI {
   lyrics: LyricsApi;
   media: MediaApi;
   downloader: DownloaderApi;
-  updater: {
-    checkForUpdates: () => Promise<{ enabled: boolean }>;
-    startDownload: () => Promise<void>;
-    installNow: () => Promise<void>;
-    onCheckingForUpdate: (callback: () => void) => () => void;
-    onUpdateAvailable: (
-      callback: (info: {
-        version: string;
-        releaseNotes: string | null;
-        releaseDate: string;
-      }) => void
-    ) => () => void;
-    onUpdateNotAvailable: (callback: () => void) => () => void;
-    onDownloadProgress: (
-      callback: (progress: {
-        bytesPerSecond: number;
-        percent: number;
-        transferred: number;
-        total: number;
-      }) => void
-    ) => () => void;
-    onUpdateDownloaded: (
-      callback: (info: {
-        version: string;
-        releaseNotes: string | null;
-        releaseDate: string;
-      }) => void
-    ) => () => void;
-    onUpdateError: (callback: (message: string) => void) => () => void;
-  };
+  updater: UpdaterApi;
   shell: ShellApi;
-  radio: {
-    favorites: {
-      getAll: () => Promise<unknown[]>;
-      add: (station: {
-        stationUuid: string;
-        name: string;
-        url: string;
-        urlResolved: string;
-        homepage?: string;
-        favicon?: string;
-        country?: string;
-        countryCode?: string;
-        language?: string;
-        codec?: string;
-        bitrate?: number;
-        tags?: string;
-      }) => Promise<unknown>;
-      remove: (stationUuid: string) => Promise<void>;
-      isFavorite: (stationUuid: string) => Promise<boolean>;
-    };
-  };
-  playlist: {
-    extract: (url: string) => Promise<
-      Array<{
-        id: string;
-        title: string;
-        uploader: string;
-        duration: number;
-        thumbnail: string;
-        url: string;
-        webpage_url: string;
-      }>
-    >;
-    cancel: () => Promise<void>;
-    onExtractProgress: (
-      callback: (data: { current: number; total: number; trackName: string }) => void
-    ) => () => void;
-  };
-  metadata: {
-    lookup: (
-      title: string,
-      artist: string
-    ) => Promise<{
-      title?: string;
-      artist?: string;
-      album?: string;
-      genre?: string;
-      year?: number;
-      trackNumber?: number;
-      coverImageUrl?: string;
-      source: 'itunes' | 'youtube' | 'none';
-      confidence: number;
-    }>;
-    enrichTracks: (
-      tracks: Array<{
-        id: string;
-        filePath: string;
-        title: string;
-        artist: string;
-        album: string;
-        albumArt: string | null;
-        genre: string;
-        year: number | null;
-        trackNumber: number | null;
-      }>,
-      options: { writeToFile: boolean; onlyMissing: boolean }
-    ) => Promise<
-      Array<{
-        id: string;
-        success: boolean;
-        updatedFields: Partial<{
-          title: string;
-          artist: string;
-          album: string;
-          genre: string;
-          year: number;
-          trackNumber: number;
-          albumArt: string;
-        }>;
-        source: string;
-        error?: string;
-      }>
-    >;
-    cancelEnrichment: () => Promise<void>;
-    onEnrichProgress: (
-      callback: (data: {
-        current: number;
-        total: number;
-        trackName: string;
-        status: 'searching' | 'downloading' | 'writing' | 'done' | 'error' | 'cancelled';
-      }) => void
-    ) => () => void;
-  };
-  share: {
-    track: (trackId: string) => Promise<{ code: string; url: string; expiresAt: string }>;
-    playlist: (playlistId: string) => Promise<{ code: string; url: string; expiresAt: string }>;
-    import: (code: string) => Promise<{
-      type: 'TRACK' | 'PLAYLIST';
-      payload: unknown;
-      code: string;
-      expiresAt: string;
-    }>;
-    cacheYoutubeId: (trackId: string, youtubeId: string) => Promise<void>;
-    onDeepLink: (callback: (code: string) => void) => () => void;
-  };
+  radio: RadioApi;
+  playlist: PlaylistApi;
+  metadata: MetadataApi;
+  share: ShareApi;
   ipc: {
     invokeWithTimeout: <T>(channel: string, timeout: number, ...args: unknown[]) => Promise<T>;
   };
@@ -295,94 +169,12 @@ const electronAPI: ElectronAPI = {
   lyrics: lyricsApi,
   media: mediaApi,
   downloader: downloaderApi,
-  updater: {
-    checkForUpdates: () => ipcRenderer.invoke('updater:check-for-updates'),
-    startDownload: () => ipcRenderer.invoke('updater:start-download'),
-    installNow: () => ipcRenderer.invoke('updater:install-now'),
-    onCheckingForUpdate: createIpcListener<void>('updater:checking-for-update'),
-    onUpdateAvailable: createIpcListener<{
-      version: string;
-      releaseNotes: string | null;
-      releaseDate: string;
-    }>('updater:update-available'),
-    onUpdateNotAvailable: createIpcListener<void>('updater:update-not-available'),
-    onDownloadProgress: createIpcListener<{
-      bytesPerSecond: number;
-      percent: number;
-      transferred: number;
-      total: number;
-    }>('updater:download-progress'),
-    onUpdateDownloaded: createIpcListener<{
-      version: string;
-      releaseNotes: string | null;
-      releaseDate: string;
-    }>('updater:update-downloaded'),
-    onUpdateError: createIpcListener<string>('updater:error'),
-  },
+  updater: updaterApi,
   shell: shellApi,
-  radio: {
-    favorites: {
-      getAll: () => ipcRenderer.invoke('radio:favorites:get-all'),
-      add: (station: {
-        stationUuid: string;
-        name: string;
-        url: string;
-        urlResolved: string;
-        homepage?: string;
-        favicon?: string;
-        country?: string;
-        countryCode?: string;
-        language?: string;
-        codec?: string;
-        bitrate?: number;
-        tags?: string;
-      }) => ipcRenderer.invoke('radio:favorites:add', station),
-      remove: (stationUuid: string) => ipcRenderer.invoke('radio:favorites:remove', stationUuid),
-      isFavorite: (stationUuid: string) =>
-        ipcRenderer.invoke('radio:favorites:is-favorite', stationUuid) as Promise<boolean>,
-    },
-  },
-  playlist: {
-    extract: (url: string) => ipcRenderer.invoke('playlist:extract', url),
-    cancel: () => ipcRenderer.invoke('playlist:cancel'),
-    onExtractProgress: createIpcListener<{
-      current: number;
-      total: number;
-      trackName: string;
-    }>('playlist:extract-progress'),
-  },
-  metadata: {
-    lookup: (title: string, artist: string) => ipcRenderer.invoke('metadata:lookup', title, artist),
-    enrichTracks: (
-      tracks: Array<{
-        id: string;
-        filePath: string;
-        title: string;
-        artist: string;
-        album: string;
-        albumArt: string | null;
-        genre: string;
-        year: number | null;
-        trackNumber: number | null;
-      }>,
-      options: { writeToFile: boolean; onlyMissing: boolean }
-    ) => ipcRenderer.invoke('metadata:enrich:tracks', tracks, options),
-    cancelEnrichment: () => ipcRenderer.invoke('metadata:enrich:cancel'),
-    onEnrichProgress: createIpcListener<{
-      current: number;
-      total: number;
-      trackName: string;
-      status: 'searching' | 'downloading' | 'writing' | 'done' | 'error' | 'cancelled';
-    }>('metadata:enrich:progress'),
-  },
-  share: {
-    track: (trackId: string) => ipcRenderer.invoke('share:track', trackId),
-    playlist: (playlistId: string) => ipcRenderer.invoke('share:playlist', playlistId),
-    import: (code: string) => ipcRenderer.invoke('share:import', code),
-    cacheYoutubeId: (trackId: string, youtubeId: string) =>
-      ipcRenderer.invoke('share:cache-youtube-id', trackId, youtubeId),
-    onDeepLink: createIpcListener<string>('share:deep-link'),
-  },
+  radio: radioApi,
+  playlist: playlistApi,
+  metadata: metadataApi,
+  share: shareApi,
   ipc: {
     invokeWithTimeout: <T>(channel: string, timeout: number, ...args: unknown[]) =>
       invokeWithTimeout<T>(channel, timeout, ...args),

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -1,10 +1,11 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge } from 'electron';
 import {
   isIpcError,
   SHARE_ERROR_CODES,
   PLAYLIST_ERROR_CODES,
   VALIDATION_ERROR_CODES,
 } from './ipc/errors';
+import { invokeWithTimeout } from './preload/context-bridge';
 import { appApi, type AppApi } from './preload/api/app';
 import { dbApi, type DbApi } from './preload/api/db';
 import { dialogApi, type DialogApi } from './preload/api/dialog';
@@ -20,116 +21,6 @@ import { shellApi, type ShellApi } from './preload/api/shell';
 import { storeApi, type StoreApi } from './preload/api/store';
 import { updaterApi, type UpdaterApi } from './preload/api/updater';
 import { windowApi, type WindowApi } from './preload/api/window';
-
-const UPDATER_IPC_CHANNELS = new Set([
-  'updater:check-for-updates',
-  'updater:start-download',
-  'updater:install-now',
-]);
-
-const ALLOWED_IPC_CHANNELS = new Set([
-  'window:minimize',
-  'window:maximize',
-  'window:close',
-  'window:is-maximized',
-  'window:set-always-on-top',
-  'window:set-compact-mode',
-  'media:playback-state',
-  'media:clear-state',
-  'store:get',
-  'store:set',
-  'store:delete',
-  'app:get-version',
-  'app:open-logs-folder',
-  'dialog:open-directory',
-  'dialog:open-file',
-  'library:parse-metadata',
-  'library:scan-folder',
-  'library:scan-folder-grouped',
-  'library:validate-files',
-  'lyrics:fetch',
-  'db:tracks:get-all',
-  'db:tracks:add',
-  'db:tracks:add-many',
-  'db:tracks:remove',
-  'db:tracks:remove-many',
-  'db:tracks:update',
-  'db:tracks:update-many',
-  'db:tracks:toggle-favorite',
-  'db:tracks:get-favorites',
-  'db:tracks:increment-play-count',
-  'db:tracks:exists',
-  'db:tracks:exists-many',
-  'db:history:record-play',
-  'db:history:get-recent',
-  'db:history:get-summary',
-  'db:history:get-activity',
-  'db:folders:get-all',
-  'db:folders:add',
-  'db:folders:remove',
-  'db:folders:update-scanned',
-  'db:playlists:get-all',
-  'db:playlists:get',
-  'db:playlists:create',
-  'db:playlists:create-with-tracks',
-  'db:playlists:update',
-  'db:playlists:delete',
-  'db:playlists:get-tracks',
-  'db:playlists:add-track',
-  'db:playlists:remove-track',
-  'db:playlists:get-playlists-for-tracks',
-  'db:playlists:reorder',
-  'shell:show-in-folder',
-  'shell:trash-file',
-  'downloader:check',
-  'downloader:get-download-location',
-  'downloader:set-download-location',
-  'downloader:check-dependencies',
-  'downloader:search',
-  'downloader:suggest',
-  'downloader:download',
-  'downloader:install-ytdlp',
-  'downloader:get-ytdlp-path',
-  'downloader:check-ffmpeg',
-  'downloader:install-ffmpeg',
-  'downloader:get-stream-url',
-  'downloader:install-dependencies',
-  'radio:favorites:get-all',
-  'radio:favorites:add',
-  'radio:favorites:remove',
-  'radio:favorites:is-favorite',
-  'playlist:extract',
-  'playlist:cancel',
-  'share:track',
-  'share:playlist',
-  'share:import',
-  'share:cache-youtube-id',
-  'metadata:lookup',
-  'metadata:enrich:tracks',
-  'metadata:enrich:cancel',
-]);
-
-function assertAllowedChannel(channel: string): void {
-  if (!ALLOWED_IPC_CHANNELS.has(channel) && !UPDATER_IPC_CHANNELS.has(channel)) {
-    throw new Error(`IPC channel not allowed: "${channel}"`);
-  }
-}
-
-function invokeWithTimeout<T>(channel: string, timeout: number, ...args: unknown[]): Promise<T> {
-  assertAllowedChannel(channel);
-  const invokePromise = ipcRenderer.invoke(channel, ...args) as Promise<T>;
-  let timer: ReturnType<typeof setTimeout>;
-  const timeoutPromise = new Promise<never>((_resolve, reject) => {
-    timer = setTimeout(() => {
-      reject(new Error(`IPC timeout: "${channel}" did not respond within ${timeout}ms`));
-      invokePromise.catch(() => {});
-    }, timeout);
-    if (typeof timer === 'object' && 'unref' in timer) {
-      timer.unref();
-    }
-  });
-  return Promise.race([invokePromise.finally(() => clearTimeout(timer)), timeoutPromise]);
-}
 
 export interface ElectronAPI {
   window: WindowApi;

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -1,88 +1,9 @@
-import { contextBridge } from 'electron';
-import {
-  isIpcError,
-  SHARE_ERROR_CODES,
-  PLAYLIST_ERROR_CODES,
-  VALIDATION_ERROR_CODES,
-} from './ipc/errors';
-import { invokeWithTimeout } from './preload/context-bridge';
-import { appApi, type AppApi } from './preload/api/app';
-import { dbApi, type DbApi } from './preload/api/db';
-import { dialogApi, type DialogApi } from './preload/api/dialog';
-import { downloaderApi, type DownloaderApi } from './preload/api/downloader';
-import { libraryApi, type LibraryApi } from './preload/api/library';
-import { lyricsApi, type LyricsApi } from './preload/api/lyrics';
-import { mediaApi, type MediaApi } from './preload/api/media';
-import { metadataApi, type MetadataApi } from './preload/api/metadata';
-import { playlistApi, type PlaylistApi } from './preload/api/playlist';
-import { radioApi, type RadioApi } from './preload/api/radio';
-import { shareApi, type ShareApi } from './preload/api/share';
-import { shellApi, type ShellApi } from './preload/api/shell';
-import { storeApi, type StoreApi } from './preload/api/store';
-import { updaterApi, type UpdaterApi } from './preload/api/updater';
-import { windowApi, type WindowApi } from './preload/api/window';
+// Electron preload entry. The actual implementation lives in `./preload/` —
+// this file is the bundler entry point referenced by esbuild.config.mjs and
+// loaded by BrowserWindow's webPreferences.preload (window.ts), kept stable so
+// the build pipeline doesn't need to track the split. Importing the index runs
+// `contextBridge.exposeInMainWorld` as a side effect.
 
-export interface ElectronAPI {
-  window: WindowApi;
-  store: StoreApi;
-  dialog: DialogApi;
-  app: AppApi;
-  library: LibraryApi;
-  db: DbApi;
-  lyrics: LyricsApi;
-  media: MediaApi;
-  downloader: DownloaderApi;
-  updater: UpdaterApi;
-  shell: ShellApi;
-  radio: RadioApi;
-  playlist: PlaylistApi;
-  metadata: MetadataApi;
-  share: ShareApi;
-  ipc: {
-    invokeWithTimeout: <T>(channel: string, timeout: number, ...args: unknown[]) => Promise<T>;
-  };
-  errors: {
-    isIpcError: (e: unknown) => e is { code: string; message: string; details?: unknown };
-    SHARE_ERROR_CODES: typeof SHARE_ERROR_CODES;
-    PLAYLIST_ERROR_CODES: typeof PLAYLIST_ERROR_CODES;
-    VALIDATION_ERROR_CODES: typeof VALIDATION_ERROR_CODES;
-  };
-  platform: NodeJS.Platform;
-}
+import './preload/index';
 
-const electronAPI: ElectronAPI = {
-  window: windowApi,
-  store: storeApi,
-  dialog: dialogApi,
-  app: appApi,
-  library: libraryApi,
-  db: dbApi,
-  lyrics: lyricsApi,
-  media: mediaApi,
-  downloader: downloaderApi,
-  updater: updaterApi,
-  shell: shellApi,
-  radio: radioApi,
-  playlist: playlistApi,
-  metadata: metadataApi,
-  share: shareApi,
-  ipc: {
-    invokeWithTimeout: <T>(channel: string, timeout: number, ...args: unknown[]) =>
-      invokeWithTimeout<T>(channel, timeout, ...args),
-  },
-  errors: {
-    isIpcError,
-    SHARE_ERROR_CODES,
-    PLAYLIST_ERROR_CODES,
-    VALIDATION_ERROR_CODES,
-  },
-  platform: process.platform,
-};
-
-contextBridge.exposeInMainWorld('electronAPI', electronAPI);
-
-declare global {
-  interface Window {
-    electronAPI: ElectronAPI;
-  }
-}
+export type { ElectronAPI } from './preload/index';

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -126,11 +126,7 @@ function invokeWithTimeout<T>(channel: string, timeout: number, ...args: unknown
   return Promise.race([invokePromise.finally(() => clearTimeout(timer)), timeoutPromise]);
 }
 
-import type {
-  ListeningActivityPoint,
-  ListeningHistoryEntry,
-  ListeningStatsSummary,
-} from './preload/types';
+import { dbApi, type DbApi } from './preload/api/db';
 
 export interface ElectronAPI {
   window: WindowApi;
@@ -138,62 +134,7 @@ export interface ElectronAPI {
   dialog: DialogApi;
   app: AppApi;
   library: LibraryApi;
-  db: {
-    tracks: {
-      getAll: () => Promise<unknown[]>;
-      add: (track: unknown) => Promise<unknown>;
-      addMany: (tracks: unknown[]) => Promise<unknown[]>;
-      remove: (id: string) => Promise<void>;
-      removeMany: (ids: string[]) => Promise<void>;
-      update: (id: string, data: unknown) => Promise<unknown>;
-      updateMany: (updates: Array<{ id: string; data: unknown }>) => Promise<unknown[]>;
-      toggleFavorite: (id: string) => Promise<unknown>;
-      getFavorites: () => Promise<unknown[]>;
-      incrementPlayCount: (id: string) => Promise<unknown>;
-      exists: (filePath: string) => Promise<boolean>;
-      existsMany: (filePaths: string[]) => Promise<string[]>;
-    };
-    history: {
-      recordPlay: (data: {
-        trackId: string;
-        playedSeconds: number;
-        duration: number | null;
-        source?: string;
-      }) => Promise<unknown>;
-      getRecent: (options?: {
-        limit?: number;
-        since?: string | null;
-      }) => Promise<ListeningHistoryEntry[]>;
-      getSummary: (options?: { since?: string | null }) => Promise<ListeningStatsSummary>;
-      getActivity: (options?: { since?: string | null }) => Promise<ListeningActivityPoint[]>;
-    };
-    folders: {
-      getAll: () => Promise<unknown[]>;
-      add: (path: string) => Promise<unknown>;
-      remove: (id: string) => Promise<void>;
-      updateScanned: (id: string) => Promise<unknown>;
-    };
-    playlists: {
-      getAll: () => Promise<unknown[]>;
-      get: (id: string) => Promise<unknown>;
-      create: (data: { name: string; description?: string; coverArt?: string }) => Promise<unknown>;
-      createWithTracks: (data: {
-        name: string;
-        description?: string;
-        trackIds: string[];
-      }) => Promise<unknown>;
-      update: (
-        id: string,
-        data: { name?: string; description?: string; coverArt?: string }
-      ) => Promise<unknown>;
-      delete: (id: string) => Promise<void>;
-      getTracks: (playlistId: string) => Promise<unknown[]>;
-      addTrack: (playlistId: string, trackId: string) => Promise<unknown>;
-      removeTrack: (playlistId: string, trackId: string) => Promise<void>;
-      getPlaylistsForTracks: (trackIds: string[]) => Promise<string[]>;
-      reorder: (playlistId: string, trackIds: string[]) => Promise<void>;
-    };
-  };
+  db: DbApi;
   lyrics: LyricsApi;
   media: MediaApi;
   downloader: {
@@ -445,64 +386,7 @@ const electronAPI: ElectronAPI = {
   dialog: dialogApi,
   app: appApi,
   library: libraryApi,
-  db: {
-    tracks: {
-      getAll: () => ipcRenderer.invoke('db:tracks:get-all'),
-      add: (track: unknown) => ipcRenderer.invoke('db:tracks:add', track),
-      addMany: (tracks: unknown[]) => ipcRenderer.invoke('db:tracks:add-many', tracks),
-      remove: (id: string) => ipcRenderer.invoke('db:tracks:remove', id),
-      removeMany: (ids: string[]) => ipcRenderer.invoke('db:tracks:remove-many', ids),
-      update: (id: string, data: unknown) => ipcRenderer.invoke('db:tracks:update', id, data),
-      updateMany: (updates: Array<{ id: string; data: unknown }>) =>
-        ipcRenderer.invoke('db:tracks:update-many', updates),
-      toggleFavorite: (id: string) => ipcRenderer.invoke('db:tracks:toggle-favorite', id),
-      getFavorites: () => ipcRenderer.invoke('db:tracks:get-favorites'),
-      incrementPlayCount: (id: string) => ipcRenderer.invoke('db:tracks:increment-play-count', id),
-      exists: (filePath: string) => ipcRenderer.invoke('db:tracks:exists', filePath),
-      existsMany: (filePaths: string[]) =>
-        ipcRenderer.invoke('db:tracks:exists-many', filePaths) as Promise<string[]>,
-    },
-    history: {
-      recordPlay: (data: {
-        trackId: string;
-        playedSeconds: number;
-        duration: number | null;
-        source?: string;
-      }) => ipcRenderer.invoke('db:history:record-play', data),
-      getRecent: (options?: { limit?: number; since?: string | null }) =>
-        ipcRenderer.invoke('db:history:get-recent', options),
-      getSummary: (options?: { since?: string | null }) =>
-        ipcRenderer.invoke('db:history:get-summary', options),
-      getActivity: (options?: { since?: string | null }) =>
-        ipcRenderer.invoke('db:history:get-activity', options),
-    },
-    folders: {
-      getAll: () => ipcRenderer.invoke('db:folders:get-all'),
-      add: (path: string) => ipcRenderer.invoke('db:folders:add', path),
-      remove: (id: string) => ipcRenderer.invoke('db:folders:remove', id),
-      updateScanned: (id: string) => ipcRenderer.invoke('db:folders:update-scanned', id),
-    },
-    playlists: {
-      getAll: () => ipcRenderer.invoke('db:playlists:get-all'),
-      get: (id: string) => ipcRenderer.invoke('db:playlists:get', id),
-      create: (data: { name: string; description?: string; coverArt?: string }) =>
-        ipcRenderer.invoke('db:playlists:create', data),
-      createWithTracks: (data: { name: string; description?: string; trackIds: string[] }) =>
-        ipcRenderer.invoke('db:playlists:create-with-tracks', data),
-      update: (id: string, data: { name?: string; description?: string; coverArt?: string }) =>
-        ipcRenderer.invoke('db:playlists:update', id, data),
-      delete: (id: string) => ipcRenderer.invoke('db:playlists:delete', id),
-      getTracks: (playlistId: string) => ipcRenderer.invoke('db:playlists:get-tracks', playlistId),
-      addTrack: (playlistId: string, trackId: string) =>
-        ipcRenderer.invoke('db:playlists:add-track', { playlistId, trackId }),
-      removeTrack: (playlistId: string, trackId: string) =>
-        ipcRenderer.invoke('db:playlists:remove-track', { playlistId, trackId }),
-      getPlaylistsForTracks: (trackIds: string[]) =>
-        ipcRenderer.invoke('db:playlists:get-playlists-for-tracks', trackIds),
-      reorder: (playlistId: string, trackIds: string[]) =>
-        ipcRenderer.invoke('db:playlists:reorder', { playlistId, trackIds }),
-    },
-  },
+  db: dbApi,
   lyrics: lyricsApi,
   media: mediaApi,
   downloader: {

--- a/apps/desktop/src/main/preload/api/app.ts
+++ b/apps/desktop/src/main/preload/api/app.ts
@@ -1,0 +1,14 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+
+const C = IPC_CHANNELS.app;
+
+export interface AppApi {
+  getVersion: () => Promise<string>;
+  openLogsFolder: () => Promise<void>;
+}
+
+export const appApi: AppApi = {
+  getVersion: () => ipcRenderer.invoke(C.getVersion),
+  openLogsFolder: () => ipcRenderer.invoke(C.openLogsFolder),
+};

--- a/apps/desktop/src/main/preload/api/db.ts
+++ b/apps/desktop/src/main/preload/api/db.ts
@@ -1,0 +1,128 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+import type {
+  ListeningActivityPoint,
+  ListeningHistoryEntry,
+  ListeningStatsSummary,
+} from '../types';
+
+const C = IPC_CHANNELS.db;
+
+export interface DbTracksApi {
+  getAll: () => Promise<unknown[]>;
+  add: (track: unknown) => Promise<unknown>;
+  addMany: (tracks: unknown[]) => Promise<unknown[]>;
+  remove: (id: string) => Promise<void>;
+  removeMany: (ids: string[]) => Promise<void>;
+  update: (id: string, data: unknown) => Promise<unknown>;
+  updateMany: (updates: Array<{ id: string; data: unknown }>) => Promise<unknown[]>;
+  toggleFavorite: (id: string) => Promise<unknown>;
+  getFavorites: () => Promise<unknown[]>;
+  incrementPlayCount: (id: string) => Promise<unknown>;
+  exists: (filePath: string) => Promise<boolean>;
+  existsMany: (filePaths: string[]) => Promise<string[]>;
+}
+
+export interface DbHistoryApi {
+  recordPlay: (data: {
+    trackId: string;
+    playedSeconds: number;
+    duration: number | null;
+    source?: string;
+  }) => Promise<unknown>;
+  getRecent: (options?: {
+    limit?: number;
+    since?: string | null;
+  }) => Promise<ListeningHistoryEntry[]>;
+  getSummary: (options?: { since?: string | null }) => Promise<ListeningStatsSummary>;
+  getActivity: (options?: { since?: string | null }) => Promise<ListeningActivityPoint[]>;
+}
+
+export interface DbFoldersApi {
+  getAll: () => Promise<unknown[]>;
+  add: (path: string) => Promise<unknown>;
+  remove: (id: string) => Promise<void>;
+  updateScanned: (id: string) => Promise<unknown>;
+}
+
+export interface DbPlaylistsApi {
+  getAll: () => Promise<unknown[]>;
+  get: (id: string) => Promise<unknown>;
+  create: (data: { name: string; description?: string; coverArt?: string }) => Promise<unknown>;
+  createWithTracks: (data: {
+    name: string;
+    description?: string;
+    trackIds: string[];
+  }) => Promise<unknown>;
+  update: (
+    id: string,
+    data: { name?: string; description?: string; coverArt?: string }
+  ) => Promise<unknown>;
+  delete: (id: string) => Promise<void>;
+  getTracks: (playlistId: string) => Promise<unknown[]>;
+  addTrack: (playlistId: string, trackId: string) => Promise<unknown>;
+  removeTrack: (playlistId: string, trackId: string) => Promise<void>;
+  getPlaylistsForTracks: (trackIds: string[]) => Promise<string[]>;
+  reorder: (playlistId: string, trackIds: string[]) => Promise<void>;
+}
+
+export interface DbApi {
+  tracks: DbTracksApi;
+  history: DbHistoryApi;
+  folders: DbFoldersApi;
+  playlists: DbPlaylistsApi;
+}
+
+const tracksApi: DbTracksApi = {
+  getAll: () => ipcRenderer.invoke(C.tracks.getAll),
+  add: track => ipcRenderer.invoke(C.tracks.add, track),
+  addMany: tracks => ipcRenderer.invoke(C.tracks.addMany, tracks),
+  remove: id => ipcRenderer.invoke(C.tracks.remove, id),
+  removeMany: ids => ipcRenderer.invoke(C.tracks.removeMany, ids),
+  update: (id, data) => ipcRenderer.invoke(C.tracks.update, id, data),
+  updateMany: updates => ipcRenderer.invoke(C.tracks.updateMany, updates),
+  toggleFavorite: id => ipcRenderer.invoke(C.tracks.toggleFavorite, id),
+  getFavorites: () => ipcRenderer.invoke(C.tracks.getFavorites),
+  incrementPlayCount: id => ipcRenderer.invoke(C.tracks.incrementPlayCount, id),
+  exists: filePath => ipcRenderer.invoke(C.tracks.exists, filePath),
+  existsMany: filePaths => ipcRenderer.invoke(C.tracks.existsMany, filePaths) as Promise<string[]>,
+};
+
+const historyApi: DbHistoryApi = {
+  recordPlay: data => ipcRenderer.invoke(C.history.recordPlay, data),
+  getRecent: options => ipcRenderer.invoke(C.history.getRecent, options),
+  getSummary: options => ipcRenderer.invoke(C.history.getSummary, options),
+  getActivity: options => ipcRenderer.invoke(C.history.getActivity, options),
+};
+
+const foldersApi: DbFoldersApi = {
+  getAll: () => ipcRenderer.invoke(C.folders.getAll),
+  add: path => ipcRenderer.invoke(C.folders.add, path),
+  remove: id => ipcRenderer.invoke(C.folders.remove, id),
+  updateScanned: id => ipcRenderer.invoke(C.folders.updateScanned, id),
+};
+
+const playlistsApi: DbPlaylistsApi = {
+  getAll: () => ipcRenderer.invoke(C.playlists.getAll),
+  get: id => ipcRenderer.invoke(C.playlists.get, id),
+  create: data => ipcRenderer.invoke(C.playlists.create, data),
+  createWithTracks: data => ipcRenderer.invoke(C.playlists.createWithTracks, data),
+  update: (id, data) => ipcRenderer.invoke(C.playlists.update, id, data),
+  delete: id => ipcRenderer.invoke(C.playlists.delete, id),
+  getTracks: playlistId => ipcRenderer.invoke(C.playlists.getTracks, playlistId),
+  addTrack: (playlistId, trackId) =>
+    ipcRenderer.invoke(C.playlists.addTrack, { playlistId, trackId }),
+  removeTrack: (playlistId, trackId) =>
+    ipcRenderer.invoke(C.playlists.removeTrack, { playlistId, trackId }),
+  getPlaylistsForTracks: trackIds =>
+    ipcRenderer.invoke(C.playlists.getPlaylistsForTracks, trackIds),
+  reorder: (playlistId, trackIds) =>
+    ipcRenderer.invoke(C.playlists.reorder, { playlistId, trackIds }),
+};
+
+export const dbApi: DbApi = {
+  tracks: tracksApi,
+  history: historyApi,
+  folders: foldersApi,
+  playlists: playlistsApi,
+};

--- a/apps/desktop/src/main/preload/api/dialog.ts
+++ b/apps/desktop/src/main/preload/api/dialog.ts
@@ -1,0 +1,14 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+
+const C = IPC_CHANNELS.dialog;
+
+export interface DialogApi {
+  openDirectory: () => Promise<string | null>;
+  openFile: (options?: unknown) => Promise<string | null>;
+}
+
+export const dialogApi: DialogApi = {
+  openDirectory: () => ipcRenderer.invoke(C.openDirectory),
+  openFile: options => ipcRenderer.invoke(C.openFile, options),
+};

--- a/apps/desktop/src/main/preload/api/dialog.ts
+++ b/apps/desktop/src/main/preload/api/dialog.ts
@@ -1,3 +1,4 @@
+import type { OpenDialogOptions } from 'electron';
 import { ipcRenderer } from 'electron';
 import { IPC_CHANNELS } from '@shiranami/contracts';
 
@@ -5,7 +6,7 @@ const C = IPC_CHANNELS.dialog;
 
 export interface DialogApi {
   openDirectory: () => Promise<string | null>;
-  openFile: (options?: unknown) => Promise<string | null>;
+  openFile: (options?: OpenDialogOptions) => Promise<string | null>;
 }
 
 export const dialogApi: DialogApi = {

--- a/apps/desktop/src/main/preload/api/downloader.ts
+++ b/apps/desktop/src/main/preload/api/downloader.ts
@@ -1,0 +1,105 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+import { createIpcListener } from '../ipc-listener';
+import type { InstallDependenciesResult } from '../../ipc/downloader';
+
+const C = IPC_CHANNELS.downloader;
+
+interface ToolStatus {
+  installed: boolean;
+  version?: string;
+  latestVersion?: string;
+  updateAvailable?: boolean;
+}
+
+interface DownloadLocation {
+  path: string;
+  defaultPath: string;
+  isDefault: boolean;
+}
+
+interface CachedToolStatus {
+  ytdlp: ToolStatus;
+  ffmpeg: ToolStatus;
+  ytdlpPath: string;
+  downloadLocation: DownloadLocation;
+  timestamp: number;
+}
+
+interface SearchResult {
+  id: string;
+  title: string;
+  uploader: string;
+  duration: number;
+  thumbnail: string;
+  url: string;
+  webpage_url: string;
+}
+
+export interface DownloaderApi {
+  getStreamUrl: (url: string) => Promise<string>;
+  suggest: (query: string) => Promise<string[]>;
+  search: (query: string) => Promise<SearchResult[]>;
+  download: (url: string) => Promise<string>;
+  getDownloadLocation: () => Promise<DownloadLocation>;
+  setDownloadLocation: (path: string | null) => Promise<DownloadLocation>;
+  checkDependencies: () => Promise<{ ytdlpInstalled: boolean; ffmpegInstalled: boolean }>;
+  getCachedToolStatus: () => Promise<CachedToolStatus | null>;
+  refreshToolStatus: () => Promise<CachedToolStatus | null>;
+  check: () => Promise<ToolStatus>;
+  onProgress: (
+    callback: (data: {
+      url: string;
+      progress: number;
+      status: 'downloading' | 'converting' | 'done' | 'error';
+      error?: string;
+    }) => void
+  ) => () => void;
+  installYtDlp: () => Promise<void>;
+  onInstallProgress: (callback: (progress: { percent: number }) => void) => () => void;
+  getYtDlpPath: () => Promise<string>;
+  checkFfmpeg: () => Promise<ToolStatus>;
+  installFfmpeg: () => Promise<void>;
+  onFfmpegInstallProgress: (callback: (progress: { percent: number }) => void) => () => void;
+  installDependencies: () => Promise<InstallDependenciesResult>;
+  onDependencyInstallProgress: (
+    callback: (progress: {
+      target: 'ytdlp' | 'ffmpeg';
+      percent: number;
+      overallPercent: number;
+      label: string;
+    }) => void
+  ) => () => void;
+}
+
+export const downloaderApi: DownloaderApi = {
+  suggest: query => ipcRenderer.invoke(C.suggest, query),
+  search: query => ipcRenderer.invoke(C.search, query),
+  getStreamUrl: url => ipcRenderer.invoke(C.getStreamUrl, url),
+  download: url => ipcRenderer.invoke(C.download, { url }),
+  getDownloadLocation: () => ipcRenderer.invoke(C.getDownloadLocation),
+  setDownloadLocation: downloadPath => ipcRenderer.invoke(C.setDownloadLocation, downloadPath),
+  checkDependencies: () => ipcRenderer.invoke(C.checkDependencies),
+  getCachedToolStatus: () => ipcRenderer.invoke(C.getCachedToolStatus),
+  refreshToolStatus: () => ipcRenderer.invoke(C.refreshToolStatus),
+  check: () => ipcRenderer.invoke(C.check),
+  onProgress: createIpcListener<{
+    url: string;
+    progress: number;
+    status: 'downloading' | 'converting' | 'done' | 'error';
+    error?: string;
+  }>(C.progress),
+  installYtDlp: () => ipcRenderer.invoke(C.installYtdlp),
+  onInstallProgress: createIpcListener<{ percent: number }>(C.installProgress),
+  getYtDlpPath: () => ipcRenderer.invoke(C.getYtdlpPath),
+  checkFfmpeg: () => ipcRenderer.invoke(C.checkFfmpeg),
+  installFfmpeg: () => ipcRenderer.invoke(C.installFfmpeg),
+  onFfmpegInstallProgress: createIpcListener<{ percent: number }>(C.ffmpegInstallProgress),
+  installDependencies: () => ipcRenderer.invoke(C.installDependencies),
+  onDependencyInstallProgress: createIpcListener<{
+    target: 'ytdlp' | 'ffmpeg';
+    percent: number;
+    overallPercent: number;
+    label: string;
+  }>(C.dependencyInstallProgress),
+};

--- a/apps/desktop/src/main/preload/api/downloader.ts
+++ b/apps/desktop/src/main/preload/api/downloader.ts
@@ -1,7 +1,7 @@
 import { ipcRenderer } from 'electron';
 import { IPC_CHANNELS } from '@shiranami/contracts';
 import { createIpcListener } from '../ipc-listener';
-import type { InstallDependenciesResult } from '../../ipc/downloader';
+import type { InstallDependenciesResult } from '../types';
 
 const C = IPC_CHANNELS.downloader;
 

--- a/apps/desktop/src/main/preload/api/library.ts
+++ b/apps/desktop/src/main/preload/api/library.ts
@@ -1,0 +1,26 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+import type { TrackMetadata } from '../types';
+
+const C = IPC_CHANNELS.library;
+
+export interface LibraryApi {
+  parseMetadata: (filePath: string) => Promise<{ filePath: string; metadata: TrackMetadata }>;
+  scanFolder: (dirPath: string) => Promise<Array<{ filePath: string; metadata: TrackMetadata }>>;
+  scanFolderGrouped: (dirPath: string) => Promise<{
+    rootTracks: Array<{ filePath: string; metadata: TrackMetadata }>;
+    subfolders: Array<{
+      name: string;
+      path: string;
+      tracks: Array<{ filePath: string; metadata: TrackMetadata }>;
+    }>;
+  }>;
+  validateFiles: (filePaths: string[]) => Promise<string[]>;
+}
+
+export const libraryApi: LibraryApi = {
+  parseMetadata: filePath => ipcRenderer.invoke(C.parseMetadata, filePath),
+  scanFolder: dirPath => ipcRenderer.invoke(C.scanFolder, dirPath),
+  scanFolderGrouped: dirPath => ipcRenderer.invoke(C.scanFolderGrouped, dirPath),
+  validateFiles: filePaths => ipcRenderer.invoke(C.validateFiles, filePaths) as Promise<string[]>,
+};

--- a/apps/desktop/src/main/preload/api/lyrics.ts
+++ b/apps/desktop/src/main/preload/api/lyrics.ts
@@ -1,0 +1,22 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+
+const C = IPC_CHANNELS.lyrics;
+
+export interface LyricsApi {
+  fetch: (
+    title: string,
+    artist: string,
+    album?: string,
+    duration?: number
+  ) => Promise<{
+    synced: Array<{ time: number; text: string }> | null;
+    plain: string | null;
+    source: 'lrclib' | 'cache' | null;
+  }>;
+}
+
+export const lyricsApi: LyricsApi = {
+  fetch: (title, artist, album, duration) =>
+    ipcRenderer.invoke(C.fetch, title, artist, album, duration),
+};

--- a/apps/desktop/src/main/preload/api/media.ts
+++ b/apps/desktop/src/main/preload/api/media.ts
@@ -1,0 +1,25 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+import { createIpcListener } from '../ipc-listener';
+
+const C = IPC_CHANNELS.media;
+
+export interface MediaApi {
+  onCommand: (callback: (command: string) => void) => () => void;
+  sendPlaybackState: (state: {
+    isPlaying: boolean;
+    title: string;
+    artist: string;
+    album: string;
+    duration: number;
+    currentTime: number;
+    albumArt: string | null;
+  }) => Promise<void>;
+  clearState: () => Promise<void>;
+}
+
+export const mediaApi: MediaApi = {
+  onCommand: createIpcListener<string>(C.command),
+  sendPlaybackState: state => ipcRenderer.invoke(C.playbackState, state),
+  clearState: () => ipcRenderer.invoke(C.clearState),
+};

--- a/apps/desktop/src/main/preload/api/metadata.ts
+++ b/apps/desktop/src/main/preload/api/metadata.ts
@@ -1,0 +1,74 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+import { createIpcListener } from '../ipc-listener';
+
+const C = IPC_CHANNELS.metadata;
+
+interface EnrichInputTrack {
+  id: string;
+  filePath: string;
+  title: string;
+  artist: string;
+  album: string;
+  albumArt: string | null;
+  genre: string;
+  year: number | null;
+  trackNumber: number | null;
+}
+
+interface EnrichResult {
+  id: string;
+  success: boolean;
+  updatedFields: Partial<{
+    title: string;
+    artist: string;
+    album: string;
+    genre: string;
+    year: number;
+    trackNumber: number;
+    albumArt: string;
+  }>;
+  source: string;
+  error?: string;
+}
+
+interface LookupResult {
+  title?: string;
+  artist?: string;
+  album?: string;
+  genre?: string;
+  year?: number;
+  trackNumber?: number;
+  coverImageUrl?: string;
+  source: 'itunes' | 'youtube' | 'none';
+  confidence: number;
+}
+
+export interface MetadataApi {
+  lookup: (title: string, artist: string) => Promise<LookupResult>;
+  enrichTracks: (
+    tracks: EnrichInputTrack[],
+    options: { writeToFile: boolean; onlyMissing: boolean }
+  ) => Promise<EnrichResult[]>;
+  cancelEnrichment: () => Promise<void>;
+  onEnrichProgress: (
+    callback: (data: {
+      current: number;
+      total: number;
+      trackName: string;
+      status: 'searching' | 'downloading' | 'writing' | 'done' | 'error' | 'cancelled';
+    }) => void
+  ) => () => void;
+}
+
+export const metadataApi: MetadataApi = {
+  lookup: (title, artist) => ipcRenderer.invoke(C.lookup, title, artist),
+  enrichTracks: (tracks, options) => ipcRenderer.invoke(C.enrichTracks, tracks, options),
+  cancelEnrichment: () => ipcRenderer.invoke(C.enrichCancel),
+  onEnrichProgress: createIpcListener<{
+    current: number;
+    total: number;
+    trackName: string;
+    status: 'searching' | 'downloading' | 'writing' | 'done' | 'error' | 'cancelled';
+  }>(C.enrichProgress),
+};

--- a/apps/desktop/src/main/preload/api/playlist.ts
+++ b/apps/desktop/src/main/preload/api/playlist.ts
@@ -1,0 +1,31 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+import { createIpcListener } from '../ipc-listener';
+
+const C = IPC_CHANNELS.playlist;
+
+interface PlaylistTrack {
+  id: string;
+  title: string;
+  uploader: string;
+  duration: number;
+  thumbnail: string;
+  url: string;
+  webpage_url: string;
+}
+
+export interface PlaylistApi {
+  extract: (url: string) => Promise<PlaylistTrack[]>;
+  cancel: () => Promise<void>;
+  onExtractProgress: (
+    callback: (data: { current: number; total: number; trackName: string }) => void
+  ) => () => void;
+}
+
+export const playlistApi: PlaylistApi = {
+  extract: url => ipcRenderer.invoke(C.extract, url),
+  cancel: () => ipcRenderer.invoke(C.cancel),
+  onExtractProgress: createIpcListener<{ current: number; total: number; trackName: string }>(
+    C.extractProgress
+  ),
+};

--- a/apps/desktop/src/main/preload/api/radio.ts
+++ b/apps/desktop/src/main/preload/api/radio.ts
@@ -1,0 +1,39 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+
+const C = IPC_CHANNELS.radio.favorites;
+
+interface RadioStation {
+  stationUuid: string;
+  name: string;
+  url: string;
+  urlResolved: string;
+  homepage?: string;
+  favicon?: string;
+  country?: string;
+  countryCode?: string;
+  language?: string;
+  codec?: string;
+  bitrate?: number;
+  tags?: string;
+}
+
+export interface RadioFavoritesApi {
+  getAll: () => Promise<unknown[]>;
+  add: (station: RadioStation) => Promise<unknown>;
+  remove: (stationUuid: string) => Promise<void>;
+  isFavorite: (stationUuid: string) => Promise<boolean>;
+}
+
+export interface RadioApi {
+  favorites: RadioFavoritesApi;
+}
+
+export const radioApi: RadioApi = {
+  favorites: {
+    getAll: () => ipcRenderer.invoke(C.getAll),
+    add: station => ipcRenderer.invoke(C.add, station),
+    remove: stationUuid => ipcRenderer.invoke(C.remove, stationUuid),
+    isFavorite: stationUuid => ipcRenderer.invoke(C.isFavorite, stationUuid) as Promise<boolean>,
+  },
+};

--- a/apps/desktop/src/main/preload/api/share.ts
+++ b/apps/desktop/src/main/preload/api/share.ts
@@ -1,0 +1,34 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+import { createIpcListener } from '../ipc-listener';
+
+const C = IPC_CHANNELS.share;
+
+interface ShareCode {
+  code: string;
+  url: string;
+  expiresAt: string;
+}
+
+interface ImportResult {
+  type: 'TRACK' | 'PLAYLIST';
+  payload: unknown;
+  code: string;
+  expiresAt: string;
+}
+
+export interface ShareApi {
+  track: (trackId: string) => Promise<ShareCode>;
+  playlist: (playlistId: string) => Promise<ShareCode>;
+  import: (code: string) => Promise<ImportResult>;
+  cacheYoutubeId: (trackId: string, youtubeId: string) => Promise<void>;
+  onDeepLink: (callback: (code: string) => void) => () => void;
+}
+
+export const shareApi: ShareApi = {
+  track: trackId => ipcRenderer.invoke(C.track, trackId),
+  playlist: playlistId => ipcRenderer.invoke(C.playlist, playlistId),
+  import: code => ipcRenderer.invoke(C.import, code),
+  cacheYoutubeId: (trackId, youtubeId) => ipcRenderer.invoke(C.cacheYoutubeId, trackId, youtubeId),
+  onDeepLink: createIpcListener<string>(C.deepLink),
+};

--- a/apps/desktop/src/main/preload/api/shell.ts
+++ b/apps/desktop/src/main/preload/api/shell.ts
@@ -1,0 +1,14 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+
+const C = IPC_CHANNELS.shell;
+
+export interface ShellApi {
+  showInFolder: (filePath: string) => Promise<void>;
+  trashFile: (filePath: string) => Promise<void>;
+}
+
+export const shellApi: ShellApi = {
+  showInFolder: filePath => ipcRenderer.invoke(C.showInFolder, filePath),
+  trashFile: filePath => ipcRenderer.invoke(C.trashFile, filePath),
+};

--- a/apps/desktop/src/main/preload/api/store.ts
+++ b/apps/desktop/src/main/preload/api/store.ts
@@ -1,16 +1,19 @@
 import { ipcRenderer } from 'electron';
 import { IPC_CHANNELS } from '@shiranami/contracts';
+import type { StoreSchema } from '../../store';
 
 const C = IPC_CHANNELS.store;
 
 export interface StoreApi {
-  get: <T>(key: string) => Promise<T | undefined>;
-  set: <T>(key: string, value: T) => Promise<void>;
-  delete: (key: string) => Promise<void>;
+  get: <K extends keyof StoreSchema>(key: K) => Promise<StoreSchema[K] | undefined>;
+  set: <K extends keyof StoreSchema>(key: K, value: StoreSchema[K]) => Promise<void>;
+  delete: <K extends keyof StoreSchema>(key: K) => Promise<void>;
 }
 
 export const storeApi: StoreApi = {
-  get: <T>(key: string) => ipcRenderer.invoke(C.get, key) as Promise<T | undefined>,
-  set: <T>(key: string, value: T) => ipcRenderer.invoke(C.set, key, value),
-  delete: key => ipcRenderer.invoke(C.delete, key),
+  get: <K extends keyof StoreSchema>(key: K) =>
+    ipcRenderer.invoke(C.get, key) as Promise<StoreSchema[K] | undefined>,
+  set: <K extends keyof StoreSchema>(key: K, value: StoreSchema[K]) =>
+    ipcRenderer.invoke(C.set, key, value),
+  delete: <K extends keyof StoreSchema>(key: K) => ipcRenderer.invoke(C.delete, key),
 };

--- a/apps/desktop/src/main/preload/api/store.ts
+++ b/apps/desktop/src/main/preload/api/store.ts
@@ -1,0 +1,16 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+
+const C = IPC_CHANNELS.store;
+
+export interface StoreApi {
+  get: <T>(key: string) => Promise<T | undefined>;
+  set: <T>(key: string, value: T) => Promise<void>;
+  delete: (key: string) => Promise<void>;
+}
+
+export const storeApi: StoreApi = {
+  get: <T>(key: string) => ipcRenderer.invoke(C.get, key) as Promise<T | undefined>,
+  set: <T>(key: string, value: T) => ipcRenderer.invoke(C.set, key, value),
+  delete: key => ipcRenderer.invoke(C.delete, key),
+};

--- a/apps/desktop/src/main/preload/api/updater.ts
+++ b/apps/desktop/src/main/preload/api/updater.ts
@@ -1,0 +1,42 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+import { createIpcListener } from '../ipc-listener';
+
+const C = IPC_CHANNELS.updater;
+
+interface UpdateInfo {
+  version: string;
+  releaseNotes: string | null;
+  releaseDate: string;
+}
+
+interface DownloadProgress {
+  bytesPerSecond: number;
+  percent: number;
+  transferred: number;
+  total: number;
+}
+
+export interface UpdaterApi {
+  checkForUpdates: () => Promise<{ enabled: boolean }>;
+  startDownload: () => Promise<void>;
+  installNow: () => Promise<void>;
+  onCheckingForUpdate: (callback: () => void) => () => void;
+  onUpdateAvailable: (callback: (info: UpdateInfo) => void) => () => void;
+  onUpdateNotAvailable: (callback: () => void) => () => void;
+  onDownloadProgress: (callback: (progress: DownloadProgress) => void) => () => void;
+  onUpdateDownloaded: (callback: (info: UpdateInfo) => void) => () => void;
+  onUpdateError: (callback: (message: string) => void) => () => void;
+}
+
+export const updaterApi: UpdaterApi = {
+  checkForUpdates: () => ipcRenderer.invoke(C.checkForUpdates),
+  startDownload: () => ipcRenderer.invoke(C.startDownload),
+  installNow: () => ipcRenderer.invoke(C.installNow),
+  onCheckingForUpdate: createIpcListener<void>(C.checkingForUpdate),
+  onUpdateAvailable: createIpcListener<UpdateInfo>(C.updateAvailable),
+  onUpdateNotAvailable: createIpcListener<void>(C.updateNotAvailable),
+  onDownloadProgress: createIpcListener<DownloadProgress>(C.downloadProgress),
+  onUpdateDownloaded: createIpcListener<UpdateInfo>(C.updateDownloaded),
+  onUpdateError: createIpcListener<string>(C.error),
+};

--- a/apps/desktop/src/main/preload/api/window.ts
+++ b/apps/desktop/src/main/preload/api/window.ts
@@ -1,0 +1,29 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+import { createIpcListener } from '../ipc-listener';
+
+const C = IPC_CHANNELS.window;
+
+export interface WindowApi {
+  minimize: () => Promise<void>;
+  maximize: () => Promise<void>;
+  close: () => Promise<void>;
+  isMaximized: () => Promise<boolean>;
+  setAlwaysOnTop: (alwaysOnTop: boolean) => Promise<void>;
+  setCompactMode: (
+    compactMode: boolean,
+    dimensions?: { width: number; height: number }
+  ) => Promise<void>;
+  onMaximizedChange: (callback: (maximized: boolean) => void) => () => void;
+}
+
+export const windowApi: WindowApi = {
+  minimize: () => ipcRenderer.invoke(C.minimize),
+  maximize: () => ipcRenderer.invoke(C.maximize),
+  close: () => ipcRenderer.invoke(C.close),
+  isMaximized: () => ipcRenderer.invoke(C.isMaximized),
+  setAlwaysOnTop: alwaysOnTop => ipcRenderer.invoke(C.setAlwaysOnTop, alwaysOnTop),
+  setCompactMode: (compactMode, dimensions) =>
+    ipcRenderer.invoke(C.setCompactMode, compactMode, dimensions),
+  onMaximizedChange: createIpcListener<boolean>(C.maximizedChange),
+};

--- a/apps/desktop/src/main/preload/context-bridge.ts
+++ b/apps/desktop/src/main/preload/context-bridge.ts
@@ -1,0 +1,47 @@
+import { ipcRenderer } from 'electron';
+import { ALL_IPC_CHANNELS } from '@shiranami/contracts';
+
+/**
+ * Allowlist of every IPC channel the renderer is permitted to invoke. Derived
+ * from the `@shiranami/contracts` manifest (`ALL_IPC_CHANNELS`) so adding a
+ * channel to the manifest automatically extends the allowlist — there is no
+ * second list to keep in sync.
+ *
+ * The previous hand-maintained set drifted: 7 channels were exposed but missing
+ * from the allowlist (`downloader:get-cached-tool-status`,
+ * `downloader:refresh-tool-status`, `media:command`, `share:deep-link`, and all
+ * 6 `updater:*` channels), making `assertAllowedChannel` decorative for those.
+ * Sourcing from the manifest closes that gap.
+ */
+export const ALLOWED_IPC_CHANNELS: ReadonlySet<string> = new Set(ALL_IPC_CHANNELS);
+
+export function assertAllowedChannel(channel: string): void {
+  if (!ALLOWED_IPC_CHANNELS.has(channel)) {
+    throw new Error(`IPC channel not allowed: "${channel}"`);
+  }
+}
+
+/**
+ * Calls `ipcRenderer.invoke` with an enforced timeout. Rejects if the channel
+ * is not on the allowlist (synchronously, before any IPC traffic) or if the
+ * main-process handler does not respond within `timeoutMs`.
+ */
+export function invokeWithTimeout<T>(
+  channel: string,
+  timeoutMs: number,
+  ...args: unknown[]
+): Promise<T> {
+  assertAllowedChannel(channel);
+  const invokePromise = ipcRenderer.invoke(channel, ...args) as Promise<T>;
+  let timer: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`IPC timeout: "${channel}" did not respond within ${timeoutMs}ms`));
+      invokePromise.catch(() => {});
+    }, timeoutMs);
+    if (typeof timer === 'object' && 'unref' in timer) {
+      timer.unref();
+    }
+  });
+  return Promise.race([invokePromise.finally(() => clearTimeout(timer)), timeoutPromise]);
+}

--- a/apps/desktop/src/main/preload/context-bridge.ts
+++ b/apps/desktop/src/main/preload/context-bridge.ts
@@ -33,15 +33,22 @@ export function invokeWithTimeout<T>(
 ): Promise<T> {
   assertAllowedChannel(channel);
   const invokePromise = ipcRenderer.invoke(channel, ...args) as Promise<T>;
-  let timer: ReturnType<typeof setTimeout>;
-  const timeoutPromise = new Promise<never>((_resolve, reject) => {
-    timer = setTimeout(() => {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
       reject(new Error(`IPC timeout: "${channel}" did not respond within ${timeoutMs}ms`));
-      invokePromise.catch(() => {});
     }, timeoutMs);
     if (typeof timer === 'object' && 'unref' in timer) {
-      timer.unref();
+      (timer as NodeJS.Timeout).unref();
     }
+    invokePromise.then(
+      result => {
+        clearTimeout(timer);
+        resolve(result);
+      },
+      error => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
   });
-  return Promise.race([invokePromise.finally(() => clearTimeout(timer)), timeoutPromise]);
 }

--- a/apps/desktop/src/main/preload/index.ts
+++ b/apps/desktop/src/main/preload/index.ts
@@ -11,7 +11,6 @@ import {
   PLAYLIST_ERROR_CODES,
   VALIDATION_ERROR_CODES,
 } from '../ipc/errors';
-import { invokeWithTimeout } from './context-bridge';
 import { appApi, type AppApi } from './api/app';
 import { dbApi, type DbApi } from './api/db';
 import { dialogApi, type DialogApi } from './api/dialog';
@@ -44,9 +43,6 @@ export interface ElectronAPI {
   playlist: PlaylistApi;
   metadata: MetadataApi;
   share: ShareApi;
-  ipc: {
-    invokeWithTimeout: <T>(channel: string, timeout: number, ...args: unknown[]) => Promise<T>;
-  };
   errors: {
     isIpcError: (e: unknown) => e is { code: string; message: string; details?: unknown };
     SHARE_ERROR_CODES: typeof SHARE_ERROR_CODES;
@@ -72,10 +68,6 @@ const electronAPI: ElectronAPI = {
   playlist: playlistApi,
   metadata: metadataApi,
   share: shareApi,
-  ipc: {
-    invokeWithTimeout: <T>(channel: string, timeout: number, ...args: unknown[]) =>
-      invokeWithTimeout<T>(channel, timeout, ...args),
-  },
   errors: {
     isIpcError,
     SHARE_ERROR_CODES,

--- a/apps/desktop/src/main/preload/index.ts
+++ b/apps/desktop/src/main/preload/index.ts
@@ -1,0 +1,94 @@
+// Electron preload entry point. Composes the per-namespace API modules into
+// the renderer-facing `window.electronAPI` shape and exposes it via Electron's
+// contextBridge. Channel allowlisting is centralized in ./context-bridge.ts and
+// derives from the `@shiranami/contracts` IPC manifest, so the security
+// surface tracks the manifest mechanically.
+
+import { contextBridge } from 'electron';
+import {
+  isIpcError,
+  SHARE_ERROR_CODES,
+  PLAYLIST_ERROR_CODES,
+  VALIDATION_ERROR_CODES,
+} from '../ipc/errors';
+import { invokeWithTimeout } from './context-bridge';
+import { appApi, type AppApi } from './api/app';
+import { dbApi, type DbApi } from './api/db';
+import { dialogApi, type DialogApi } from './api/dialog';
+import { downloaderApi, type DownloaderApi } from './api/downloader';
+import { libraryApi, type LibraryApi } from './api/library';
+import { lyricsApi, type LyricsApi } from './api/lyrics';
+import { mediaApi, type MediaApi } from './api/media';
+import { metadataApi, type MetadataApi } from './api/metadata';
+import { playlistApi, type PlaylistApi } from './api/playlist';
+import { radioApi, type RadioApi } from './api/radio';
+import { shareApi, type ShareApi } from './api/share';
+import { shellApi, type ShellApi } from './api/shell';
+import { storeApi, type StoreApi } from './api/store';
+import { updaterApi, type UpdaterApi } from './api/updater';
+import { windowApi, type WindowApi } from './api/window';
+
+export interface ElectronAPI {
+  window: WindowApi;
+  store: StoreApi;
+  dialog: DialogApi;
+  app: AppApi;
+  library: LibraryApi;
+  db: DbApi;
+  lyrics: LyricsApi;
+  media: MediaApi;
+  downloader: DownloaderApi;
+  updater: UpdaterApi;
+  shell: ShellApi;
+  radio: RadioApi;
+  playlist: PlaylistApi;
+  metadata: MetadataApi;
+  share: ShareApi;
+  ipc: {
+    invokeWithTimeout: <T>(channel: string, timeout: number, ...args: unknown[]) => Promise<T>;
+  };
+  errors: {
+    isIpcError: (e: unknown) => e is { code: string; message: string; details?: unknown };
+    SHARE_ERROR_CODES: typeof SHARE_ERROR_CODES;
+    PLAYLIST_ERROR_CODES: typeof PLAYLIST_ERROR_CODES;
+    VALIDATION_ERROR_CODES: typeof VALIDATION_ERROR_CODES;
+  };
+  platform: NodeJS.Platform;
+}
+
+const electronAPI: ElectronAPI = {
+  window: windowApi,
+  store: storeApi,
+  dialog: dialogApi,
+  app: appApi,
+  library: libraryApi,
+  db: dbApi,
+  lyrics: lyricsApi,
+  media: mediaApi,
+  downloader: downloaderApi,
+  updater: updaterApi,
+  shell: shellApi,
+  radio: radioApi,
+  playlist: playlistApi,
+  metadata: metadataApi,
+  share: shareApi,
+  ipc: {
+    invokeWithTimeout: <T>(channel: string, timeout: number, ...args: unknown[]) =>
+      invokeWithTimeout<T>(channel, timeout, ...args),
+  },
+  errors: {
+    isIpcError,
+    SHARE_ERROR_CODES,
+    PLAYLIST_ERROR_CODES,
+    VALIDATION_ERROR_CODES,
+  },
+  platform: process.platform,
+};
+
+contextBridge.exposeInMainWorld('electronAPI', electronAPI);
+
+declare global {
+  interface Window {
+    electronAPI: ElectronAPI;
+  }
+}

--- a/apps/desktop/src/main/preload/ipc-listener.ts
+++ b/apps/desktop/src/main/preload/ipc-listener.ts
@@ -1,0 +1,19 @@
+import { ipcRenderer, type IpcRendererEvent } from 'electron';
+
+/**
+ * Build a typed `ipcRenderer.on` subscription helper for `channel`.
+ *
+ * Returns a `subscribe(callback)` function. Each call wires up a fresh handler
+ * and yields an `unsubscribe` function that removes only that listener — not
+ * every listener on the channel — so multiple components can subscribe to the
+ * same event without trampling each other.
+ */
+export function createIpcListener<T>(channel: string): (callback: (data: T) => void) => () => void {
+  return (callback: (data: T) => void) => {
+    const handler = (_event: IpcRendererEvent, data: T) => callback(data);
+    ipcRenderer.on(channel, handler);
+    return () => {
+      ipcRenderer.removeListener(channel, handler);
+    };
+  };
+}

--- a/apps/desktop/src/main/preload/types.ts
+++ b/apps/desktop/src/main/preload/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Preload-side shape of the values flowing across the contextBridge.
+ *
+ * These mirror the renderer-facing `apps/web/src/types/electron.d.ts` and the
+ * domain types in `@shiranami/contracts`. They live here (and not in contracts)
+ * because the preload `ElectronAPI` is currently the source of truth for the
+ * renderer surface; migrating individual interfaces into contracts is staged
+ * follow-up work.
+ */
+
+export interface TrackMetadata {
+  title: string;
+  artist: string;
+  album: string;
+  duration: number;
+  genre: string;
+  year: number | null;
+  trackNumber: number | null;
+  discNumber: number | null;
+  albumArt: string | null;
+}
+
+export interface ListeningHistoryEntry {
+  id: string;
+  trackId: string;
+  title: string;
+  artist: string;
+  album: string;
+  albumArt: string | null;
+  duration: number | null;
+  playedAt: string;
+  playedSeconds: number;
+  completionRatio: number;
+  completed: boolean;
+  source: string;
+}
+
+export interface ListeningStatsTrack {
+  trackId: string;
+  title: string;
+  artist: string;
+  album: string;
+  albumArt: string | null;
+  playCount: number;
+  listenedSeconds: number;
+  lastPlayedAt: string;
+}
+
+export interface ListeningStatsArtist {
+  artist: string;
+  playCount: number;
+  listenedSeconds: number;
+}
+
+export interface ListeningStatsSummary {
+  totalPlays: number;
+  totalMinutes: number;
+  uniqueTracks: number;
+  uniqueArtists: number;
+  completedPlays: number;
+  topTracks: ListeningStatsTrack[];
+  topArtists: ListeningStatsArtist[];
+}
+
+export interface ListeningActivityPoint {
+  date: string;
+  playCount: number;
+  listenedMinutes: number;
+}

--- a/apps/desktop/src/main/preload/types.ts
+++ b/apps/desktop/src/main/preload/types.ts
@@ -67,3 +67,13 @@ export interface ListeningActivityPoint {
   playCount: number;
   listenedMinutes: number;
 }
+
+export interface ToolInstallResult {
+  tool: 'ytdlp' | 'ffmpeg';
+  success: boolean;
+  error?: string;
+}
+
+export interface InstallDependenciesResult {
+  results: ToolInstallResult[];
+}

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -2,7 +2,6 @@ import '@testing-library/jest-dom/vitest';
 import { vi } from 'vitest';
 import type { ElectronAPI } from '@/types/electron';
 
-
 // Test-accessible ResizeObserver mock. Captures the callback and target so
 // tests can trigger synthetic resize entries via `triggerResize(el, rect)`.
 interface ResizeObserverMockInstance {
@@ -32,10 +31,24 @@ class ResizeObserverMock {
 globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 
 export function triggerResize(target: Element, rect: { width: number; height: number }): void {
-  const contentRect = { ...rect, top: 0, left: 0, right: rect.width, bottom: rect.height, x: 0, y: 0 } as DOMRectReadOnly;
+  const contentRect = {
+    ...rect,
+    top: 0,
+    left: 0,
+    right: rect.width,
+    bottom: rect.height,
+    x: 0,
+    y: 0,
+  } as DOMRectReadOnly;
   for (const inst of resizeObserverInstances) {
     if (!inst.targets.has(target)) continue;
-    const entry = { target, contentRect, borderBoxSize: [], contentBoxSize: [], devicePixelContentBoxSize: [] } as unknown as ResizeObserverEntry;
+    const entry = {
+      target,
+      contentRect,
+      borderBoxSize: [],
+      contentBoxSize: [],
+      devicePixelContentBoxSize: [],
+    } as unknown as ResizeObserverEntry;
     inst.callback([entry], {} as ResizeObserver);
   }
 }
@@ -192,8 +205,16 @@ function createElectronAPIMock(): ElectronAPI {
       onEnrichProgress: vi.fn(() => noopUnsub()),
     },
     share: {
-      track: asyncFn({ code: 'abc', url: 'https://example.com/s/abc', expiresAt: new Date(Date.now() + 3600000).toISOString() }),
-      playlist: asyncFn({ code: 'def', url: 'https://example.com/s/def', expiresAt: new Date(Date.now() + 3600000).toISOString() }),
+      track: asyncFn({
+        code: 'abc',
+        url: 'https://example.com/s/abc',
+        expiresAt: new Date(Date.now() + 3600000).toISOString(),
+      }),
+      playlist: asyncFn({
+        code: 'def',
+        url: 'https://example.com/s/def',
+        expiresAt: new Date(Date.now() + 3600000).toISOString(),
+      }),
       import: asyncFn({ type: 'TRACK' as const, payload: null }),
       cacheYoutubeId: asyncFn(undefined),
       onDeepLink: vi.fn(() => () => {}),
@@ -210,9 +231,6 @@ function createElectronAPIMock(): ElectronAPI {
       extract: asyncFn([]),
       cancel: asyncFn(undefined),
       onExtractProgress: vi.fn(() => noopUnsub()),
-    },
-    ipc: {
-      invokeWithTimeout: vi.fn(),
     },
     platform: 'win32',
   };

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -414,9 +414,6 @@ export interface ElectronAPI {
     cacheYoutubeId: (trackId: string, youtubeId: string) => Promise<void>;
     onDeepLink: (callback: (code: string) => void) => () => void;
   };
-  ipc: {
-    invokeWithTimeout: <T>(channel: string, timeout: number, ...args: unknown[]) => Promise<T>;
-  };
   platform: NodeJS.Platform;
 }
 


### PR DESCRIPTION
## Summary

Splits the 800-LOC `apps/desktop/src/main/preload.ts` god-file into per-namespace modules, and derives `ALLOWED_IPC_CHANNELS` from the `@shiranami/contracts` manifest landed in #157. **This is the final step (item #5) in the long-term architecture roadmap from [the chain audit](docs/chain/2026-05-03-shiranami-longterm-architecture.md)** — items #1, #3, #4, and #5 from the unified priority order are now all merged.

The original `preload.ts` was both a security boundary (every line is part of the renderer's threat surface) and a structural sore spot (14 distinct concerns in one file). After this PR, each IPC namespace lives in its own file with its own typed surface, and the IPC channel manifest is now load-bearing for security — adding a channel to the manifest is the only way it ever reaches the allowlist.

### The security win

The audit identified **7 channels exposed in preload but missing from the hand-maintained `ALLOWED_IPC_CHANNELS`**, making the allowlist decorative for those:

- `downloader:get-cached-tool-status`
- `downloader:refresh-tool-status`
- `media:command`
- `share:deep-link`
- `updater:check-for-updates`
- `updater:start-download`
- `updater:install-now`

The previous code partially carved out the 6 `updater:*` *event* channels via a separate `UPDATER_IPC_CHANNELS` set, but the 3 invoke channels above had no carve-out at all — `assertAllowedChannel` would have rejected them if the renderer had ever routed them through `invokeWithTimeout`. After this PR, all 99 channels in the contracts manifest are properly allowlisted by construction:

```ts
import { ALL_IPC_CHANNELS } from '@shiranami/contracts';
export const ALLOWED_IPC_CHANNELS: ReadonlySet<string> = new Set(ALL_IPC_CHANNELS);
```

### Structure

```
apps/desktop/src/main/
  preload.ts                     (9 LOC shim — esbuild entry + re-export, kept stable so the build pipeline doesn't need to track the split)
  preload/
    index.ts                     (94)  — entry, ElectronAPI composition + contextBridge.exposeInMainWorld
    context-bridge.ts            (47)  — ALLOWED_IPC_CHANNELS derivation + assertAllowedChannel + invokeWithTimeout
    ipc-listener.ts              (19)  — createIpcListener helper
    types.ts                     (69)  — TrackMetadata + listening-history/stats interfaces
    api/{app,db,dialog,downloader,library,lyrics,media,metadata,
         playlist,radio,share,shell,store,updater,window}.ts
```

15 namespace files. LOC range: 14 (`app`/`dialog`/`shell`) to 128 (`db`). The largest are `db` (128), `downloader` (105), and `metadata` (74) — those map cleanly to the audit's "ipc/downloader.ts and ipc/database.ts are god-files too" callout, but their main-side splits remain a separate follow-up.

### Renderer impact

**None at runtime.** `window.electronAPI` shape is identical. All 16 namespaces present on the exposed object. `apps/web/src/types/electron.d.ts` not touched.

### Manifest drift check

Every preload-exposed channel matches a leaf in `IPC_CHANNELS` — Step 2's manifest was correct. No additions or removals.

### Build path

Old `preload.ts` survives as a 9-line shim that re-exports from `preload/index`. `apps/desktop/esbuild.config.mjs` still treats `preload.ts` as the bundler entry, and `BrowserWindow.webPreferences.preload` (in `window.ts:72`) still points at `preload.js`. **No build pipeline changes were needed.**

## Intentionally NOT in this PR (deferred follow-ups)

- **Migrating `Track` to `@shiranami/contracts`.** Renderer-Track migration is its own PR.
- **Per-channel IPC payload Zod schemas** validating arguments at the preload boundary. Manifest gives names; schemas come later as PRs touch each channel.
- **Refactoring main-side `ipcMain.handle` registrations** to use `IPC_CHANNELS` constants. Optional follow-up.
- **`apps/web/src/types/electron.d.ts` cleanup** — the agent noticed it's missing the `errors` namespace (drift vs. preload's `ElectronAPI`); the renderer doesn't reference it so nothing is broken, but it's a candidate for the deferred sync PR.
- **Splitting `apps/desktop/src/main/ipc/downloader.ts` and `ipc/database.ts`.** Separate refactors not part of this audit's top-5.

## Test plan

- [x] `pnpm typecheck` clean across all 7 projects (web + desktop + 3 packages + server + landing)
- [x] `pnpm test` 1130 passed + 1 skipped (matches baseline; no regressions)
- [x] `pnpm build` produces `dist/main/preload.js` (23.6 kB) successfully
- [x] All 16 `window.electronAPI.<namespace>` namespaces still present on the exposed object
- [ ] Smoke: launch the desktop app, hit a representative channel from each namespace (start a download, share a track, change window state, navigate library, open settings) — confirm IPC still works end-to-end
- [ ] Smoke: confirm renderer's update-check / radio / metadata-enrich flows still work (those touch the previously-not-allowlisted channels and should now route through the derived allowlist correctly)

## Commits

Atomic conventional commits, each one keeps the codebase compiling:

1. `refactor(desktop/preload): scaffold preload/ directory with helpers`
2. `refactor(desktop/preload): extract simple namespace bindings`
3. `refactor(desktop/preload): extract db namespace bindings`
4. `refactor(desktop/preload): extract downloader namespace bindings`
5. `refactor(desktop/preload): extract updater/radio/playlist/metadata/share`
6. `feat(desktop/preload): derive ALLOWED_IPC_CHANNELS from contracts manifest`
7. `refactor(desktop/preload): move composition into preload/index.ts`

## Roadmap status

With this merging, the audit's unified priority items #1, #3, #4, and #5 are all complete on master. Item #2 (bulk-IPC primitives, perf H5+H7+H6) was deferred when we sequenced the four-step plan; it's a natural follow-up alongside the deferred Track-migration PR.