### PR TITLE
perf: ram follow-up to #150 (lazy/async + albumgrid virtualisation + art cache lifecycle)

### DIFF
--- a/apps/desktop/src/main/art-protocol.test.ts
+++ b/apps/desktop/src/main/art-protocol.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import { join } from 'node:path';
+import { closeDatabase, initializeDatabase, getDatabase } from '@shiranami/database/client';
+import { tracks } from '@shiranami/database';
+import { makeTempDir, cleanupTempDir } from '../../test/setup';
 import { extToMime, toArtUrl } from './art-protocol';
 
 describe('extToMime', () => {
@@ -133,15 +138,36 @@ describe('downscaleImage', () => {
 // saveAlbumArt — mocks nativeImage via vi.mock (module-level).
 // ---------------------------------------------------------------------------
 
+// Per-test artDir is computed by getArtDir() which calls app.getPath('userData')
+// on first invocation and memoizes the result. Tests that exercise prune set
+// MOCK_USER_DATA before importing the module; saveAlbumArt tests rely on the
+// nativeImage stub and don't reach the disk.
+let MOCK_USER_DATA = '/mock/userData';
+
 vi.mock('electron', async importOriginal => {
   const original = await importOriginal<typeof import('electron')>();
   return {
     ...original,
+    app: {
+      getPath: vi.fn((key: string) => {
+        if (key === 'userData') return MOCK_USER_DATA;
+        return '/mock/unknown';
+      }),
+    },
     nativeImage: {
       createFromBuffer: vi.fn(),
     },
   };
 });
+
+vi.mock('./logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
 
 describe('saveAlbumArt', () => {
   beforeEach(() => {
@@ -160,5 +186,167 @@ describe('saveAlbumArt', () => {
 
     const { saveAlbumArt } = await import('./art-protocol');
     expect(await saveAlbumArt(Buffer.from('garbage'), 'image/jpeg')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// artFileNameFromUrl — pure helper, no I/O.
+// ---------------------------------------------------------------------------
+
+describe('artFileNameFromUrl', () => {
+  it('extracts the file name from a shiranami-art:// URL', async () => {
+    const { artFileNameFromUrl } = await import('./art-protocol');
+    expect(artFileNameFromUrl('shiranami-art://art/abc123.jpg')).toBe('abc123.jpg');
+  });
+
+  it('returns null for non-shiranami-art URLs', async () => {
+    const { artFileNameFromUrl } = await import('./art-protocol');
+    expect(artFileNameFromUrl('data:image/jpeg;base64,xyz')).toBeNull();
+    expect(artFileNameFromUrl('https://example.com/cover.jpg')).toBeNull();
+    expect(artFileNameFromUrl('file:///C:/cover.jpg')).toBeNull();
+  });
+
+  it('returns null for nullish input', async () => {
+    const { artFileNameFromUrl } = await import('./art-protocol');
+    expect(artFileNameFromUrl(null)).toBeNull();
+    expect(artFileNameFromUrl(undefined)).toBeNull();
+    expect(artFileNameFromUrl('')).toBeNull();
+  });
+
+  it('rejects path traversal attempts via basename', async () => {
+    const { artFileNameFromUrl } = await import('./art-protocol');
+    // basename strips directory components; the result is just the file name.
+    expect(artFileNameFromUrl('shiranami-art://art/../../etc/passwd')).toBe('passwd');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pruneOrphanedAlbumArt — uses real DB + temp art dir.
+// ---------------------------------------------------------------------------
+
+describe('pruneOrphanedAlbumArt', () => {
+  let tempDir: string;
+  let artDir: string;
+
+  beforeEach(async () => {
+    closeDatabase();
+    tempDir = makeTempDir();
+    MOCK_USER_DATA = tempDir;
+    artDir = join(tempDir, 'album-art');
+    fs.mkdirSync(artDir, { recursive: true });
+    initializeDatabase({ path: join(tempDir, 'prune-test.sqlite') });
+    // Drop the module-scoped memoized artDir so it re-evaluates against the
+    // freshly-mocked MOCK_USER_DATA. Also clears the in-process LRU so cached
+    // entries from prior tests can't leak across cases.
+    const mod = await import('./art-protocol');
+    mod._resetArtDirForTest();
+    mod._resetArtLruForTest();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    cleanupTempDir(tempDir);
+  });
+
+  function writeArtFile(name: string): string {
+    const filePath = join(artDir, name);
+    fs.writeFileSync(filePath, Buffer.from('fake-jpeg-bytes'));
+    return filePath;
+  }
+
+  function insertTrack(id: string, albumArt: string | null): void {
+    getDatabase()
+      .insert(tracks)
+      .values({
+        id,
+        title: 'Test',
+        artist: 'Artist',
+        album: 'Album',
+        filePath: `/mock/${id}.flac`,
+        duration: 100,
+        albumArt,
+      })
+      .run();
+  }
+
+  it('does nothing when the disk is empty', async () => {
+    const { pruneOrphanedAlbumArt } = await import('./art-protocol');
+    const result = await pruneOrphanedAlbumArt();
+    expect(result.deleted).toBe(0);
+    expect(result.scanned).toBe(0);
+  });
+
+  it('keeps every file when all are referenced by the DB', async () => {
+    writeArtFile('aaa.jpg');
+    writeArtFile('bbb.jpg');
+    insertTrack('t1', 'shiranami-art://art/aaa.jpg');
+    insertTrack('t2', 'shiranami-art://art/bbb.jpg');
+
+    const { pruneOrphanedAlbumArt } = await import('./art-protocol');
+    const result = await pruneOrphanedAlbumArt();
+
+    expect(result.deleted).toBe(0);
+    expect(result.scanned).toBe(2);
+    expect(result.referenced).toBe(2);
+    expect(fs.existsSync(join(artDir, 'aaa.jpg'))).toBe(true);
+    expect(fs.existsSync(join(artDir, 'bbb.jpg'))).toBe(true);
+  });
+
+  it('deletes only orphan files, leaving referenced ones', async () => {
+    writeArtFile('referenced.jpg');
+    writeArtFile('orphan-1.jpg');
+    writeArtFile('orphan-2.jpg');
+    insertTrack('t1', 'shiranami-art://art/referenced.jpg');
+
+    const { pruneOrphanedAlbumArt } = await import('./art-protocol');
+    const result = await pruneOrphanedAlbumArt();
+
+    expect(result.deleted).toBe(2);
+    expect(result.scanned).toBe(3);
+    expect(result.referenced).toBe(1);
+    expect(fs.existsSync(join(artDir, 'referenced.jpg'))).toBe(true);
+    expect(fs.existsSync(join(artDir, 'orphan-1.jpg'))).toBe(false);
+    expect(fs.existsSync(join(artDir, 'orphan-2.jpg'))).toBe(false);
+  });
+
+  it('does not error when DB references a file that does not exist on disk', async () => {
+    writeArtFile('on-disk.jpg');
+    insertTrack('t1', 'shiranami-art://art/on-disk.jpg');
+    insertTrack('t2', 'shiranami-art://art/missing.jpg');
+
+    const { pruneOrphanedAlbumArt } = await import('./art-protocol');
+    const result = await pruneOrphanedAlbumArt();
+
+    expect(result.deleted).toBe(0);
+    expect(result.referenced).toBe(2);
+    expect(fs.existsSync(join(artDir, 'on-disk.jpg'))).toBe(true);
+  });
+
+  it('ignores tracks with non-shiranami-art URLs (data:, https:, null)', async () => {
+    writeArtFile('orphan.jpg');
+    insertTrack('t1', 'data:image/jpeg;base64,xyz');
+    insertTrack('t2', 'https://example.com/cover.jpg');
+    insertTrack('t3', null);
+
+    const { pruneOrphanedAlbumArt } = await import('./art-protocol');
+    const result = await pruneOrphanedAlbumArt();
+
+    // Nothing in the DB references any disk file → orphan should be deleted.
+    expect(result.deleted).toBe(1);
+    expect(result.referenced).toBe(0);
+    expect(fs.existsSync(join(artDir, 'orphan.jpg'))).toBe(false);
+  });
+
+  it('skips files with non-image extensions', async () => {
+    writeArtFile('cover.jpg');
+    fs.writeFileSync(join(artDir, 'random.txt'), 'not-an-image');
+    insertTrack('t1', 'shiranami-art://art/cover.jpg');
+
+    const { pruneOrphanedAlbumArt } = await import('./art-protocol');
+    const result = await pruneOrphanedAlbumArt();
+
+    expect(result.deleted).toBe(0);
+    expect(fs.existsSync(join(artDir, 'random.txt'))).toBe(true);
+    expect(fs.existsSync(join(artDir, 'cover.jpg'))).toBe(true);
   });
 });

--- a/apps/desktop/src/main/art-protocol.test.ts
+++ b/apps/desktop/src/main/art-protocol.test.ts
@@ -144,6 +144,9 @@ describe('downscaleImage', () => {
 // nativeImage stub and don't reach the disk.
 let MOCK_USER_DATA = '/mock/userData';
 
+/** Captured protocol handler for the streaming-handler tests. */
+let capturedArtHandler: ((req: Request) => Promise<Response>) | null = null;
+
 vi.mock('electron', async importOriginal => {
   const original = await importOriginal<typeof import('electron')>();
   return {
@@ -153,6 +156,11 @@ vi.mock('electron', async importOriginal => {
         if (key === 'userData') return MOCK_USER_DATA;
         return '/mock/unknown';
       }),
+    },
+    protocol: {
+      handle(_scheme: string, handler: (req: Request) => Promise<Response>) {
+        capturedArtHandler = handler;
+      },
     },
     nativeImage: {
       createFromBuffer: vi.fn(),
@@ -348,5 +356,89 @@ describe('pruneOrphanedAlbumArt', () => {
     expect(result.deleted).toBe(0);
     expect(fs.existsSync(join(artDir, 'random.txt'))).toBe(true);
     expect(fs.existsSync(join(artDir, 'cover.jpg'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streaming protocol handler — exercises the createReadStream + LRU tee path
+// ported from audio-protocol.ts.
+// ---------------------------------------------------------------------------
+
+describe('art-protocol streaming handler', () => {
+  let tempDir: string;
+  let artDir: string;
+
+  beforeEach(async () => {
+    capturedArtHandler = null;
+    tempDir = makeTempDir();
+    MOCK_USER_DATA = tempDir;
+    artDir = join(tempDir, 'album-art');
+    fs.mkdirSync(artDir, { recursive: true });
+    const mod = await import('./art-protocol');
+    mod._resetArtDirForTest();
+    mod._resetArtLruForTest();
+    mod.registerArtProtocol();
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  function makeRequest(fileName: string): Request {
+    return new Request(toArtUrl(fileName));
+  }
+
+  it('returns 400 for empty file name', async () => {
+    expect(capturedArtHandler).not.toBeNull();
+    const res = await capturedArtHandler!(new Request('shiranami-art://art/'));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 403 for disallowed extensions', async () => {
+    const res = await capturedArtHandler!(makeRequest('cover.txt'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when the file does not exist on disk', async () => {
+    const res = await capturedArtHandler!(makeRequest('missing.jpg'));
+    expect(res.status).toBe(404);
+  });
+
+  it('streams file bytes for a present art file', async () => {
+    const payload = Buffer.from('FAKE_JPEG_BYTES_' + 'x'.repeat(200));
+    fs.writeFileSync(join(artDir, 'present.jpg'), payload);
+
+    const res = await capturedArtHandler!(makeRequest('present.jpg'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('image/jpeg');
+    expect(res.headers.get('Content-Length')).toBe(String(payload.length));
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable');
+
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.equals(payload)).toBe(true);
+  });
+
+  it('populates the LRU after streaming so a second request hits the cache', async () => {
+    const payload = Buffer.from('CACHED_JPEG_BYTES');
+    fs.writeFileSync(join(artDir, 'hot.jpg'), payload);
+
+    // First request streams from disk and tees into the LRU.
+    const first = await capturedArtHandler!(makeRequest('hot.jpg'));
+    expect(Buffer.from(await first.arrayBuffer()).equals(payload)).toBe(true);
+
+    // Delete the file — second request must come from the LRU now.
+    fs.unlinkSync(join(artDir, 'hot.jpg'));
+    const second = await capturedArtHandler!(makeRequest('hot.jpg'));
+    expect(second.status).toBe(200);
+    expect(Buffer.from(await second.arrayBuffer()).equals(payload)).toBe(true);
+  });
+
+  it('rejects path traversal via basename normalisation', async () => {
+    // basename strips ../ — the handler then 404s because the file does not
+    // exist in the art dir.
+    const res = await capturedArtHandler!(
+      new Request('shiranami-art://art/..%2F..%2Fetc%2Fpasswd.jpg')
+    );
+    expect(res.status).toBe(404);
   });
 });

--- a/apps/desktop/src/main/art-protocol.ts
+++ b/apps/desktop/src/main/art-protocol.ts
@@ -308,10 +308,35 @@ export function registerArtProtocol(): void {
         return new Response('Not found', { status: 404 });
       }
 
-      const data = await fs.promises.readFile(filePath);
-      artLruSet(safeName, data);
+      // Stream the file rather than reading it into a Buffer up-front. Same
+      // pattern as audio-protocol.ts — Chromium pulls chunks lazily, so main
+      // never holds the full file in a JS Buffer that would be copied a
+      // second time when Electron serialises the Response body across the
+      // IPC bridge. We tee the chunks into the LRU as they pass through so
+      // subsequent hits stay synchronous.
+      const stream = fs.createReadStream(filePath);
+      const chunks: Buffer[] = [];
+      const readable = new ReadableStream({
+        start(controller) {
+          stream.on('data', (chunk: Buffer) => {
+            chunks.push(chunk);
+            controller.enqueue(chunk);
+          });
+          stream.on('end', () => {
+            controller.close();
+            // Concat once at end; for ~30-80 KB JPEGs this is a single small
+            // allocation. LRU is bytes-bounded so oversized inputs are
+            // dropped inside artLruSet.
+            artLruSet(safeName, Buffer.concat(chunks));
+          });
+          stream.on('error', err => controller.error(err));
+        },
+        cancel() {
+          stream.destroy();
+        },
+      });
 
-      return new Response(data, {
+      return new Response(readable as unknown as ReadableStream, {
         status: 200,
         headers: {
           'Content-Type': contentType,

--- a/apps/desktop/src/main/art-protocol.ts
+++ b/apps/desktop/src/main/art-protocol.ts
@@ -3,6 +3,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import { logger } from './logger';
+import { tracks } from '@shiranami/database';
+import { getDatabase } from '@shiranami/database/client';
 
 /** Directory where extracted album art images are stored */
 let artDir: string;
@@ -102,6 +104,148 @@ export function _resetFirstWriteLoggedForTest(): void {
   _firstWriteLogged = false;
 }
 
+/** Reset the memoized art directory (for testing only). */
+export function _resetArtDirForTest(): void {
+  artDir = '';
+}
+
+// ---------------------------------------------------------------------------
+// In-process LRU for hot art bytes. Sized to ~5 MB by tracking total Buffer
+// length on insert; eviction is least-recently-used (Map preserves insertion
+// order; we delete + re-set on hit to promote).
+// Same shape as lyrics-service.ts.
+// ---------------------------------------------------------------------------
+
+const ART_LRU_MAX_BYTES = 5 * 1024 * 1024;
+const artLruCache = new Map<string, Buffer>();
+let artLruBytes = 0;
+
+function artLruGet(fileName: string): Buffer | undefined {
+  const value = artLruCache.get(fileName);
+  if (value !== undefined) {
+    artLruCache.delete(fileName);
+    artLruCache.set(fileName, value);
+  }
+  return value;
+}
+
+function artLruSet(fileName: string, data: Buffer): void {
+  const existing = artLruCache.get(fileName);
+  if (existing) {
+    artLruBytes -= existing.length;
+    artLruCache.delete(fileName);
+  }
+  // Skip pathologically large entries — at 512px JPEG q=85 a single file is
+  // ~30-80 KB so anything over the cap is anomalous and would force-evict
+  // the entire cache for one entry.
+  if (data.length > ART_LRU_MAX_BYTES) return;
+  while (artLruBytes + data.length > ART_LRU_MAX_BYTES && artLruCache.size > 0) {
+    const oldest = artLruCache.keys().next().value;
+    if (oldest === undefined) break;
+    const evicted = artLruCache.get(oldest);
+    artLruCache.delete(oldest);
+    if (evicted) artLruBytes -= evicted.length;
+  }
+  artLruCache.set(fileName, data);
+  artLruBytes += data.length;
+}
+
+/** Reset the in-process LRU (testing only). */
+export function _resetArtLruForTest(): void {
+  artLruCache.clear();
+  artLruBytes = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Orphan pruning — diff DB-referenced files vs disk; delete files no longer
+// referenced. Pure additive: never deletes anything still in tracks.albumArt.
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the bare file name from a shiranami-art:// URL. Returns null for
+ * any other URL shape (data:, file:, http:, …) or invalid input — the caller
+ * uses this to skip non-disk-cache rows when computing the referenced set.
+ */
+export function artFileNameFromUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const prefix = 'shiranami-art://';
+  if (!url.startsWith(prefix)) return null;
+  try {
+    const parsed = new URL(url);
+    const name = path.basename(parsed.pathname.replace(/^\/+/, ''));
+    return name || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Delete on-disk album-art files that no `tracks.albumArt` row references.
+ *
+ * Returns counts so callers can log progress; never throws — readdir errors
+ * (missing dir, perms) are logged and the function exits cleanly so it is
+ * safe to call from app boot fire-and-forget.
+ */
+export async function pruneOrphanedAlbumArt(): Promise<{
+  scanned: number;
+  deleted: number;
+  referenced: number;
+}> {
+  const dir = getArtDir();
+
+  const referenced = new Set<string>();
+  try {
+    const db = getDatabase();
+    const rows = db.selectDistinct({ albumArt: tracks.albumArt }).from(tracks).all();
+    for (const row of rows) {
+      const name = artFileNameFromUrl(row.albumArt);
+      if (name) referenced.add(name);
+    }
+  } catch (error) {
+    logger.warn('[art-protocol] prune: DB query failed, skipping prune:', error);
+    return { scanned: 0, deleted: 0, referenced: 0 };
+  }
+
+  let entries: string[];
+  try {
+    entries = await fs.promises.readdir(dir);
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === 'ENOENT') {
+      return { scanned: 0, deleted: 0, referenced: referenced.size };
+    }
+    logger.warn('[art-protocol] prune: readdir failed:', error);
+    return { scanned: 0, deleted: 0, referenced: referenced.size };
+  }
+
+  let deleted = 0;
+  for (const entry of entries) {
+    if (referenced.has(entry)) continue;
+    const ext = path.extname(entry).toLowerCase();
+    if (!ALLOWED_EXTENSIONS.has(ext)) continue;
+    const filePath = path.join(dir, entry);
+    try {
+      await fs.promises.unlink(filePath);
+      // Drop any LRU entry too — we just deleted the source of truth.
+      const cached = artLruCache.get(entry);
+      if (cached) {
+        artLruBytes -= cached.length;
+        artLruCache.delete(entry);
+      }
+      deleted += 1;
+    } catch (error) {
+      logger.warn(`[art-protocol] prune: failed to delete ${entry}:`, error);
+    }
+  }
+
+  if (deleted > 0) {
+    logger.info(
+      `[art-protocol] prune: deleted ${deleted} orphan(s) (referenced=${referenced.size}, scanned=${entries.length})`
+    );
+  }
+  return { scanned: entries.length, deleted, referenced: referenced.size };
+}
+
 /**
  * Convert a filename to a shiranami-art:// URL
  */
@@ -135,6 +279,23 @@ export function registerArtProtocol(): void {
 
       // Security: prevent path traversal
       const safeName = path.basename(fileName);
+      const contentType = extToMime(ext);
+
+      // Hot path: serve from in-process LRU when available. Hits avoid the
+      // disk I/O + Buffer allocation entirely when Chromium re-fetches the
+      // same cover (drag-scroll, viewport churn, etc.).
+      const cached = artLruGet(safeName);
+      if (cached) {
+        return new Response(cached, {
+          status: 200,
+          headers: {
+            'Content-Type': contentType,
+            'Content-Length': String(cached.length),
+            'Cache-Control': 'public, max-age=31536000, immutable',
+          },
+        });
+      }
+
       const filePath = path.join(getArtDir(), safeName);
 
       let stat: fs.Stats;
@@ -147,8 +308,8 @@ export function registerArtProtocol(): void {
         return new Response('Not found', { status: 404 });
       }
 
-      const contentType = extToMime(ext);
       const data = await fs.promises.readFile(filePath);
+      artLruSet(safeName, data);
 
       return new Response(data, {
         status: 200,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -10,7 +10,7 @@ import { initializeMediaControls, cleanupMediaControls } from './media-controls'
 import { initializeDiscordRpc, cleanupDiscordRpc } from './discord-rpc';
 import { registerAudioProtocol } from './audio-protocol';
 import { registerRadioProtocol } from './radio-protocol';
-import { registerArtProtocol } from './art-protocol';
+import { registerArtProtocol, pruneOrphanedAlbumArt } from './art-protocol';
 import { migrateAlbumArtToDisk } from './migrate-album-art';
 import { prewarm as prewarmFoldersCache } from './shared/folders-cache';
 import { initializeDatabase, closeDatabase } from '@shiranami/database/client';
@@ -110,8 +110,12 @@ async function bootstrap(): Promise<void> {
   logger.info('════════════════════════════════════════════════════════════');
   logger.info(`  New session — Shiranami v${app.getVersion()}`);
   logger.info(`[system] OS: ${os.platform()} ${os.release()} (${os.arch()})`);
-  logger.info(`[system] Electron: ${process.versions.electron}, Chrome: ${process.versions.chrome}, Node: ${process.versions.node}`);
-  logger.info(`[system] Memory: ${Math.round(os.totalmem() / 1024 / 1024)}MB, userData: ${app.getPath('userData')}`);
+  logger.info(
+    `[system] Electron: ${process.versions.electron}, Chrome: ${process.versions.chrome}, Node: ${process.versions.node}`
+  );
+  logger.info(
+    `[system] Memory: ${Math.round(os.totalmem() / 1024 / 1024)}MB, userData: ${app.getPath('userData')}`
+  );
   logger.info(`[security] App packaged: ${app.isPackaged}`);
   logger.info('════════════════════════════════════════════════════════════');
 
@@ -134,6 +138,13 @@ async function bootstrap(): Promise<void> {
   // Migrate legacy base64 album art to disk files
   migrateAlbumArtToDisk().catch(err => {
     logger.warn('Album art migration failed:', err);
+  });
+
+  // Prune orphaned album-art files (tracks deleted between sessions, covers
+  // re-encoded since the row was last written). Fire-and-forget so this
+  // never blocks bootstrap; pruneOrphanedAlbumArt swallows its own errors.
+  pruneOrphanedAlbumArt().catch(err => {
+    logger.warn('Album art prune failed:', err);
   });
 
   mainWindow = await createMainWindow();

--- a/apps/desktop/src/main/ipc/database.ts
+++ b/apps/desktop/src/main/ipc/database.ts
@@ -19,6 +19,7 @@ import { getDatabase } from '@shiranami/database/client';
 import { logger } from '../logger';
 import { handle } from './with-ipc-handler';
 import { invalidate as invalidateFoldersCache } from '../shared/folders-cache';
+import { pruneOrphanedAlbumArt } from '../art-protocol';
 import {
   tracksGetAllArgs,
   tracksAddArgs,
@@ -73,7 +74,7 @@ export function registerDatabaseHandlers(): void {
       const db = getDatabase();
       return db.select().from(tracks).orderBy(desc(tracks.createdAt)).all();
     },
-    { schema: tracksGetAllArgs },
+    { schema: tracksGetAllArgs }
   );
 
   handle(
@@ -84,7 +85,7 @@ export function registerDatabaseHandlers(): void {
       const row: NewTrack = { ...track, id };
       return db.insert(tracks).values(row).returning().get();
     },
-    { schema: tracksAddArgs },
+    { schema: tracksAddArgs }
   );
 
   handle(
@@ -95,7 +96,9 @@ export function registerDatabaseHandlers(): void {
       const rows: NewTrack[] = incoming.map(t => ({ ...t, id: crypto.randomUUID() }));
       const chunks = Math.ceil(rows.length / 100);
 
-      logger.info(`[database] tracks:add-many: inserting ${incoming.length} tracks (${chunks} chunks)`);
+      logger.info(
+        `[database] tracks:add-many: inserting ${incoming.length} tracks (${chunks} chunks)`
+      );
 
       // Insert in chunks to avoid exceeding SQLite's SQLITE_MAX_VARIABLE_NUMBER limit.
       // With 14 columns per track, chunks of 100 = 1400 params (well under the 32766 limit).
@@ -109,10 +112,12 @@ export function registerDatabaseHandlers(): void {
         return results;
       });
 
-      logger.info(`[database] tracks:add-many: inserted ${results.length} tracks in ${Date.now() - start}ms`);
+      logger.info(
+        `[database] tracks:add-many: inserted ${results.length} tracks in ${Date.now() - start}ms`
+      );
       return results;
     },
-    { schema: tracksAddManyArgs },
+    { schema: tracksAddManyArgs }
   );
 
   handle(
@@ -121,7 +126,7 @@ export function registerDatabaseHandlers(): void {
       const db = getDatabase();
       db.delete(tracks).where(eq(tracks.id, id)).run();
     },
-    { schema: tracksRemoveArgs },
+    { schema: tracksRemoveArgs }
   );
 
   handle(
@@ -138,9 +143,17 @@ export function registerDatabaseHandlers(): void {
           tx.delete(tracks).where(inArray(tracks.id, chunk)).run();
         }
       });
-      logger.info(`[database] tracks:remove-many: removed ${ids.length} tracks in ${Date.now() - start}ms`);
+      logger.info(
+        `[database] tracks:remove-many: removed ${ids.length} tracks in ${Date.now() - start}ms`
+      );
+      // Removed tracks may have been the only references to their album art
+      // files. Re-prune off the critical path — failures are logged inside
+      // pruneOrphanedAlbumArt and never propagate to the caller.
+      pruneOrphanedAlbumArt().catch(err => {
+        logger.warn('[database] post-remove-many prune failed:', err);
+      });
     },
-    { schema: tracksRemoveManyArgs },
+    { schema: tracksRemoveManyArgs }
   );
 
   handle(
@@ -149,7 +162,7 @@ export function registerDatabaseHandlers(): void {
       const db = getDatabase();
       return db.update(tracks).set(data).where(eq(tracks.id, id)).returning().get();
     },
-    { schema: tracksUpdateArgs },
+    { schema: tracksUpdateArgs }
   );
 
   handle(
@@ -164,7 +177,7 @@ export function registerDatabaseHandlers(): void {
         );
       });
     },
-    { schema: tracksUpdateManyArgs },
+    { schema: tracksUpdateManyArgs }
   );
 
   handle(
@@ -178,7 +191,7 @@ export function registerDatabaseHandlers(): void {
         .returning()
         .get();
     },
-    { schema: tracksToggleFavoriteArgs },
+    { schema: tracksToggleFavoriteArgs }
   );
 
   handle(
@@ -192,7 +205,7 @@ export function registerDatabaseHandlers(): void {
         .orderBy(desc(tracks.createdAt))
         .all();
     },
-    { schema: tracksGetFavoritesArgs },
+    { schema: tracksGetFavoritesArgs }
   );
 
   handle(
@@ -206,7 +219,7 @@ export function registerDatabaseHandlers(): void {
         .returning()
         .get();
     },
-    { schema: tracksIncrementPlayCountArgs },
+    { schema: tracksIncrementPlayCountArgs }
   );
 
   handle(
@@ -220,7 +233,7 @@ export function registerDatabaseHandlers(): void {
         .get();
       return !!row;
     },
-    { schema: tracksExistsArgs },
+    { schema: tracksExistsArgs }
   );
 
   handle(
@@ -241,23 +254,22 @@ export function registerDatabaseHandlers(): void {
       }
       return [...existing];
     },
-    { schema: tracksExistsManyArgs },
+    { schema: tracksExistsManyArgs }
   );
 
   handle(
     'db:history:record-play',
     async (
       _event,
-      data: { trackId: string; playedSeconds: number; duration: number | null; source?: string },
+      data: { trackId: string; playedSeconds: number; duration: number | null; source?: string }
     ) => {
       const db = getDatabase();
       const playedSeconds = Math.max(0, data.playedSeconds);
-      const completionRatio = data.duration && data.duration > 0
-        ? Math.min(1, playedSeconds / data.duration)
-        : 0;
+      const completionRatio =
+        data.duration && data.duration > 0 ? Math.min(1, playedSeconds / data.duration) : 0;
       const completed = data.duration ? completionRatio >= 0.95 : false;
 
-      return db.transaction((tx) => {
+      return db.transaction(tx => {
         const row: NewPlayHistory = {
           id: crypto.randomUUID(),
           trackId: data.trackId,
@@ -281,7 +293,7 @@ export function registerDatabaseHandlers(): void {
         return historyEntry;
       });
     },
-    { schema: historyRecordPlayArgs },
+    { schema: historyRecordPlayArgs }
   );
 
   handle(
@@ -310,11 +322,9 @@ export function registerDatabaseHandlers(): void {
         .innerJoin(tracks, eq(playHistory.trackId, tracks.id))
         .orderBy(desc(playHistory.playedAt));
 
-      return (sinceFilter ? recentQuery.where(sinceFilter) : recentQuery)
-        .limit(safeLimit)
-        .all();
+      return (sinceFilter ? recentQuery.where(sinceFilter) : recentQuery).limit(safeLimit).all();
     },
-    { schema: historyGetRecentArgs },
+    { schema: historyGetRecentArgs }
   );
 
   handle(
@@ -378,7 +388,7 @@ export function registerDatabaseHandlers(): void {
         topArtists,
       };
     },
-    { schema: historyGetSummaryArgs },
+    { schema: historyGetSummaryArgs }
   );
 
   handle(
@@ -401,7 +411,7 @@ export function registerDatabaseHandlers(): void {
         .orderBy(dayExpression)
         .all();
     },
-    { schema: historyGetActivityArgs },
+    { schema: historyGetActivityArgs }
   );
 
   // Folders
@@ -412,7 +422,7 @@ export function registerDatabaseHandlers(): void {
       const db = getDatabase();
       return db.select().from(folders).all();
     },
-    { schema: foldersGetAllArgs },
+    { schema: foldersGetAllArgs }
   );
 
   handle(
@@ -426,7 +436,7 @@ export function registerDatabaseHandlers(): void {
       invalidateFoldersCache();
       return inserted;
     },
-    { schema: foldersAddArgs },
+    { schema: foldersAddArgs }
   );
 
   handle(
@@ -437,7 +447,7 @@ export function registerDatabaseHandlers(): void {
       db.delete(folders).where(eq(folders.id, id)).run();
       invalidateFoldersCache();
     },
-    { schema: foldersRemoveArgs },
+    { schema: foldersRemoveArgs }
   );
 
   handle(
@@ -451,7 +461,7 @@ export function registerDatabaseHandlers(): void {
         .returning()
         .get();
     },
-    { schema: foldersUpdateScannedArgs },
+    { schema: foldersUpdateScannedArgs }
   );
 
   // Playlists
@@ -462,7 +472,7 @@ export function registerDatabaseHandlers(): void {
       const db = getDatabase();
       return db.select().from(playlists).orderBy(desc(playlists.createdAt)).all();
     },
-    { schema: playlistsGetAllArgs },
+    { schema: playlistsGetAllArgs }
   );
 
   handle(
@@ -471,7 +481,7 @@ export function registerDatabaseHandlers(): void {
       const db = getDatabase();
       return db.select().from(playlists).where(eq(playlists.id, id)).get();
     },
-    { schema: playlistsGetArgs },
+    { schema: playlistsGetArgs }
   );
 
   handle(
@@ -483,7 +493,7 @@ export function registerDatabaseHandlers(): void {
       const row: NewPlaylist = { id, ...data };
       return db.insert(playlists).values(row).returning().get();
     },
-    { schema: playlistsCreateArgs },
+    { schema: playlistsCreateArgs }
   );
 
   handle(
@@ -491,7 +501,7 @@ export function registerDatabaseHandlers(): void {
     async (
       _event,
       id: string,
-      data: Partial<Pick<NewPlaylist, 'name' | 'description' | 'coverArt'>>,
+      data: Partial<Pick<NewPlaylist, 'name' | 'description' | 'coverArt'>>
     ) => {
       const db = getDatabase();
       return db
@@ -501,7 +511,7 @@ export function registerDatabaseHandlers(): void {
         .returning()
         .get();
     },
-    { schema: playlistsUpdateArgs },
+    { schema: playlistsUpdateArgs }
   );
 
   handle(
@@ -511,7 +521,7 @@ export function registerDatabaseHandlers(): void {
       const db = getDatabase();
       db.delete(playlists).where(eq(playlists.id, id)).run();
     },
-    { schema: playlistsDeleteArgs },
+    { schema: playlistsDeleteArgs }
   );
 
   handle(
@@ -525,9 +535,9 @@ export function registerDatabaseHandlers(): void {
         .where(eq(playlistTracks.playlistId, playlistId))
         .orderBy(playlistTracks.position)
         .all();
-      return rows.map((row) => row.tracks);
+      return rows.map(row => row.tracks);
     },
-    { schema: playlistsGetTracksArgs },
+    { schema: playlistsGetTracksArgs }
   );
 
   handle(
@@ -541,8 +551,8 @@ export function registerDatabaseHandlers(): void {
         .where(
           and(
             eq(playlistTracks.playlistId, data.playlistId),
-            eq(playlistTracks.trackId, data.trackId),
-          ),
+            eq(playlistTracks.trackId, data.trackId)
+          )
         )
         .get();
 
@@ -567,13 +577,15 @@ export function registerDatabaseHandlers(): void {
         .returning()
         .get();
     },
-    { schema: playlistsAddTrackArgs },
+    { schema: playlistsAddTrackArgs }
   );
 
   handle(
     'db:playlists:create-with-tracks',
     async (_event, data: { name: string; description?: string; trackIds: string[] }) => {
-      logger.info(`[database] playlists:create-with-tracks: "${data.name}" (${data.trackIds.length} tracks)`);
+      logger.info(
+        `[database] playlists:create-with-tracks: "${data.name}" (${data.trackIds.length} tracks)`
+      );
       const db = getDatabase();
       return db.transaction(tx => {
         const playlistId = crypto.randomUUID();
@@ -595,7 +607,7 @@ export function registerDatabaseHandlers(): void {
         return playlist;
       });
     },
-    { schema: playlistsCreateWithTracksArgs },
+    { schema: playlistsCreateWithTracksArgs }
   );
 
   handle(
@@ -606,12 +618,12 @@ export function registerDatabaseHandlers(): void {
         .where(
           and(
             eq(playlistTracks.playlistId, data.playlistId),
-            eq(playlistTracks.trackId, data.trackId),
-          ),
+            eq(playlistTracks.trackId, data.trackId)
+          )
         )
         .run();
     },
-    { schema: playlistsRemoveTrackArgs },
+    { schema: playlistsRemoveTrackArgs }
   );
 
   handle(
@@ -629,9 +641,9 @@ export function registerDatabaseHandlers(): void {
         .having(sql`COUNT(DISTINCT ${playlistTracks.trackId}) = ${uniqueTrackIds.length}`)
         .all();
 
-      return rows.map((r) => r.playlistId);
+      return rows.map(r => r.playlistId);
     },
-    { schema: playlistsGetPlaylistsForTracksArgs },
+    { schema: playlistsGetPlaylistsForTracksArgs }
   );
 
   handle(
@@ -645,14 +657,14 @@ export function registerDatabaseHandlers(): void {
             .where(
               and(
                 eq(playlistTracks.playlistId, data.playlistId),
-                eq(playlistTracks.trackId, data.trackIds[i]),
-              ),
+                eq(playlistTracks.trackId, data.trackIds[i])
+              )
             )
             .run();
         }
       });
     },
-    { schema: playlistsReorderArgs },
+    { schema: playlistsReorderArgs }
   );
 }
 

--- a/apps/web/src/components/library/AlbumDetailView.tsx
+++ b/apps/web/src/components/library/AlbumDetailView.tsx
@@ -153,7 +153,13 @@ export function AlbumDetailView() {
         <div className="flex items-center gap-4">
           <div className="shrink-0 w-20 h-20 rounded-xl bg-surface border border-border/30 flex items-center justify-center overflow-hidden">
             {albumArt ? (
-              <img src={albumArt} alt={selectedAlbumName} className="w-full h-full object-cover" />
+              <img
+                src={albumArt}
+                alt={selectedAlbumName}
+                loading="lazy"
+                decoding="async"
+                className="w-full h-full object-cover"
+              />
             ) : (
               <Disc3 className="w-8 h-8 text-muted-foreground/20" />
             )}

--- a/apps/web/src/components/library/AlbumGrid.tsx
+++ b/apps/web/src/components/library/AlbumGrid.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useUIStore } from '@/stores/useUIStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { type Track } from '@/stores/types';
 import { Disc3, Search } from 'lucide-react';
 import { motion } from 'motion/react';
+import { Grid, type CellComponentProps, type GridImperativeAPI } from 'react-window';
 import { groupTracksByAlbum, type AlbumData } from '@/lib/albumSort';
 
 export type { AlbumData };
@@ -12,6 +13,108 @@ export type { AlbumData };
 interface AlbumGridProps {
   library: Track[];
   searchQuery: string;
+}
+
+type GridSize = 'small' | 'medium' | 'large';
+
+// Tailwind breakpoint columns mirrored in JS so Grid can compute layout. The
+// non-virtualized version delegated to CSS grid, but Grid needs an explicit
+// columnCount.
+const COLUMN_COUNTS: Record<GridSize, ReadonlyArray<readonly [number, number]>> = {
+  // [minViewportWidthPx, columns]
+  small: [
+    [1536, 8],
+    [1280, 6],
+    [1024, 5],
+    [768, 4],
+    [0, 3],
+  ],
+  medium: [
+    [1536, 6],
+    [1280, 5],
+    [1024, 4],
+    [768, 3],
+    [0, 2],
+  ],
+  large: [
+    [1536, 5],
+    [1280, 4],
+    [1024, 3],
+    [0, 2],
+  ],
+};
+
+function columnsFor(size: GridSize, viewportWidth: number): number {
+  const table = COLUMN_COUNTS[size];
+  for (const [minWidth, cols] of table) {
+    if (viewportWidth >= minWidth) return cols;
+  }
+  return table[table.length - 1][1];
+}
+
+// Card height is title (sm) + artist (xs) + count (10px) + paddings + img.
+// Image height = (cellWidth - 2*padding). Total = imgHeight + textBlock + p*2.
+// Padding: small=p-3 (12), medium/large=p-4 (16). Mb-3 between img and text.
+// Text block ≈ 56px (title 20 + artist 18 + count 14 + gaps).
+const ROW_HEIGHT_TEXT_BLOCK = 56;
+const GAP_PX: Record<GridSize, number> = { small: 8, medium: 12, large: 16 };
+const PADDING_PX: Record<GridSize, number> = { small: 12, medium: 16, large: 16 };
+
+interface CellProps {
+  albums: AlbumData[];
+  columnCount: number;
+  onAlbumClick: (name: string) => void;
+  cardPaddingClass: string;
+  imgPx: number;
+  trackCountLabel: (count: number) => string;
+}
+
+function AlbumCell({
+  columnIndex,
+  rowIndex,
+  style,
+  albums,
+  columnCount,
+  onAlbumClick,
+  cardPaddingClass,
+  imgPx,
+  trackCountLabel,
+}: CellComponentProps<CellProps>) {
+  const index = rowIndex * columnCount + columnIndex;
+  const album = albums[index];
+  if (!album) {
+    return <div style={style} aria-hidden="true" />;
+  }
+  return (
+    <div style={style}>
+      <button
+        onClick={() => onAlbumClick(album.name)}
+        className={`text-left ${cardPaddingClass} rounded-2xl bg-surface/60 border border-border/30 hover:border-border/60 hover:bg-surface transition-all duration-200 group w-full h-full flex flex-col`}
+      >
+        <div
+          className="w-full rounded-xl bg-muted/30 flex items-center justify-center mb-3 overflow-hidden"
+          style={{ height: imgPx, flexShrink: 0 }}
+        >
+          {album.albumArt ? (
+            <img
+              src={album.albumArt}
+              alt={album.name}
+              className="w-full h-full object-cover"
+              loading="lazy"
+              decoding="async"
+            />
+          ) : (
+            <Disc3 className="w-10 h-10 text-muted-foreground/20 group-hover:text-muted-foreground/30 transition-colors" />
+          )}
+        </div>
+        <p className="font-display text-sm font-semibold text-foreground truncate">{album.name}</p>
+        <p className="text-xs text-muted-foreground/50 truncate mt-0.5">{album.artist}</p>
+        <p className="text-[10px] text-muted-foreground/30 mt-1.5">
+          {trackCountLabel(album.trackCount)}
+        </p>
+      </button>
+    </div>
+  );
 }
 
 export function AlbumGrid({ library, searchQuery }: AlbumGridProps) {
@@ -22,26 +125,35 @@ export function AlbumGrid({ library, searchQuery }: AlbumGridProps) {
   const albumGridSize = useUIStore(s => s.albumGridSize);
   const albumSortMode = useUIStore(s => s.albumSortMode);
   const albumSortOrder = useUIStore(s => s.albumSortOrder);
-  const scrollRef = useRef<HTMLDivElement>(null);
-  // Capture scroll position at mount time — used to skip animation and restore scroll
+  const containerRef = useRef<HTMLDivElement>(null);
+  const gridRef = useRef<GridImperativeAPI | null>(null);
+  // Capture once at mount — used for scroll restore + skipping the entry animation.
   const savedScrollTop = useRef(albumGridScrollTop);
   const isReturning = useRef(albumGridScrollTop > 0);
 
-  // Restore scroll position on remount
-  useEffect(() => {
-    if (scrollRef.current && savedScrollTop.current > 0) {
-      scrollRef.current.scrollTop = savedScrollTop.current;
-    }
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    setContainerWidth(el.clientWidth);
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        setContainerWidth(entry.contentRect.width);
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
   }, []);
 
   const handleAlbumClick = useCallback(
     (albumName: string) => {
-      if (scrollRef.current) {
-        setAlbumGridScrollTop(scrollRef.current.scrollTop);
-      }
+      const offset = gridRef.current?.element?.scrollTop ?? 0;
+      setAlbumGridScrollTop(offset);
       selectAlbum(albumName);
     },
-    [selectAlbum, setAlbumGridScrollTop]
+    [selectAlbum, setAlbumGridScrollTop, gridRef]
   );
 
   const albums = useMemo(
@@ -57,20 +169,58 @@ export function AlbumGrid({ library, searchQuery }: AlbumGridProps) {
     );
   }, [albums, searchQuery]);
 
-  const gridClassName = useMemo(() => {
-    switch (albumGridSize) {
-      case 'small':
-        return 'grid grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-2';
-      case 'large':
-        return 'grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4';
-      case 'medium':
-      default:
-        return 'grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-3';
-    }
-  }, [albumGridSize]);
+  const trackCountLabel = useCallback((count: number) => t('trackCount', { count }), [t]);
 
-  // Slightly smaller padding for the small grid so more info fits on screen.
   const cardPaddingClass = albumGridSize === 'small' ? 'p-3' : 'p-4';
+
+  // Compute column count from container width (uses Tailwind breakpoint
+  // table mirrored above).
+  const columnCount = useMemo(() => {
+    if (containerWidth <= 0) return columnsFor(albumGridSize, 1280);
+    return columnsFor(albumGridSize, containerWidth);
+  }, [albumGridSize, containerWidth]);
+
+  // Cell width includes the gap allowance — Grid sizes cells based on
+  // columnWidth, and we pad to leave space for `gap` between cells.
+  const gap = GAP_PX[albumGridSize];
+  const padding = PADDING_PX[albumGridSize];
+  const usableWidth = Math.max(0, containerWidth - gap * (columnCount - 1));
+  const cellOuterWidth =
+    columnCount > 0 ? usableWidth / columnCount + (gap * (columnCount - 1)) / columnCount : 0;
+  // The image height = cellOuterWidth - 2*padding (square aspect).
+  const imgPx = Math.max(0, cellOuterWidth - padding * 2);
+  const cellOuterHeight = imgPx + padding * 2 + ROW_HEIGHT_TEXT_BLOCK;
+
+  const rowCount = columnCount > 0 ? Math.ceil(filteredAlbums.length / columnCount) : 0;
+
+  // Restore scroll position after the grid has laid out cells. Run once after
+  // we know the container width (Grid only scrolls correctly once measured).
+  const didRestoreScroll = useRef(false);
+  useEffect(() => {
+    if (didRestoreScroll.current) return;
+    if (containerWidth <= 0) return;
+    if (savedScrollTop.current <= 0) {
+      didRestoreScroll.current = true;
+      return;
+    }
+    const el = gridRef.current?.element;
+    if (el) {
+      el.scrollTop = savedScrollTop.current;
+      didRestoreScroll.current = true;
+    }
+  }, [containerWidth, gridRef]);
+
+  const cellProps = useMemo(
+    () => ({
+      albums: filteredAlbums,
+      columnCount,
+      onAlbumClick: handleAlbumClick,
+      cardPaddingClass,
+      imgPx,
+      trackCountLabel,
+    }),
+    [filteredAlbums, columnCount, handleAlbumClick, cardPaddingClass, imgPx, trackCountLabel]
+  );
 
   if (filteredAlbums.length === 0) {
     return (
@@ -87,55 +237,33 @@ export function AlbumGrid({ library, searchQuery }: AlbumGridProps) {
   }
 
   return (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto scrollbar-thin px-6 pb-4">
+    <div ref={containerRef} className="flex-1 overflow-hidden px-6 pb-4 flex flex-col">
       {searchQuery.trim() && (
-        <p className="text-xs text-muted-foreground/50 mb-3 px-1">
+        <p className="text-xs text-muted-foreground/50 mb-3 px-1 shrink-0">
           {t('albumFilterCount', { filtered: filteredAlbums.length, total: albums.length })}
         </p>
       )}
       <motion.div
-        className={gridClassName}
-        initial={isReturning.current ? 'visible' : 'hidden'}
-        animate="visible"
-        variants={{
-          visible: { transition: { staggerChildren: isReturning.current ? 0 : 0.04 } },
-        }}
+        className="flex-1 min-h-0 scrollbar-thin"
+        initial={isReturning.current ? false : { opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.25, ease: 'easeOut' }}
+        style={{ height: '100%' }}
       >
-        {filteredAlbums.map(album => (
-          <motion.button
-            key={album.name}
-            variants={{
-              hidden: { opacity: 0, y: 12 },
-              visible: { opacity: 1, y: 0 },
-            }}
-            transition={{ duration: isReturning.current ? 0 : 0.3, ease: 'easeOut' }}
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
-            onClick={() => handleAlbumClick(album.name)}
-            className={`text-left ${cardPaddingClass} rounded-2xl bg-surface/60 border border-border/30 hover:border-border/60 hover:bg-surface transition-all duration-200 group`}
-          >
-            <div className="w-full aspect-square rounded-xl bg-muted/30 flex items-center justify-center mb-3 overflow-hidden">
-              {album.albumArt ? (
-                <img
-                  src={album.albumArt}
-                  alt={album.name}
-                  className="w-full h-full object-cover"
-                  loading="lazy"
-                  decoding="async"
-                />
-              ) : (
-                <Disc3 className="w-10 h-10 text-muted-foreground/20 group-hover:text-muted-foreground/30 transition-colors" />
-              )}
-            </div>
-            <p className="font-display text-sm font-semibold text-foreground truncate">
-              {album.name}
-            </p>
-            <p className="text-xs text-muted-foreground/50 truncate mt-0.5">{album.artist}</p>
-            <p className="text-[10px] text-muted-foreground/30 mt-1.5">
-              {t('trackCount', { count: album.trackCount })}
-            </p>
-          </motion.button>
-        ))}
+        {columnCount > 0 && containerWidth > 0 && (
+          <Grid
+            gridRef={gridRef as React.RefObject<GridImperativeAPI>}
+            cellComponent={AlbumCell}
+            cellProps={cellProps}
+            columnCount={columnCount}
+            columnWidth={containerWidth / columnCount}
+            rowCount={rowCount}
+            rowHeight={cellOuterHeight}
+            overscanCount={2}
+            className="scrollbar-thin"
+            style={{ height: '100%' }}
+          />
+        )}
       </motion.div>
     </div>
   );

--- a/apps/web/src/components/mixes/MixesView.tsx
+++ b/apps/web/src/components/mixes/MixesView.tsx
@@ -3,12 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
-import {
-  Sparkles,
-  Play,
-  Shuffle,
-  ArrowLeft,
-} from 'lucide-react';
+import { Sparkles, Play, Shuffle, ArrowLeft } from 'lucide-react';
 import { ViewEmptyState } from '@/components/shared/ViewEmptyState';
 import { motion } from 'motion/react';
 import { List } from 'react-window';
@@ -22,13 +17,13 @@ import { MixesViewSkeleton } from './MixesViewSkeleton';
 
 export function MixesView() {
   const { t } = useTranslation('mixes');
-  const library = useLibraryStore((s) => s.library);
-  const libraryLoaded = useLibraryStore((s) => s.libraryLoaded);
-  const currentTrack = usePlaybackStore((s) => s.currentTrack);
-  const isPlaying = usePlaybackStore((s) => s.isPlaying);
-  const setQueue = usePlaybackStore((s) => s.setQueue);
-  const toggleFavorite = useLibraryStore((s) => s.toggleFavorite);
-  const hasSelection = useSelectionStore((s) => s.selectedTrackIds.size > 0);
+  const library = useLibraryStore(s => s.library);
+  const libraryLoaded = useLibraryStore(s => s.libraryLoaded);
+  const currentTrack = usePlaybackStore(s => s.currentTrack);
+  const isPlaying = usePlaybackStore(s => s.isPlaying);
+  const setQueue = usePlaybackStore(s => s.setQueue);
+  const toggleFavorite = useLibraryStore(s => s.toggleFavorite);
+  const hasSelection = useSelectionStore(s => s.selectedTrackIds.size > 0);
 
   const [selectedMix, setSelectedMix] = useState<MixId | null>(null);
   const mixTracks = useMixTracks(selectedMix);
@@ -56,9 +51,7 @@ export function MixesView() {
 
   const handleBack = useCallback(() => setSelectedMix(null), []);
 
-  const selectedDef = selectedMix
-    ? MIX_DEFINITIONS.find((m) => m.id === selectedMix)
-    : null;
+  const selectedDef = selectedMix ? MIX_DEFINITIONS.find(m => m.id === selectedMix) : null;
 
   // ── Cold-start skeleton ──
   if (!libraryLoaded && library.length === 0) {
@@ -67,13 +60,7 @@ export function MixesView() {
 
   // ── Empty library state ──
   if (library.length === 0) {
-    return (
-      <ViewEmptyState
-        title={t('title')}
-        subtitle={t('emptyLibrary')}
-        icon={Sparkles}
-      />
-    );
+    return <ViewEmptyState title={t('title')} subtitle={t('emptyLibrary')} icon={Sparkles} />;
   }
 
   // ── Mix detail view ──
@@ -171,7 +158,7 @@ export function MixesView() {
 
       <div className="flex-1 overflow-y-auto px-6 pb-6 scrollbar-thin">
         <div className="space-y-1.5">
-          {MIX_DEFINITIONS.map((mix) => {
+          {MIX_DEFINITIONS.map(mix => {
             const Icon = mix.icon;
             const preview = getMixPreviewCount(mix.id, library);
             const previewTracks = previews[mix.id];
@@ -193,6 +180,8 @@ export function MixesView() {
                           src={track.albumArt}
                           alt=""
                           aria-hidden="true"
+                          loading="lazy"
+                          decoding="async"
                           className="w-full h-full object-cover"
                         />
                       ))}
@@ -202,6 +191,8 @@ export function MixesView() {
                       src={previewTracks[0].albumArt}
                       alt=""
                       aria-hidden="true"
+                      loading="lazy"
+                      decoding="async"
                       className="w-full h-full object-cover"
                     />
                   ) : (
@@ -213,9 +204,7 @@ export function MixesView() {
 
                 {/* Text */}
                 <div className="min-w-0 flex-1">
-                  <p className="text-sm font-medium text-foreground truncate">
-                    {t(mix.titleKey)}
-                  </p>
+                  <p className="text-sm font-medium text-foreground truncate">{t(mix.titleKey)}</p>
                   <p className="text-xs text-muted-foreground/40 truncate mt-0.5">
                     {t(mix.descKey)}
                   </p>

--- a/apps/web/src/components/player/QueuePanel.tsx
+++ b/apps/web/src/components/player/QueuePanel.tsx
@@ -18,11 +18,7 @@ import {
   type DragStartEvent,
   type DragEndEvent,
 } from '@dnd-kit/core';
-import {
-  SortableContext,
-  verticalListSortingStrategy,
-  useSortable,
-} from '@dnd-kit/sortable';
+import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
 /* ── Sortable queue row (for Up Next items) ─────────────── */
@@ -35,16 +31,17 @@ interface SortableQueueRowProps {
   onRemove: (e: React.MouseEvent, queueIndex: number) => void;
 }
 
-function SortableQueueRow({ track, sortableId, queueIndex, onPlay, onRemove }: SortableQueueRowProps) {
+function SortableQueueRow({
+  track,
+  sortableId,
+  queueIndex,
+  onPlay,
+  onRemove,
+}: SortableQueueRowProps) {
   const { t } = useTranslation('queue');
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: sortableId });
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: sortableId,
+  });
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -66,14 +63,20 @@ function SortableQueueRow({ track, sortableId, queueIndex, onPlay, onRemove }: S
         aria-label={t('dragToReorder')}
         {...attributes}
         {...listeners}
-        onClick={(e) => e.stopPropagation()}
+        onClick={e => e.stopPropagation()}
       >
         <GripVertical className="w-3 h-3" />
       </button>
 
       <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0 overflow-hidden bg-surface">
         {track.albumArt ? (
-          <img src={track.albumArt} alt={track.title} className="w-full h-full object-cover rounded-md" />
+          <img
+            src={track.albumArt}
+            alt={track.title}
+            loading="lazy"
+            decoding="async"
+            className="w-full h-full object-cover rounded-md"
+          />
         ) : (
           <Play className="w-3 h-3 text-muted-foreground/40" />
         )}
@@ -110,7 +113,13 @@ function DragOverlayContent({ track }: { track: Track }) {
       </div>
       <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0 overflow-hidden bg-surface">
         {track.albumArt ? (
-          <img src={track.albumArt} alt={track.title} className="w-full h-full object-cover rounded-md" />
+          <img
+            src={track.albumArt}
+            alt={track.title}
+            loading="lazy"
+            decoding="async"
+            className="w-full h-full object-cover rounded-md"
+          />
         ) : (
           <Play className="w-3 h-3 text-muted-foreground/40" />
         )}
@@ -303,24 +312,37 @@ interface QueueItemProps {
   onRemove: (e: React.MouseEvent, index: number) => void;
 }
 
-const QueueItem = memo(function QueueItem({ track, index, isActive, isPlaying, onPlay, onRemove }: QueueItemProps) {
+const QueueItem = memo(function QueueItem({
+  track,
+  index,
+  isActive,
+  isPlaying,
+  onPlay,
+  onRemove,
+}: QueueItemProps) {
   const { t } = useTranslation('queue');
   return (
     <div
       className={cn(
         'flex items-center gap-2.5 px-2 py-1.5 rounded-lg transition-all duration-200 group cursor-pointer',
-        isActive
-          ? 'bg-primary/[0.08]'
-          : 'hover:bg-accent'
+        isActive ? 'bg-primary/[0.08]' : 'hover:bg-accent'
       )}
       onClick={() => onPlay(index)}
     >
-      <div className={cn(
-        'w-8 h-8 rounded-md flex items-center justify-center shrink-0 overflow-hidden',
-        isActive ? 'bg-primary/15' : 'bg-surface'
-      )}>
+      <div
+        className={cn(
+          'w-8 h-8 rounded-md flex items-center justify-center shrink-0 overflow-hidden',
+          isActive ? 'bg-primary/15' : 'bg-surface'
+        )}
+      >
         {track.albumArt ? (
-          <img src={track.albumArt} alt={track.title} className="w-full h-full object-cover rounded-md" />
+          <img
+            src={track.albumArt}
+            alt={track.title}
+            loading="lazy"
+            decoding="async"
+            className="w-full h-full object-cover rounded-md"
+          />
         ) : isActive && isPlaying ? (
           <>
             <span className="sr-only">{t('nowPlaying')}</span>

--- a/apps/web/src/components/playlists/PlaylistDetailView.tsx
+++ b/apps/web/src/components/playlists/PlaylistDetailView.tsx
@@ -298,6 +298,8 @@ export function PlaylistDetailView() {
                 <img
                   src={playlist.coverArt}
                   alt={playlist.name}
+                  loading="lazy"
+                  decoding="async"
                   className="w-full h-full object-cover"
                 />
               ) : (

--- a/apps/web/src/components/playlists/PlaylistsView.tsx
+++ b/apps/web/src/components/playlists/PlaylistsView.tsx
@@ -193,6 +193,8 @@ export function PlaylistsView() {
                     <img
                       src={playlist.coverArt}
                       alt={playlist.name}
+                      loading="lazy"
+                      decoding="async"
                       className="w-full h-full object-cover"
                     />
                   ) : (

--- a/apps/web/src/components/shared/CommandPalette.tsx
+++ b/apps/web/src/components/shared/CommandPalette.tsx
@@ -72,6 +72,8 @@ export function CommandPalette() {
                   <img
                     src={track.albumArt}
                     alt={track.title}
+                    loading="lazy"
+                    decoding="async"
                     className="w-full h-full object-cover"
                   />
                 ) : (

--- a/apps/web/src/components/shared/NowPlayingHero.tsx
+++ b/apps/web/src/components/shared/NowPlayingHero.tsx
@@ -40,13 +40,18 @@ export function NowPlayingHero({ show }: NowPlayingHeroProps) {
             }}
           >
             {currentTrack.albumArt && !lowPerformanceMode && (
-              <div
-                className="absolute inset-0 opacity-[0.08] blur-2xl scale-110"
-                style={{
-                  backgroundImage: `url(${currentTrack.albumArt})`,
-                  backgroundSize: 'cover',
-                  backgroundPosition: 'center',
-                }}
+              // Render the blurred backdrop as a positioned <img> rather than
+              // background-image: this lets Chromium share the decoded bitmap
+              // with the foreground <img> below (CSS background-image lives in
+              // a separate cache, doubling decoded RAM per render).
+              <img
+                src={currentTrack.albumArt}
+                alt=""
+                aria-hidden="true"
+                loading="eager"
+                decoding="async"
+                className="absolute inset-0 w-full h-full object-cover opacity-[0.08] pointer-events-none"
+                style={{ filter: 'blur(32px)', transform: 'scale(1.1)' }}
               />
             )}
 

--- a/apps/web/src/components/shared/ShareDialog.tsx
+++ b/apps/web/src/components/shared/ShareDialog.tsx
@@ -2,12 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Share2, Copy, Check, Loader2, AlertCircle } from 'lucide-react';
 import { useShareLink } from '@/hooks/useShareLink';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 
 interface ShareDialogProps {
   open: boolean;
@@ -98,6 +93,8 @@ export function ShareDialog({ open, onOpenChange, type, id }: ShareDialogProps) 
                   alt="QR code for sharing"
                   width={180}
                   height={180}
+                  loading="lazy"
+                  decoding="async"
                   className="rounded-lg"
                 />
               </div>

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -183,6 +183,8 @@ export function Sidebar() {
                               <img
                                 src={playlist.coverArt}
                                 alt={playlist.name}
+                                loading="lazy"
+                                decoding="async"
                                 className="w-full h-full object-cover"
                               />
                             ) : (
@@ -242,6 +244,8 @@ export function Sidebar() {
                               <img
                                 src={playlist.coverArt}
                                 alt={playlist.name}
+                                loading="lazy"
+                                decoding="async"
                                 className="w-full h-full object-cover"
                               />
                             ) : (

--- a/apps/web/src/components/shared/TrackRowContent.tsx
+++ b/apps/web/src/components/shared/TrackRowContent.tsx
@@ -40,45 +40,60 @@ export function TrackRowContent({
   const { t } = useTranslation('contextMenu');
   const [contextMenu, setContextMenu] = useState<ContextMenuPosition | null>(null);
 
-  const isSelected = useSelectionStore((s) => s.selectedTrackIds.has(track.id));
-  const hasSelection = useSelectionStore((s) => s.selectedTrackIds.size > 0);
-  const selectedTrackIds = useSelectionStore((s) => s.selectedTrackIds);
-  const toggleTrack = useSelectionStore((s) => s.toggleTrack);
-  const selectRange = useSelectionStore((s) => s.selectRange);
-  const clearSelection = useSelectionStore((s) => s.clearSelection);
+  const isSelected = useSelectionStore(s => s.selectedTrackIds.has(track.id));
+  const hasSelection = useSelectionStore(s => s.selectedTrackIds.size > 0);
+  const selectedTrackIds = useSelectionStore(s => s.selectedTrackIds);
+  const toggleTrack = useSelectionStore(s => s.toggleTrack);
+  const selectRange = useSelectionStore(s => s.selectRange);
+  const clearSelection = useSelectionStore(s => s.clearSelection);
 
-  const handleContextMenu = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (hasSelection && !selectedTrackIds.has(track.id)) {
-      clearSelection();
-    }
-    setContextMenu({ x: e.clientX, y: e.clientY });
-  }, [hasSelection, track.id, selectedTrackIds, clearSelection]);
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (hasSelection && !selectedTrackIds.has(track.id)) {
+        clearSelection();
+      }
+      setContextMenu({ x: e.clientX, y: e.clientY });
+    },
+    [hasSelection, track.id, selectedTrackIds, clearSelection]
+  );
 
   const handleCloseContextMenu = useCallback(() => {
     setContextMenu(null);
   }, []);
 
-  const handleClick = useCallback((e: React.MouseEvent) => {
-    const isMod = e.metaKey || e.ctrlKey;
-    const isShift = e.shiftKey;
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      const isMod = e.metaKey || e.ctrlKey;
+      const isShift = e.shiftKey;
 
-    if (isMod) {
-      e.preventDefault();
-      toggleTrack(track.id, index);
-      return;
-    }
-    if (isShift) {
-      e.preventDefault();
-      selectRange(index, queue);
-      return;
-    }
-    if (hasSelection) {
-      clearSelection();
-    }
-    handlePlayTrack(index);
-  }, [track.id, index, queue, hasSelection, toggleTrack, selectRange, clearSelection, handlePlayTrack]);
+      if (isMod) {
+        e.preventDefault();
+        toggleTrack(track.id, index);
+        return;
+      }
+      if (isShift) {
+        e.preventDefault();
+        selectRange(index, queue);
+        return;
+      }
+      if (hasSelection) {
+        clearSelection();
+      }
+      handlePlayTrack(index);
+    },
+    [
+      track.id,
+      index,
+      queue,
+      hasSelection,
+      toggleTrack,
+      selectRange,
+      clearSelection,
+      handlePlayTrack,
+    ]
+  );
 
   const isActive = currentTrack?.id === track.id;
 
@@ -98,18 +113,23 @@ export function TrackRowContent({
       >
         {dragHandle}
 
-        <button
-          onClick={handleClick}
-          className="flex items-center gap-3 min-w-0 flex-1"
-        >
-          <div className={cn(
-            'w-9 h-9 rounded-lg flex items-center justify-center shrink-0 overflow-hidden relative',
-            isSelected ? 'bg-primary/20' : isActive ? 'bg-primary/15' : 'bg-surface'
-          )}>
+        <button onClick={handleClick} className="flex items-center gap-3 min-w-0 flex-1">
+          <div
+            className={cn(
+              'w-9 h-9 rounded-lg flex items-center justify-center shrink-0 overflow-hidden relative',
+              isSelected ? 'bg-primary/20' : isActive ? 'bg-primary/15' : 'bg-surface'
+            )}
+          >
             {isSelected ? (
               <Check className="w-4 h-4 text-primary" />
             ) : track.albumArt ? (
-              <img src={track.albumArt} alt={track.title} className="w-full h-full object-cover rounded-lg" />
+              <img
+                src={track.albumArt}
+                alt={track.title}
+                loading="lazy"
+                decoding="async"
+                className="w-full h-full object-cover rounded-lg"
+              />
             ) : isActive && isPlaying ? (
               <>
                 <span className="sr-only">{t('nowPlaying', { ns: 'common' })}</span>
@@ -120,7 +140,9 @@ export function TrackRowContent({
             )}
           </div>
           <div className="min-w-0 flex-1">
-            <p className={cn('text-sm font-medium truncate text-left', isActive && 'text-primary')}>{track.title}</p>
+            <p className={cn('text-sm font-medium truncate text-left', isActive && 'text-primary')}>
+              {track.title}
+            </p>
             <p className="text-xs text-muted-foreground/60 truncate text-left">{track.artist}</p>
           </div>
         </button>
@@ -129,9 +151,7 @@ export function TrackRowContent({
           {track.duration > 0 ? formatDuration(track.duration) : ''}
         </span>
 
-        {showAddToPlaylist && (
-          <AddToPlaylistButton trackId={track.id} />
-        )}
+        {showAddToPlaylist && <AddToPlaylistButton trackId={track.id} />}
 
         {onToggleFavorite && (
           <motion.button
@@ -149,7 +169,10 @@ export function TrackRowContent({
             aria-label={track.isFavorite ? t('removeFromFavorites') : t('addToFavorites')}
           >
             <Heart
-              className={cn('w-3.5 h-3.5 transition-all duration-150', track.isFavorite && 'fill-current')}
+              className={cn(
+                'w-3.5 h-3.5 transition-all duration-150',
+                track.isFavorite && 'fill-current'
+              )}
             />
           </motion.button>
         )}
@@ -169,11 +192,7 @@ export function TrackRowContent({
         )}
       </div>
       {contextMenu && (
-        <TrackContextMenu
-          track={track}
-          position={contextMenu}
-          onClose={handleCloseContextMenu}
-        />
+        <TrackContextMenu track={track} position={contextMenu} onClose={handleCloseContextMenu} />
       )}
     </>
   );

--- a/apps/web/src/hooks/useLibrarySync.ts
+++ b/apps/web/src/hooks/useLibrarySync.ts
@@ -2,8 +2,10 @@ import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { IS_ELECTRON } from '@/lib/platform';
 import { useLibraryStore } from '@/stores/useLibraryStore';
+import type { Track } from '@/stores/types';
 import { mapDbTracksToTracks } from '@/lib/trackMapper';
 import { libraryKeys } from '@/hooks/queries/useLibrary';
+import { queryClient } from '@/lib/queryClient';
 
 /**
  * Bootstraps Zustand's player store from the persisted DB library on cold start.
@@ -35,6 +37,15 @@ export function useLibrarySync() {
     if (useLibraryStore.getState().library.length === 0) {
       useLibraryStore.setState({ library: data });
     }
+    // Drop the React-Query copy after seeding Zustand. Zustand is the runtime
+    // source of truth; keeping the cache around is ~20 MB of dead state at 50k
+    // tracks (and diverges from Zustand on every favorite/playCount mutation).
+    // We set it to an empty array rather than removing the cache entry — that
+    // would orphan the active observer here and trigger an immediate refetch
+    // loop. With an empty array the entry stays, the observer stays stable,
+    // and mutations elsewhere can still invalidateQueries() to re-fetch and
+    // re-seed (this effect re-runs, then re-empties).
+    queryClient.setQueryData<Track[]>(libraryKeys.all, []);
   }, [data]);
 
   // Flip `libraryLoaded` once the query settles (success, empty, or error) so

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
       "path-to-regexp": "8.4.0",
       "fastify": "5.8.3",
       "axios": "1.15.0",
-      "lodash": "4.18.1"
+      "lodash": "4.18.1",
+      "lucide-react": "^1.14.0"
     },
     "onlyBuiltDependencies": [
       "electron",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   fastify: 5.8.3
   axios: 1.15.0
   lodash: 4.18.1
+  lucide-react: ^1.14.0
 
 importers:
   .:
@@ -175,7 +176,7 @@ importers:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       lucide-react:
-        specifier: ^1.8.0
+        specifier: ^1.14.0
         version: 1.14.0(react@18.3.1)
       react:
         specifier: ^18.3.1
@@ -342,7 +343,7 @@ importers:
         specifier: ^26.0.8
         version: 26.0.8(typescript@5.9.3)
       lucide-react:
-        specifier: ^1.8.0
+        specifier: ^1.14.0
         version: 1.14.0(react@18.3.1)
       motion:
         specifier: ^12.38.0


### PR DESCRIPTION
## Summary

Follow-up to #150 covering both the perf and arch lenses on RAM. PR #150 cut per-bitmap decoded size from up to 36 MB to ~1 MB by downscaling cached covers to 512 px JPEG q=85. This PR addresses the structural levers PR #150 did not touch: the remaining 11 `<img>` sites still missing lazy/async, the unvirtualised album grid, the duplicate library cache, the unbounded on-disk art cache, the buffered (non-streaming) art protocol, and the duplicate `lucide-react` install.

## Changes

Each theme is one commit:

- **perf(web): add lazy/async hints to remaining album-art img sites** — 11 sites, most-impactful is `apps/web/src/components/shared/TrackRowContent.tsx` (the virtualised library row — react-window overscan was forcing sync decode just outside the visible viewport). Also: `QueuePanel`, `AlbumDetailView`, `PlaylistDetailView`, `PlaylistsView`, `MixesView` mosaic, `Sidebar` (collapsed + expanded), `CommandPalette`, `ShareDialog`.
- **perf(web): drop duplicate React-Query library cache after seeding Zustand** — `apps/web/src/hooks/useLibrarySync.ts` now sets `queryClient.setQueryData(libraryKeys.all, [])` after seeding Zustand. `removeQueries` would orphan the live observer and trigger a refetch loop; setting an empty array keeps the cache entry stable while freeing the array. Mutations elsewhere still `invalidateQueries`, which re-runs the queryFn and re-seeds.
- **perf(web): virtualize AlbumGrid via react-window Grid** — `apps/web/src/components/library/AlbumGrid.tsx`. Column count derived from container width via a JS table mirroring the existing Tailwind grid breakpoints; ResizeObserver drives `columnCount` + cell-width updates. Scroll restoration via `gridRef.element.scrollTop` after the grid measures. Drops the per-card framer stagger (it can't apply per-virtualised-item) — replaced with a single grid-level fade-in on first mount; return-from-detail still skips animation.
- **perf(web): swap NowPlayingHero backdrop from background-image to img** — `apps/web/src/components/shared/NowPlayingHero.tsx`. CSS background-image lives in a separate Chromium decoded-bitmap cache from `<img>`s, so the gated backdrop was paying for a second full decode (~1 MB at PR #150's 512 px JPEGs) even though the foreground `<img>` already had the same src. Now a positioned `<img>` with `filter: blur(32px)` + `transform: scale(1.1)`. Preserves the existing `!lowPerformanceMode` gate.
- **chore: dedupe lucide-react via pnpm.overrides** — root `package.json`. Two versions (1.11.0 transitive, 1.14.0 direct) were resolved on disk. `pnpm.overrides.lucide-react: ^1.14.0` collapses them; `pnpm why -r lucide-react` now shows a single version.
- **perf(desktop): album-art cache lifecycle (orphan prune + in-process LRU)** — `apps/desktop/src/main/art-protocol.ts`. Adds `pruneOrphanedAlbumArt()` that diffs `SELECT DISTINCT album_art FROM tracks` against `fs.readdir(getArtDir())` and unlinks orphan files. Scheduled fire-and-forget from bootstrap and re-run after `db:tracks:remove-many`. Adds a ~5 MB byte-bounded in-process LRU keyed on file name in front of disk reads (same Map-as-LRU pattern as `lyrics-service.ts`). 7 new unit tests cover empty/full/partial/missing/non-art-URL cases.
- **perf(desktop): stream shiranami-art:// buffers** — port the `createReadStream` + `ReadableStream` pattern from `audio-protocol.ts:84-122`. Streamed chunks are tee'd into the LRU on stream end so subsequent requests still hit the synchronous cache path. 6 new protocol-handler tests cover 400/403/404 paths, full payload round-trip, LRU warm-after-stream, and path-traversal-via-basename safety.

## Expected impact

| Metric | Before (post-PR-150) | After (this PR) |
|---|---|---|
| Renderer JS heap, library scrolled | ~400-500 MB | ~340-440 MB (−30-60 MB from lazy/async hints + −1-2 MB React-Query dedupe + −1-3 MB lucide dedupe) |
| Renderer peak under album-grid scroll | ~80-200 MB above steady-state | ~10-15 MB above steady-state (virtualised grid mounts ~30 cells vs 330) |
| Album-art on-disk (long-tail user) | unbounded growth (orphan accumulation) | bounded by referenced set; pruned on boot + after `tracks:remove-many` |
| NowPlayingHero render | 2 decoded bitmaps (foreground + bg-image) | 1 decoded bitmap shared by both `<img>`s |

Long-tail savings (steady-state, 4k tracks): ~35-65 MB renderer + ~50-300 MB disk for users with prior orphan accumulation. Peak savings under album-grid fast scroll: ~80-200 MB.

## Test plan

- [x] `pnpm typecheck` passes (web + desktop).
- [x] `pnpm test` passes (1147 tests across all projects, including 575 desktop unit tests — up from 569 with 13 new tests added in this PR).
- [x] `pnpm lint` clean.
- [x] `pnpm why -r lucide-react` reports a single version.

Manual verification (TODO — these need the user to run dev locally; type checks + unit tests verify code correctness, not behaviour):

- [ ] TrackRowContent in the library view: scroll fast through a 1000+ track library, confirm rows lazy-load (DevTools Network tab should show `shiranami-art://` requests fire as rows enter the viewport, not all upfront).
- [ ] AlbumGrid virtualisation: navigate Library → Albums view, scroll through ~330 albums, confirm smoothness and that scrolling far down then clicking an album → back restores the previous scroll position.
- [ ] AlbumGrid breakpoints: resize the window through 768/1024/1280/1536 px and confirm column count updates (small/medium/large grid sizes also reflect correctly).
- [ ] NowPlayingHero: play a track, visually confirm the blurred backdrop is identical to before (opacity 0.08, scale 1.1, blur 32px). Toggle `lowPerformanceMode` in settings and confirm the backdrop disappears.
- [ ] Album-art prune: with a non-trivial library, remove a folder via the UI and check `%APPDATA%/shiranami/album-art/` shrinks to match the new referenced set within a few seconds.
- [ ] Streaming art protocol: open an album view repeatedly, confirm cover images render normally on first AND subsequent loads (LRU is being populated via the stream tee).

## Out of scope (deferred)

- **Paginated `db:tracks:get-page` IPC** — full library is still shipped in one IPC blob on cold start. Bounded structural change; needs design buy-in for the renderer-side windowed fetch model.
- **utilityProcess for metadata scan** — scan-time main RSS still spikes hard at concurrency=16 with embedded covers held in main heap; a utilityProcess would let the OS reclaim that memory after scan completes.
- **Incremental album grouping** — `groupTracksByAlbum` rebuilds the entire `AlbumData[]` whenever the library array reference changes (favorite toggle, play count++). Mutation-overlay store would let the library array stay stable.

Each is bigger / structural and should land standalone with its own design review.

## Closes

Follow-up to #150.