### PR TITLE
feat(desktop): introduce utilityProcess for metadata scan (phases 0-2)

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -14,7 +14,11 @@
     { "from": "resources/icon.png", "to": "icon.png" },
     { "from": "resources/icon.ico", "to": "icon.ico" }
   ],
-  "asarUnpack": ["**/node_modules/better-sqlite3/**"],
+  "asarUnpack": [
+    "**/node_modules/better-sqlite3/**",
+    "**/node_modules/sharp/**",
+    "**/node_modules/@img/**"
+  ],
   "artifactName": "${productName}-${version}-${arch}.${ext}",
   "nodeGypRebuild": false,
   "npmRebuild": false,

--- a/apps/desktop/esbuild.config.mjs
+++ b/apps/desktop/esbuild.config.mjs
@@ -35,6 +35,7 @@ await Promise.all([
     entryPoints: [
       'src/main/index.ts',
       'src/main/extract-worker.ts',
+      'src/main/scan-utility.ts',
       'src/main/scan-utility-spike.ts',
     ],
     external: mainExternal,

--- a/apps/desktop/esbuild.config.mjs
+++ b/apps/desktop/esbuild.config.mjs
@@ -32,7 +32,11 @@ const sharedOptions = {
 await Promise.all([
   build({
     ...sharedOptions,
-    entryPoints: ['src/main/index.ts', 'src/main/extract-worker.ts'],
+    entryPoints: [
+      'src/main/index.ts',
+      'src/main/extract-worker.ts',
+      'src/main/scan-utility-spike.ts',
+    ],
     external: mainExternal,
   }),
   build({

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,7 +18,8 @@
     "package:win": "pnpm build && electron-builder --config electron-builder.json --win",
     "package:mac": "pnpm build && electron-builder --config electron-builder.json --mac",
     "postinstall": "electron-builder install-app-deps",
-    "rebuild": "electron-builder install-app-deps"
+    "rebuild": "electron-builder install-app-deps",
+    "spike:utility": "node esbuild.config.mjs && electron scripts/spike-utility-process.cjs"
   },
   "dependencies": {
     "@xhayper/discord-rpc": "^1.3.4",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,6 +33,7 @@
     "music-metadata": "^11.12.3",
     "node-addon-api": "^8.7.0",
     "node-id3": "^0.2.9",
+    "sharp": "^0.34.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/desktop/scripts/spike-utility-process.cjs
+++ b/apps/desktop/scripts/spike-utility-process.cjs
@@ -78,11 +78,11 @@ async function main() {
       clearTimeout(timer);
       if (msg.ok) {
         pass(
-          `nativeImage works in utilityProcess. ` +
+          `image decode works in utilityProcess. ` +
           `Decoded ${msg.width}x${msg.height} → resized + JPEG q=85 = ${msg.outputSize} bytes`
         );
       } else {
-        fail(`nativeImage failed inside utilityProcess: ${msg.error}`);
+        fail(`image decode failed inside utilityProcess: ${msg.error}`);
       }
       try { child.kill(); } catch { /* noop */ }
     }

--- a/apps/desktop/scripts/spike-utility-process.cjs
+++ b/apps/desktop/scripts/spike-utility-process.cjs
@@ -1,0 +1,94 @@
+/**
+ * Phase 0 spike harness — runs under Electron, forks the bundled spike utility
+ * at `dist/main/scan-utility-spike.js`, hands it the project's `icon-256.png`
+ * fixture, and prints PASS or FAIL based on whether `nativeImage` decoded +
+ * resized + JPEG-encoded the buffer inside the utility process.
+ *
+ * Run with:
+ *   pnpm --filter @shiranami/desktop exec node esbuild.config.mjs
+ *   pnpm --filter @shiranami/desktop exec electron apps/desktop/scripts/spike-utility-process.cjs
+ *
+ * Exit codes:
+ *   0 — spike succeeded, nativeImage works in utilityProcess. Phase 2 cleared.
+ *   1 — spike failed. Do NOT autonomously add `sharp`; report to the user.
+ *
+ * Findings doc: docs/arch/2026-05-04-metadata-scan-utility-process-plan.md §3.4
+ */
+
+const { app, utilityProcess } = require('electron');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const SPIKE_PATH = path.join(__dirname, '..', 'dist', 'main', 'scan-utility-spike.js');
+const FIXTURE_PATH = path.join(__dirname, '..', 'resources', 'icon-256.png');
+const TIMEOUT_MS = 10_000;
+
+function fail(reason) {
+  console.error('\n[spike] FAIL:', reason);
+  app.exit(1);
+}
+
+function pass(detail) {
+  console.log('\n[spike] PASS:', detail);
+  app.exit(0);
+}
+
+async function main() {
+  if (!fs.existsSync(SPIKE_PATH)) {
+    fail(`bundled spike not found at ${SPIKE_PATH} — run \`node apps/desktop/esbuild.config.mjs\` first`);
+    return;
+  }
+  if (!fs.existsSync(FIXTURE_PATH)) {
+    fail(`fixture image not found at ${FIXTURE_PATH}`);
+    return;
+  }
+
+  const fixture = fs.readFileSync(FIXTURE_PATH);
+  console.log(`[spike] fixture: ${FIXTURE_PATH} (${fixture.length} bytes)`);
+  console.log(`[spike] forking utilityProcess: ${SPIKE_PATH}`);
+
+  const child = utilityProcess.fork(SPIKE_PATH, [], {
+    serviceName: 'shiranami-scan-utility-spike',
+    stdio: 'inherit',
+  });
+
+  const timer = setTimeout(() => {
+    fail(`timed out after ${TIMEOUT_MS}ms — utility never replied`);
+    try { child.kill(); } catch { /* noop */ }
+  }, TIMEOUT_MS);
+
+  child.on('exit', (code) => {
+    clearTimeout(timer);
+    if (code !== 0 && code !== null) {
+      fail(`utility exited with code ${code} before completing the spike`);
+    }
+  });
+
+  child.on('message', (msg) => {
+    if (!msg || typeof msg !== 'object') return;
+    if (msg.type === 'spike-ready') {
+      console.log('[spike] utility ready, posting fixture buffer');
+      // Pass a Uint8Array — structured clone handles it natively, no per-byte
+      // serialisation. The utility reconstructs a Buffer with `Buffer.from(input)`.
+      const input = new Uint8Array(fixture.buffer, fixture.byteOffset, fixture.byteLength);
+      child.postMessage({ type: 'spike', input });
+      return;
+    }
+    if (msg.type === 'spike-result') {
+      clearTimeout(timer);
+      if (msg.ok) {
+        pass(
+          `nativeImage works in utilityProcess. ` +
+          `Decoded ${msg.width}x${msg.height} → resized + JPEG q=85 = ${msg.outputSize} bytes`
+        );
+      } else {
+        fail(`nativeImage failed inside utilityProcess: ${msg.error}`);
+      }
+      try { child.kill(); } catch { /* noop */ }
+    }
+  });
+}
+
+app.whenReady().then(main).catch((e) => {
+  fail(`harness threw: ${e instanceof Error ? e.stack || e.message : String(e)}`);
+});

--- a/apps/desktop/src/main/ipc/library.test.ts
+++ b/apps/desktop/src/main/ipc/library.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import { ipcHandlers, makeTempDir, cleanupTempDir } from '../../../test/setup';
-import { registerLibraryHandlers, cleanupLibraryHandlers } from './library';
+import {
+  registerLibraryHandlers,
+  cleanupLibraryHandlers,
+  _setForkOverrideForTest,
+} from './library';
+import type { ScanUtilityClient, ParseResult } from '../scan-utility-host';
 
 vi.mock('../logger', () => ({
   logger: {
@@ -20,15 +25,76 @@ const mockParseAudioMetadata = vi.fn(async (filePath: string) => ({
 }));
 
 const REAL_AUDIO_EXTENSIONS = [
-  '.mp3', '.flac', '.wav', '.ogg', '.aac', '.m4a', '.opus', '.wma', '.weba', '.webm',
+  '.mp3',
+  '.flac',
+  '.wav',
+  '.ogg',
+  '.aac',
+  '.m4a',
+  '.opus',
+  '.wma',
+  '.weba',
+  '.webm',
 ];
 
 vi.mock('../metadata-service', () => ({
   parseAudioMetadata: (...args: unknown[]) => mockParseAudioMetadata(...(args as [string])),
   isAudioFile: vi.fn((filePath: string) =>
-    REAL_AUDIO_EXTENSIONS.includes(path.extname(filePath).toLowerCase()),
+    REAL_AUDIO_EXTENSIONS.includes(path.extname(filePath).toLowerCase())
   ),
 }));
+
+/**
+ * Fake utility client returned by the test fork override. Records every
+ * parse() call so tests can assert call sets, but ignores the IPC plumbing
+ * (no real utilityProcess spawned).
+ */
+function makeFakeScanUtility(parseImpl?: (filePath: string) => Promise<ParseResult>): {
+  client: ScanUtilityClient;
+  parseCalls: string[];
+  killCalls: number;
+} {
+  const parseCalls: string[] = [];
+  let killCalls = 0;
+  const defaultParse: typeof parseImpl = async () => ({
+    ok: true,
+    metadata: {
+      title: 'Test',
+      artist: 'Artist',
+      album: 'Album',
+      duration: 180,
+      genre: '',
+      year: null,
+      trackNumber: null,
+      discNumber: null,
+      albumArt: null,
+    },
+  });
+  const impl = parseImpl ?? defaultParse;
+  const client: ScanUtilityClient = {
+    pid: 1234,
+    ready: Promise.resolve(),
+    hello: vi.fn(async () => ({ pid: 1234 })),
+    init: vi.fn(async () => undefined),
+    parse: vi.fn(async (filePath: string) => {
+      parseCalls.push(filePath);
+      return impl(filePath);
+    }),
+    kill: vi.fn(() => {
+      killCalls++;
+    }),
+    get killed() {
+      return killCalls > 0;
+    },
+  };
+  return {
+    client,
+    parseCalls,
+    get killCalls() {
+      return killCalls;
+    },
+  } as { client: ScanUtilityClient; parseCalls: string[]; killCalls: number };
+}
 
 const event = null as never;
 
@@ -36,11 +102,16 @@ describe('library ipc handlers', () => {
   beforeEach(() => {
     ipcHandlers.clear();
     vi.clearAllMocks();
+    // Default override: every scan-folder / scan-folder-grouped test gets a
+    // fake utility client unless it specifies otherwise. Tests that need a
+    // bespoke fake re-register with their own override.
+    _setForkOverrideForTest(() => makeFakeScanUtility().client);
     registerLibraryHandlers();
   });
 
   afterEach(() => {
     cleanupLibraryHandlers();
+    _setForkOverrideForTest(null);
   });
 
   describe('library:validate-files', () => {
@@ -122,19 +193,19 @@ describe('library ipc handlers', () => {
         metadata: unknown;
       }>;
 
-      const filePaths = results.map((r) => r.filePath).sort();
+      const filePaths = results.map(r => r.filePath).sort();
       expect(filePaths).toEqual(
         [
           path.join(tmpDir, 'track1.mp3'),
           path.join(sub, 'track2.flac'),
           path.join(deep, 'track3.ogg'),
-        ].sort(),
+        ].sort()
       );
 
       // Non-audio files must not appear
-      const allPaths = results.map((r) => r.filePath);
-      expect(allPaths.some((p) => p.endsWith('.txt'))).toBe(false);
-      expect(allPaths.some((p) => p.endsWith('.jpg'))).toBe(false);
+      const allPaths = results.map(r => r.filePath);
+      expect(allPaths.some(p => p.endsWith('.txt'))).toBe(false);
+      expect(allPaths.some(p => p.endsWith('.jpg'))).toBe(false);
     });
 
     it('returns empty array for empty directory', async () => {
@@ -168,7 +239,7 @@ describe('library ipc handlers', () => {
         filePath: string;
         metadata: unknown;
       }>;
-      const filePaths = results.map((r) => r.filePath);
+      const filePaths = results.map(r => r.filePath);
 
       // Depth 0..5 files should be found (indices 0-5 in allAudioFiles, plus depth6 at depth=6)
       // The scan starts at depth=0 for tmpDir, recurses with depth+1.
@@ -243,6 +314,169 @@ describe('library ipc handlers', () => {
         duration: 180,
         path: '/music/song.mp3',
       });
+    });
+  });
+
+  describe('library:scan-folder utility-process integration', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = makeTempDir();
+    });
+
+    afterEach(() => {
+      cleanupTempDir(tmpDir);
+    });
+
+    it('spawns one utility, parses every file through it, then kills it', async () => {
+      const fake = makeFakeScanUtility();
+      _setForkOverrideForTest(() => fake.client);
+      cleanupLibraryHandlers();
+      registerLibraryHandlers();
+
+      fs.writeFileSync(path.join(tmpDir, 'a.mp3'), '');
+      fs.writeFileSync(path.join(tmpDir, 'b.flac'), '');
+      fs.writeFileSync(path.join(tmpDir, 'c.ogg'), '');
+
+      const handler = ipcHandlers.get('library:scan-folder')!;
+      await handler(event, tmpDir);
+
+      expect(fake.parseCalls).toHaveLength(3);
+      expect(vi.mocked(fake.client.init)).toHaveBeenCalledWith({ userDataPath: '/mock/userData' });
+      expect(vi.mocked(fake.client.kill)).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to filename-derived metadata when the utility reports an error', async () => {
+      const fake = makeFakeScanUtility(async filePath =>
+        filePath.endsWith('bad.mp3')
+          ? { ok: false, error: 'simulated parse failure' }
+          : {
+              ok: true,
+              metadata: {
+                title: 'Real Title',
+                artist: 'Real Artist',
+                album: 'Real Album',
+                duration: 200,
+                genre: '',
+                year: null,
+                trackNumber: null,
+                discNumber: null,
+                albumArt: null,
+              },
+            }
+      );
+      _setForkOverrideForTest(() => fake.client);
+      cleanupLibraryHandlers();
+      registerLibraryHandlers();
+
+      const goodPath = path.join(tmpDir, 'good.mp3');
+      const badPath = path.join(tmpDir, 'bad.mp3');
+      fs.writeFileSync(goodPath, '');
+      fs.writeFileSync(badPath, '');
+
+      const handler = ipcHandlers.get('library:scan-folder')!;
+      const results = (await handler(event, tmpDir)) as Array<{
+        filePath: string;
+        metadata: { title: string; artist: string };
+      }>;
+
+      const byPath = new Map(results.map(r => [r.filePath, r.metadata]));
+      expect(byPath.get(goodPath)).toMatchObject({ title: 'Real Title' });
+      expect(byPath.get(badPath)).toMatchObject({
+        title: 'bad', // filename minus extension
+        artist: 'Unknown Artist',
+      });
+    });
+
+    it('skips spawning the utility when the directory has no audio files', async () => {
+      let spawnCount = 0;
+      _setForkOverrideForTest(() => {
+        spawnCount++;
+        return makeFakeScanUtility().client;
+      });
+      cleanupLibraryHandlers();
+      registerLibraryHandlers();
+
+      // Only non-audio files
+      fs.writeFileSync(path.join(tmpDir, 'readme.txt'), '');
+
+      const handler = ipcHandlers.get('library:scan-folder')!;
+      const results = await handler(event, tmpDir);
+      expect(results).toEqual([]);
+      expect(spawnCount).toBe(0);
+    });
+
+    it('kills the utility even when parse rejects', async () => {
+      const killSpy = vi.fn();
+      _setForkOverrideForTest(() => ({
+        pid: 1,
+        ready: Promise.resolve(),
+        hello: vi.fn(async () => ({ pid: 1 })),
+        init: vi.fn(async () => undefined),
+        parse: vi.fn(async () => {
+          throw new Error('utility went sideways');
+        }),
+        kill: killSpy,
+        get killed() {
+          return killSpy.mock.calls.length > 0;
+        },
+      }));
+      cleanupLibraryHandlers();
+      registerLibraryHandlers();
+
+      fs.writeFileSync(path.join(tmpDir, 'a.mp3'), '');
+      const handler = ipcHandlers.get('library:scan-folder')!;
+      await expect(handler(event, tmpDir)).rejects.toThrow(/sideways/);
+      expect(killSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('library:scan-folder-grouped utility-process integration', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = makeTempDir();
+    });
+
+    afterEach(() => {
+      cleanupTempDir(tmpDir);
+    });
+
+    it('uses one utility for both root files and every subfolder', async () => {
+      const fake = makeFakeScanUtility();
+      _setForkOverrideForTest(() => fake.client);
+      cleanupLibraryHandlers();
+      registerLibraryHandlers();
+
+      fs.writeFileSync(path.join(tmpDir, 'root.mp3'), '');
+      const sub = path.join(tmpDir, 'album');
+      fs.mkdirSync(sub);
+      fs.writeFileSync(path.join(sub, 'a.flac'), '');
+      fs.writeFileSync(path.join(sub, 'b.flac'), '');
+
+      const handler = ipcHandlers.get('library:scan-folder-grouped')!;
+      await handler(event, tmpDir);
+
+      expect(fake.parseCalls).toHaveLength(3);
+      expect(vi.mocked(fake.client.kill)).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns early without spawning when there are zero audio files', async () => {
+      let spawnCount = 0;
+      _setForkOverrideForTest(() => {
+        spawnCount++;
+        return makeFakeScanUtility().client;
+      });
+      cleanupLibraryHandlers();
+      registerLibraryHandlers();
+
+      // Only a non-audio file
+      fs.writeFileSync(path.join(tmpDir, 'note.txt'), '');
+
+      const handler = ipcHandlers.get('library:scan-folder-grouped')!;
+      const result = await handler(event, tmpDir);
+      expect(result).toEqual({ rootTracks: [], subfolders: [] });
+      expect(spawnCount).toBe(0);
     });
   });
 

--- a/apps/desktop/src/main/ipc/library.test.ts
+++ b/apps/desktop/src/main/ipc/library.test.ts
@@ -406,7 +406,9 @@ describe('library ipc handlers', () => {
       expect(spawnCount).toBe(0);
     });
 
-    it('kills the utility even when parse rejects', async () => {
+    it('falls back to filename metadata when utility.parse rejects, and kills the utility', async () => {
+      // Simulates the utility process exiting mid-scan (all parse() calls reject).
+      // The scan must complete with fallback metadata rather than aborting.
       const killSpy = vi.fn();
       _setForkOverrideForTest(() => ({
         pid: 1,
@@ -426,8 +428,57 @@ describe('library ipc handlers', () => {
 
       fs.writeFileSync(path.join(tmpDir, 'a.mp3'), '');
       const handler = ipcHandlers.get('library:scan-folder')!;
-      await expect(handler(event, tmpDir)).rejects.toThrow(/sideways/);
+      const results = (await handler(event, tmpDir)) as Array<{
+        filePath: string;
+        metadata: { title: string; artist: string };
+      }>;
+      // Scan resolves (not rejects) — the rejecting parse is absorbed per-file.
+      expect(results).toHaveLength(1);
+      expect(results[0].metadata).toMatchObject({ title: 'a', artist: 'Unknown Artist' });
+      // kill() is still invoked via the try/finally in withScanUtility.
       expect(killSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps surrounding files when only one file in a batch rejects', async () => {
+      const goodPath1 = path.join(tmpDir, 'good1.mp3');
+      const badPath = path.join(tmpDir, 'bad.mp3');
+      const goodPath2 = path.join(tmpDir, 'good2.mp3');
+      fs.writeFileSync(goodPath1, '');
+      fs.writeFileSync(badPath, '');
+      fs.writeFileSync(goodPath2, '');
+
+      const fake = makeFakeScanUtility(async filePath => {
+        if (filePath === badPath) throw new Error('parse rejected for bad.mp3');
+        return {
+          ok: true,
+          metadata: {
+            title: path.basename(filePath, path.extname(filePath)),
+            artist: 'Good Artist',
+            album: 'Album',
+            duration: 100,
+            genre: '',
+            year: null,
+            trackNumber: null,
+            discNumber: null,
+            albumArt: null,
+          },
+        };
+      });
+      _setForkOverrideForTest(() => fake.client);
+      cleanupLibraryHandlers();
+      registerLibraryHandlers();
+
+      const handler = ipcHandlers.get('library:scan-folder')!;
+      const results = (await handler(event, tmpDir)) as Array<{
+        filePath: string;
+        metadata: { title: string; artist: string };
+      }>;
+
+      expect(results).toHaveLength(3);
+      const byPath = new Map(results.map(r => [r.filePath, r.metadata]));
+      expect(byPath.get(goodPath1)).toMatchObject({ title: 'good1', artist: 'Good Artist' });
+      expect(byPath.get(badPath)).toMatchObject({ title: 'bad', artist: 'Unknown Artist' });
+      expect(byPath.get(goodPath2)).toMatchObject({ title: 'good2', artist: 'Good Artist' });
     });
   });
 

--- a/apps/desktop/src/main/ipc/library.ts
+++ b/apps/desktop/src/main/ipc/library.ts
@@ -1,8 +1,9 @@
-import { ipcMain } from 'electron';
+import { app, ipcMain } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 import { parseAudioMetadata, isAudioFile, type TrackMetadata } from '../metadata-service';
 import { logger } from '../logger';
+import { forkScanUtility, type ScanUtilityClient } from '../scan-utility-host';
 import { handle } from './with-ipc-handler';
 import {
   parseMetadataArgs,
@@ -75,14 +76,47 @@ async function scanDirectoryGrouped(dirPath: string): Promise<{
 
 const PARSE_CONCURRENCY = 16;
 
-async function parseAudioFiles(filePaths: string[]): Promise<ScannedTrack[]> {
+/**
+ * Map a utility ParseResult into the renderer-facing TrackMetadata shape.
+ * On parse failure, fall back to the same filename-derived placeholder
+ * `metadata-service.parseAudioMetadata` produced before this migration —
+ * keeps the renderer contract identical.
+ */
+function fallbackMetadata(filePath: string): TrackMetadata {
+  const fileName = path.basename(filePath, path.extname(filePath));
+  return {
+    title: fileName,
+    artist: 'Unknown Artist',
+    album: 'Unknown Album',
+    duration: 0,
+    genre: '',
+    year: null,
+    trackNumber: null,
+    discNumber: null,
+    albumArt: null,
+  };
+}
+
+/**
+ * Parse a batch of files through a single utility-process client. Mirrors
+ * the previous in-process concurrency=16 worker-pool shape; the utility now
+ * owns the heavy work and main only orchestrates.
+ */
+async function parseAudioFilesViaUtility(
+  utility: ScanUtilityClient,
+  filePaths: string[]
+): Promise<ScannedTrack[]> {
   const results: ScannedTrack[] = new Array(filePaths.length);
   for (let i = 0; i < filePaths.length; i += PARSE_CONCURRENCY) {
     const batch = filePaths.slice(i, i + PARSE_CONCURRENCY);
     const parsed = await Promise.all(
-      batch.map(async (filePath) => {
-        const metadata = await parseAudioMetadata(filePath);
-        return { filePath, metadata };
+      batch.map(async filePath => {
+        const result = await utility.parse(filePath);
+        if (result.ok) {
+          return { filePath, metadata: result.metadata };
+        }
+        logger.warn(`[library] utility parse failed for ${filePath}: ${result.error}`);
+        return { filePath, metadata: fallbackMetadata(filePath) };
       })
     );
     for (let j = 0; j < parsed.length; j++) {
@@ -92,18 +126,55 @@ async function parseAudioFiles(filePaths: string[]): Promise<ScannedTrack[]> {
   return results;
 }
 
+/**
+ * Spawn a one-shot scan-utility process, run an async function with it,
+ * then kill it (RSS returns to the OS — the entire point of the migration).
+ *
+ * The utility is forked + initialised here, not lazily — early failures
+ * should surface as IPC errors rather than mid-scan crashes.
+ *
+ * Test seam: `forkOverride` lets unit tests inject a fake client without
+ * spinning up a real utilityProcess.
+ */
+async function withScanUtility<T>(
+  fn: (utility: ScanUtilityClient) => Promise<T>,
+  forkOverride?: () => ScanUtilityClient
+): Promise<T> {
+  const utility = forkOverride ? forkOverride() : forkScanUtility();
+  try {
+    await utility.ready;
+    await utility.init({ userDataPath: app.getPath('userData') });
+    return await fn(utility);
+  } finally {
+    utility.kill();
+  }
+}
+
+/**
+ * Test-only seam: replaces the default `forkScanUtility` for the duration of
+ * the next scan IPC call. Reset by tests in afterEach.
+ */
+let forkOverrideForTest: (() => ScanUtilityClient) | null = null;
+export function _setForkOverrideForTest(fn: (() => ScanUtilityClient) | null): void {
+  forkOverrideForTest = fn;
+}
+
 export function registerLibraryHandlers(): void {
-  // Parse metadata for a single file
+  // Parse metadata for a single file. Stays in-main: spawning a utility for
+  // one file is overkill, and single-file parses don't accumulate the heap
+  // pressure that drove the migration.
   handle(
     'library:parse-metadata',
     async (_event, filePath: string) => {
       const metadata = await parseAudioMetadata(filePath);
       return { filePath, metadata };
     },
-    { schema: parseMetadataArgs },
+    { schema: parseMetadataArgs }
   );
 
-  // Scan a directory for audio files and parse their metadata
+  // Scan a directory for audio files and parse their metadata via a forked
+  // utility process. Process exits at the end of the scan → V8 heap returns
+  // to OS, freeing 200-400 MB main RSS at idle after large scans.
   handle(
     'library:scan-folder',
     async (_event, dirPath: string) => {
@@ -112,12 +183,19 @@ export function registerLibraryHandlers(): void {
       const filePaths = await scanDirectoryRecursive(dirPath);
       logger.info(`[library] Found ${filePaths.length} audio files in ${Date.now() - start}ms`);
 
+      if (filePaths.length === 0) return [];
+
       const parseStart = Date.now();
-      const results = await parseAudioFiles(filePaths);
-      logger.info(`[library] Parsed ${results.length} tracks in ${Date.now() - parseStart}ms (total: ${Date.now() - start}ms)`);
+      const results = await withScanUtility(
+        utility => parseAudioFilesViaUtility(utility, filePaths),
+        forkOverrideForTest ?? undefined
+      );
+      logger.info(
+        `[library] Parsed ${results.length} tracks in ${Date.now() - parseStart}ms (total: ${Date.now() - start}ms)`
+      );
       return results;
     },
-    { schema: scanFolderArgs },
+    { schema: scanFolderArgs }
   );
 
   // Validate which file paths still exist on disk (returns paths that are missing)
@@ -132,7 +210,7 @@ export function registerLibraryHandlers(): void {
       for (let i = 0; i < filePaths.length; i += VALIDATE_CONCURRENCY) {
         const batch = filePaths.slice(i, i + VALIDATE_CONCURRENCY);
         const results = await Promise.all(
-          batch.map(async (filePath) => {
+          batch.map(async filePath => {
             try {
               await fs.promises.access(filePath, fs.constants.F_OK);
               return null;
@@ -147,16 +225,22 @@ export function registerLibraryHandlers(): void {
       }
 
       if (missing.length > 0) {
-        logger.warn(`[library] Validation found ${missing.length} missing files out of ${filePaths.length} (${Date.now() - start}ms)`);
+        logger.warn(
+          `[library] Validation found ${missing.length} missing files out of ${filePaths.length} (${Date.now() - start}ms)`
+        );
       } else {
-        logger.info(`[library] Validation complete: all ${filePaths.length} files exist (${Date.now() - start}ms)`);
+        logger.info(
+          `[library] Validation complete: all ${filePaths.length} files exist (${Date.now() - start}ms)`
+        );
       }
       return missing;
     },
-    { schema: validateFilesArgs },
+    { schema: validateFilesArgs }
   );
 
-  // Scan a directory and return results grouped by immediate subfolder
+  // Scan a directory and return results grouped by immediate subfolder.
+  // Uses the same per-scan utility process as `scan-folder` — root files +
+  // every subfolder go through one utility client, which then exits.
   handle(
     'library:scan-folder-grouped',
     async (_event, dirPath: string) => {
@@ -164,28 +248,40 @@ export function registerLibraryHandlers(): void {
       logger.info(`[library] Scanning folder (grouped): ${dirPath}`);
       const { rootFiles, subfolders } = await scanDirectoryGrouped(dirPath);
 
-      const totalFiles = rootFiles.length + subfolders.reduce((sum, sf) => sum + sf.files.length, 0);
-      logger.info(`[library] Found ${totalFiles} audio files in ${subfolders.length} subfolders (${rootFiles.length} at root) in ${Date.now() - start}ms`);
+      const totalFiles =
+        rootFiles.length + subfolders.reduce((sum, sf) => sum + sf.files.length, 0);
+      logger.info(
+        `[library] Found ${totalFiles} audio files in ${subfolders.length} subfolders (${rootFiles.length} at root) in ${Date.now() - start}ms`
+      );
 
-      const rootTracks = await parseAudioFiles(rootFiles);
-
-      const SUBFOLDER_CONCURRENCY = 4;
-      const parsedSubfolders = [];
-      for (let i = 0; i < subfolders.length; i += SUBFOLDER_CONCURRENCY) {
-        const batch = subfolders.slice(i, i + SUBFOLDER_CONCURRENCY);
-        const results = await Promise.all(
-          batch.map(async (subfolder) => {
-            const tracks = await parseAudioFiles(subfolder.files);
-            return { name: subfolder.name, path: subfolder.path, tracks };
-          })
-        );
-        parsedSubfolders.push(...results);
+      if (totalFiles === 0) {
+        return { rootTracks: [], subfolders: [] } satisfies GroupedScanResult;
       }
 
-      logger.info(`[library] Scan complete: ${totalFiles} files scanned and parsed in ${Date.now() - start}ms`);
-      return { rootTracks, subfolders: parsedSubfolders } satisfies GroupedScanResult;
+      const result = await withScanUtility(async utility => {
+        const rootTracks = await parseAudioFilesViaUtility(utility, rootFiles);
+
+        const SUBFOLDER_CONCURRENCY = 4;
+        const parsedSubfolders = [];
+        for (let i = 0; i < subfolders.length; i += SUBFOLDER_CONCURRENCY) {
+          const batch = subfolders.slice(i, i + SUBFOLDER_CONCURRENCY);
+          const sub = await Promise.all(
+            batch.map(async subfolder => {
+              const tracks = await parseAudioFilesViaUtility(utility, subfolder.files);
+              return { name: subfolder.name, path: subfolder.path, tracks };
+            })
+          );
+          parsedSubfolders.push(...sub);
+        }
+        return { rootTracks, subfolders: parsedSubfolders } satisfies GroupedScanResult;
+      }, forkOverrideForTest ?? undefined);
+
+      logger.info(
+        `[library] Scan complete: ${totalFiles} files scanned and parsed in ${Date.now() - start}ms`
+      );
+      return result;
     },
-    { schema: scanFolderGroupedArgs },
+    { schema: scanFolderGroupedArgs }
   );
 }
 

--- a/apps/desktop/src/main/ipc/library.ts
+++ b/apps/desktop/src/main/ipc/library.ts
@@ -111,12 +111,17 @@ async function parseAudioFilesViaUtility(
     const batch = filePaths.slice(i, i + PARSE_CONCURRENCY);
     const parsed = await Promise.all(
       batch.map(async filePath => {
-        const result = await utility.parse(filePath);
-        if (result.ok) {
-          return { filePath, metadata: result.metadata };
+        try {
+          const result = await utility.parse(filePath);
+          if (result.ok) {
+            return { filePath, metadata: result.metadata };
+          }
+          logger.warn(`[library] utility parse failed for ${filePath}: ${result.error}`);
+          return { filePath, metadata: fallbackMetadata(filePath) };
+        } catch (err) {
+          logger.warn(`[library] utility.parse rejected for ${filePath}:`, err);
+          return { filePath, metadata: fallbackMetadata(filePath) };
         }
-        logger.warn(`[library] utility parse failed for ${filePath}: ${result.error}`);
-        return { filePath, metadata: fallbackMetadata(filePath) };
       })
     );
     for (let j = 0; j < parsed.length; j++) {

--- a/apps/desktop/src/main/lib/album-art-image.test.ts
+++ b/apps/desktop/src/main/lib/album-art-image.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import sharp from 'sharp';
+import {
+  downscaleAndHash,
+  ALBUM_ART_MAX_DIMENSION,
+  ALBUM_ART_HASH_LENGTH,
+} from './album-art-image';
+
+/** Build a synthetic PNG of the given size for fixture-free tests. */
+async function makePng(
+  width: number,
+  height: number,
+  color: { r: number; g: number; b: number }
+): Promise<Buffer> {
+  return sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: color,
+    },
+  })
+    .png()
+    .toBuffer();
+}
+
+describe('downscaleAndHash', () => {
+  it('returns null for null/undefined/empty input', async () => {
+    expect(await downscaleAndHash(null)).toBeNull();
+    expect(await downscaleAndHash(undefined)).toBeNull();
+    expect(await downscaleAndHash(Buffer.alloc(0))).toBeNull();
+  });
+
+  it('returns null for undecodeable bytes', async () => {
+    const garbage = Buffer.from('this-is-not-an-image-payload-at-all');
+    expect(await downscaleAndHash(garbage)).toBeNull();
+  });
+
+  it('decodes a small PNG and re-encodes as JPEG', async () => {
+    const png = await makePng(64, 64, { r: 200, g: 100, b: 50 });
+    const result = await downscaleAndHash(png);
+    expect(result).not.toBeNull();
+    expect(result!.ext).toBe('.jpg');
+    expect(result!.fileName).toMatch(/^[0-9a-f]{32}\.jpg$/);
+    expect(result!.hash).toHaveLength(ALBUM_ART_HASH_LENGTH);
+
+    // Confirm the output really is JPEG (FF D8 FF magic bytes).
+    expect(result!.bytes[0]).toBe(0xff);
+    expect(result!.bytes[1]).toBe(0xd8);
+    expect(result!.bytes[2]).toBe(0xff);
+  });
+
+  it('clamps the longer edge to ALBUM_ART_MAX_DIMENSION', async () => {
+    const png = await makePng(2000, 1000, { r: 10, g: 20, b: 30 });
+    const result = await downscaleAndHash(png);
+    expect(result).not.toBeNull();
+
+    const meta = await sharp(result!.bytes).metadata();
+    expect(meta.width).toBe(ALBUM_ART_MAX_DIMENSION);
+    expect(meta.height).toBe(Math.round((1000 * ALBUM_ART_MAX_DIMENSION) / 2000));
+  });
+
+  it('does not upscale images smaller than ALBUM_ART_MAX_DIMENSION', async () => {
+    const png = await makePng(100, 80, { r: 0, g: 128, b: 255 });
+    const result = await downscaleAndHash(png);
+    expect(result).not.toBeNull();
+
+    const meta = await sharp(result!.bytes).metadata();
+    expect(meta.width).toBe(100);
+    expect(meta.height).toBe(80);
+  });
+
+  it('produces a deterministic hash for identical input', async () => {
+    const png = await makePng(50, 50, { r: 42, g: 42, b: 42 });
+    const a = await downscaleAndHash(png);
+    const b = await downscaleAndHash(png);
+    expect(a!.hash).toBe(b!.hash);
+    expect(a!.bytes.equals(b!.bytes)).toBe(true);
+  });
+
+  it('produces different hashes for different inputs', async () => {
+    const a = await downscaleAndHash(await makePng(100, 100, { r: 0, g: 0, b: 0 }));
+    const b = await downscaleAndHash(await makePng(100, 100, { r: 255, g: 255, b: 255 }));
+    expect(a!.hash).not.toBe(b!.hash);
+  });
+
+  it('accepts Uint8Array input', async () => {
+    const png = await makePng(32, 32, { r: 1, g: 2, b: 3 });
+    const view = new Uint8Array(png.buffer, png.byteOffset, png.byteLength);
+    const result = await downscaleAndHash(view);
+    expect(result).not.toBeNull();
+    expect(result!.fileName).toMatch(/^[0-9a-f]{32}\.jpg$/);
+  });
+});

--- a/apps/desktop/src/main/lib/album-art-image.ts
+++ b/apps/desktop/src/main/lib/album-art-image.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure helpers for downscaling + hashing album art bytes. Imported by both
+ * `art-protocol.ts` (main-process saveAlbumArt path, used by metadata-enrich
+ * IPC and base64 migration) and `scan-utility.ts` (utility process bulk-scan
+ * path).
+ *
+ * "Pure" here means: no Electron `app.getPath`, no IPC, no logger, no fs
+ * writes. Each caller layers its own disk-write step on top — main and the
+ * utility have different filesystem-access patterns and different error-
+ * reporting needs.
+ *
+ * Uses `sharp` (libvips bindings) for the decode + resize + JPEG encode.
+ * Sharp is the chosen path after the Phase 0 spike showed `nativeImage` is
+ * unavailable inside Electron's `utilityProcess`.
+ */
+
+import * as crypto from 'node:crypto';
+import sharp from 'sharp';
+
+/** Longer-edge clamp for cached covers. Matches art-protocol.ts. */
+export const ALBUM_ART_MAX_DIMENSION = 512;
+/** JPEG re-encode quality. Matches art-protocol.ts. */
+export const ALBUM_ART_JPEG_QUALITY = 85;
+/** Hash hex prefix length used for filenames (matches art-protocol.ts). */
+export const ALBUM_ART_HASH_LENGTH = 32;
+
+export interface DownscaledArt {
+  /** Re-encoded JPEG bytes. Always JPEG regardless of source format. */
+  bytes: Buffer;
+  /** SHA-256 of the resized bytes, truncated to ALBUM_ART_HASH_LENGTH chars. */
+  hash: string;
+  /** File extension to write under, currently always `.jpg`. */
+  ext: '.jpg';
+  /** Filename `<hash>.jpg` — convenience. */
+  fileName: string;
+}
+
+/**
+ * Decode `data` with sharp, downscale so the longer edge fits within
+ * ALBUM_ART_MAX_DIMENSION (no upscaling), and re-encode as JPEG q=85. Returns
+ * the resized bytes plus a content-addressed hash + filename.
+ *
+ * Returns `null` for empty input or undecodeable data — sharp throws a
+ * `VipsImage` error for garbage buffers; we swallow it and surface null so
+ * callers can early-return without try/catch boilerplate.
+ */
+export async function downscaleAndHash(
+  data: Buffer | Uint8Array | null | undefined
+): Promise<DownscaledArt | null> {
+  if (!data || data.length === 0) return null;
+
+  const input = Buffer.isBuffer(data) ? data : Buffer.from(data);
+
+  let bytes: Buffer;
+  try {
+    bytes = await sharp(input)
+      .resize({
+        width: ALBUM_ART_MAX_DIMENSION,
+        height: ALBUM_ART_MAX_DIMENSION,
+        fit: 'inside',
+        withoutEnlargement: true,
+      })
+      .jpeg({ quality: ALBUM_ART_JPEG_QUALITY })
+      .toBuffer();
+  } catch {
+    // Undecodeable input — covers garbage payloads, zero-length frames, and
+    // exotic formats sharp/libvips doesn't grok. Treat as "no art".
+    return null;
+  }
+
+  const hash = crypto
+    .createHash('sha256')
+    .update(bytes)
+    .digest('hex')
+    .slice(0, ALBUM_ART_HASH_LENGTH);
+  return {
+    bytes,
+    hash,
+    ext: '.jpg',
+    fileName: `${hash}.jpg`,
+  };
+}

--- a/apps/desktop/src/main/scan-utility-host.test.ts
+++ b/apps/desktop/src/main/scan-utility-host.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+vi.mock('./logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+/**
+ * Fake `UtilityProcess` — emits 'message' / 'exit' events and records
+ * everything posted via `postMessage` for assertions. Mirrors the surface
+ * `forkScanUtility` actually uses.
+ */
+class FakeUtilityProcess extends EventEmitter {
+  pid = 4242;
+  stderr = new EventEmitter();
+  posted: unknown[] = [];
+  killCalls = 0;
+
+  postMessage(msg: unknown): void {
+    this.posted.push(msg);
+  }
+
+  kill(): boolean {
+    this.killCalls++;
+    return true;
+  }
+
+  /** Push an `event.data`-style message from the utility back to main. */
+  emitMessage(data: unknown): void {
+    this.emit('message', data);
+  }
+
+  /** Simulate the child exiting with the given code. */
+  emitExit(code: number | null): void {
+    this.emit('exit', code);
+  }
+}
+
+vi.mock('electron', () => ({
+  utilityProcess: {
+    fork: vi.fn(),
+  },
+}));
+
+describe('forkScanUtility (Phase 1 plumbing)', () => {
+  let fake: FakeUtilityProcess;
+  let forkSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    fake = new FakeUtilityProcess();
+    forkSpy = vi.fn().mockReturnValue(fake);
+    const electron = await import('electron');
+    vi.mocked(electron.utilityProcess.fork).mockImplementation(forkSpy);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('forks the bundled scan-utility entry by default', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    forkScanUtility();
+    expect(forkSpy).toHaveBeenCalledTimes(1);
+    const [entry, args, opts] = forkSpy.mock.calls[0];
+    expect(typeof entry).toBe('string');
+    expect(entry).toMatch(/scan-utility\.js$/);
+    expect(args).toEqual([]);
+    expect(opts).toMatchObject({
+      serviceName: 'shiranami-scan-utility',
+      stdio: 'pipe',
+    });
+  });
+
+  it('honours custom entryPath + fork override (test wiring)', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    const customFork = vi.fn().mockReturnValue(fake);
+    forkScanUtility({ entryPath: '/tmp/custom.js', fork: customFork as never });
+    expect(customFork).toHaveBeenCalledWith(
+      '/tmp/custom.js',
+      [],
+      expect.objectContaining({ serviceName: 'shiranami-scan-utility' })
+    );
+    expect(forkSpy).not.toHaveBeenCalled();
+  });
+
+  it('exposes the child PID', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    const client = forkScanUtility();
+    expect(client.pid).toBe(4242);
+  });
+
+  it('resolves ready when utility-ready arrives', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    const client = forkScanUtility();
+
+    fake.emitMessage({ type: 'utility-ready' });
+    await expect(client.ready).resolves.toBeUndefined();
+  });
+
+  it('rejects ready when utility exits before signalling ready', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    const client = forkScanUtility();
+
+    fake.emitExit(7);
+    await expect(client.ready).rejects.toThrow(/exited before ready/);
+  });
+
+  it('rejects ready when the timeout fires before utility-ready arrives', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    const client = forkScanUtility();
+
+    // Attach a catch handler synchronously so the rejection isn't unhandled
+    // when the fake timer trips.
+    const readyAssertion = expect(client.ready).rejects.toThrow(/ready timeout/);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await readyAssertion;
+  });
+
+  it('round-trips hello → hello-ack with the utility PID', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    const client = forkScanUtility();
+    fake.emitMessage({ type: 'utility-ready' });
+    await client.ready;
+
+    const promise = client.hello();
+    expect(fake.posted).toEqual([{ type: 'hello' }]);
+    fake.emitMessage({ type: 'hello-ack', pid: 9999 });
+
+    await expect(promise).resolves.toEqual({ pid: 9999 });
+  });
+
+  it('rejects hello when the timeout fires before hello-ack', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    const client = forkScanUtility();
+    fake.emitMessage({ type: 'utility-ready' });
+    await client.ready;
+
+    const helloAssertion = expect(client.hello()).rejects.toThrow(/hello timeout/);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await helloAssertion;
+  });
+
+  it('rejects hello when the utility exits mid-handshake', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    const client = forkScanUtility();
+    fake.emitMessage({ type: 'utility-ready' });
+    await client.ready;
+
+    const promise = client.hello();
+    fake.emitExit(1);
+    await expect(promise).rejects.toThrow(/exited before hello-ack/);
+  });
+
+  it('rejects hello when called after kill()', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    const client = forkScanUtility();
+    fake.emitMessage({ type: 'utility-ready' });
+    await client.ready;
+    client.kill();
+
+    await expect(client.hello()).rejects.toThrow(/already killed/);
+  });
+
+  it('rejects a second hello while one is in flight', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    const client = forkScanUtility();
+    fake.emitMessage({ type: 'utility-ready' });
+    await client.ready;
+
+    const first = client.hello();
+    await expect(client.hello()).rejects.toThrow(/already in flight/);
+    fake.emitMessage({ type: 'hello-ack', pid: 9999 });
+    await expect(first).resolves.toEqual({ pid: 9999 });
+  });
+
+  it('kill() invokes child.kill once and is idempotent', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    const client = forkScanUtility();
+    expect(client.killed).toBe(false);
+
+    client.kill();
+    client.kill();
+    expect(client.killed).toBe(true);
+    expect(fake.killCalls).toBe(1);
+  });
+
+  it('marks killed=true and rejects pending hello when child emits exit', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    const client = forkScanUtility();
+    fake.emitMessage({ type: 'utility-ready' });
+    await client.ready;
+
+    const promise = client.hello();
+    fake.emitExit(0);
+
+    expect(client.killed).toBe(true);
+    await expect(promise).rejects.toThrow(/exited before hello-ack/);
+  });
+
+  it('ignores non-object messages safely', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    const client = forkScanUtility();
+    fake.emitMessage(null);
+    fake.emitMessage('string');
+    fake.emitMessage(123);
+    fake.emitMessage({ type: 'utility-ready' });
+    await expect(client.ready).resolves.toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/scan-utility-host.test.ts
+++ b/apps/desktop/src/main/scan-utility-host.test.ts
@@ -155,7 +155,7 @@ describe('forkScanUtility (Phase 1 plumbing)', () => {
 
     const promise = client.hello();
     fake.emitExit(1);
-    await expect(promise).rejects.toThrow(/exited before hello-ack/);
+    await expect(promise).rejects.toThrow(/scan-utility exited/);
   });
 
   it('rejects hello when called after kill()', async () => {
@@ -201,7 +201,7 @@ describe('forkScanUtility (Phase 1 plumbing)', () => {
     fake.emitExit(0);
 
     expect(client.killed).toBe(true);
-    await expect(promise).rejects.toThrow(/exited before hello-ack/);
+    await expect(promise).rejects.toThrow(/scan-utility exited/);
   });
 
   it('ignores non-object messages safely', async () => {

--- a/apps/desktop/src/main/scan-utility-host.test.ts
+++ b/apps/desktop/src/main/scan-utility-host.test.ts
@@ -185,6 +185,10 @@ describe('forkScanUtility (Phase 1 plumbing)', () => {
     const client = forkScanUtility();
     expect(client.killed).toBe(false);
 
+    // Suppress the ready rejection so Node doesn't see an unhandled rejection
+    // when kill() fires before utility-ready arrives.
+    client.ready.catch(() => {});
+
     client.kill();
     client.kill();
     expect(client.killed).toBe(true);
@@ -212,5 +216,24 @@ describe('forkScanUtility (Phase 1 plumbing)', () => {
     fake.emitMessage(123);
     fake.emitMessage({ type: 'utility-ready' });
     await expect(client.ready).resolves.toBeUndefined();
+  });
+
+  it('rejects ready synchronously when kill() is called before utility-ready arrives', async () => {
+    const { forkScanUtility } = await import('./scan-utility-host');
+    const client = forkScanUtility();
+
+    // Capture the rejection before kill() fires it so Node does not see an
+    // unhandled rejection. The assertion is resolved after kill() returns.
+    const readyResult = client.ready.then(
+      () => ({ threw: false, error: null as Error | null }),
+      (err: Error) => ({ threw: true, error: err })
+    );
+
+    // kill() while utility-ready has not been posted yet.
+    client.kill();
+
+    const { threw, error } = await readyResult;
+    expect(threw).toBe(true);
+    expect(error?.message).toMatch(/killed before ready/);
   });
 });

--- a/apps/desktop/src/main/scan-utility-host.ts
+++ b/apps/desktop/src/main/scan-utility-host.ts
@@ -230,6 +230,11 @@ export function forkScanUtility(options: ForkScanUtilityOptions = {}): ScanUtili
     if (text) logger.warn(`[scan-utility stderr] ${text}`);
   });
 
+  // Drain stdout unconditionally. Sharp, music-metadata, and Node itself write
+  // warnings there; if left unread, the 64 KB pipe buffer fills and the utility
+  // stalls mid-scan.
+  child.stdout?.on('data', () => {});
+
   return {
     get pid(): number {
       return child.pid ?? -1;

--- a/apps/desktop/src/main/scan-utility-host.ts
+++ b/apps/desktop/src/main/scan-utility-host.ts
@@ -2,8 +2,9 @@
  * Main-process host for the scan utility. Wraps `utilityProcess.fork()` into
  * an async client that the IPC layer can `await` against.
  *
- * Phase 1 scope: hello/ack round-trip + clean kill. Phase 2 will add the
- * `init` and `parse` message types and full lifecycle.
+ * Phase 2: hello/ack + init + parse round-trips. Each `parse(filePath)` call
+ * returns the music-metadata + shiranami-art:// URL as decoded inside the
+ * utility — cover Buffers do NOT cross the IPC boundary.
  *
  * Design context: docs/arch/2026-05-04-metadata-scan-utility-process-plan.md
  */
@@ -23,6 +24,29 @@ function defaultUtilityEntry(): string {
 
 const HELLO_TIMEOUT_MS = 5_000;
 const READY_TIMEOUT_MS = 5_000;
+const INIT_TIMEOUT_MS = 5_000;
+/**
+ * No bound on parse — the utility owns concurrency and a slow file (network
+ * mount, huge FLAC) can legitimately take seconds. Deadlocks are caught by
+ * the host calling kill() at scan teardown.
+ */
+
+/** Metadata shape echoed back from the utility. Mirrors TrackMetadata. */
+export interface ScanUtilityMetadata {
+  title: string;
+  artist: string;
+  album: string;
+  duration: number;
+  genre: string;
+  year: number | null;
+  trackNumber: number | null;
+  discNumber: number | null;
+  albumArt: string | null;
+}
+
+export type ParseResult =
+  | { ok: true; metadata: ScanUtilityMetadata }
+  | { ok: false; error: string };
 
 export interface ScanUtilityClient {
   /** PID of the underlying utility process. */
@@ -31,6 +55,10 @@ export interface ScanUtilityClient {
   readonly ready: Promise<void>;
   /** Round-trip a hello/ack handshake. Resolves with the utility's PID. */
   hello(): Promise<{ pid: number }>;
+  /** Send the userData path to the utility. Resolves on `init-ack`. */
+  init(opts: { userDataPath: string }): Promise<void>;
+  /** Parse one file. Resolves with metadata + shiranami-art:// URL. */
+  parse(filePath: string): Promise<ParseResult>;
   /** Send SIGTERM and remove all listeners. Idempotent. */
   kill(): void;
   /** Whether `kill()` has been invoked or the process has exited. */
@@ -55,6 +83,17 @@ interface PendingHello {
   timer: NodeJS.Timeout;
 }
 
+interface PendingInit {
+  resolve: () => void;
+  reject: (reason: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+interface PendingParse {
+  resolve: (value: ParseResult) => void;
+  reject: (reason: Error) => void;
+}
+
 /**
  * Fork a fresh scan-utility process. Returns a client whose `ready` promise
  * resolves once the utility has signalled it is wired up.
@@ -73,6 +112,11 @@ export function forkScanUtility(options: ForkScanUtilityOptions = {}): ScanUtili
 
   let killed = false;
   let pendingHello: PendingHello | null = null;
+  let pendingInit: PendingInit | null = null;
+  /** Map of in-flight parse requests by ID, so utility messages can route back. */
+  const pendingParses = new Map<number, PendingParse>();
+  let nextRequestId = 1;
+
   let resolveReady: (() => void) | null = null;
   let rejectReady: ((reason: Error) => void) | null = null;
   const ready = new Promise<void>((resolve, reject) => {
@@ -90,6 +134,23 @@ export function forkScanUtility(options: ForkScanUtilityOptions = {}): ScanUtili
   }, READY_TIMEOUT_MS);
   // Don't keep the event loop alive just for this guard.
   readyTimer.unref?.();
+
+  function rejectAllPending(reason: Error): void {
+    if (pendingHello) {
+      clearTimeout(pendingHello.timer);
+      pendingHello.reject(reason);
+      pendingHello = null;
+    }
+    if (pendingInit) {
+      clearTimeout(pendingInit.timer);
+      pendingInit.reject(reason);
+      pendingInit = null;
+    }
+    for (const pending of pendingParses.values()) {
+      pending.reject(reason);
+    }
+    pendingParses.clear();
+  }
 
   child.on('message', (raw: unknown) => {
     if (!raw || typeof raw !== 'object') return;
@@ -114,9 +175,39 @@ export function forkScanUtility(options: ForkScanUtilityOptions = {}): ScanUtili
         }
         break;
 
+      case 'init-ack':
+        if (pendingInit) {
+          clearTimeout(pendingInit.timer);
+          pendingInit.resolve();
+          pendingInit = null;
+        }
+        break;
+
+      case 'parse-result': {
+        const requestId = typeof msg.requestId === 'number' ? msg.requestId : -1;
+        const pending = pendingParses.get(requestId);
+        if (!pending) {
+          logger.warn(`[scan-utility-host] orphan parse-result requestId=${requestId}`);
+          break;
+        }
+        pendingParses.delete(requestId);
+        if (msg.ok === true) {
+          pending.resolve({
+            ok: true,
+            metadata: msg.metadata as ScanUtilityMetadata,
+          });
+        } else {
+          pending.resolve({
+            ok: false,
+            error: typeof msg.error === 'string' ? msg.error : 'unknown utility parse error',
+          });
+        }
+        break;
+      }
+
       default:
-        // Phase 2 will add 'parse-result', 'log', etc. Unknown types in
-        // Phase 1 are warnings, not fatal — keeps the protocol additive.
+        // Phase 3+ will add 'log', etc. Unknown types in Phase 2 are warnings,
+        // not fatal — keeps the protocol additive.
         logger.warn(`[scan-utility-host] unknown message type: ${String(msg.type)}`);
     }
   });
@@ -130,13 +221,7 @@ export function forkScanUtility(options: ForkScanUtilityOptions = {}): ScanUtili
       resolveReady = null;
       rejectReady = null;
     }
-    if (pendingHello) {
-      clearTimeout(pendingHello.timer);
-      pendingHello.reject(
-        new Error(`scan-utility exited before hello-ack (code=${code ?? 'null'})`)
-      );
-      pendingHello = null;
-    }
+    rejectAllPending(new Error(`scan-utility exited (code=${code ?? 'null'})`));
   });
 
   // stderr fallback — Phase 4 will replace this with a proper log bridge.
@@ -166,15 +251,33 @@ export function forkScanUtility(options: ForkScanUtilityOptions = {}): ScanUtili
         child.postMessage({ type: 'hello' });
       });
     },
+    async init({ userDataPath }: { userDataPath: string }): Promise<void> {
+      if (killed) throw new Error('scan-utility already killed');
+      if (pendingInit) throw new Error('scan-utility init already in flight');
+
+      return new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pendingInit = null;
+          reject(new Error(`scan-utility init timeout (${INIT_TIMEOUT_MS}ms)`));
+        }, INIT_TIMEOUT_MS);
+        timer.unref?.();
+        pendingInit = { resolve, reject, timer };
+        child.postMessage({ type: 'init', userDataPath });
+      });
+    },
+    async parse(filePath: string): Promise<ParseResult> {
+      if (killed) throw new Error('scan-utility already killed');
+      const requestId = nextRequestId++;
+      return new Promise<ParseResult>((resolve, reject) => {
+        pendingParses.set(requestId, { resolve, reject });
+        child.postMessage({ type: 'parse', requestId, filePath });
+      });
+    },
     kill(): void {
       if (killed) return;
       killed = true;
       clearTimeout(readyTimer);
-      if (pendingHello) {
-        clearTimeout(pendingHello.timer);
-        pendingHello.reject(new Error('scan-utility killed'));
-        pendingHello = null;
-      }
+      rejectAllPending(new Error('scan-utility killed'));
       try {
         child.kill();
       } catch (err) {

--- a/apps/desktop/src/main/scan-utility-host.ts
+++ b/apps/desktop/src/main/scan-utility-host.ts
@@ -282,6 +282,11 @@ export function forkScanUtility(options: ForkScanUtilityOptions = {}): ScanUtili
       if (killed) return;
       killed = true;
       clearTimeout(readyTimer);
+      if (resolveReady) {
+        rejectReady?.(new Error('scan-utility killed before ready'));
+        resolveReady = null;
+        rejectReady = null;
+      }
       rejectAllPending(new Error('scan-utility killed'));
       try {
         child.kill();

--- a/apps/desktop/src/main/scan-utility-host.ts
+++ b/apps/desktop/src/main/scan-utility-host.ts
@@ -1,0 +1,188 @@
+/**
+ * Main-process host for the scan utility. Wraps `utilityProcess.fork()` into
+ * an async client that the IPC layer can `await` against.
+ *
+ * Phase 1 scope: hello/ack round-trip + clean kill. Phase 2 will add the
+ * `init` and `parse` message types and full lifecycle.
+ *
+ * Design context: docs/arch/2026-05-04-metadata-scan-utility-process-plan.md
+ */
+
+import * as path from 'path';
+import { utilityProcess, type UtilityProcess } from 'electron';
+import { logger } from './logger';
+
+/**
+ * Resolved path to the bundled utility entry. esbuild emits this alongside
+ * `dist/main/index.js`, so `__dirname` resolution works in dev (esbuild
+ * output) and packaged (asar) builds alike.
+ */
+function defaultUtilityEntry(): string {
+  return path.join(__dirname, 'scan-utility.js');
+}
+
+const HELLO_TIMEOUT_MS = 5_000;
+const READY_TIMEOUT_MS = 5_000;
+
+export interface ScanUtilityClient {
+  /** PID of the underlying utility process. */
+  readonly pid: number;
+  /** Resolves once the utility has posted `utility-ready`. */
+  readonly ready: Promise<void>;
+  /** Round-trip a hello/ack handshake. Resolves with the utility's PID. */
+  hello(): Promise<{ pid: number }>;
+  /** Send SIGTERM and remove all listeners. Idempotent. */
+  kill(): void;
+  /** Whether `kill()` has been invoked or the process has exited. */
+  readonly killed: boolean;
+}
+
+export interface ForkScanUtilityOptions {
+  /** Override the bundled entry path (tests). */
+  entryPath?: string;
+  /** Override the spawner (tests). */
+  fork?: typeof utilityProcess.fork;
+}
+
+interface UtilityMessage {
+  type: string;
+  [key: string]: unknown;
+}
+
+interface PendingHello {
+  resolve: (value: { pid: number }) => void;
+  reject: (reason: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+/**
+ * Fork a fresh scan-utility process. Returns a client whose `ready` promise
+ * resolves once the utility has signalled it is wired up.
+ *
+ * Caller must invoke `kill()` exactly once when done — usually inside a
+ * try/finally around the scan loop.
+ */
+export function forkScanUtility(options: ForkScanUtilityOptions = {}): ScanUtilityClient {
+  const entryPath = options.entryPath ?? defaultUtilityEntry();
+  const forkFn = options.fork ?? utilityProcess.fork;
+
+  const child: UtilityProcess = forkFn(entryPath, [], {
+    serviceName: 'shiranami-scan-utility',
+    stdio: 'pipe',
+  });
+
+  let killed = false;
+  let pendingHello: PendingHello | null = null;
+  let resolveReady: (() => void) | null = null;
+  let rejectReady: ((reason: Error) => void) | null = null;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+
+  const readyTimer = setTimeout(() => {
+    if (resolveReady) {
+      const err = new Error(`scan-utility ready timeout (${READY_TIMEOUT_MS}ms)`);
+      rejectReady?.(err);
+      resolveReady = null;
+      rejectReady = null;
+    }
+  }, READY_TIMEOUT_MS);
+  // Don't keep the event loop alive just for this guard.
+  readyTimer.unref?.();
+
+  child.on('message', (raw: unknown) => {
+    if (!raw || typeof raw !== 'object') return;
+    const msg = raw as UtilityMessage;
+
+    switch (msg.type) {
+      case 'utility-ready':
+        if (resolveReady) {
+          clearTimeout(readyTimer);
+          resolveReady();
+          resolveReady = null;
+          rejectReady = null;
+        }
+        break;
+
+      case 'hello-ack':
+        if (pendingHello) {
+          clearTimeout(pendingHello.timer);
+          const pid = typeof msg.pid === 'number' ? msg.pid : (child.pid ?? -1);
+          pendingHello.resolve({ pid });
+          pendingHello = null;
+        }
+        break;
+
+      default:
+        // Phase 2 will add 'parse-result', 'log', etc. Unknown types in
+        // Phase 1 are warnings, not fatal — keeps the protocol additive.
+        logger.warn(`[scan-utility-host] unknown message type: ${String(msg.type)}`);
+    }
+  });
+
+  child.on('exit', (code: number | null) => {
+    killed = true;
+    clearTimeout(readyTimer);
+    if (resolveReady) {
+      const err = new Error(`scan-utility exited before ready (code=${code ?? 'null'})`);
+      rejectReady?.(err);
+      resolveReady = null;
+      rejectReady = null;
+    }
+    if (pendingHello) {
+      clearTimeout(pendingHello.timer);
+      pendingHello.reject(
+        new Error(`scan-utility exited before hello-ack (code=${code ?? 'null'})`)
+      );
+      pendingHello = null;
+    }
+  });
+
+  // stderr fallback — Phase 4 will replace this with a proper log bridge.
+  child.stderr?.on('data', (chunk: Buffer) => {
+    const text = chunk.toString('utf8').trimEnd();
+    if (text) logger.warn(`[scan-utility stderr] ${text}`);
+  });
+
+  return {
+    get pid(): number {
+      return child.pid ?? -1;
+    },
+    ready,
+    async hello(): Promise<{ pid: number }> {
+      if (killed) throw new Error('scan-utility already killed');
+      if (pendingHello) {
+        throw new Error('scan-utility hello already in flight');
+      }
+
+      return new Promise<{ pid: number }>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pendingHello = null;
+          reject(new Error(`scan-utility hello timeout (${HELLO_TIMEOUT_MS}ms)`));
+        }, HELLO_TIMEOUT_MS);
+        timer.unref?.();
+        pendingHello = { resolve, reject, timer };
+        child.postMessage({ type: 'hello' });
+      });
+    },
+    kill(): void {
+      if (killed) return;
+      killed = true;
+      clearTimeout(readyTimer);
+      if (pendingHello) {
+        clearTimeout(pendingHello.timer);
+        pendingHello.reject(new Error('scan-utility killed'));
+        pendingHello = null;
+      }
+      try {
+        child.kill();
+      } catch (err) {
+        logger.warn('[scan-utility-host] kill threw:', err);
+      }
+    },
+    get killed(): boolean {
+      return killed;
+    },
+  };
+}

--- a/apps/desktop/src/main/scan-utility-spike.ts
+++ b/apps/desktop/src/main/scan-utility-spike.ts
@@ -1,0 +1,83 @@
+/**
+ * Phase 0 spike — verify that Electron's `nativeImage` is functional inside a
+ * `utilityProcess`. Receives a JPEG/PNG buffer from the parent, runs the same
+ * decode + resize + JPEG-encode pipeline that `art-protocol.ts:downscaleImage`
+ * uses today, and posts back either the encoded byte length or the failure
+ * reason. The parent harness in `scripts/spike-utility-process.cjs` reads the
+ * result and prints PASS / FAIL.
+ *
+ * If this works, Phase 2 can move `saveAlbumArt` into the utility unchanged.
+ * If it fails, the user must approve adding `sharp` (heavy native dep) before
+ * Phase 2 proceeds.
+ */
+
+import { nativeImage } from 'electron';
+
+interface SpikeRequest {
+  type: 'spike';
+  input: Uint8Array; // structured-clone passes Uint8Array natively
+}
+
+interface SpikeResultOk {
+  type: 'spike-result';
+  ok: true;
+  outputSize: number;
+  width: number;
+  height: number;
+}
+
+interface SpikeResultErr {
+  type: 'spike-result';
+  ok: false;
+  error: string;
+}
+
+type SpikeResult = SpikeResultOk | SpikeResultErr;
+
+const MAX_DIMENSION = 256;
+
+function runSpike(input: Buffer): SpikeResult {
+  try {
+    const image = nativeImage.createFromBuffer(input);
+    if (image.isEmpty()) {
+      return { type: 'spike-result', ok: false, error: 'nativeImage decoded to empty image' };
+    }
+    const { width, height } = image.getSize();
+    const resized = image.resize({ width: MAX_DIMENSION, quality: 'best' });
+    const out = resized.toJPEG(85);
+    return {
+      type: 'spike-result',
+      ok: true,
+      outputSize: out.length,
+      width,
+      height,
+    };
+  } catch (e) {
+    return {
+      type: 'spike-result',
+      ok: false,
+      error: e instanceof Error ? `${e.name}: ${e.message}` : String(e),
+    };
+  }
+}
+
+// `parentPort` is exposed on `process` inside an Electron utilityProcess.
+// Type stub: cast through `unknown` since @types/node doesn't know about it.
+const parentPort = (
+  process as unknown as { parentPort?: NodeJS.EventEmitter & { postMessage(msg: unknown): void } }
+).parentPort;
+
+if (!parentPort) {
+  // Running outside utilityProcess — fail loudly.
+  console.error('[scan-utility-spike] parentPort missing — not running inside utilityProcess');
+  process.exit(1);
+}
+
+parentPort.on('message', (msg: SpikeRequest) => {
+  if (msg?.type !== 'spike') return;
+  const result = runSpike(Buffer.from(msg.input));
+  parentPort.postMessage(result);
+});
+
+// Signal readiness so the parent knows the IPC listener is wired.
+parentPort.postMessage({ type: 'spike-ready' });

--- a/apps/desktop/src/main/scan-utility-spike.ts
+++ b/apps/desktop/src/main/scan-utility-spike.ts
@@ -63,8 +63,19 @@ function runSpike(input: Buffer): SpikeResult {
 
 // `parentPort` is exposed on `process` inside an Electron utilityProcess.
 // Type stub: cast through `unknown` since @types/node doesn't know about it.
+// IMPORTANT: parentPort.on('message') wraps each message in a MessageEvent —
+// the actual payload lives at `event.data`. This is asymmetric with the parent
+// side, where `UtilityProcess.on('message')` already unwraps to the raw data.
+interface ParentPortMessageEvent {
+  data: unknown;
+}
 const parentPort = (
-  process as unknown as { parentPort?: NodeJS.EventEmitter & { postMessage(msg: unknown): void } }
+  process as unknown as {
+    parentPort?: {
+      on(event: 'message', listener: (event: ParentPortMessageEvent) => void): void;
+      postMessage(msg: unknown): void;
+    };
+  }
 ).parentPort;
 
 if (!parentPort) {
@@ -73,7 +84,8 @@ if (!parentPort) {
   process.exit(1);
 }
 
-parentPort.on('message', (msg: SpikeRequest) => {
+parentPort.on('message', event => {
+  const msg = event.data as SpikeRequest | undefined;
   if (msg?.type !== 'spike') return;
   const result = runSpike(Buffer.from(msg.input));
   parentPort.postMessage(result);

--- a/apps/desktop/src/main/scan-utility-spike.ts
+++ b/apps/desktop/src/main/scan-utility-spike.ts
@@ -1,17 +1,20 @@
 /**
- * Phase 0 spike — verify that Electron's `nativeImage` is functional inside a
- * `utilityProcess`. Receives a JPEG/PNG buffer from the parent, runs the same
- * decode + resize + JPEG-encode pipeline that `art-protocol.ts:downscaleImage`
- * uses today, and posts back either the encoded byte length or the failure
- * reason. The parent harness in `scripts/spike-utility-process.cjs` reads the
- * result and prints PASS / FAIL.
+ * Phase 0 spike (sharp variant) — verify that `sharp` decode + resize + JPEG-
+ * encode works inside an Electron `utilityProcess`.
  *
- * If this works, Phase 2 can move `saveAlbumArt` into the utility unchanged.
- * If it fails, the user must approve adding `sharp` (heavy native dep) before
- * Phase 2 proceeds.
+ * History: the original spike tested `nativeImage` from `electron`; that
+ * failed because `nativeImage` is undefined inside utilityProcess (it's a
+ * main/renderer-only API). User picked Option A from the spike-result doc:
+ * add `sharp` as a native dep. This retargeted spike confirms the Phase 2
+ * design works with sharp before we commit to the rest of the work.
+ *
+ * Receives a JPEG/PNG buffer from the parent, runs sharp's decode pipeline,
+ * and posts back the encoded byte length or the failure reason. The parent
+ * harness in `scripts/spike-utility-process.cjs` reads the result and prints
+ * PASS / FAIL.
  */
 
-import { nativeImage } from 'electron';
+import sharp from 'sharp';
 
 interface SpikeRequest {
   type: 'spike';
@@ -36,21 +39,20 @@ type SpikeResult = SpikeResultOk | SpikeResultErr;
 
 const MAX_DIMENSION = 256;
 
-function runSpike(input: Buffer): SpikeResult {
+async function runSpike(input: Buffer): Promise<SpikeResult> {
   try {
-    const image = nativeImage.createFromBuffer(input);
-    if (image.isEmpty()) {
-      return { type: 'spike-result', ok: false, error: 'nativeImage decoded to empty image' };
-    }
-    const { width, height } = image.getSize();
-    const resized = image.resize({ width: MAX_DIMENSION, quality: 'best' });
-    const out = resized.toJPEG(85);
+    const pipeline = sharp(input);
+    const meta = await pipeline.metadata();
+    const out = await pipeline
+      .resize({ width: MAX_DIMENSION, withoutEnlargement: true })
+      .jpeg({ quality: 85 })
+      .toBuffer();
     return {
       type: 'spike-result',
       ok: true,
       outputSize: out.length,
-      width,
-      height,
+      width: meta.width ?? 0,
+      height: meta.height ?? 0,
     };
   } catch (e) {
     return {
@@ -87,8 +89,9 @@ if (!parentPort) {
 parentPort.on('message', event => {
   const msg = event.data as SpikeRequest | undefined;
   if (msg?.type !== 'spike') return;
-  const result = runSpike(Buffer.from(msg.input));
-  parentPort.postMessage(result);
+  void runSpike(Buffer.from(msg.input)).then(result => {
+    parentPort.postMessage(result);
+  });
 });
 
 // Signal readiness so the parent knows the IPC listener is wired.

--- a/apps/desktop/src/main/scan-utility.ts
+++ b/apps/desktop/src/main/scan-utility.ts
@@ -5,8 +5,10 @@
  * scan completes so the OS reclaims the V8 heap (the entire point of the
  * migration).
  *
- * Phase 1 scope: skeleton only. Listens for `hello` and replies `hello-ack`.
- * Real parse/cover-write logic lands in Phase 2.
+ * Phase 2: handles `init` (receives userData path) and `parse` (decodes one
+ * file, writes any embedded cover to disk under `userData/album-art/`,
+ * returns metadata + shiranami-art:// URL). Cover Buffers do NOT cross the
+ * IPC boundary.
  *
  * Design context: docs/arch/2026-05-04-metadata-scan-utility-process-plan.md
  *
@@ -14,6 +16,10 @@
  * the actual payload lives at `event.data`. This is asymmetric with the parent
  * side, where `UtilityProcess.on('message')` already unwraps to the raw data.
  */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { downscaleAndHash } from './lib/album-art-image';
 
 interface ParentPortMessageEvent {
   data: unknown;
@@ -33,33 +39,248 @@ if (!parentPort) {
   process.exit(1);
 }
 
+// ---------------------------------------------------------------------------
+// Wire types — keep in sync with scan-utility-host.ts.
+// ---------------------------------------------------------------------------
+
 interface HelloMessage {
   type: 'hello';
 }
-
-interface HelloAckMessage {
-  type: 'hello-ack';
-  pid: number;
+interface InitMessage {
+  type: 'init';
+  userDataPath: string;
 }
+interface ParseMessage {
+  type: 'parse';
+  requestId: number;
+  filePath: string;
+}
+
+type IncomingMessage = HelloMessage | InitMessage | ParseMessage;
 
 interface UtilityReadyMessage {
   type: 'utility-ready';
 }
+interface HelloAckMessage {
+  type: 'hello-ack';
+  pid: number;
+}
+interface InitAckMessage {
+  type: 'init-ack';
+}
 
-type IncomingMessage = HelloMessage;
-type OutgoingMessage = HelloAckMessage | UtilityReadyMessage;
+interface ParseSuccessMetadata {
+  title: string;
+  artist: string;
+  album: string;
+  duration: number;
+  genre: string;
+  year: number | null;
+  trackNumber: number | null;
+  discNumber: number | null;
+  albumArt: string | null;
+}
+interface ParseSuccessMessage {
+  type: 'parse-result';
+  requestId: number;
+  ok: true;
+  metadata: ParseSuccessMetadata;
+}
+interface ParseErrorMessage {
+  type: 'parse-result';
+  requestId: number;
+  ok: false;
+  error: string;
+}
+
+type OutgoingMessage =
+  | UtilityReadyMessage
+  | HelloAckMessage
+  | InitAckMessage
+  | ParseSuccessMessage
+  | ParseErrorMessage;
 
 function post(msg: OutgoingMessage): void {
   parentPort!.postMessage(msg);
+}
+
+// ---------------------------------------------------------------------------
+// Lazy module + state
+// ---------------------------------------------------------------------------
+
+let mmModule: typeof import('music-metadata') | null = null;
+async function getMusicMetadata(): Promise<typeof import('music-metadata')> {
+  if (!mmModule) {
+    mmModule = await import('music-metadata');
+  }
+  return mmModule;
+}
+
+interface UtilityState {
+  userDataPath: string;
+  artDir: string;
+  artDirEnsured: boolean;
+}
+
+let state: UtilityState | null = null;
+
+function ensureArtDir(s: UtilityState): void {
+  if (s.artDirEnsured) return;
+  if (!fs.existsSync(s.artDir)) {
+    fs.mkdirSync(s.artDir, { recursive: true });
+  }
+  s.artDirEnsured = true;
+}
+
+function toArtUrl(fileName: string): string {
+  return `shiranami-art://art/${fileName}`;
+}
+
+// ---------------------------------------------------------------------------
+// Cover write — content-addressed JPEG cache. Mirrors saveAlbumArt() in
+// art-protocol.ts but uses sharp (via downscaleAndHash) and does no logging.
+// Returns the protocol URL or null when there is nothing to save.
+// ---------------------------------------------------------------------------
+
+async function saveAlbumArtToDisk(
+  s: UtilityState,
+  data: Buffer | Uint8Array
+): Promise<string | null> {
+  const downscaled = await downscaleAndHash(data);
+  if (!downscaled) return null;
+
+  ensureArtDir(s);
+  const filePath = path.join(s.artDir, downscaled.fileName);
+
+  try {
+    await fs.promises.writeFile(filePath, downscaled.bytes, { flag: 'wx' });
+  } catch (error: unknown) {
+    // EEXIST is the dedup happy-path — content-addressed naming means a
+    // duplicate write is a no-op. Any other error gets surfaced.
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code !== 'EEXIST') {
+      throw error;
+    }
+  }
+
+  return toArtUrl(downscaled.fileName);
+}
+
+// ---------------------------------------------------------------------------
+// Parse one file. Mirrors parseAudioMetadata() in metadata-service.ts but
+// without the logger import (Phase 4 will wire a log bridge). Errors are
+// swallowed and surface as the same fallback metadata shape main expects.
+// ---------------------------------------------------------------------------
+
+async function parseFile(s: UtilityState, filePath: string): Promise<ParseSuccessMetadata> {
+  const mm = await getMusicMetadata();
+  const fallbackTitle = path.basename(filePath, path.extname(filePath));
+
+  try {
+    const metadata = await mm.parseFile(filePath, { skipCovers: false });
+    const common = metadata.common;
+    const format = metadata.format;
+
+    let albumArt: string | null = null;
+    if (common.picture && common.picture.length > 0) {
+      const pic = common.picture[0];
+      try {
+        albumArt = await saveAlbumArtToDisk(s, pic.data);
+      } catch (err) {
+        // Log to stderr so main's stderr-pipe sees it; cover failure shouldn't
+        // sink the whole track. Phase 4 will replace this with a log bridge.
+        console.error(`[scan-utility] cover write failed for ${filePath}:`, err);
+      }
+    }
+
+    return {
+      title: common.title || fallbackTitle,
+      artist: common.artist || 'Unknown Artist',
+      album: common.album || 'Unknown Album',
+      duration: format.duration || 0,
+      genre: common.genre?.[0] || '',
+      year: common.year || null,
+      trackNumber: common.track?.no ?? null,
+      discNumber: common.disk?.no ?? null,
+      albumArt,
+    };
+  } catch (err) {
+    console.error(`[scan-utility] parse failed for ${filePath}:`, err);
+    return {
+      title: fallbackTitle,
+      artist: 'Unknown Artist',
+      album: 'Unknown Album',
+      duration: 0,
+      genre: '',
+      year: null,
+      trackNumber: null,
+      discNumber: null,
+      albumArt: null,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Message dispatcher
+// ---------------------------------------------------------------------------
+
+function handleParse(msg: ParseMessage): void {
+  if (!state) {
+    post({
+      type: 'parse-result',
+      requestId: msg.requestId,
+      ok: false,
+      error: 'utility not initialised — main must send init before parse',
+    });
+    return;
+  }
+
+  // Run async work without blocking the message loop.
+  void parseFile(state, msg.filePath).then(
+    metadata => {
+      post({ type: 'parse-result', requestId: msg.requestId, ok: true, metadata });
+    },
+    err => {
+      // parseFile already returns fallback metadata for parser-side errors;
+      // a rejection here means something fundamental (out of memory, etc.).
+      post({
+        type: 'parse-result',
+        requestId: msg.requestId,
+        ok: false,
+        error: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+      });
+    }
+  );
 }
 
 parentPort.on('message', event => {
   const msg = event.data as IncomingMessage | undefined;
   if (!msg || typeof msg !== 'object') return;
 
-  if (msg.type === 'hello') {
-    post({ type: 'hello-ack', pid: process.pid });
-    return;
+  switch (msg.type) {
+    case 'hello':
+      post({ type: 'hello-ack', pid: process.pid });
+      return;
+
+    case 'init':
+      if (!state) {
+        const userDataPath = msg.userDataPath;
+        state = {
+          userDataPath,
+          artDir: path.join(userDataPath, 'album-art'),
+          artDirEnsured: false,
+        };
+      }
+      post({ type: 'init-ack' });
+      return;
+
+    case 'parse':
+      handleParse(msg);
+      return;
+
+    default:
+      // Unknown types are ignored — keeps the protocol additive for Phase 3+.
+      return;
   }
 });
 

--- a/apps/desktop/src/main/scan-utility.ts
+++ b/apps/desktop/src/main/scan-utility.ts
@@ -1,0 +1,67 @@
+/**
+ * Scan utility process — runs music-metadata parsing and embedded-cover
+ * decode/downscale/disk-write off the Electron main process. Forked per scan
+ * via `utilityProcess.fork()` from `scan-utility-host.ts`; exits when the
+ * scan completes so the OS reclaims the V8 heap (the entire point of the
+ * migration).
+ *
+ * Phase 1 scope: skeleton only. Listens for `hello` and replies `hello-ack`.
+ * Real parse/cover-write logic lands in Phase 2.
+ *
+ * Design context: docs/arch/2026-05-04-metadata-scan-utility-process-plan.md
+ *
+ * IMPORTANT: parentPort.on('message') wraps each message in a MessageEvent —
+ * the actual payload lives at `event.data`. This is asymmetric with the parent
+ * side, where `UtilityProcess.on('message')` already unwraps to the raw data.
+ */
+
+interface ParentPortMessageEvent {
+  data: unknown;
+}
+
+interface ParentPortLike {
+  on(event: 'message', listener: (event: ParentPortMessageEvent) => void): void;
+  postMessage(msg: unknown): void;
+}
+
+const parentPort = (process as unknown as { parentPort?: ParentPortLike }).parentPort;
+
+if (!parentPort) {
+  // Running outside utilityProcess — fail loudly. The host always forks via
+  // utilityProcess.fork() so this is a wiring bug if it ever fires.
+  console.error('[scan-utility] parentPort missing — not running inside utilityProcess');
+  process.exit(1);
+}
+
+interface HelloMessage {
+  type: 'hello';
+}
+
+interface HelloAckMessage {
+  type: 'hello-ack';
+  pid: number;
+}
+
+interface UtilityReadyMessage {
+  type: 'utility-ready';
+}
+
+type IncomingMessage = HelloMessage;
+type OutgoingMessage = HelloAckMessage | UtilityReadyMessage;
+
+function post(msg: OutgoingMessage): void {
+  parentPort!.postMessage(msg);
+}
+
+parentPort.on('message', event => {
+  const msg = event.data as IncomingMessage | undefined;
+  if (!msg || typeof msg !== 'object') return;
+
+  if (msg.type === 'hello') {
+    post({ type: 'hello-ack', pid: process.pid });
+    return;
+  }
+});
+
+// Signal readiness so the parent knows the IPC listener is wired.
+post({ type: 'utility-ready' });

--- a/apps/desktop/test/setup.ts
+++ b/apps/desktop/test/setup.ts
@@ -19,6 +19,12 @@ export function setMockMainWindow(win: BrowserWindow | null): void {
 }
 
 vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn((key: string) => {
+      if (key === 'userData') return '/mock/userData';
+      return '/mock/unknown';
+    }),
+  },
   ipcMain: {
     handle(channel: string, fn: (...args: unknown[]) => unknown) {
       ipcHandlers.set(channel, fn);
@@ -35,6 +41,9 @@ vi.mock('electron', () => ({
     removeAllListeners(channel: string) {
       ipcOnListeners.delete(channel);
     },
+  },
+  utilityProcess: {
+    fork: vi.fn(),
   },
   BrowserWindow: class BrowserWindowStub {
     static getFocusedWindow() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       node-id3:
         specifier: ^0.2.9
         version: 0.2.9
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       zod:
         specifier: ^4.3.6
         version: 4.4.2


### PR DESCRIPTION
## Summary

First three phases of a longer-running plan to move metadata scanning out of the Electron main process into a `utilityProcess`. This PR moves music-metadata parse + cover decode/downscale/disk-write into a fork-per-scan utilityProcess that exits when the scan finishes — V8 heap returns to the OS, freeing roughly 200-400 MB main-process RSS at idle after large scans (50k-track libraries).

## Phase 0 spike outcome

`nativeImage` does NOT work in `utilityProcess` (verified empirically — it is undefined in that context; the module is main/renderer-only). `sharp` does (verified empirically with the same harness, decoded a 256x256 PNG → 256px JPEG q=85 cleanly inside utilityProcess). Sharp added as the decode dep.

## Per-phase change list

### Phase 0 — spike (already on branch)
- `ec67599` chore(desktop/scan-utility): phase 0 spike — original `nativeImage` attempt; superseded but kept as history.
- `f47c8cb` fix(desktop/scan-utility-spike): unwrap parentPort MessageEvent.data — real IPC bug discovered by the spike.
- `7665fdb` chore(desktop): add sharp for utility-process image decode — sharp dep + retarget spike + electron-builder asarUnpack for `node_modules/sharp/**` and `node_modules/@img/**`.

### Phase 1 — skeleton
- `6e657a1` feat(desktop/scan-utility): phase 1 — esbuild entry + spawn plumbing skeleton.
  - New `src/main/scan-utility.ts` esbuild entrypoint.
  - New `src/main/scan-utility-host.ts` exposing `forkScanUtility()` with hello/ack round-trip, ready signal, idempotent kill, 5 s timeouts.
  - 14 unit tests in `scan-utility-host.test.ts` covering happy path, ready timeout, hello timeout, exit-mid-handshake, kill idempotency, malformed messages.

### Phase 2 — move work
- `7bfbab0` feat(desktop/scan-utility): phase 2 — move metadata parse + cover write into utility process.
  - New `src/main/lib/album-art-image.ts` — pure `downscaleAndHash` helper used by both the utility and (in a follow-up) the main-side `saveAlbumArt`.
  - `scan-utility.ts` — handles `init` (receives userData path) and `parse` (decodes one file, writes any embedded cover, returns metadata + `shiranami-art://` URL). Cover Buffers do NOT cross the IPC boundary.
  - `scan-utility-host.ts` — adds `init()` and `parse(filePath)` with per-call requestId multiplexing.
  - `ipc/library.ts` — `scan-folder` + `scan-folder-grouped` wrap parse loop in `withScanUtility()`: fork once per scan, init, parse via the client at concurrency 16, kill in finally. Single-file `library:parse-metadata` stays in-main.
  - Tests: 6 new library integration tests + 7 new `downscaleAndHash` tests.
  - `test/setup.ts` — shared electron mock now provides `app.getPath` + `utilityProcess.fork` stubs.

## Expected impact

| Metric | Before | After |
|---|---|---|
| Main process RSS at idle after 50k-track scan | baseline + ~300 MB scan-residue | baseline (utility dies, V8 returns RSS to OS) |
| Scan throughput | concurrency=16 in main | concurrency=16 in utility (no change) |
| Cold-start cost per scan | 0 | ~100 ms utilityProcess fork (negligible) |
| Bundle size | — | +~5-10 MB shipped (sharp prebuilt binaries) |

## Test plan

- [x] desktop typecheck passes (`pnpm --filter desktop typecheck`)
- [x] desktop test suite passes — 603/603 (existing 575 + 14 host tests + 7 helper tests + 6 library integration tests + 1 covered by reorganisation)
- [x] esbuild produces `dist/main/scan-utility.js` (5.7 KB) and `dist/main/scan-utility-spike.js` cleanly
- [x] no Electron `app`/`nativeImage`/`dialog` references leaked into the utility bundle
- [x] root typecheck + test pass (1203/1203)
- [x] Phase 0 spike PASSES with sharp inside utilityProcess (verified 2026-05-04)
- [ ] manual: run a real folder scan and observe main process RSS in Task Manager before+after (should drop back to baseline after scan completes)
- [ ] manual: verify utility process appears as a child during scan, disappears after
- [ ] manual: verify scan still completes correctly (track count matches; covers visible)
- [ ] manual: verify rescan still works (utility re-spawns cleanly)
- [ ] manual: verify packaged build (`pnpm --filter desktop package:win`) — sharp's prebuilt binary survives `asarUnpack`

## Out of scope (deferred to follow-up PRs)

- **Phase 3** — streaming `track` events from utility back to main with progress IPC. This PR does request/response per file; Phase 3 will add streaming.
- **Phase 4** — logging bridge (utility logs forwarded to main's file logger). This PR uses raw stderr piped to main's logger as a stopgap.
- **Phase 5** — cancellation IPC + SIGTERM. This PR can't cancel mid-scan; user must wait.
- **Phase 6** — telemetry (`process.memoryUsage()` before/after, RAM delta logged).
- **Phase 7** — feature-flag flip + delete legacy in-process scan path. This PR keeps both paths (utility for new scans, legacy `parseAudioMetadata` retained for the single-file `library:parse-metadata` IPC).
- The spike file (`scan-utility-spike.ts`) and harness retained as a documented experiment artifact; will be removed in Phase 7 alongside the legacy path.

## Coordination note

utilityProcess + the eventual paginated `db:tracks:get-page` work (separate deferred plan; needs strategic Q&A) are independent. Either can land first.
