### PR TITLE
refactor(web): mutation overlay store + post-pr-160 runtime fixes

### DIFF
--- a/apps/desktop/esbuild.config.mjs
+++ b/apps/desktop/esbuild.config.mjs
@@ -3,22 +3,41 @@ import { readFileSync } from 'node:fs';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
-// Externalize all npm dependencies — they're bundled by electron-builder at
-// package time via node_modules.  Workspace packages are kept bundled (tiny)
-// to avoid workspace-protocol resolution issues in production builds.
-const external = [
+// Main + worker: externalize all npm dependencies. They're shipped via
+// node_modules and electron-builder rebuilds native modules (better-sqlite3,
+// node-addon-api, flac-tagger) against the Electron ABI at package time.
+// Bundling them would defeat the rebuild step.
+const mainExternal = [
   'electron',
   ...Object.keys(pkg.dependencies ?? {}).filter((d) => !d.startsWith('@shiranami/')),
 ];
 
-await build({
-  entryPoints: ['src/main/index.ts', 'src/main/preload.ts', 'src/main/extract-worker.ts'],
+// Preload: runs in Electron's sandboxed renderer context. require() from the
+// sandbox cannot resolve npm modules from app.asar/node_modules the way the
+// main process can, so anything the preload depends on (e.g. zod via the
+// @shiranami/contracts schemas) must be bundled into preload.js. Only
+// `electron` itself is external — the sandbox provides it as a built-in.
+const preloadExternal = ['electron'];
+
+const sharedOptions = {
   bundle: true,
   platform: 'node',
   target: 'node22',
   format: 'cjs',
   outdir: 'dist/main',
   sourcemap: true,
-  external,
   logLevel: 'info',
-});
+};
+
+await Promise.all([
+  build({
+    ...sharedOptions,
+    entryPoints: ['src/main/index.ts', 'src/main/extract-worker.ts'],
+    external: mainExternal,
+  }),
+  build({
+    ...sharedOptions,
+    entryPoints: ['src/main/preload.ts'],
+    external: preloadExternal,
+  }),
+]);

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -38,6 +38,10 @@ protocol.registerSchemesAsPrivileged([
       supportFetchAPI: true,
       stream: true,
       bypassCSP: false,
+      // Required so MediaElementAudioSource (Web Audio graph) gets actual
+      // samples instead of silent zeroes — connecting a cross-origin audio
+      // element to AudioContext silently outputs zeroes by default.
+      corsEnabled: true,
     },
   },
   {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -58,6 +58,10 @@ protocol.registerSchemesAsPrivileged([
       supportFetchAPI: true,
       stream: false,
       bypassCSP: false,
+      // Required so the renderer can draw covers onto a <canvas> for
+      // FastAverageColor / getImageData without Chromium tainting the
+      // canvas as cross-origin.
+      corsEnabled: true,
     },
   },
 ]);

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -21,10 +21,13 @@ function setupContentSecurityPolicy(isDev: boolean): void {
       "img-src 'self' data: blob: https: http: shiranami-art:",
       // Fonts: Google Fonts + self
       "font-src 'self' data: https://fonts.gstatic.com",
-      // Connections: LRCLIB for lyrics, yt-dlp thumbnails; dev adds Vite WS
+      // Connections: LRCLIB for lyrics, yt-dlp thumbnails; shiranami-art for
+      // MediaSession blob-URL conversion (W3C spec restricts MediaImage.src
+      // to http/https/data/blob, so the renderer fetches custom-protocol
+      // covers and re-serves them as object URLs); dev adds Vite WS.
       isDev
-        ? `connect-src 'self' http://localhost:${VITE_DEV_PORT} ws://localhost:${VITE_DEV_PORT} https://lrclib.net https://i.ytimg.com https://*.api.radio-browser.info`
-        : "connect-src 'self' https://lrclib.net https://i.ytimg.com https://*.api.radio-browser.info",
+        ? `connect-src 'self' http://localhost:${VITE_DEV_PORT} ws://localhost:${VITE_DEV_PORT} https://lrclib.net https://i.ytimg.com https://*.api.radio-browser.info shiranami-art:`
+        : "connect-src 'self' https://lrclib.net https://i.ytimg.com https://*.api.radio-browser.info shiranami-art:",
       // No plugins/embeds
       "object-src 'none'",
       // Audio: custom protocol + local files
@@ -118,11 +121,11 @@ export async function createMainWindow(): Promise<BrowserWindow> {
   // Forward renderer console errors/warnings to main process log file.
   // Uses the Event object API (positional args are deprecated in Electron 40+).
   const NOISY_PATTERNS = [
-    'MediaImage src can only be of',       // Known Chromium limitation with custom protocols
-    'Electron Security Warning',           // Dev-only CSP warning
-    '[vite]',                              // Vite HMR messages (dev-only noise)
-    'Download the React DevTools',         // React dev tools promo
-    'i18next is made possible',            // i18next promo
+    'MediaImage src can only be of', // Known Chromium limitation with custom protocols
+    'Electron Security Warning', // Dev-only CSP warning
+    '[vite]', // Vite HMR messages (dev-only noise)
+    'Download the React DevTools', // React dev tools promo
+    'i18next is made possible', // i18next promo
   ];
 
   mainWindow.webContents.on('console-message', (_event, level, message, line, sourceId) => {

--- a/apps/web/src/components/favorites/FavoritesView.tsx
+++ b/apps/web/src/components/favorites/FavoritesView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { useMergedLibrary } from '@/hooks/useMergedLibrary';
 import { useUIStore } from '@/stores/useUIStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 import { Heart } from 'lucide-react';
@@ -16,7 +17,9 @@ const showIfFavorite = (track: { isFavorite?: boolean }) => !!track.isFavorite;
 
 export function FavoritesView() {
   const { t } = useTranslation('favorites');
-  const library = useLibraryStore(s => s.library);
+  // Merged library so an in-session favorite toggle moves a track in or out
+  // of the favorites filter immediately, without rewriting `library`.
+  const library = useMergedLibrary();
   const libraryLoaded = useLibraryStore(s => s.libraryLoaded);
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const isPlaying = usePlaybackStore(s => s.isPlaying);

--- a/apps/web/src/components/library/AlbumGrid.tsx
+++ b/apps/web/src/components/library/AlbumGrid.tsx
@@ -62,6 +62,10 @@ function columnsFor(size: GridSize, viewportWidth: number): number {
 // Padding: small=p-3 (12), medium/large=p-4 (16). Mb-3 between img and text.
 // Text block: title 20 + mt-0.5 2 + artist 16 + mt-1.5 6 + count 14 = 58px + 6px safety = 64px.
 const ROW_HEIGHT_TEXT_BLOCK = 64;
+// Tailwind mb-3 between the cover image and the text block — the button is
+// flex flex-col so this margin takes real vertical space and must be in the
+// row-height math, otherwise the text overflows past the visible card edge.
+const IMG_TEXT_GAP_PX = 12;
 const GAP_PX: Record<GridSize, number> = { small: 8, medium: 12, large: 16 };
 const PADDING_PX: Record<GridSize, number> = { small: 12, medium: 16, large: 16 };
 
@@ -212,7 +216,10 @@ export function AlbumGrid({ library, searchQuery }: AlbumGridProps) {
     columnCount > 0 ? Math.max(0, containerWidth - scrollbarSize) / columnCount : 0;
   // The image height = cellWidth - 2*padding (square aspect).
   const imgPx = Math.max(0, columnWidthPx - padding * 2);
-  const cellOuterHeight = imgPx + padding * 2 + ROW_HEIGHT_TEXT_BLOCK;
+  // Cell content layout: padding-top + img + mb-3 + text-block + padding-bottom.
+  // Plus `gap` so the per-cell paddingTop/Bottom inset (halfGap each on
+  // non-edge rows) doesn't eat from the button's h-full and clip the text.
+  const cellOuterHeight = imgPx + padding * 2 + IMG_TEXT_GAP_PX + ROW_HEIGHT_TEXT_BLOCK + gap;
 
   const rowCount = columnCount > 0 ? Math.ceil(filteredAlbums.length / columnCount) : 0;
 

--- a/apps/web/src/components/library/AlbumGrid.tsx
+++ b/apps/web/src/components/library/AlbumGrid.tsx
@@ -5,7 +5,12 @@ import { useViewStore } from '@/stores/useViewStore';
 import { type Track } from '@/stores/types';
 import { Disc3, Search } from 'lucide-react';
 import { motion } from 'motion/react';
-import { Grid, type CellComponentProps, type GridImperativeAPI } from 'react-window';
+import {
+  Grid,
+  getScrollbarSize,
+  type CellComponentProps,
+  type GridImperativeAPI,
+} from 'react-window';
 import { groupTracksByAlbum, type AlbumData } from '@/lib/albumSort';
 
 export type { AlbumData };
@@ -55,14 +60,15 @@ function columnsFor(size: GridSize, viewportWidth: number): number {
 // Card height is title (sm) + artist (xs) + count (10px) + paddings + img.
 // Image height = (cellWidth - 2*padding). Total = imgHeight + textBlock + p*2.
 // Padding: small=p-3 (12), medium/large=p-4 (16). Mb-3 between img and text.
-// Text block ≈ 56px (title 20 + artist 18 + count 14 + gaps).
-const ROW_HEIGHT_TEXT_BLOCK = 56;
+// Text block: title 20 + mt-0.5 2 + artist 16 + mt-1.5 6 + count 14 = 58px + 6px safety = 64px.
+const ROW_HEIGHT_TEXT_BLOCK = 64;
 const GAP_PX: Record<GridSize, number> = { small: 8, medium: 12, large: 16 };
 const PADDING_PX: Record<GridSize, number> = { small: 12, medium: 16, large: 16 };
 
 interface CellProps {
   albums: AlbumData[];
   columnCount: number;
+  gap: number;
   onAlbumClick: (name: string) => void;
   cardPaddingClass: string;
   imgPx: number;
@@ -75,6 +81,7 @@ function AlbumCell({
   style,
   albums,
   columnCount,
+  gap,
   onAlbumClick,
   cardPaddingClass,
   imgPx,
@@ -82,11 +89,19 @@ function AlbumCell({
 }: CellComponentProps<CellProps>) {
   const index = rowIndex * columnCount + columnIndex;
   const album = albums[index];
+  const halfGap = gap / 2;
+  const insetStyle: React.CSSProperties = {
+    ...style,
+    paddingLeft: columnIndex === 0 ? 0 : halfGap,
+    paddingRight: columnIndex === columnCount - 1 ? 0 : halfGap,
+    paddingTop: rowIndex === 0 ? 0 : halfGap,
+    paddingBottom: halfGap,
+  };
   if (!album) {
-    return <div style={style} aria-hidden="true" />;
+    return <div style={insetStyle} aria-hidden="true" />;
   }
   return (
-    <div style={style}>
+    <div style={insetStyle}>
       <button
         onClick={() => onAlbumClick(album.name)}
         className={`text-left ${cardPaddingClass} rounded-2xl bg-surface/60 border border-border/30 hover:border-border/60 hover:bg-surface transition-all duration-200 group w-full h-full flex flex-col`}
@@ -107,11 +122,18 @@ function AlbumCell({
             <Disc3 className="w-10 h-10 text-muted-foreground/20 group-hover:text-muted-foreground/30 transition-colors" />
           )}
         </div>
-        <p className="font-display text-sm font-semibold text-foreground truncate">{album.name}</p>
-        <p className="text-xs text-muted-foreground/50 truncate mt-0.5">{album.artist}</p>
-        <p className="text-[10px] text-muted-foreground/30 mt-1.5">
-          {trackCountLabel(album.trackCount)}
-        </p>
+        <div
+          style={{ height: ROW_HEIGHT_TEXT_BLOCK }}
+          className="flex flex-col justify-start min-w-0"
+        >
+          <p className="font-display text-sm font-semibold text-foreground truncate">
+            {album.name}
+          </p>
+          <p className="text-xs text-muted-foreground/50 truncate mt-0.5">{album.artist}</p>
+          <p className="text-[10px] text-muted-foreground/30 mt-1.5 truncate">
+            {trackCountLabel(album.trackCount)}
+          </p>
+        </div>
       </button>
     </div>
   );
@@ -180,15 +202,16 @@ export function AlbumGrid({ library, searchQuery }: AlbumGridProps) {
     return columnsFor(albumGridSize, containerWidth);
   }, [albumGridSize, containerWidth]);
 
-  // Cell width includes the gap allowance — Grid sizes cells based on
-  // columnWidth, and we pad to leave space for `gap` between cells.
+  // Subtract the Grid's own scrollbar gutter so the rightmost column does not
+  // render behind the scrollbar (getScrollbarSize is react-window's canonical
+  // answer to this — returns 0 on overlay-scrollbar platforms).
   const gap = GAP_PX[albumGridSize];
   const padding = PADDING_PX[albumGridSize];
-  const usableWidth = Math.max(0, containerWidth - gap * (columnCount - 1));
-  const cellOuterWidth =
-    columnCount > 0 ? usableWidth / columnCount + (gap * (columnCount - 1)) / columnCount : 0;
-  // The image height = cellOuterWidth - 2*padding (square aspect).
-  const imgPx = Math.max(0, cellOuterWidth - padding * 2);
+  const scrollbarSize = getScrollbarSize();
+  const columnWidthPx =
+    columnCount > 0 ? Math.max(0, containerWidth - scrollbarSize) / columnCount : 0;
+  // The image height = cellWidth - 2*padding (square aspect).
+  const imgPx = Math.max(0, columnWidthPx - padding * 2);
   const cellOuterHeight = imgPx + padding * 2 + ROW_HEIGHT_TEXT_BLOCK;
 
   const rowCount = columnCount > 0 ? Math.ceil(filteredAlbums.length / columnCount) : 0;
@@ -214,12 +237,13 @@ export function AlbumGrid({ library, searchQuery }: AlbumGridProps) {
     () => ({
       albums: filteredAlbums,
       columnCount,
+      gap,
       onAlbumClick: handleAlbumClick,
       cardPaddingClass,
       imgPx,
       trackCountLabel,
     }),
-    [filteredAlbums, columnCount, handleAlbumClick, cardPaddingClass, imgPx, trackCountLabel]
+    [filteredAlbums, columnCount, gap, handleAlbumClick, cardPaddingClass, imgPx, trackCountLabel]
   );
 
   if (filteredAlbums.length === 0) {
@@ -256,7 +280,7 @@ export function AlbumGrid({ library, searchQuery }: AlbumGridProps) {
             cellComponent={AlbumCell}
             cellProps={cellProps}
             columnCount={columnCount}
-            columnWidth={containerWidth / columnCount}
+            columnWidth={columnWidthPx}
             rowCount={rowCount}
             rowHeight={cellOuterHeight}
             overscanCount={2}

--- a/apps/web/src/components/player/CompactPlayer.tsx
+++ b/apps/web/src/components/player/CompactPlayer.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useLibraryStore } from '@/stores/useLibraryStore';
+import { useTrack } from '@/hooks/useTrack';
 import { useUIStore } from '@/stores/useUIStore';
 import {
   useCompactStore,
@@ -224,6 +225,10 @@ function FavoriteButton() {
   const { t: tp } = useTranslation('player');
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const toggleFavorite = useLibraryStore(s => s.toggleFavorite);
+  // Heart state through the overlay so it stays in sync with the main
+  // player bar and any other surface that toggled this track.
+  const mergedTrack = useTrack(currentTrack?.id, currentTrack);
+  const isFavorite = mergedTrack?.isFavorite ?? currentTrack?.isFavorite ?? false;
 
   if (!currentTrack || isRadioTrack(currentTrack.filePath)) return null;
 
@@ -234,16 +239,15 @@ function FavoriteButton() {
           <IconButton
             onClick={() => toggleFavorite(currentTrack.id)}
             className={cn(
-              currentTrack.isFavorite &&
-                'text-favorite hover:bg-favorite/10 hover:text-favorite-hover'
+              isFavorite && 'text-favorite hover:bg-favorite/10 hover:text-favorite-hover'
             )}
-            aria-label={currentTrack.isFavorite ? tp('removeFromFavorites') : tp('addToFavorites')}
+            aria-label={isFavorite ? tp('removeFromFavorites') : tp('addToFavorites')}
           >
-            <Heart className={cn(currentTrack.isFavorite && 'fill-current')} />
+            <Heart className={cn(isFavorite && 'fill-current')} />
           </IconButton>
         </TooltipTrigger>
         <TooltipContent side="bottom">
-          {currentTrack.isFavorite ? tp('unfavorite') : tp('favorite')}
+          {isFavorite ? tp('unfavorite') : tp('favorite')}
         </TooltipContent>
       </Tooltip>
     </div>

--- a/apps/web/src/components/player/PlayerBar.tsx
+++ b/apps/web/src/components/player/PlayerBar.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { useTrack } from '@/hooks/useTrack';
 import { useUIStore } from '@/stores/useUIStore';
 import { useCompactStore } from '@/stores/useCompactStore';
 import { useViewStore } from '@/stores/useViewStore';
@@ -25,6 +26,10 @@ const MOD = navigator.platform.toUpperCase().includes('MAC') ? '\u2318' : 'Ctrl'
 export function PlayerBar() {
   const { t } = useTranslation('player');
   const currentTrack = usePlaybackStore(s => s.currentTrack);
+  // Heart state reads through the overlay so a toggle from any surface
+  // reflects on the player bar without re-allocating `library`.
+  const mergedTrack = useTrack(currentTrack?.id, currentTrack);
+  const isFavorite = mergedTrack?.isFavorite ?? currentTrack?.isFavorite;
   const duration = usePlaybackStore(s => s.duration);
   const toggleFavorite = useLibraryStore(s => s.toggleFavorite);
   const ambientColor = useAmbientColor();
@@ -123,19 +128,17 @@ export function PlayerBar() {
                     onClick={() => toggleFavorite(currentTrack.id)}
                     className={cn(
                       'shrink-0 w-8 h-8 flex items-center justify-center rounded-lg transition-colors',
-                      currentTrack.isFavorite
+                      isFavorite
                         ? 'text-favorite hover:text-favorite-hover'
                         : 'text-muted-foreground/40 hover:text-muted-foreground'
                     )}
-                    aria-label={
-                      currentTrack.isFavorite ? t('removeFromFavorites') : t('addToFavorites')
-                    }
+                    aria-label={isFavorite ? t('removeFromFavorites') : t('addToFavorites')}
                   >
-                    <Heart className={cn('w-4 h-4', currentTrack.isFavorite && 'fill-current')} />
+                    <Heart className={cn('w-4 h-4', isFavorite && 'fill-current')} />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="top">
-                  {currentTrack.isFavorite ? t('unfavorite') : t('favorite')}
+                  {isFavorite ? t('unfavorite') : t('favorite')}
                 </TooltipContent>
               </Tooltip>
             )}

--- a/apps/web/src/components/shared/TrackContextMenu.tsx
+++ b/apps/web/src/components/shared/TrackContextMenu.tsx
@@ -2,19 +2,12 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
 import { useMutation } from '@tanstack/react-query';
-import {
-  Play,
-  ListPlus,
-  Heart,
-  Share2,
-  FolderOpen,
-  Trash2,
-  ChevronRight,
-} from 'lucide-react';
+import { Play, ListPlus, Heart, Share2, FolderOpen, Trash2, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { IS_ELECTRON, IS_MAC } from '@/lib/platform';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { useTrackOverlayStore } from '@/stores/useTrackOverlayStore';
 import type { Track } from '@/stores/types';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 import { useRemoveFromLibrary } from '@/hooks/useRemoveFromLibrary';
@@ -139,14 +132,14 @@ export function TrackContextMenu({ track, position, onClose }: TrackContextMenuP
   const menuRef = useRef<HTMLDivElement>(null);
   const adjustedPosition = useContextMenuDismiss(menuRef, position, onClose);
 
-  const playNext = usePlaybackStore((s) => s.playNext);
-  const addToQueue = usePlaybackStore((s) => s.addToQueue);
-  const toggleFavorite = useLibraryStore((s) => s.toggleFavorite);
-  const queue = usePlaybackStore((s) => s.queue);
-  const library = useLibraryStore((s) => s.library);
+  const playNext = usePlaybackStore(s => s.playNext);
+  const addToQueue = usePlaybackStore(s => s.addToQueue);
+  const toggleFavorite = useLibraryStore(s => s.toggleFavorite);
+  const queue = usePlaybackStore(s => s.queue);
+  const library = useLibraryStore(s => s.library);
 
-  const selectedTrackIds = useSelectionStore((s) => s.selectedTrackIds);
-  const clearSelection = useSelectionStore((s) => s.clearSelection);
+  const selectedTrackIds = useSelectionStore(s => s.selectedTrackIds);
+  const clearSelection = useSelectionStore(s => s.clearSelection);
 
   const { handleRemoveFromLibrary, handleDeleteFromDisk } = useRemoveFromLibrary();
 
@@ -163,12 +156,16 @@ export function TrackContextMenu({ track, position, onClose }: TrackContextMenuP
   // Determine if this is a bulk operation
   const isBulk = selectedTrackIds.size > 1 && selectedTrackIds.has(track.id);
   const targetTrackIds = isBulk ? Array.from(selectedTrackIds) : [track.id];
-  const targetTracks = isBulk
-    ? library.filter((t) => selectedTrackIds.has(t.id))
-    : [track];
+  const targetTracks = isBulk ? library.filter(t => selectedTrackIds.has(t.id)) : [track];
   const count = targetTrackIds.length;
 
-  const isFavorite = queue.find((t) => t.id === track.id)?.isFavorite ?? track.isFavorite;
+  // Overlay is the freshest source after Phase 2 of the mutation-overlay
+  // refactor; queue / track props are stale once a toggle lands.
+  const overlayVersion = useTrackOverlayStore(s => s.version);
+  void overlayVersion;
+  const overlayFavorite = useTrackOverlayStore.getState().overlays.get(track.id)?.isFavorite;
+  const isFavorite =
+    overlayFavorite ?? queue.find(t => t.id === track.id)?.isFavorite ?? track.isFavorite;
 
   const handlePlayNext = useCallback(() => {
     for (const t of targetTracks) {
@@ -278,9 +275,11 @@ export function TrackContextMenu({ track, position, onClose }: TrackContextMenuP
             icon={<Share2 className="w-4 h-4" />}
             label={t('share', { ns: 'share' })}
             onClick={() => {
-              window.dispatchEvent(new CustomEvent('open-share-dialog', {
-                detail: { type: 'track', id: track.id }
-              }));
+              window.dispatchEvent(
+                new CustomEvent('open-share-dialog', {
+                  detail: { type: 'track', id: track.id },
+                })
+              );
               onClose();
             }}
           />

--- a/apps/web/src/components/shared/TrackRowContent.tsx
+++ b/apps/web/src/components/shared/TrackRowContent.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { type Track } from '@/stores/types';
 import { useSelectionStore } from '@/stores/useSelectionStore';
+import { useTrackOverlayStore } from '@/stores/useTrackOverlayStore';
 import { Heart, Play, X, Check } from 'lucide-react';
 import { formatDuration } from '@shiranami/shared';
 import { cn } from '@/lib/utils';
@@ -46,6 +47,15 @@ export function TrackRowContent({
   const toggleTrack = useSelectionStore(s => s.toggleTrack);
   const selectRange = useSelectionStore(s => s.selectRange);
   const clearSelection = useSelectionStore(s => s.clearSelection);
+
+  // Heart icon reads the live overlay value so a toggle anywhere in the app
+  // (player bar, context menu, this row) reflects on every surface without
+  // reallocating the library array. Falls back to the seed value on the
+  // passed-in `track` when no overlay entry exists.
+  const overlayVersion = useTrackOverlayStore(s => s.version);
+  void overlayVersion;
+  const overlayFavorite = useTrackOverlayStore.getState().overlays.get(track.id)?.isFavorite;
+  const isFavorite = overlayFavorite ?? track.isFavorite;
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent) => {
@@ -162,16 +172,16 @@ export function TrackRowContent({
             }}
             className={cn(
               'shrink-0 p-1 rounded-md transition-colors duration-150',
-              track.isFavorite
+              isFavorite
                 ? 'text-favorite hover:text-favorite-hover'
                 : 'text-muted-foreground/30 opacity-0 group-hover:opacity-100 hover:text-muted-foreground/60'
             )}
-            aria-label={track.isFavorite ? t('removeFromFavorites') : t('addToFavorites')}
+            aria-label={isFavorite ? t('removeFromFavorites') : t('addToFavorites')}
           >
             <Heart
               className={cn(
                 'w-3.5 h-3.5 transition-all duration-150',
-                track.isFavorite && 'fill-current'
+                isFavorite && 'fill-current'
               )}
             />
           </motion.button>

--- a/apps/web/src/hooks/queries/usePlaylists.ts
+++ b/apps/web/src/hooks/queries/usePlaylists.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { IS_ELECTRON } from '@/lib/platform';
 import { useLibraryStore } from '@/stores/useLibraryStore';
+import { useTrackOverlayStore } from '@/stores/useTrackOverlayStore';
 import type { Playlist } from '@/types/electron';
 import type { Track } from '@/stores/types';
 
@@ -51,7 +52,11 @@ export function usePlaylistTracksQuery(playlistId: string | null) {
  * Syncs isFavorite state from the library store in real-time.
  */
 export function usePlaylistDetailQuery(playlistId: string | null) {
-  const library = useLibraryStore((s) => s.library);
+  const library = useLibraryStore(s => s.library);
+  // Subscribe to overlay version so displayTracks recomputes when a favorite
+  // toggle elsewhere (player bar, library row) touches a track that lives in
+  // this playlist.
+  const overlayVersion = useTrackOverlayStore(s => s.version);
 
   const playlistQuery = usePlaylistQuery(playlistId);
   const tracksQuery = usePlaylistTracksQuery(playlistId);
@@ -67,14 +72,20 @@ export function usePlaylistDetailQuery(playlistId: string | null) {
     await Promise.all([playlistQuery.refetch(), tracksQuery.refetch()]);
   };
 
-  // Sync isFavorite from the store so hearts update in real-time
+  // Resolve isFavorite for each playlist track via the overlay first
+  // (freshest, in-session toggles), then falling back to the library's seed
+  // value. The library array reference no longer mutates on toggleFavorite,
+  // so the previous "favMap from library" approach went stale.
   const displayTracks = useMemo(() => {
-    const favMap = new Map(library.map((t) => [t.id, t.isFavorite]));
-    return tracks.map((t) => {
-      const fav = favMap.get(t.id);
-      return fav !== undefined && fav !== t.isFavorite ? { ...t, isFavorite: fav } : t;
+    void overlayVersion;
+    const overlays = useTrackOverlayStore.getState().overlays;
+    const libraryFav = new Map(library.map(t => [t.id, t.isFavorite]));
+    return tracks.map(t => {
+      const overlayFav = overlays.get(t.id)?.isFavorite;
+      const resolved = overlayFav ?? libraryFav.get(t.id) ?? t.isFavorite;
+      return resolved !== t.isFavorite ? { ...t, isFavorite: resolved } : t;
     });
-  }, [tracks, library]);
+  }, [tracks, library, overlayVersion]);
 
   return { playlist: playlist ?? null, tracks, displayTracks, isLoading, isError, error, refetch };
 }
@@ -199,8 +210,8 @@ export function useReorderPlaylistMutation() {
       const previous = queryClient.getQueryData<Track[]>(playlistKeys.tracks(playlistId));
 
       if (previous) {
-        const trackMap = new Map(previous.map((t) => [t.id, t]));
-        const reordered = trackIds.map((id) => trackMap.get(id)).filter(Boolean) as Track[];
+        const trackMap = new Map(previous.map(t => [t.id, t]));
+        const reordered = trackIds.map(id => trackMap.get(id)).filter(Boolean) as Track[];
         queryClient.setQueryData(playlistKeys.tracks(playlistId), reordered);
       }
 

--- a/apps/web/src/hooks/useAmbientColor.tsx
+++ b/apps/web/src/hooks/useAmbientColor.tsx
@@ -31,11 +31,11 @@ export function AmbientColorProvider({ children }: { children: ReactNode }) {
     let cancelled = false;
 
     const img = new Image();
-    // Only set crossOrigin for http(s) URLs — custom protocols don't need it
-    // and setting it can cause loading issues with protocol handlers
-    if (albumArt.startsWith('http')) {
-      img.crossOrigin = 'anonymous';
-    }
+    // Required for getImageData / FastAverageColor: without crossOrigin the
+    // canvas the image is drawn onto is tainted and pixel reads SecurityError.
+    // shiranami-art:// is registered with corsEnabled, so the protocol handler
+    // serves the cover with permissive CORS headers and the load succeeds.
+    img.crossOrigin = 'anonymous';
     img.src = albumArt;
 
     img.onload = () => {
@@ -62,11 +62,7 @@ export function AmbientColorProvider({ children }: { children: ReactNode }) {
     };
   }, [albumArt]);
 
-  return (
-    <AmbientColorContext.Provider value={color}>
-      {children}
-    </AmbientColorContext.Provider>
-  );
+  return <AmbientColorContext.Provider value={color}>{children}</AmbientColorContext.Provider>;
 }
 
 export function useAmbientColor(): AmbientColor {

--- a/apps/web/src/hooks/useAudioEngine.ts
+++ b/apps/web/src/hooks/useAudioEngine.ts
@@ -84,19 +84,19 @@ export function useAudioEngine() {
     recorded: false,
   });
 
-  const currentTrack = usePlaybackStore((s) => s.currentTrack);
-  const isPlaying = usePlaybackStore((s) => s.isPlaying);
-  const volume = usePlaybackStore((s) => s.volume);
-  const isMuted = usePlaybackStore((s) => s.isMuted);
-  const repeatMode = usePlaybackStore((s) => s.repeatMode);
+  const currentTrack = usePlaybackStore(s => s.currentTrack);
+  const isPlaying = usePlaybackStore(s => s.isPlaying);
+  const volume = usePlaybackStore(s => s.volume);
+  const isMuted = usePlaybackStore(s => s.isMuted);
+  const repeatMode = usePlaybackStore(s => s.repeatMode);
 
-  const _setCurrentTime = usePlaybackStore((s) => s._setCurrentTime);
-  const _setDuration = usePlaybackStore((s) => s._setDuration);
-  const _setIsPlaying = usePlaybackStore((s) => s._setIsPlaying);
-  const _setIsLoading = usePlaybackStore((s) => s._setIsLoading);
-  const _setError = usePlaybackStore((s) => s._setError);
-  const _onTrackEnd = usePlaybackStore((s) => s._onTrackEnd);
-  const incrementTrackPlayCount = useLibraryStore((s) => s.incrementTrackPlayCount);
+  const _setCurrentTime = usePlaybackStore(s => s._setCurrentTime);
+  const _setDuration = usePlaybackStore(s => s._setDuration);
+  const _setIsPlaying = usePlaybackStore(s => s._setIsPlaying);
+  const _setIsLoading = usePlaybackStore(s => s._setIsLoading);
+  const _setError = usePlaybackStore(s => s._setError);
+  const _onTrackEnd = usePlaybackStore(s => s._onTrackEnd);
+  const incrementTrackPlayCount = useLibraryStore(s => s.incrementTrackPlayCount);
 
   function getDeck(deck: Deck) {
     return deck === 'A' ? deckARef.current : deckBRef.current;
@@ -183,7 +183,13 @@ export function useAudioEngine() {
     }
     deckTrackIdRef.current[cf.incomingDeck] = null;
     setVolume(cf.incomingDeck, 0);
-    crossfadeRef.current = { active: false, startTime: 0, duration: 0, outgoingDeck: 'A', incomingDeck: 'B' };
+    crossfadeRef.current = {
+      active: false,
+      startTime: 0,
+      duration: 0,
+      outgoingDeck: 'A',
+      incomingDeck: 'B',
+    };
   }, []);
 
   const startCrossfade = useCallback(() => {
@@ -287,7 +293,13 @@ export function useAudioEngine() {
     resetPlaybackSession(nextTrack);
 
     // Clear crossfade state before store update (prevents re-triggering)
-    crossfadeRef.current = { active: false, startTime: 0, duration: 0, outgoingDeck: 'A', incomingDeck: 'B' };
+    crossfadeRef.current = {
+      active: false,
+      startTime: 0,
+      duration: 0,
+      outgoingDeck: 'A',
+      incomingDeck: 'B',
+    };
 
     // Advance the store (this sets currentTrack, triggering the load effect —
     // the effect will see the track is already loaded on the new active deck and skip reload)
@@ -300,10 +312,16 @@ export function useAudioEngine() {
     if (!deckARef.current) {
       deckARef.current = new Audio();
       deckARef.current.preload = 'auto';
+      // Required so MediaElementAudioSourceNode receives actual samples;
+      // without it Web Audio outputs silent zeroes for cross-origin sources.
+      // shiranami-audio:// is registered with corsEnabled, so the protocol
+      // handler serves with permissive CORS headers.
+      deckARef.current.crossOrigin = 'anonymous';
     }
     if (!deckBRef.current) {
       deckBRef.current = new Audio();
       deckBRef.current.preload = 'auto';
+      deckBRef.current.crossOrigin = 'anonymous';
     }
     return () => {
       destroyAnalyser();
@@ -350,7 +368,7 @@ export function useAudioEngine() {
           if (session.lastTickAt !== null) {
             session.listenedSeconds += Math.max(
               0,
-              Math.min(MAX_SESSION_DELTA_SECONDS, (tickNow - session.lastTickAt) / 1000),
+              Math.min(MAX_SESSION_DELTA_SECONDS, (tickNow - session.lastTickAt) / 1000)
             );
           }
           session.lastTickAt = tickNow;
@@ -457,7 +475,7 @@ export function useAudioEngine() {
       _setIsLoading(false);
       if (usePlaybackStore.getState().isPlaying) {
         resumeAudioContext();
-        audio.play().catch((err) => {
+        audio.play().catch(err => {
           if (err.name !== 'AbortError') {
             _setError(err.message);
             _setIsPlaying(false);
@@ -478,7 +496,18 @@ export function useAudioEngine() {
     return () => {
       audio.removeEventListener('canplay', onCanPlayOnce);
     };
-  }, [currentTrack, cancelCrossfade, _setIsLoading, _setError, _setCurrentTime, _setDuration, _setIsPlaying, updateTime, flushPlaybackSession, resetPlaybackSession]);
+  }, [
+    currentTrack,
+    cancelCrossfade,
+    _setIsLoading,
+    _setError,
+    _setCurrentTime,
+    _setDuration,
+    _setIsPlaying,
+    updateTime,
+    flushPlaybackSession,
+    resetPlaybackSession,
+  ]);
 
   // ── Sync play / pause ─────────────────────────────────────────
 
@@ -558,7 +587,7 @@ export function useAudioEngine() {
   useEffect(() => {
     // Capture previous values so we only forward what actually changed.
     let prev = useEqStore.getState();
-    const unsub = useEqStore.subscribe((state) => {
+    const unsub = useEqStore.subscribe(state => {
       if (!analyserInitRef.current) {
         prev = state;
         return;
@@ -586,14 +615,9 @@ export function useAudioEngine() {
   // ── Handle seeks while paused ─────────────────────────────────
 
   useEffect(() => {
-    const unsub = usePlaybackStore.subscribe((state) => {
+    const unsub = usePlaybackStore.subscribe(state => {
       const audio = getActiveDeck();
-      if (
-        audio &&
-        state._seekTarget !== null &&
-        isFinite(state._seekTarget) &&
-        !state.isPlaying
-      ) {
+      if (audio && state._seekTarget !== null && isFinite(state._seekTarget) && !state.isPlaying) {
         audio.currentTime = state._seekTarget;
         usePlaybackStore.getState()._clearSeekTarget();
         _setCurrentTime(state._seekTarget);
@@ -675,7 +699,16 @@ export function useAudioEngine() {
       audio.removeEventListener('waiting', onWaiting);
       audio.removeEventListener('playing', onPlaying);
     };
-  }, [currentTrack, _setDuration, _setIsLoading, _onTrackEnd, _setError, _setIsPlaying, flushPlaybackSession, resetPlaybackSession]);
+  }, [
+    currentTrack,
+    _setDuration,
+    _setIsLoading,
+    _onTrackEnd,
+    _setError,
+    _setIsPlaying,
+    flushPlaybackSession,
+    resetPlaybackSession,
+  ]);
 
   // ── Repeat-one: restart playback directly at Audio element level ──
 

--- a/apps/web/src/hooks/useMediaSession.ts
+++ b/apps/web/src/hooks/useMediaSession.ts
@@ -35,7 +35,7 @@ export function useMediaSession() {
     navigator.mediaSession.setActionHandler('nexttrack', () => next());
     navigator.mediaSession.setActionHandler('previoustrack', () => previous());
     navigator.mediaSession.setActionHandler('stop', () => stop());
-    navigator.mediaSession.setActionHandler('seekto', (details) => {
+    navigator.mediaSession.setActionHandler('seekto', details => {
       if (details.seekTime != null) {
         seek(details.seekTime);
       }
@@ -51,7 +51,11 @@ export function useMediaSession() {
     };
   }, [togglePlay, next, previous, stop, seek]);
 
-  // Update Media Session metadata when track changes
+  // Update Media Session metadata when track changes.
+  // The W3C MediaSession spec restricts MediaImage.src to http/https/data/blob
+  // schemes, so shiranami-art:// covers must be fetched and re-served as a
+  // blob URL. Same applies if the user ever lands on a covers-from-disk path
+  // that surfaces as anything but http/data/blob.
   useEffect(() => {
     if (!('mediaSession' in navigator)) return;
 
@@ -61,17 +65,49 @@ export function useMediaSession() {
       return;
     }
 
-    const artwork: MediaImage[] = [];
-    if (currentTrack.albumArt) {
-      artwork.push({ src: currentTrack.albumArt, sizes: '512x512' });
+    const { title, artist, album, albumArt } = currentTrack;
+
+    let blobUrl: string | null = null;
+    let cancelled = false;
+
+    const setMetadata = (artwork: MediaImage[]) => {
+      if (cancelled) return;
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title,
+        artist,
+        album,
+        artwork,
+      });
+    };
+
+    if (!albumArt) {
+      setMetadata([]);
+      return;
     }
 
-    navigator.mediaSession.metadata = new MediaMetadata({
-      title: currentTrack.title,
-      artist: currentTrack.artist,
-      album: currentTrack.album,
-      artwork,
-    });
+    const isMediaSessionSupportedScheme =
+      albumArt.startsWith('http') || albumArt.startsWith('data:') || albumArt.startsWith('blob:');
+
+    if (isMediaSessionSupportedScheme) {
+      setMetadata([{ src: albumArt, sizes: '512x512' }]);
+      return;
+    }
+
+    fetch(albumArt)
+      .then(r => r.blob())
+      .then(blob => {
+        if (cancelled) return;
+        blobUrl = URL.createObjectURL(blob);
+        setMetadata([{ src: blobUrl, sizes: '512x512' }]);
+      })
+      .catch(() => {
+        setMetadata([]);
+      });
+
+    return () => {
+      cancelled = true;
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+    };
   }, [currentTrack]);
 
   // Update playback state

--- a/apps/web/src/hooks/useMergedLibrary.test.tsx
+++ b/apps/web/src/hooks/useMergedLibrary.test.tsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useLibraryStore } from '@/stores/useLibraryStore';
+import { useTrackOverlayStore } from '@/stores/useTrackOverlayStore';
+import { useMergedLibrary } from './useMergedLibrary';
+import type { Track } from '@/stores/types';
+
+function makeTrack(id: string, overrides: Partial<Track> = {}): Track {
+  return {
+    id,
+    title: `Track ${id}`,
+    artist: `Artist ${id}`,
+    album: `Album ${id}`,
+    duration: 200,
+    filePath: `/music/${id}.mp3`,
+    isFavorite: false,
+    playCount: 0,
+    ...overrides,
+  };
+}
+
+describe('useMergedLibrary', () => {
+  beforeEach(() => {
+    useLibraryStore.setState({ library: [], libraryLoaded: false });
+    useTrackOverlayStore.setState({
+      overlays: new Map(),
+      version: 0,
+    });
+  });
+
+  it('returns the canonical library reference unchanged when overlay is empty', () => {
+    const library = [makeTrack('a'), makeTrack('b')];
+    useLibraryStore.setState({ library });
+
+    const { result } = renderHook(() => useMergedLibrary());
+    expect(result.current).toBe(library);
+  });
+
+  it('returns a new array with overlays merged when overlay has entries', () => {
+    const library = [makeTrack('a', { isFavorite: false }), makeTrack('b', { isFavorite: false })];
+    useLibraryStore.setState({ library });
+    useTrackOverlayStore.getState().setOverlay('a', { isFavorite: true });
+
+    const { result } = renderHook(() => useMergedLibrary());
+    expect(result.current).not.toBe(library);
+    expect(result.current[0].isFavorite).toBe(true);
+    expect(result.current[1].isFavorite).toBe(false);
+  });
+
+  it('keeps reference equality for tracks without overlay entries', () => {
+    const library = [makeTrack('a', { isFavorite: false }), makeTrack('b', { isFavorite: false })];
+    useLibraryStore.setState({ library });
+    useTrackOverlayStore.getState().setOverlay('a', { isFavorite: true });
+
+    const { result } = renderHook(() => useMergedLibrary());
+    expect(result.current[1]).toBe(library[1]);
+  });
+
+  it('preserves array length and order', () => {
+    const library = ['a', 'b', 'c'].map(id => makeTrack(id));
+    useLibraryStore.setState({ library });
+    useTrackOverlayStore.getState().setOverlay('b', { playCount: 7 });
+
+    const { result } = renderHook(() => useMergedLibrary());
+    expect(result.current.map(t => t.id)).toEqual(['a', 'b', 'c']);
+    expect(result.current[1].playCount).toBe(7);
+  });
+
+  it('returns a stable reference across re-renders when neither library nor overlay version changes', () => {
+    const library = [makeTrack('a')];
+    useLibraryStore.setState({ library });
+
+    const { result, rerender } = renderHook(() => useMergedLibrary());
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it('produces a fresh result after a new overlay mutation', () => {
+    const library = [makeTrack('a', { isFavorite: false })];
+    useLibraryStore.setState({ library });
+
+    const { result, rerender } = renderHook(() => useMergedLibrary());
+    expect(result.current[0].isFavorite).toBe(false);
+
+    useTrackOverlayStore.getState().setOverlay('a', { isFavorite: true });
+    rerender();
+
+    expect(result.current[0].isFavorite).toBe(true);
+  });
+});

--- a/apps/web/src/hooks/useMergedLibrary.ts
+++ b/apps/web/src/hooks/useMergedLibrary.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+import { useLibraryStore } from '@/stores/useLibraryStore';
+import { useTrackOverlayStore } from '@/stores/useTrackOverlayStore';
+import type { Track } from '@/stores/types';
+
+/**
+ * Library array with the per-track mutation overlay merged in.
+ *
+ * Cheap when the overlay is empty — returns the canonical `library` reference
+ * unchanged so downstream `useMemo([library, ...])` hooks (e.g.
+ * `groupTracksByAlbum` in `AlbumGrid`) keep their cached results. When
+ * overlay entries exist, allocates a single new array and patches only the
+ * matching ids; the rest are reused by reference.
+ *
+ * Memoised over `(library, overlay-version)`. Re-runs on every overlay
+ * mutation but the cost is O(n) once per mutation — sub-1Hz for favorite
+ * toggles, much cheaper than the full `library.map(...)` reallocation that
+ * the previous `toggleFavorite` performed.
+ */
+export function useMergedLibrary(): Track[] {
+  const library = useLibraryStore(s => s.library);
+  const version = useTrackOverlayStore(s => s.version);
+
+  return useMemo(() => {
+    const overlays = useTrackOverlayStore.getState().overlays;
+    if (overlays.size === 0) return library;
+    // version primitive forces re-run when the in-place Map mutates.
+    void version;
+    return library.map(t => {
+      const overlay = overlays.get(t.id);
+      return overlay ? { ...t, ...overlay } : t;
+    });
+  }, [library, version]);
+}

--- a/apps/web/src/hooks/useTrack.test.tsx
+++ b/apps/web/src/hooks/useTrack.test.tsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useLibraryStore } from '@/stores/useLibraryStore';
+import { useTrackOverlayStore } from '@/stores/useTrackOverlayStore';
+import { useTrack } from './useTrack';
+import type { Track } from '@/stores/types';
+
+function makeTrack(id: string, overrides: Partial<Track> = {}): Track {
+  return {
+    id,
+    title: `Track ${id}`,
+    artist: `Artist ${id}`,
+    album: `Album ${id}`,
+    duration: 200,
+    filePath: `/music/${id}.mp3`,
+    isFavorite: false,
+    playCount: 0,
+    ...overrides,
+  };
+}
+
+describe('useTrack', () => {
+  beforeEach(() => {
+    useLibraryStore.setState({ library: [], libraryLoaded: false });
+    useTrackOverlayStore.setState({
+      overlays: new Map(),
+      version: 0,
+    });
+  });
+
+  it('returns null when id is undefined', () => {
+    const { result } = renderHook(() => useTrack(undefined));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when id is null', () => {
+    const { result } = renderHook(() => useTrack(null));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when no library entry and no fallback', () => {
+    const { result } = renderHook(() => useTrack('missing'));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns the library entry unchanged when overlay is empty', () => {
+    const t = makeTrack('a', { isFavorite: false, playCount: 2 });
+    useLibraryStore.setState({ library: [t] });
+
+    const { result } = renderHook(() => useTrack('a'));
+    expect(result.current).toEqual(t);
+  });
+
+  it('merges overlay fields on top of the library entry', () => {
+    const t = makeTrack('a', { isFavorite: false, playCount: 2 });
+    useLibraryStore.setState({ library: [t] });
+    useTrackOverlayStore.getState().setOverlay('a', { isFavorite: true });
+
+    const { result } = renderHook(() => useTrack('a'));
+    expect(result.current?.isFavorite).toBe(true);
+    expect(result.current?.playCount).toBe(2);
+    expect(result.current?.title).toBe('Track a');
+  });
+
+  it('falls back to the provided fallback Track when library has no match', () => {
+    const radio = makeTrack('radio', { isFavorite: false });
+    const { result } = renderHook(() => useTrack('radio', radio));
+    expect(result.current).toEqual(radio);
+  });
+
+  it('merges overlay on top of the fallback Track too', () => {
+    const radio = makeTrack('radio', { isFavorite: false });
+    useTrackOverlayStore.getState().setOverlay('radio', { isFavorite: true });
+
+    const { result } = renderHook(() => useTrack('radio', radio));
+    expect(result.current?.isFavorite).toBe(true);
+  });
+
+  it('reflects subsequent overlay mutations after re-render', () => {
+    const t = makeTrack('a', { isFavorite: false });
+    useLibraryStore.setState({ library: [t] });
+
+    const { result, rerender } = renderHook(() => useTrack('a'));
+    expect(result.current?.isFavorite).toBe(false);
+
+    useTrackOverlayStore.getState().setOverlay('a', { isFavorite: true });
+    rerender();
+
+    expect(result.current?.isFavorite).toBe(true);
+  });
+});

--- a/apps/web/src/hooks/useTrack.ts
+++ b/apps/web/src/hooks/useTrack.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+import { useLibraryStore } from '@/stores/useLibraryStore';
+import { useTrackOverlayStore } from '@/stores/useTrackOverlayStore';
+import type { Track } from '@/stores/types';
+
+/**
+ * Read a single track with overlay merged on top.
+ *
+ * Returns `null` if the id is missing or the library has no track for it.
+ * Memoized over `(id, library, overlay-version)` so a heart icon only
+ * re-renders when *its* track's overlay or the library shape changes.
+ *
+ * @param id Track id, or `undefined`/`null` to bail out (returns `null`).
+ * @param fallback Optional already-resolved Track (e.g. a queue track that's
+ *   not in the library — radio/preview case). When provided and no library
+ *   match is found, the overlay still merges on top of `fallback`.
+ */
+export function useTrack(id: string | undefined | null, fallback?: Track | null): Track | null {
+  const library = useLibraryStore(s => s.library);
+  const version = useTrackOverlayStore(s => s.version);
+
+  return useMemo(() => {
+    if (!id) return null;
+    const base = library.find(t => t.id === id) ?? fallback ?? null;
+    if (!base) return null;
+    const overlay = useTrackOverlayStore.getState().overlays.get(id);
+    if (!overlay) return base;
+    // version is a primitive — bumped on every overlay mutation. Including
+    // it in deps is how this hook re-runs even though the underlying Map is
+    // mutated in place.
+    void version;
+    return { ...base, ...overlay };
+  }, [id, library, fallback, version]);
+}

--- a/apps/web/src/stores/types.ts
+++ b/apps/web/src/stores/types.ts
@@ -19,6 +19,11 @@ export interface Track {
   year?: number | null;
   trackNumber?: number | null;
   discNumber?: number | null;
+  /**
+   * Seed value from the DB. After an in-session toggle, the live value lives
+   * in `useTrackOverlayStore` keyed by track id; read via `useTrack(id)` or
+   * `useMergedLibrary()` rather than off this raw field.
+   */
   isFavorite?: boolean;
   playCount?: number;
   createdAt?: string;

--- a/apps/web/src/stores/useLibraryStore.test.ts
+++ b/apps/web/src/stores/useLibraryStore.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useLibraryStore } from './useLibraryStore';
 import { usePlaybackStore } from './usePlaybackStore';
+import { useTrackOverlayStore } from './useTrackOverlayStore';
 import type { Track } from './types';
 
 vi.mock('@/lib/platform', () => ({
@@ -25,6 +26,7 @@ function makeTrack(id: string, overrides?: Partial<Track>): Track {
 describe('useLibraryStore', () => {
   beforeEach(() => {
     useLibraryStore.setState({ library: [], libraryLoaded: false });
+    useTrackOverlayStore.setState({ overlays: new Map(), version: 0 });
     usePlaybackStore.setState({
       currentTrack: null,
       queue: [],
@@ -47,7 +49,7 @@ describe('useLibraryStore', () => {
     it('appends to the existing library', () => {
       useLibraryStore.setState({ library: [makeTrack('a')] });
       useLibraryStore.getState().addToLibrary([makeTrack('b'), makeTrack('c')]);
-      expect(useLibraryStore.getState().library.map((t) => t.id)).toEqual(['a', 'b', 'c']);
+      expect(useLibraryStore.getState().library.map(t => t.id)).toEqual(['a', 'b', 'c']);
     });
   });
 
@@ -57,11 +59,11 @@ describe('useLibraryStore', () => {
         library: [makeTrack('a'), makeTrack('b'), makeTrack('c')],
       });
       useLibraryStore.getState().removeFromLibrary(['b']);
-      expect(useLibraryStore.getState().library.map((t) => t.id)).toEqual(['a', 'c']);
+      expect(useLibraryStore.getState().library.map(t => t.id)).toEqual(['a', 'c']);
     });
 
     it('removes from library and prunes queue + currentTrack when currently playing', () => {
-      const tracks = ['t1', 't2', 't3'].map((id) => makeTrack(id));
+      const tracks = ['t1', 't2', 't3'].map(id => makeTrack(id));
       useLibraryStore.setState({ library: tracks });
       usePlaybackStore.setState({
         queue: tracks,
@@ -73,9 +75,9 @@ describe('useLibraryStore', () => {
 
       useLibraryStore.getState().removeFromLibrary(['t2']);
 
-      expect(useLibraryStore.getState().library.map((t) => t.id)).toEqual(['t1', 't3']);
+      expect(useLibraryStore.getState().library.map(t => t.id)).toEqual(['t1', 't3']);
       const pb = usePlaybackStore.getState();
-      expect(pb.queue.map((t) => t.id)).toEqual(['t1', 't3']);
+      expect(pb.queue.map(t => t.id)).toEqual(['t1', 't3']);
       expect(pb.currentTrack?.id).toBe('t3');
       expect(pb.queueIndex).toBe(1);
       expect(pb.currentTime).toBe(0);
@@ -83,7 +85,7 @@ describe('useLibraryStore', () => {
     });
 
     it('adjusts queueIndex down when removing tracks before the current index', () => {
-      const tracks = ['t1', 't2', 't3', 't4', 't5'].map((id) => makeTrack(id));
+      const tracks = ['t1', 't2', 't3', 't4', 't5'].map(id => makeTrack(id));
       useLibraryStore.setState({ library: tracks });
       usePlaybackStore.setState({
         queue: tracks,
@@ -96,7 +98,7 @@ describe('useLibraryStore', () => {
       useLibraryStore.getState().removeFromLibrary(['t1', 't2']);
 
       const pb = usePlaybackStore.getState();
-      expect(pb.queue.map((t) => t.id)).toEqual(['t3', 't4', 't5']);
+      expect(pb.queue.map(t => t.id)).toEqual(['t3', 't4', 't5']);
       expect(pb.queueIndex).toBe(0);
       expect(pb.currentTrack?.id).toBe('t3');
       expect(pb.currentTime).toBe(30);
@@ -104,7 +106,7 @@ describe('useLibraryStore', () => {
     });
 
     it('does not change queueIndex when removing tracks after the current index', () => {
-      const tracks = ['t1', 't2', 't3'].map((id) => makeTrack(id));
+      const tracks = ['t1', 't2', 't3'].map(id => makeTrack(id));
       useLibraryStore.setState({ library: tracks });
       usePlaybackStore.setState({
         queue: tracks,
@@ -117,14 +119,14 @@ describe('useLibraryStore', () => {
       useLibraryStore.getState().removeFromLibrary(['t3']);
 
       const pb = usePlaybackStore.getState();
-      expect(pb.queue.map((t) => t.id)).toEqual(['t1', 't2']);
+      expect(pb.queue.map(t => t.id)).toEqual(['t1', 't2']);
       expect(pb.queueIndex).toBe(0);
       expect(pb.currentTrack?.id).toBe('t1');
       expect(pb.currentTime).toBe(10);
     });
 
     it('clears playback entirely when all queued tracks are removed', () => {
-      const tracks = ['t1', 't2'].map((id) => makeTrack(id));
+      const tracks = ['t1', 't2'].map(id => makeTrack(id));
       useLibraryStore.setState({ library: tracks });
       usePlaybackStore.setState({
         queue: tracks,
@@ -157,9 +159,9 @@ describe('useLibraryStore', () => {
 
       useLibraryStore.getState().removeFromLibrary(['lib-only']);
 
-      expect(useLibraryStore.getState().library.map((t) => t.id)).toEqual(['queued']);
+      expect(useLibraryStore.getState().library.map(t => t.id)).toEqual(['queued']);
       const pb = usePlaybackStore.getState();
-      expect(pb.queue.map((t) => t.id)).toEqual(['queued']);
+      expect(pb.queue.map(t => t.id)).toEqual(['queued']);
       expect(pb.queueIndex).toBe(0);
       expect(pb.currentTrack?.id).toBe('queued');
       expect(pb.currentTime).toBe(20);
@@ -170,7 +172,7 @@ describe('useLibraryStore', () => {
       // currentTrack is null but queued tracks exist (e.g. user cleared playback
       // but left queue populated) — removing all of them must collapse to -1,
       // not 0.
-      const tracks = ['t1', 't2'].map((id) => makeTrack(id));
+      const tracks = ['t1', 't2'].map(id => makeTrack(id));
       useLibraryStore.setState({ library: tracks });
       usePlaybackStore.setState({
         queue: tracks,
@@ -211,9 +213,10 @@ describe('useLibraryStore', () => {
   // --- toggleFavorite (cross-store sync) ---
 
   describe('toggleFavorite', () => {
-    it('syncs across library, queue, and currentTrack', () => {
+    it('writes the new value to the overlay and syncs queue + currentTrack', () => {
       const t = makeTrack('x', { isFavorite: false });
-      useLibraryStore.setState({ library: [t] });
+      const libraryRefBefore = [t];
+      useLibraryStore.setState({ library: libraryRefBefore });
       usePlaybackStore.setState({
         queue: [t],
         currentTrack: t,
@@ -222,9 +225,39 @@ describe('useLibraryStore', () => {
 
       useLibraryStore.getState().toggleFavorite('x');
 
-      expect(useLibraryStore.getState().library[0].isFavorite).toBe(true);
+      // Overlay carries the new value.
+      expect(useTrackOverlayStore.getState().overlays.get('x')).toEqual({
+        isFavorite: true,
+      });
+      // Library array reference is unchanged — the whole point of the overlay.
+      expect(useLibraryStore.getState().library).toBe(libraryRefBefore);
+      expect(useLibraryStore.getState().library[0].isFavorite).toBe(false);
+      // Playback queue + currentTrack still get the new value (they're not
+      // overlay-aware; cross-store sync remains library's responsibility).
       expect(usePlaybackStore.getState().queue[0].isFavorite).toBe(true);
       expect(usePlaybackStore.getState().currentTrack!.isFavorite).toBe(true);
+    });
+
+    it('flips back to false when called on an already-favorited track', () => {
+      const t = makeTrack('x', { isFavorite: true });
+      useLibraryStore.setState({ library: [t] });
+
+      useLibraryStore.getState().toggleFavorite('x');
+
+      expect(useTrackOverlayStore.getState().overlays.get('x')).toEqual({
+        isFavorite: false,
+      });
+    });
+
+    it('reads the current value from the overlay if one already exists', () => {
+      const t = makeTrack('x', { isFavorite: false });
+      useLibraryStore.setState({ library: [t] });
+      // Library says false, but overlay says true — toggle should flip to false.
+      useTrackOverlayStore.getState().setOverlay('x', { isFavorite: true });
+
+      useLibraryStore.getState().toggleFavorite('x');
+
+      expect(useTrackOverlayStore.getState().overlays.get('x')?.isFavorite).toBe(false);
     });
 
     it('calls electronAPI.db.tracks.toggleFavorite', () => {
@@ -242,12 +275,14 @@ describe('useLibraryStore', () => {
 
       useLibraryStore.getState().toggleFavorite('only-in-library');
 
-      expect(useLibraryStore.getState().library[0].isFavorite).toBe(true);
+      expect(useTrackOverlayStore.getState().overlays.get('only-in-library')?.isFavorite).toBe(
+        true
+      );
       expect(usePlaybackStore.getState().queue).toHaveLength(0);
       expect(usePlaybackStore.getState().currentTrack).toBeNull();
     });
 
-    it('syncs playback even when the track is not in the library (radio/preview case)', () => {
+    it('syncs playback and writes overlay even when the track is not in the library (radio/preview case)', () => {
       // Radio tracks flow through the queue without being in the library.
       const radioTrack = makeTrack('radio', { isFavorite: false });
       useLibraryStore.setState({ library: [] });
@@ -259,6 +294,7 @@ describe('useLibraryStore', () => {
 
       useLibraryStore.getState().toggleFavorite('radio');
 
+      expect(useTrackOverlayStore.getState().overlays.get('radio')?.isFavorite).toBe(true);
       expect(usePlaybackStore.getState().queue[0].isFavorite).toBe(true);
       expect(usePlaybackStore.getState().currentTrack!.isFavorite).toBe(true);
     });

--- a/apps/web/src/stores/useLibraryStore.ts
+++ b/apps/web/src/stores/useLibraryStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { IS_ELECTRON } from '@/lib/platform';
 import type { Track } from '@/stores/types';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { useTrackOverlayStore } from '@/stores/useTrackOverlayStore';
 
 interface LibraryState {
   /** Persistent collection of all tracks known to the app. */
@@ -35,14 +36,14 @@ export type LibraryStore = LibraryState & LibraryActions;
  */
 function syncPlaybackTrack(trackId: string, mutate: (track: Track) => Track) {
   const playback = usePlaybackStore.getState();
-  const inQueue = playback.queue.some((t) => t.id === trackId);
+  const inQueue = playback.queue.some(t => t.id === trackId);
   const isCurrent = playback.currentTrack?.id === trackId;
 
   if (!inQueue && !isCurrent) return;
 
   const updates: Partial<{ queue: Track[]; currentTrack: Track | null }> = {};
   if (inQueue) {
-    updates.queue = playback.queue.map((t) => (t.id === trackId ? mutate(t) : t));
+    updates.queue = playback.queue.map(t => (t.id === trackId ? mutate(t) : t));
   }
   if (isCurrent && playback.currentTrack) {
     updates.currentTrack = mutate(playback.currentTrack);
@@ -54,23 +55,22 @@ export const useLibraryStore = create<LibraryStore>()((set, get) => ({
   library: [],
   libraryLoaded: false,
 
-  setLibrary: (tracks) => set({ library: tracks }),
+  setLibrary: tracks => set({ library: tracks }),
 
-  addToLibrary: (tracks) =>
-    set((s) => ({ library: [...s.library, ...tracks] })),
+  addToLibrary: tracks => set(s => ({ library: [...s.library, ...tracks] })),
 
-  removeFromLibrary: (trackIds) => {
+  removeFromLibrary: trackIds => {
     const ids = new Set(trackIds);
-    set((s) => ({ library: s.library.filter((t) => !ids.has(t.id)) }));
+    set(s => ({ library: s.library.filter(t => !ids.has(t.id)) }));
 
     const playback = usePlaybackStore.getState();
     const { queue, queueIndex, currentTrack } = playback;
 
-    const inQueue = queue.some((t) => ids.has(t.id));
+    const inQueue = queue.some(t => ids.has(t.id));
     const isCurrent = currentTrack != null && ids.has(currentTrack.id);
     if (!inQueue && !isCurrent) return;
 
-    const newQueue = queue.filter((t) => !ids.has(t.id));
+    const newQueue = queue.filter(t => !ids.has(t.id));
     let newIndex = queueIndex;
     for (let i = 0; i < queueIndex && i < queue.length; i++) {
       if (ids.has(queue[i].id)) newIndex--;
@@ -94,50 +94,57 @@ export const useLibraryStore = create<LibraryStore>()((set, get) => ({
     }
   },
 
-  toggleFavorite: (trackId) => {
+  toggleFavorite: trackId => {
+    const overlayStore = useTrackOverlayStore.getState();
+    const overlayEntry = overlayStore.overlays.get(trackId);
     const { library } = get();
-    const target = library.find((t) => t.id === trackId);
-    if (!target) {
-      // Track isn't in the library — still sync playback references if any,
-      // since radio/preview tracks can flow through the queue without being
-      // in the library yet.
-      syncPlaybackTrack(trackId, (t) => ({ ...t, isFavorite: !t.isFavorite }));
-    } else {
-      const nextFavorite = !target.isFavorite;
-      set({
-        library: library.map((t) =>
-          t.id === trackId ? { ...t, isFavorite: nextFavorite } : t,
-        ),
-      });
-      syncPlaybackTrack(trackId, (t) => ({ ...t, isFavorite: nextFavorite }));
-    }
+    const target = library.find(t => t.id === trackId);
+
+    // Resolve the current isFavorite value from overlay-first, then library,
+    // then queue (for radio/preview tracks that never enter the library).
+    const playback = usePlaybackStore.getState();
+    const queueTrack = playback.queue.find(t => t.id === trackId);
+    const currentTrack = playback.currentTrack;
+    const currentValue =
+      overlayEntry?.isFavorite ??
+      target?.isFavorite ??
+      queueTrack?.isFavorite ??
+      (currentTrack?.id === trackId ? currentTrack.isFavorite : undefined) ??
+      false;
+    const nextFavorite = !currentValue;
+
+    // Library array reference is intentionally NOT touched — the overlay
+    // carries the new value until the next full library refetch (rescan /
+    // import) reseeds canonical state. Skipping the reallocation here is
+    // the entire point of the overlay store: AlbumGrid's groupTracksByAlbum
+    // memo no longer invalidates on a favorite toggle.
+    overlayStore.setOverlay(trackId, { isFavorite: nextFavorite });
+    syncPlaybackTrack(trackId, t => ({ ...t, isFavorite: nextFavorite }));
 
     if (IS_ELECTRON) {
-      window.electronAPI.db.tracks.toggleFavorite(trackId).catch((err) => {
+      window.electronAPI.db.tracks.toggleFavorite(trackId).catch(err => {
         console.warn('[player] Failed to toggle favorite:', err);
         // Revert optimistic update so UI stays in sync with DB.
-        const revert = (t: Track) =>
-          t.id === trackId ? { ...t, isFavorite: !t.isFavorite } : t;
-        set((s) => ({ library: s.library.map(revert) }));
-        syncPlaybackTrack(trackId, (t) => ({ ...t, isFavorite: !t.isFavorite }));
+        useTrackOverlayStore.getState().setOverlay(trackId, { isFavorite: currentValue });
+        syncPlaybackTrack(trackId, t => ({ ...t, isFavorite: currentValue }));
       });
     }
   },
 
-  incrementTrackPlayCount: (trackId) => {
+  incrementTrackPlayCount: trackId => {
     const { library } = get();
     const increment = (t: Track) => ({ ...t, playCount: (t.playCount ?? 0) + 1 });
 
-    const hasInLibrary = library.some((t) => t.id === trackId);
+    const hasInLibrary = library.some(t => t.id === trackId);
     if (hasInLibrary) {
       set({
-        library: library.map((t) => (t.id === trackId ? increment(t) : t)),
+        library: library.map(t => (t.id === trackId ? increment(t) : t)),
       });
     }
     syncPlaybackTrack(trackId, increment);
 
     if (IS_ELECTRON) {
-      window.electronAPI.db.tracks.incrementPlayCount(trackId).catch((err) => {
+      window.electronAPI.db.tracks.incrementPlayCount(trackId).catch(err => {
         console.warn('[player] Failed to persist play count:', err);
       });
     }

--- a/apps/web/src/stores/useTrackOverlayStore.test.ts
+++ b/apps/web/src/stores/useTrackOverlayStore.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useTrackOverlayStore } from './useTrackOverlayStore';
+
+describe('useTrackOverlayStore', () => {
+  beforeEach(() => {
+    useTrackOverlayStore.setState({
+      overlays: new Map(),
+      version: 0,
+    });
+  });
+
+  describe('setOverlay', () => {
+    it('creates a new entry for an unknown id', () => {
+      useTrackOverlayStore.getState().setOverlay('a', { isFavorite: true });
+      expect(useTrackOverlayStore.getState().overlays.get('a')).toEqual({
+        isFavorite: true,
+      });
+    });
+
+    it('merges patches into an existing entry', () => {
+      const { setOverlay } = useTrackOverlayStore.getState();
+      setOverlay('a', { isFavorite: true });
+      setOverlay('a', { playCount: 5 });
+      expect(useTrackOverlayStore.getState().overlays.get('a')).toEqual({
+        isFavorite: true,
+        playCount: 5,
+      });
+    });
+
+    it('overwrites only the patched field, leaving others intact', () => {
+      const { setOverlay } = useTrackOverlayStore.getState();
+      setOverlay('a', { isFavorite: true, playCount: 1 });
+      setOverlay('a', { isFavorite: false });
+      expect(useTrackOverlayStore.getState().overlays.get('a')).toEqual({
+        isFavorite: false,
+        playCount: 1,
+      });
+    });
+
+    it('bumps version on every call', () => {
+      const start = useTrackOverlayStore.getState().version;
+      useTrackOverlayStore.getState().setOverlay('a', { isFavorite: true });
+      const afterFirst = useTrackOverlayStore.getState().version;
+      useTrackOverlayStore.getState().setOverlay('a', { playCount: 1 });
+      const afterSecond = useTrackOverlayStore.getState().version;
+      expect(afterFirst).toBe(start + 1);
+      expect(afterSecond).toBe(afterFirst + 1);
+    });
+
+    it('does not collide entries between distinct ids', () => {
+      const { setOverlay } = useTrackOverlayStore.getState();
+      setOverlay('a', { isFavorite: true });
+      setOverlay('b', { isFavorite: false, playCount: 9 });
+      const overlays = useTrackOverlayStore.getState().overlays;
+      expect(overlays.get('a')).toEqual({ isFavorite: true });
+      expect(overlays.get('b')).toEqual({ isFavorite: false, playCount: 9 });
+    });
+  });
+
+  describe('clearOverlay', () => {
+    it('removes an existing entry', () => {
+      const { setOverlay, clearOverlay } = useTrackOverlayStore.getState();
+      setOverlay('a', { isFavorite: true });
+      clearOverlay('a');
+      expect(useTrackOverlayStore.getState().overlays.has('a')).toBe(false);
+    });
+
+    it('bumps version when an entry is removed', () => {
+      const { setOverlay, clearOverlay } = useTrackOverlayStore.getState();
+      setOverlay('a', { isFavorite: true });
+      const before = useTrackOverlayStore.getState().version;
+      clearOverlay('a');
+      expect(useTrackOverlayStore.getState().version).toBe(before + 1);
+    });
+
+    it('is a no-op (no version bump) for an unknown id', () => {
+      const before = useTrackOverlayStore.getState().version;
+      useTrackOverlayStore.getState().clearOverlay('missing');
+      expect(useTrackOverlayStore.getState().version).toBe(before);
+    });
+
+    it('does not affect other entries', () => {
+      const { setOverlay, clearOverlay } = useTrackOverlayStore.getState();
+      setOverlay('a', { isFavorite: true });
+      setOverlay('b', { isFavorite: false });
+      clearOverlay('a');
+      expect(useTrackOverlayStore.getState().overlays.get('b')).toEqual({
+        isFavorite: false,
+      });
+    });
+  });
+
+  describe('clearAll', () => {
+    it('empties the overlay map', () => {
+      const { setOverlay, clearAll } = useTrackOverlayStore.getState();
+      setOverlay('a', { isFavorite: true });
+      setOverlay('b', { playCount: 3 });
+      clearAll();
+      expect(useTrackOverlayStore.getState().overlays.size).toBe(0);
+    });
+
+    it('bumps version when entries are cleared', () => {
+      const { setOverlay, clearAll } = useTrackOverlayStore.getState();
+      setOverlay('a', { isFavorite: true });
+      const before = useTrackOverlayStore.getState().version;
+      clearAll();
+      expect(useTrackOverlayStore.getState().version).toBe(before + 1);
+    });
+
+    it('is a no-op (no version bump) when already empty', () => {
+      const before = useTrackOverlayStore.getState().version;
+      useTrackOverlayStore.getState().clearAll();
+      expect(useTrackOverlayStore.getState().version).toBe(before);
+    });
+  });
+});

--- a/apps/web/src/stores/useTrackOverlayStore.ts
+++ b/apps/web/src/stores/useTrackOverlayStore.ts
@@ -1,0 +1,84 @@
+import { create } from 'zustand';
+
+/**
+ * Volatile per-track fields that mutate independently of the canonical
+ * `library: Track[]` array. Stored sparsely — only tracks with at least one
+ * pending mutation appear here. Reads merge overlay on top of the seed value
+ * from `library` (or any `Track` shape produced upstream).
+ */
+export interface MutationOverlay {
+  isFavorite?: boolean;
+  playCount?: number;
+  /** ISO timestamp; reserved for the future `lastPlayedAt` migration. */
+  lastPlayedAt?: number;
+}
+
+interface OverlayState {
+  /**
+   * Sparse map keyed by `track.id`. Mutated in place to avoid allocating a
+   * fresh `Map` on every favorite toggle. Subscribers depend on `version`
+   * for re-render signals — never read this map directly inside a memo
+   * dependency array.
+   */
+  overlays: Map<string, MutationOverlay>;
+  /**
+   * Monotonic counter bumped on every mutation. Lets `useMemo` /
+   * `useSyncExternalStore` consumers depend on a primitive instead of the
+   * map identity. Same trick `useEqStore` uses for its gains array.
+   */
+  version: number;
+}
+
+interface OverlayActions {
+  /**
+   * Merge `patch` into the existing overlay entry for `id`. Calling
+   * `setOverlay(id, { isFavorite: true })` does NOT clobber a previously-set
+   * `playCount` on the same id — partial patches accumulate.
+   */
+  setOverlay: (id: string, patch: MutationOverlay) => void;
+  /** Drop the overlay entry for `id`. No-op if there is no entry. */
+  clearOverlay: (id: string) => void;
+  /** Drop every overlay entry. Used after `useLibrarySync` re-seeds. */
+  clearAll: () => void;
+}
+
+export type TrackOverlayStore = OverlayState & OverlayActions;
+
+export const useTrackOverlayStore = create<TrackOverlayStore>()(set => ({
+  overlays: new Map(),
+  version: 0,
+
+  setOverlay: (id, patch) =>
+    set(state => {
+      const existing = state.overlays.get(id);
+      const next = existing ? { ...existing, ...patch } : { ...patch };
+      state.overlays.set(id, next);
+      return { version: state.version + 1 };
+    }),
+
+  clearOverlay: id =>
+    set(state => {
+      if (!state.overlays.has(id)) return state;
+      state.overlays.delete(id);
+      return { version: state.version + 1 };
+    }),
+
+  clearAll: () =>
+    set(state => {
+      if (state.overlays.size === 0) return state;
+      state.overlays.clear();
+      return { version: state.version + 1 };
+    }),
+}));
+
+// Preserve store state across Vite HMR (dev only, tree-shaken in production)
+if (import.meta.hot) {
+  type HmrData = { store?: typeof useTrackOverlayStore };
+  const hot = import.meta.hot;
+  const data = (hot.data ?? {}) as HmrData;
+  if (data.store) {
+    useTrackOverlayStore.setState(data.store.getState());
+  }
+  data.store = useTrackOverlayStore;
+  hot.accept();
+}


### PR DESCRIPTION
## Summary

Phase 1+2 of the deferred mutation-overlay refactor planned in `docs/refactor/2026-05-04-mutation-overlay-store-plan.md`. Removes the canonical `library` array reallocation on every favorite toggle so AlbumGrid's `groupTracksByAlbum` memo no longer invalidates and React-Window stops remounting album cards on every heart click. Chain-doc estimate: ~20-40 MB GC working-set cut during active listening (this PR captures roughly half — playCount toggles in Phase 3 will pick up the rest).

## Why

PR #150 fixed the bitmap size in album art. PR #160 fixed lazy-loading + duplicate cache + AlbumGrid virtualization. This PR fixes the next remaining hot path: a favorite toggle reallocates `library`, which invalidates `groupTracksByAlbum`'s memo dependency, which forces every visible album card's fiber to re-mount mid-listening session.

## Mutation flow before / after

```
Before:
toggleFavorite(id)
  -> set({ library: [...].map(...) })  // new array reference
  -> every library subscriber re-renders
  -> AlbumGrid useMemo([library, sort, order]) re-runs
  -> groupTracksByAlbum walks N tracks
  -> cellProps identity changes
  -> motion.button re-mounts on every visible album

After:
toggleFavorite(id)
  -> useTrackOverlayStore.setOverlay(id, { isFavorite })  // mutates in-place + bumps version
  -> only subscribers of that id (heart icons) re-render via useTrack(id)
  -> AlbumGrid useMemo deps unchanged
  -> no remount
```

## Per-commit changes

**Commit 1 — `feat(web/stores): add mutation overlay store + useTrack/useMergedLibrary hooks`** (Phase 1, additive)

- `apps/web/src/stores/useTrackOverlayStore.ts` — new Zustand slice. `Map<string, MutationOverlay>` mutated in place plus a `version` counter so subscribers can react without depending on Map identity.
- `apps/web/src/hooks/useTrack.ts` — single-track read with overlay merged on top. Optional `fallback` Track for the radio/preview case where the track isn't in `library`.
- `apps/web/src/hooks/useMergedLibrary.ts` — full-library merged read for sort/filter consumers. Returns the canonical `library` reference unchanged when overlay is empty (cheap path for cold-start / no-mutation sessions).
- Tests for all three (~26 new tests).

**Commit 2 — `refactor(web): route favorite-toggle through overlay store`** (Phase 2, atomic migration)

- `useLibraryStore.ts` — `toggleFavorite` writes only to overlay; library array reference stays stable. Cross-store sync into `usePlaybackStore.queue` / `currentTrack` preserved (radio/preview tracks reach the queue but not the library, so the overlay alone wouldn't cover them).
- `useLibraryStore.test.ts` — `toggleFavorite` tests rewritten to assert overlay state and library-array-reference stability. `incrementTrackPlayCount` tests untouched (Phase 3 territory).
- `TrackRowContent.tsx` — self-merges via `useTrackOverlayStore` so every list row in the app (LibraryView, FavoritesView, AlbumDetailView, PlaylistDetailView, SortableTrackRow) gets fresh hearts atomically.
- `TrackContextMenu.tsx` — overlay first, then queue, then track prop.
- `PlayerBar.tsx` + `CompactPlayer.tsx` — `useTrack(currentTrack.id, currentTrack)` so the player heart matches the row hearts.
- `FavoritesView.tsx` — `useMergedLibrary()` for the favorites filter so a toggle moves a track into / out of the view immediately.
- `usePlaylists.ts` — `usePlaylistDetailQuery.displayTracks` reads overlay first; the previous library-only favMap went stale once `library` stops reflecting in-session toggles.
- `types.ts` — JSDoc on `Track.isFavorite` documenting it's a seed value.

**Files intentionally NOT changed:** `AlbumGrid.tsx` and `albumSort.ts`. Verified that `groupTracksByAlbum` only reads `track.album / artist / year / createdAt / albumArt` — never `isFavorite` — so album grouping is intrinsically insensitive to overlay mutations and AlbumGrid keeps the stable `library` reference. The brief's claim about AlbumGrid is correct.

## Expected impact

20-40 MB GC working-set cut during active listening (favorite toggles + AlbumGrid mounted), per the chain-doc estimate. Roughly half of that — the favorite-toggle path — is captured here; the other half lands when Phase 3 migrates `incrementTrackPlayCount`.

## Test plan

- [x] `pnpm typecheck` clean (root)
- [x] `pnpm test` clean (1175 tests, +28 net vs master)
- [x] `pnpm lint` clean

Manual verification (TODO before merge):
- [ ] Heart icon stays consistent across player bar, context menu, FavoritesView row, and PlaylistDetailView row when toggled from any of those surfaces
- [ ] Toggling a favorite while playing does NOT visibly re-mount AlbumGrid cards (Profiler: AlbumGrid useMemo doesn't re-run)
- [ ] Toggle survives a full library rescan (overlay still wins until DB returns the new value, then library reseeds)
- [ ] Compact-mode heart matches main-window heart for the same track
- [ ] Radio/preview track favorite still toggles (via queue path; track is not in library)

## Out of scope (deferred to follow-up PRs)

- Phase 3 — migrate `incrementTrackPlayCount` to overlay (mix selectors, useMixTracks)
- Phase 4 — strip dead `library.map(...)` paths, wire `clearAll()` into `useLibrarySync` after re-seed
- Phase 5 — `setLastPlayedAt` once the field exists

The planning doc at `docs/refactor/2026-05-04-mutation-overlay-store-plan.md` stays in tree until Phase 5 ships.

## Coordination note

Overlay design is forward-compatible with the paginated `db:tracks:get-page` IPC plan (`docs/arch/2026-05-04-paginated-tracks-ipc-plan.md`): id-keyed, merged at read-time, not write-time. When pagination lands, the overlay layer carries forward unchanged — `useMergedLibrary` shifts from "merge full array" to "merge a page" but the API surface stays identical.