### PR TITLE
fix(web+desktop): metadata-enrich correctness, perf quick wins, a11y (PR 1 of 3)

### DIFF
--- a/apps/desktop/src/main/ipc/metadata-enrich.test.ts
+++ b/apps/desktop/src/main/ipc/metadata-enrich.test.ts
@@ -84,7 +84,9 @@ describe('metadata-enrich handlers', () => {
     vi.clearAllMocks();
 
     win = createMainWindowMock();
-    (win as unknown as { isDestroyed: ReturnType<typeof vi.fn> }).isDestroyed = vi.fn().mockReturnValue(false);
+    (win as unknown as { isDestroyed: ReturnType<typeof vi.fn> }).isDestroyed = vi
+      .fn()
+      .mockReturnValue(false);
     setMockMainWindow(asBrowserWindow(win));
     registerMetadataEnrichHandlers();
   });
@@ -117,20 +119,20 @@ describe('metadata-enrich handlers', () => {
     it('only fills fields that are missing/default, leaves existing values untouched', async () => {
       const track = makeTrack({
         artist: 'Existing Artist', // already has artist — should NOT be overwritten
-        album: 'Unknown Album',    // default — should be overwritten
-        genre: 'Rock',             // already has genre — should NOT be overwritten
-        year: null,                // missing — should be filled
-        trackNumber: 5,            // already has value — should NOT be overwritten
-        albumArt: 'existing-art',  // already has art — cover download should be skipped
+        album: 'Unknown Album', // default — should be overwritten
+        genre: 'Rock', // already has genre — should NOT be overwritten
+        year: null, // missing — should be filled
+        trackNumber: 5, // already has value — should NOT be overwritten
+        albumArt: 'existing-art', // already has art — cover download should be skipped
       });
 
       mockedLookup.mockResolvedValue(makeLookupResult());
 
       const handler = ipcHandlers.get('metadata:enrich:tracks')!;
-      const results = await handler(null as never, [track], {
+      const results = (await handler(null as never, [track], {
         writeToFile: false,
         onlyMissing: true,
-      }) as EnrichTrackResult[];
+      })) as EnrichTrackResult[];
 
       expect(results).toHaveLength(1);
       const r = results[0];
@@ -169,10 +171,10 @@ describe('metadata-enrich handlers', () => {
       mockedDownloadImage.mockResolvedValue(Buffer.from('fake-image'));
 
       const handler = ipcHandlers.get('metadata:enrich:tracks')!;
-      const results = await handler(null as never, [track], {
+      const results = (await handler(null as never, [track], {
         writeToFile: false,
         onlyMissing: false,
-      }) as EnrichTrackResult[];
+      })) as EnrichTrackResult[];
 
       expect(results).toHaveLength(1);
       const r = results[0];
@@ -197,42 +199,36 @@ describe('metadata-enrich handlers', () => {
   // ---------------------------------------------------------------
   describe('metadata:enrich:cancel', () => {
     it('cancels in-progress enrichment', async () => {
-      vi.useFakeTimers();
-
       const tracks = [
         makeTrack({ id: '550e8400-e29b-41d4-a716-446655440001', title: 'Song 1' }),
         makeTrack({ id: '550e8400-e29b-41d4-a716-446655440002', title: 'Song 2' }),
         makeTrack({ id: '550e8400-e29b-41d4-a716-446655440003', title: 'Song 3' }),
       ];
 
-      mockedLookup.mockResolvedValue(makeLookupResult({ coverImageUrl: undefined }));
+      const cancelHandler = ipcHandlers.get('metadata:enrich:cancel')!;
+
+      mockedLookup
+        .mockResolvedValueOnce(makeLookupResult({ coverImageUrl: undefined })) // track 1: completes
+        .mockImplementationOnce(async () => {
+          // track 2: trigger cancel mid-flight, then resolve
+          await cancelHandler(null as never);
+          return makeLookupResult({ coverImageUrl: undefined });
+        })
+        .mockResolvedValue(makeLookupResult({ coverImageUrl: undefined })); // unused safety
 
       const handler = ipcHandlers.get('metadata:enrich:tracks')!;
-
-      // Start enrichment (don't await yet — it will block on the inter-track delay)
-      const enrichPromise = handler(null as never, tracks, {
+      const results = (await handler(null as never, tracks, {
         writeToFile: false,
         onlyMissing: false,
-      }) as Promise<EnrichTrackResult[]>;
+      })) as EnrichTrackResult[];
 
-      // Let microtasks settle so the first track processes
-      await vi.advanceTimersByTimeAsync(0);
-
-      // Cancel after first track
-      const cancelHandler = ipcHandlers.get('metadata:enrich:cancel')!;
-      await cancelHandler(null as never);
-
-      // Advance past the inter-track delay so the loop continues and hits the cancel check
-      await vi.advanceTimersByTimeAsync(1000);
-
-      const results = await enrichPromise;
-
-      // Should have processed track 1, then cancelled before track 3
-      expect(results.length).toBeLessThan(tracks.length);
+      // Track 1 completed; track 2 completed (cancel flag set after its lookup resolved);
+      // track 3 short-circuits at the top-of-loop enrichCancelled check and never runs.
+      expect(results.length).toBe(2);
       expect(results[0].id).toBe('550e8400-e29b-41d4-a716-446655440001');
       expect(results[0].success).toBe(true);
 
-      // Should have sent a 'cancelled' progress event
+      // Should have sent a 'cancelled' progress event for track 3
       const progressCalls = win.webContents.send.mock.calls.filter(
         (c: unknown[]) => c[0] === 'metadata:enrich:progress'
       );
@@ -240,8 +236,6 @@ describe('metadata-enrich handlers', () => {
         (c: unknown[]) => (c[1] as { status: string }).status === 'cancelled'
       );
       expect(cancelledProgress).toBeDefined();
-
-      vi.useRealTimers();
     });
   });
 
@@ -256,10 +250,10 @@ describe('metadata-enrich handlers', () => {
       });
 
       const handler = ipcHandlers.get('metadata:enrich:tracks')!;
-      const results = await handler(null as never, [makeTrack()], {
+      const results = (await handler(null as never, [makeTrack()], {
         writeToFile: false,
         onlyMissing: false,
-      }) as EnrichTrackResult[];
+      })) as EnrichTrackResult[];
 
       expect(results).toHaveLength(1);
       expect(results[0].success).toBe(false);
@@ -278,10 +272,10 @@ describe('metadata-enrich handlers', () => {
       mockedDownloadImage.mockRejectedValue(new Error('Network error'));
 
       const handler = ipcHandlers.get('metadata:enrich:tracks')!;
-      const results = await handler(null as never, [makeTrack()], {
+      const results = (await handler(null as never, [makeTrack()], {
         writeToFile: false,
         onlyMissing: false,
-      }) as EnrichTrackResult[];
+      })) as EnrichTrackResult[];
 
       expect(results).toHaveLength(1);
       const r = results[0];
@@ -353,7 +347,9 @@ describe('metadata-enrich handlers', () => {
     });
 
     it('does not send progress if window is destroyed', async () => {
-      (win as unknown as { isDestroyed: ReturnType<typeof vi.fn> }).isDestroyed.mockReturnValue(true);
+      (win as unknown as { isDestroyed: ReturnType<typeof vi.fn> }).isDestroyed.mockReturnValue(
+        true
+      );
 
       mockedLookup.mockResolvedValue(makeLookupResult({ coverImageUrl: undefined }));
 
@@ -378,10 +374,10 @@ describe('metadata-enrich handlers', () => {
 
       const track = makeTrack();
       const handler = ipcHandlers.get('metadata:enrich:tracks')!;
-      const results = await handler(null as never, [track], {
+      const results = (await handler(null as never, [track], {
         writeToFile: true,
         onlyMissing: false,
-      }) as EnrichTrackResult[];
+      })) as EnrichTrackResult[];
 
       expect(mockedWriteMetadata).toHaveBeenCalledWith(
         '/music/song.mp3',
@@ -440,7 +436,7 @@ describe('metadata-enrich handlers', () => {
       });
 
       await vi.advanceTimersByTimeAsync(2000);
-      const results = await resultPromise as EnrichTrackResult[];
+      const results = (await resultPromise) as EnrichTrackResult[];
 
       expect(results).toHaveLength(2);
 

--- a/apps/desktop/src/main/ipc/metadata-enrich.ts
+++ b/apps/desktop/src/main/ipc/metadata-enrich.ts
@@ -54,7 +54,7 @@ export function registerMetadataEnrichHandlers(): void {
     async (_event, title: string, artist: string): Promise<MetadataLookupResult> => {
       return lookupMetadata(title, artist);
     },
-    { schema: metadataLookupArgs },
+    { schema: metadataLookupArgs }
   );
 
   // Cancel ongoing enrichment
@@ -64,7 +64,7 @@ export function registerMetadataEnrichHandlers(): void {
       enrichCancelled = true;
       logger.info('[metadata:enrich] Cancellation requested');
     },
-    { schema: metadataEnrichCancelArgs },
+    { schema: metadataEnrichCancelArgs }
   );
 
   // Batch enrich multiple tracks
@@ -75,7 +75,9 @@ export function registerMetadataEnrichHandlers(): void {
       tracks: EnrichTrackInput[],
       options: { writeToFile: boolean; onlyMissing: boolean }
     ): Promise<EnrichTrackResult[]> => {
-      logger.info(`[metadata:enrich] Starting batch enrichment: ${tracks.length} tracks (writeToFile: ${options.writeToFile}, onlyMissing: ${options.onlyMissing})`);
+      logger.info(
+        `[metadata:enrich] Starting batch enrichment: ${tracks.length} tracks (writeToFile: ${options.writeToFile}, onlyMissing: ${options.onlyMissing})`
+      );
 
       enrichCancelled = false;
       const results: EnrichTrackResult[] = [];
@@ -113,7 +115,9 @@ export function registerMetadataEnrichHandlers(): void {
           const lookup = await lookupMetadata(track.title, track.artist);
 
           if (lookup.source === 'none') {
-            logger.info(`[metadata:enrich] [${i + 1}/${tracks.length}] No results: "${track.title}"`);
+            logger.info(
+              `[metadata:enrich] [${i + 1}/${tracks.length}] No results: "${track.title}"`
+            );
             results.push({
               id: track.id,
               success: false,
@@ -179,7 +183,10 @@ export function registerMetadataEnrichHandlers(): void {
                 ? 'image/png'
                 : 'image/jpeg';
             } catch (dlError) {
-              logger.warn(`[metadata:enrich] Failed to download cover art for "${track.title}":`, dlError);
+              logger.warn(
+                `[metadata:enrich] Failed to download cover art for "${track.title}":`,
+                dlError
+              );
             }
           }
 
@@ -212,7 +219,9 @@ export function registerMetadataEnrichHandlers(): void {
           }
 
           const fieldCount = Object.keys(updatedFields).length;
-          logger.info(`[metadata:enrich] [${i + 1}/${tracks.length}] ${fieldCount > 0 ? 'Updated' : 'No changes'}: "${track.title}" (source: ${lookup.source}, fields: ${fieldCount > 0 ? Object.keys(updatedFields).join(', ') : 'none'})`);
+          logger.info(
+            `[metadata:enrich] [${i + 1}/${tracks.length}] ${fieldCount > 0 ? 'Updated' : 'No changes'}: "${track.title}" (source: ${lookup.source}, fields: ${fieldCount > 0 ? Object.keys(updatedFields).join(', ') : 'none'})`
+          );
 
           results.push({
             id: track.id,
@@ -227,11 +236,6 @@ export function registerMetadataEnrichHandlers(): void {
             trackName: track.title,
             status: 'done',
           });
-
-          // Small delay between requests to avoid rate limiting
-          if (i < tracks.length - 1) {
-            await new Promise(resolve => setTimeout(resolve, 1000));
-          }
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : 'Unknown error';
           logger.error(`[metadata:enrich] Failed to enrich "${track.title}":`, error);
@@ -255,11 +259,13 @@ export function registerMetadataEnrichHandlers(): void {
 
       const successCount = results.filter(r => r.success).length;
       const failedCount = results.filter(r => !r.success).length;
-      logger.info(`[metadata:enrich] Batch complete: ${successCount} updated, ${failedCount} failed/no-results out of ${tracks.length} tracks${enrichCancelled ? ' (cancelled)' : ''}`);
+      logger.info(
+        `[metadata:enrich] Batch complete: ${successCount} updated, ${failedCount} failed/no-results out of ${tracks.length} tracks${enrichCancelled ? ' (cancelled)' : ''}`
+      );
 
       return results;
     },
-    { schema: metadataEnrichTracksArgs },
+    { schema: metadataEnrichTracksArgs }
   );
 }
 

--- a/apps/desktop/src/main/metadata-writer.ts
+++ b/apps/desktop/src/main/metadata-writer.ts
@@ -32,10 +32,7 @@ export async function writeMetadataToFile(
 
   // Save cover art to disk cache regardless of format
   if (options.coverImageBuffer && options.coverImageMime) {
-    albumArtUrl = await saveAlbumArt(
-      options.coverImageBuffer,
-      options.coverImageMime
-    );
+    albumArtUrl = await saveAlbumArt(options.coverImageBuffer, options.coverImageMime);
   }
 
   try {
@@ -67,13 +64,10 @@ export async function writeMetadataToFile(
   return albumArtUrl;
 }
 
-async function writeMp3Tags(
-  filePath: string,
-  options: WriteMetadataOptions
-): Promise<void> {
+async function writeMp3Tags(filePath: string, options: WriteMetadataOptions): Promise<void> {
   // node-id3 is CJS — dynamic import wraps exports under .default in bundled contexts
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const NodeID3Module = await import('node-id3') as any;
+  const NodeID3Module = (await import('node-id3')) as any;
   const NodeID3 = NodeID3Module.default ?? NodeID3Module;
 
   const tags: Record<string, unknown> = {};
@@ -102,10 +96,7 @@ async function writeMp3Tags(
   }
 }
 
-async function writeFlacTags(
-  filePath: string,
-  options: WriteMetadataOptions
-): Promise<void> {
+async function writeFlacTags(filePath: string, options: WriteMetadataOptions): Promise<void> {
   const { writeFlacTags: writeFlac } = await import('flac-tagger');
 
   const tagMap: Record<string, string> = {};
@@ -131,10 +122,7 @@ async function writeFlacTags(
   await writeFlac(tags, filePath);
 }
 
-async function writeTagsWithFFmpeg(
-  filePath: string,
-  options: WriteMetadataOptions
-): Promise<void> {
+async function writeTagsWithFFmpeg(filePath: string, options: WriteMetadataOptions): Promise<void> {
   if (!isFFmpegInstalled()) {
     logger.warn('[metadata-writer] ffmpeg not installed, skipping tag write for:', filePath);
     return;
@@ -157,7 +145,9 @@ async function writeTagsWithFFmpeg(
     args.push('-i', coverTempPath);
     args.push('-map', '0:a', '-map', '1:v', '-disposition:v', 'attached_pic');
   } else {
-    args.push('-map', '0:a');
+    // Copy audio and preserve any existing embedded video stream (album art).
+    // The '?' makes the map optional — files without a video stream still write cleanly.
+    args.push('-map', '0:a', '-map', '0:v?');
   }
 
   args.push('-c', 'copy');
@@ -174,7 +164,7 @@ async function writeTagsWithFFmpeg(
 
   try {
     await new Promise<void>((resolve, reject) => {
-      execFile(getFFmpegPath(), args, { timeout: 30000 }, (err) => {
+      execFile(getFFmpegPath(), args, { timeout: 30000 }, err => {
         if (err) reject(err);
         else resolve();
       });
@@ -185,8 +175,16 @@ async function writeTagsWithFFmpeg(
   } finally {
     // Clean up temp files
     if (coverTempPath) {
-      try { await fs.promises.unlink(coverTempPath); } catch { /* ignore */ }
+      try {
+        await fs.promises.unlink(coverTempPath);
+      } catch {
+        /* ignore */
+      }
     }
-    try { await fs.promises.unlink(tempPath); } catch { /* ignore */ }
+    try {
+      await fs.promises.unlink(tempPath);
+    } catch {
+      /* ignore */
+    }
   }
 }

--- a/apps/web/src/components/settings/EnrichProgressBar.tsx
+++ b/apps/web/src/components/settings/EnrichProgressBar.tsx
@@ -1,0 +1,70 @@
+import { useTranslation } from 'react-i18next';
+import { useMetadataEnrichStore } from '@/stores/useMetadataEnrichStore';
+import { Loader2, Check, X, Ban } from 'lucide-react';
+
+/**
+ * Isolated subscriber for high-frequency progress state.
+ * Extracted so MetadataEnrichSection does not re-render on every per-track event.
+ * Only mounts when isEnriching is true (parent gates rendering).
+ */
+export function EnrichProgressBar() {
+  const { t } = useTranslation('settings');
+  const progress = useMetadataEnrichStore(s => s.progress);
+  const isEnriching = useMetadataEnrichStore(s => s.isEnriching);
+  const isCancelling = useMetadataEnrichStore(s => s.isCancelling);
+
+  if (!isEnriching || !progress) return null;
+
+  const progressPercent =
+    progress.total > 0 ? Math.min(100, Math.max(0, (progress.current / progress.total) * 100)) : 0;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="false"
+      className="px-3 py-3 rounded-xl bg-primary/5 border border-primary/20 space-y-2"
+    >
+      <div className="flex items-center gap-2">
+        <Loader2 className="w-3.5 h-3.5 animate-spin text-primary" aria-hidden="true" />
+        <span className="text-sm text-foreground">
+          {t('lib.enrichProgress', { current: progress.current, total: progress.total })}
+        </span>
+      </div>
+      <div className="text-xs text-muted-foreground min-w-0">
+        {progress.status === 'searching' && t('lib.enrichSearching', { track: progress.trackName })}
+        {progress.status === 'downloading' && t('lib.enrichDownloading')}
+        {progress.status === 'writing' && t('lib.enrichWriting')}
+        {progress.status === 'done' && (
+          <span className="flex items-center gap-1 min-w-0">
+            <Check className="w-3 h-3 text-green-500 shrink-0" aria-hidden="true" />
+            <span className="truncate">{progress.trackName}</span>
+          </span>
+        )}
+        {progress.status === 'error' && (
+          <span className="flex items-center gap-1 min-w-0">
+            <X className="w-3 h-3 text-destructive shrink-0" aria-hidden="true" />
+            <span className="truncate">{progress.trackName}</span>
+          </span>
+        )}
+        {progress.status === 'cancelled' && (
+          <span className="flex items-center gap-1 min-w-0">
+            <Ban className="w-3 h-3 text-muted-foreground shrink-0" aria-hidden="true" />
+            <span className="truncate">
+              {t('lib.enrichCancelledStatus', { trackName: progress.trackName })}
+            </span>
+          </span>
+        )}
+      </div>
+      {/* Progress bar */}
+      <div className="w-full h-1.5 bg-border/30 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-primary rounded-full transition-all duration-300"
+          style={{ width: `${progressPercent}%` }}
+          aria-hidden="true"
+        />
+      </div>
+      {isCancelling && <p className="text-xs text-muted-foreground">{t('lib.enrichCancelling')}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/MetadataEnrichSection.tsx
+++ b/apps/web/src/components/settings/MetadataEnrichSection.tsx
@@ -173,6 +173,12 @@ export function MetadataEnrichSection() {
                     {progress.trackName}
                   </span>
                 )}
+                {progress.status === 'cancelled' && (
+                  <span className="flex items-center gap-1">
+                    <Ban className="w-3 h-3 text-muted-foreground" />
+                    {t('lib.enrichCancelledStatus', { trackName: progress.trackName })}
+                  </span>
+                )}
               </div>
               {/* Progress bar */}
               <div className="w-full h-1.5 bg-border/30 rounded-full overflow-hidden">

--- a/apps/web/src/components/settings/MetadataEnrichSection.tsx
+++ b/apps/web/src/components/settings/MetadataEnrichSection.tsx
@@ -80,13 +80,17 @@ export function MetadataEnrichSection() {
     if (!writeToFile && confirmWrite) setConfirmWrite(false);
   }, [writeToFile, confirmWrite]);
 
-  // Focus the confirm's primary action when it mounts; restore focus on dismiss.
+  // Focus the confirm's primary action when it opens; restore focus on dismiss.
+  // prevConfirmWrite guards the restore branch so it only runs on a true→false
+  // transition, not on initial mount when confirmWrite is already false.
+  const prevConfirmWrite = useRef(false);
   useEffect(() => {
     if (confirmWrite) {
       confirmYesRef.current?.focus();
-    } else {
+    } else if (prevConfirmWrite.current) {
       enrichButtonRef.current?.focus();
     }
+    prevConfirmWrite.current = confirmWrite;
   }, [confirmWrite]);
 
   if (!IS_ELECTRON) return null;

--- a/apps/web/src/components/settings/MetadataEnrichSection.tsx
+++ b/apps/web/src/components/settings/MetadataEnrichSection.tsx
@@ -3,20 +3,11 @@ import { useTranslation } from 'react-i18next';
 import { IS_ELECTRON } from '@/lib/platform';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { useMetadataEnrichStore } from '@/stores/useMetadataEnrichStore';
-import {
-  Search,
-  Loader2,
-  Disc3,
-  Check,
-  X,
-  Ban,
-  Info,
-  AlertTriangle,
-  FileWarning,
-} from 'lucide-react';
+import { Search, Loader2, Disc3, Ban, Info, AlertTriangle, FileWarning } from 'lucide-react';
 import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsCard';
 import { Button } from '@/components/ui/button';
 import { StatusBadge } from '@/components/ui/status-badge';
+import { EnrichProgressBar } from '@/components/settings/EnrichProgressBar';
 
 // DB writes these exact strings (scan-utility.ts, metadata-service.ts).
 // Module-level so the useMemo dep is a stable reference and never causes a spurious rebuild.
@@ -28,7 +19,6 @@ export function MetadataEnrichSection() {
   const { t: tc } = useTranslation('common');
   const library = useLibraryStore(s => s.library);
   const isEnriching = useMetadataEnrichStore(s => s.isEnriching);
-  const progress = useMetadataEnrichStore(s => s.progress);
   const startEnrichment = useMetadataEnrichStore(s => s.startEnrichment);
   const skippedIds = useMetadataEnrichStore(s => s.skippedIds);
   const loadSkipped = useMetadataEnrichStore(s => s.loadSkipped);
@@ -86,11 +76,6 @@ export function MetadataEnrichSection() {
   useEffect(() => {
     if (!writeToFile && confirmWrite) setConfirmWrite(false);
   }, [writeToFile, confirmWrite]);
-
-  const progressPercent =
-    progress && progress.total > 0
-      ? Math.min(100, Math.max(0, (progress.current / progress.total) * 100))
-      : 0;
 
   if (!IS_ELECTRON) return null;
 
@@ -151,48 +136,8 @@ export function MetadataEnrichSection() {
             )}
           </div>
 
-          {/* Progress */}
-          {isEnriching && progress && (
-            <div className="px-3 py-3 rounded-xl bg-primary/5 border border-primary/20 space-y-2">
-              <div className="flex items-center gap-2">
-                <Loader2 className="w-3.5 h-3.5 animate-spin text-primary" />
-                <span className="text-sm text-foreground">
-                  {t('lib.enrichProgress', { current: progress.current, total: progress.total })}
-                </span>
-              </div>
-              <div className="text-xs text-muted-foreground truncate">
-                {progress.status === 'searching' &&
-                  t('lib.enrichSearching', { track: progress.trackName })}
-                {progress.status === 'downloading' && t('lib.enrichDownloading')}
-                {progress.status === 'writing' && t('lib.enrichWriting')}
-                {progress.status === 'done' && (
-                  <span className="flex items-center gap-1">
-                    <Check className="w-3 h-3 text-green-500" />
-                    {progress.trackName}
-                  </span>
-                )}
-                {progress.status === 'error' && (
-                  <span className="flex items-center gap-1">
-                    <X className="w-3 h-3 text-destructive" />
-                    {progress.trackName}
-                  </span>
-                )}
-                {progress.status === 'cancelled' && (
-                  <span className="flex items-center gap-1">
-                    <Ban className="w-3 h-3 text-muted-foreground" />
-                    {t('lib.enrichCancelledStatus', { trackName: progress.trackName })}
-                  </span>
-                )}
-              </div>
-              {/* Progress bar */}
-              <div className="w-full h-1.5 bg-border/30 rounded-full overflow-hidden">
-                <div
-                  className="h-full bg-primary rounded-full transition-all duration-300"
-                  style={{ width: `${progressPercent}%` }}
-                />
-              </div>
-            </div>
-          )}
+          {/* Progress — isolated subscriber so parent does not re-render on every event */}
+          <EnrichProgressBar />
 
           {/* Action row — swaps to an inline confirmation when about to write to disk. */}
           {confirmWrite && !isEnriching ? (

--- a/apps/web/src/components/settings/MetadataEnrichSection.tsx
+++ b/apps/web/src/components/settings/MetadataEnrichSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IS_ELECTRON } from '@/lib/platform';
 import { useLibraryStore } from '@/stores/useLibraryStore';
@@ -24,6 +24,9 @@ export function MetadataEnrichSection() {
   const loadSkipped = useMetadataEnrichStore(s => s.loadSkipped);
   const cancelEnrichment = useMetadataEnrichStore(s => s.cancelEnrichment);
   const isCancelling = useMetadataEnrichStore(s => s.isCancelling);
+
+  const enrichButtonRef = useRef<HTMLButtonElement>(null);
+  const confirmYesRef = useRef<HTMLButtonElement>(null);
 
   const [onlyMissing, setOnlyMissing] = useState(true);
   // Default OFF — writing to files is irreversible, so it must be an explicit opt-in (issue #37).
@@ -76,6 +79,15 @@ export function MetadataEnrichSection() {
   useEffect(() => {
     if (!writeToFile && confirmWrite) setConfirmWrite(false);
   }, [writeToFile, confirmWrite]);
+
+  // Focus the confirm's primary action when it mounts; restore focus on dismiss.
+  useEffect(() => {
+    if (confirmWrite) {
+      confirmYesRef.current?.focus();
+    } else {
+      enrichButtonRef.current?.focus();
+    }
+  }, [confirmWrite]);
 
   if (!IS_ELECTRON) return null;
 
@@ -141,14 +153,23 @@ export function MetadataEnrichSection() {
 
           {/* Action row — swaps to an inline confirmation when about to write to disk. */}
           {confirmWrite && !isEnriching ? (
-            <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-3 space-y-3">
+            <div
+              role="alertdialog"
+              aria-labelledby="enrich-confirm-title"
+              aria-describedby="enrich-confirm-body"
+              onKeyDown={e => e.key === 'Escape' && setConfirmWrite(false)}
+              className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-3 space-y-3"
+            >
               <div className="flex items-start gap-2">
-                <AlertTriangle className="w-4 h-4 text-amber-500 mt-0.5 shrink-0" />
+                <AlertTriangle
+                  className="w-4 h-4 text-amber-500 mt-0.5 shrink-0"
+                  aria-hidden="true"
+                />
                 <div className="space-y-1">
-                  <p className="text-sm font-medium text-foreground">
+                  <p id="enrich-confirm-title" className="text-sm font-medium text-foreground">
                     {t('lib.enrichConfirmWriteTitle')}
                   </p>
-                  <p className="text-xs text-muted-foreground">
+                  <p id="enrich-confirm-body" className="text-xs text-muted-foreground">
                     {t('lib.enrichConfirmWriteBody', {
                       count: tracksNeedingEnrichment.length,
                     })}
@@ -157,6 +178,7 @@ export function MetadataEnrichSection() {
               </div>
               <div className="flex gap-2">
                 <Button
+                  ref={confirmYesRef}
                   size="sm"
                   onClick={handleConfirmedEnrich}
                   className="gap-2 rounded-lg bg-amber-500 text-sm text-black shadow-none hover:bg-amber-500/90 [&_svg]:size-3.5"
@@ -177,13 +199,19 @@ export function MetadataEnrichSection() {
           ) : (
             <div className="flex gap-2">
               <Button
+                ref={enrichButtonRef}
                 onClick={handleEnrich}
                 disabled={
                   isEnriching || library.length === 0 || tracksNeedingEnrichment.length === 0
                 }
+                aria-busy={isEnriching}
                 className="rounded-xl bg-primary/15 text-primary shadow-none hover:bg-primary/25 [&_svg]:size-3.5"
               >
-                {isEnriching ? <Loader2 className="animate-spin" /> : <Search />}
+                {isEnriching ? (
+                  <Loader2 className="animate-spin" aria-hidden="true" />
+                ) : (
+                  <Search aria-hidden="true" />
+                )}
                 {isEnriching ? t('lib.enriching') : t('lib.enrichMetadata')}
               </Button>
               {isEnriching && (
@@ -191,9 +219,14 @@ export function MetadataEnrichSection() {
                   variant="destructiveGhost"
                   onClick={cancelEnrichment}
                   disabled={isCancelling}
+                  aria-busy={isCancelling}
                   className="rounded-xl [&_svg]:size-3.5"
                 >
-                  {isCancelling ? <Loader2 className="animate-spin" /> : <Ban />}
+                  {isCancelling ? (
+                    <Loader2 className="animate-spin" aria-hidden="true" />
+                  ) : (
+                    <Ban aria-hidden="true" />
+                  )}
                   {isCancelling ? t('lib.enrichCancelling') : t('lib.enrichCancel')}
                 </Button>
               )}

--- a/apps/web/src/components/settings/MetadataEnrichSection.tsx
+++ b/apps/web/src/components/settings/MetadataEnrichSection.tsx
@@ -18,6 +18,11 @@ import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsC
 import { Button } from '@/components/ui/button';
 import { StatusBadge } from '@/components/ui/status-badge';
 
+// DB writes these exact strings (scan-utility.ts, metadata-service.ts).
+// Module-level so the useMemo dep is a stable reference and never causes a spurious rebuild.
+const UNKNOWN_ARTIST = 'Unknown Artist';
+const UNKNOWN_ALBUM = 'Unknown Album';
+
 export function MetadataEnrichSection() {
   const { t } = useTranslation('settings');
   const { t: tc } = useTranslation('common');
@@ -41,28 +46,27 @@ export function MetadataEnrichSection() {
     loadSkipped();
   }, [loadSkipped]);
 
-  // Count tracks with missing metadata.
-  // DB stores the English literals 'Unknown Artist' / 'Unknown Album' (written by
-  // scan-utility.ts and metadata-service.ts). trackMapper's ?? fallback never fires
-  // because those truthy strings are already in the row. Compare against the literals
-  // so Polish (and any other locale) users see the correct count.
-  const unknownArtist = 'Unknown Artist';
-  const unknownAlbum = 'Unknown Album';
+  // Count tracks with missing metadata. UNKNOWN_ARTIST/UNKNOWN_ALBUM are module-level
+  // constants so the memo dep is stable and never rebuilds on locale switches.
   const tracksNeedingEnrichment = useMemo(
     () =>
       library.filter(
         t =>
-          t.artist === unknownArtist ||
-          t.album === unknownAlbum ||
+          t.artist === UNKNOWN_ARTIST ||
+          t.album === UNKNOWN_ALBUM ||
           !t.albumArt ||
           !t.genre ||
           !t.year
       ),
-    [library, unknownArtist, unknownAlbum]
+    [library]
   );
 
-  // How many of those are skipped (already tried, no results)
-  const skippedCount = tracksNeedingEnrichment.filter(t => skippedIds.has(t.id)).length;
+  // Memoized: skippedCount only changes when the enrichment list or skip set changes,
+  // not on every progress tick.
+  const skippedCount = useMemo(
+    () => tracksNeedingEnrichment.filter(t => skippedIds.has(t.id)).length,
+    [tracksNeedingEnrichment, skippedIds]
+  );
 
   const handleEnrich = useCallback(() => {
     // Gate destructive path behind inline confirm. Safe path (DB only) runs immediately.

--- a/apps/web/src/components/settings/MetadataEnrichSection.tsx
+++ b/apps/web/src/components/settings/MetadataEnrichSection.tsx
@@ -41,17 +41,25 @@ export function MetadataEnrichSection() {
     loadSkipped();
   }, [loadSkipped]);
 
-  // Count tracks with missing metadata. Compare against localized fallbacks
-  // because trackMapper populates missing artist/album with the translated
-  // "Unknown Artist"/"Unknown Album" strings at DB-read time.
-  const tracksNeedingEnrichment = useMemo(() => {
-    const unknownArtist = tc('unknownArtist');
-    const unknownAlbum = tc('unknownAlbum');
-    return library.filter(
-      t =>
-        t.artist === unknownArtist || t.album === unknownAlbum || !t.albumArt || !t.genre || !t.year
-    );
-  }, [library, tc]);
+  // Count tracks with missing metadata.
+  // DB stores the English literals 'Unknown Artist' / 'Unknown Album' (written by
+  // scan-utility.ts and metadata-service.ts). trackMapper's ?? fallback never fires
+  // because those truthy strings are already in the row. Compare against the literals
+  // so Polish (and any other locale) users see the correct count.
+  const unknownArtist = 'Unknown Artist';
+  const unknownAlbum = 'Unknown Album';
+  const tracksNeedingEnrichment = useMemo(
+    () =>
+      library.filter(
+        t =>
+          t.artist === unknownArtist ||
+          t.album === unknownAlbum ||
+          !t.albumArt ||
+          !t.genre ||
+          !t.year
+      ),
+    [library, unknownArtist, unknownAlbum]
+  );
 
   // How many of those are skipped (already tried, no results)
   const skippedCount = tracksNeedingEnrichment.filter(t => skippedIds.has(t.id)).length;

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -73,7 +73,6 @@
     "enrichFileWriteSubtitle": "Optional gate for writing metadata directly to your audio files on disk",
     "enrichWriteToFile": "Write tags to audio files",
     "enrichWriteToFileDesc": "Off: results are stored only in Shiranami's database. Your audio files on disk stay untouched.",
-    "enrichWriteToFileDestructive": "On: embeds metadata directly into your audio files on disk (MP3, FLAC, M4A). This cannot be undone.",
     "enrichConfirmWriteTitle": "Modify audio files on disk?",
     "enrichConfirmWriteBody": "About to write tags to up to {{count}} audio file(s). This modifies the files on disk and cannot be undone.",
     "enrichYesWrite": "Yes, modify files",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -77,6 +77,7 @@
     "enrichConfirmWriteTitle": "Modify audio files on disk?",
     "enrichConfirmWriteBody": "About to write tags to up to {{count}} audio file(s). This modifies the files on disk and cannot be undone.",
     "enrichYesWrite": "Yes, modify files",
+    "enrichCancelledStatus": "Cancelled at {{trackName}}",
     "enrichProgress": "Processing {{current}} of {{total}}...",
     "enrichSearching": "Searching for \"{{track}}\"...",
     "enrichDownloading": "Downloading cover art...",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -77,6 +77,7 @@
     "enrichConfirmWriteTitle": "Zmodyfikować pliki audio na dysku?",
     "enrichConfirmWriteBody": "Zaraz zostaną zapisane tagi w maksymalnie {{count}} plikach audio. To zmodyfikuje pliki na dysku i nie można tego cofnąć.",
     "enrichYesWrite": "Tak, zmodyfikuj pliki",
+    "enrichCancelledStatus": "Anulowano przy {{trackName}}",
     "enrichProgress": "Przetwarzanie {{current}} z {{total}}...",
     "enrichSearching": "Wyszukiwanie \"{{track}}\"...",
     "enrichDownloading": "Pobieranie okładki...",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -73,7 +73,6 @@
     "enrichFileWriteSubtitle": "Opcjonalna zgoda na zapisywanie metadanych bezpośrednio do plików audio",
     "enrichWriteToFile": "Zapisz tagi w plikach audio",
     "enrichWriteToFileDesc": "Wyłączone: wyniki są zapisywane tylko w bazie danych Shiranami. Twoje pliki audio na dysku pozostają nietknięte.",
-    "enrichWriteToFileDestructive": "Włączone: osadza metadane bezpośrednio w plikach audio na dysku (MP3, FLAC, M4A). Tej operacji nie można cofnąć.",
     "enrichConfirmWriteTitle": "Zmodyfikować pliki audio na dysku?",
     "enrichConfirmWriteBody": "Zaraz zostaną zapisane tagi w maksymalnie {{count}} plikach audio. To zmodyfikuje pliki na dysku i nie można tego cofnąć.",
     "enrichYesWrite": "Tak, zmodyfikuj pliki",

--- a/apps/web/src/stores/useMetadataEnrichStore.ts
+++ b/apps/web/src/stores/useMetadataEnrichStore.ts
@@ -236,7 +236,15 @@ export const useMetadataEnrichStore = create<MetadataEnrichState & MetadataEnric
 
 if (import.meta.hot?.data) {
   if (import.meta.hot.data.store) {
-    useMetadataEnrichStore.setState(import.meta.hot.data.store.getState());
+    // Omit runtime-only fields — replaying isEnriching/isCancelling/progress
+    // during HMR while a run is idle would leave the UI stuck in a busy state.
+    const {
+      isEnriching: _ie,
+      isCancelling: _ic,
+      progress: _p,
+      ...rest
+    } = import.meta.hot.data.store.getState();
+    useMetadataEnrichStore.setState(rest);
   }
   import.meta.hot.data.store = useMetadataEnrichStore;
   import.meta.hot.accept();

--- a/apps/web/src/stores/useMetadataEnrichStore.ts
+++ b/apps/web/src/stores/useMetadataEnrichStore.ts
@@ -65,7 +65,7 @@ export const useMetadataEnrichStore = create<MetadataEnrichState & MetadataEnric
     skippedIds: new Set(),
     skippedLoaded: false,
 
-    updateProgress: (progress) => set({ progress }),
+    updateProgress: progress => set({ progress }),
 
     loadSkipped: async () => {
       if (!IS_ELECTRON || get().skippedLoaded) return;
@@ -110,14 +110,14 @@ export const useMetadataEnrichStore = create<MetadataEnrichState & MetadataEnric
       const library = useLibraryStore.getState().library;
       const { skippedIds } = get();
 
-      const unknownArtist = i18n.t('unknownArtist', { ns: 'common' });
-      const unknownAlbum = i18n.t('unknownAlbum', { ns: 'common' });
-
+      // DB stores the English literals 'Unknown Artist' / 'Unknown Album' (scan-utility.ts,
+      // metadata-service.ts). Compare against the literals so the filter is consistent
+      // with what the main-process onlyMissing gate checks at metadata-enrich.ts:138,141.
       let candidates = onlyMissing
         ? library.filter(
             t =>
-              t.artist === unknownArtist ||
-              t.album === unknownAlbum ||
+              t.artist === 'Unknown Artist' ||
+              t.album === 'Unknown Album' ||
               !t.albumArt ||
               !t.genre ||
               !t.year
@@ -154,16 +154,13 @@ export const useMetadataEnrichStore = create<MetadataEnrichState & MetadataEnric
           trackNumber: track.trackNumber ?? null,
         }));
 
-        const results: EnrichTrackResult[] =
-          await window.electronAPI.metadata.enrichTracks(input, {
-            writeToFile,
-            onlyMissing,
-          });
+        const results: EnrichTrackResult[] = await window.electronAPI.metadata.enrichTracks(input, {
+          writeToFile,
+          onlyMissing,
+        });
 
         // Track which IDs returned no results so we skip them next time
-        const noResultIds = results
-          .filter(r => !r.success && r.source === 'none')
-          .map(r => r.id);
+        const noResultIds = results.filter(r => !r.success && r.source === 'none').map(r => r.id);
         if (noResultIds.length > 0) {
           const prev = get().skippedIds;
           const next = new Set(prev);
@@ -187,9 +184,7 @@ export const useMetadataEnrichStore = create<MetadataEnrichState & MetadataEnric
         if (successResults.length > 0) {
           const allDbTracks = await window.electronAPI.db.tracks.getAll();
           const { mapDbTracksToTracks } = await import('@/lib/trackMapper');
-          const refreshedTracks = mapDbTracksToTracks(
-            allDbTracks as Record<string, unknown>[]
-          );
+          const refreshedTracks = mapDbTracksToTracks(allDbTracks as Record<string, unknown>[]);
           useLibraryStore.setState({ library: refreshedTracks });
 
           // Update current track and queue if affected


### PR DESCRIPTION
## Summary

Implements all priorities 1-8 from the kirei-chain findings doc (`docs/chain/2026-05-04-metadata-enrich-chain.md`). This is the correctness + perf quick wins + a11y bundle. PR 2 (AbortController) and PR 3 (types-to-contracts + hook extraction) follow separately.

### Phase 1 — Data-loss fix (Theme: General B12)
- `metadata-writer.ts` — ffmpeg `writeTagsWithFFmpeg`: when no new cover is supplied, appends `-map 0:v?` so any existing embedded album art stream is copied through. The `?` makes the mapping optional — files without a video stream still write cleanly. Highest-priority fix in the run.

### Phase 2 — Correctness (Theme A, Theme B, General B4)
- `MetadataEnrichSection.tsx` — Compare against English literals `'Unknown Artist'` / `'Unknown Album'` instead of `tc('unknownArtist')` / `tc('unknownAlbum')`. DB stores the English literals (scan-utility.ts, metadata-service.ts convention). Polish users were silently excluded from the filter.
- `useMetadataEnrichStore.ts` — Same literal fix in `startEnrichment` filter, aligning renderer with the main-process onlyMissing gate.
- `MetadataEnrichSection.tsx` + EN/PL settings.json — Add `cancelled` status branch to the progress strip (Ban icon + new `lib.enrichCancelledStatus` key). Main emits `'cancelled'` but no JSX branch existed; status line went blank after cancel.
- `useMetadataEnrichStore.ts` — HMR replay: omit `isEnriching`, `isCancelling`, `progress` from the state snapshot. Replaying those fields left the Cancel button stuck disabled after a hot module reload while idle.

### Phase 3 — Perf quick wins (Theme E)
- `metadata-enrich.ts` — Delete the 1s `setTimeout` between tracks. Per-host gates in `http.ts` (iTunes: 500ms, ytimg: 100ms) already cover rate limiting. Saves ~16 min for 1k tracks, ~83 min for 5k tracks.
- `MetadataEnrichSection.tsx` — Hoist `UNKNOWN_ARTIST`/`UNKNOWN_ALBUM` to module-level constants; deps array now `[library]` only. Wrap `skippedCount` in `useMemo([tracksNeedingEnrichment, skippedIds])` so the filter does not re-run on every progress tick.
- `EnrichProgressBar.tsx` (new) — Isolated subcomponent subscribing to `progress`/`isEnriching`/`isCancelling` only. Parent `MetadataEnrichSection` no longer re-renders on every per-track event (~4000 renders reduced to ~5 per batch). Adds `min-w-0 truncate` on long track name spans (D8 fix).

### Phase 4 — A11y (UI B1, B2, B3, B4, D8)
- `MetadataEnrichSection.tsx` — `role="alertdialog"` + `aria-labelledby`/`aria-describedby` on the confirm card; focus management (`useRef`+`useEffect`) moves focus to "Yes, modify files" on open and restores to Enrich button on dismiss; Esc-to-dismiss handler; `aria-busy={isEnriching}` on Enrich, `aria-busy={isCancelling}` on Cancel.
- `EnrichProgressBar.tsx` — `role="status" aria-live="polite"` on the progress card wrapper.

### Phase 5 — Cleanup (Theme F)
- EN + PL settings.json — Delete dead key `enrichWriteToFileDestructive`. Translated in both locales but never rendered.

## Verification

- [x] `apps/web` typecheck passes clean (zero errors)
- [x] `apps/desktop` typecheck: same 47 pre-existing test-file errors as master, no regressions
- [x] Commits are atomic and conventional, one per logical change
- [x] No em-dashes or en-dashes in any user-facing copy added
- [x] No Co-Authored-By in commits
- [ ] UI smoke-test by user: Polish locale count badge; cancel mid-run shows "Cancelled at ..."; m4a with embedded art survives writeToFile

## Related

- PR 2: replace `enrichCancelled` flag with AbortController (priority 9)
- PR 3: extract types to @shiranami/contracts + useMetadataEnrich hook (priorities 10-11)