### PR TITLE
refactor(desktop/metadata-enrich): replace enrichCancelled flag with AbortController per run

### DIFF
--- a/apps/desktop/src/main/http.ts
+++ b/apps/desktop/src/main/http.ts
@@ -5,6 +5,7 @@ import { MinIntervalGate } from './utils/min-interval-gate';
 type RequestOptions = {
   headers?: Record<string, string>;
   timeoutMs?: number;
+  signal?: AbortSignal;
 };
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -22,7 +23,7 @@ export class HttpError extends Error {
     public readonly url: string,
     public readonly status: number,
     public readonly headers: Record<string, string | string[]>,
-    public readonly retryAfterMs: number | null,
+    public readonly retryAfterMs: number | null
   ) {
     super(`Request failed with status ${status}: ${url}`);
     this.name = 'HttpError';
@@ -35,7 +36,7 @@ export class HttpError extends Error {
  * milliseconds, clamped to [0, 300_000]. Returns null when unparseable.
  */
 export function parseRetryAfter(
-  headers: Record<string, string | string[] | undefined>,
+  headers: Record<string, string | string[] | undefined>
 ): number | null {
   const lower: Record<string, string | string[] | undefined> = {};
   for (const [key, value] of Object.entries(headers)) {
@@ -122,16 +123,34 @@ export function __resetGatesForTests(): void {
 
 function requestTextRaw(url: string, options: RequestOptions = {}): Promise<string> {
   const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const { signal } = options;
   const startTime = Date.now();
 
   return new Promise<string>((resolve, reject) => {
     let settled = false;
     const request = net.request(url);
 
+    const onAbort = () => {
+      if (!settled) {
+        settled = true;
+        request.abort();
+        reject(new DOMException('The operation was aborted', 'AbortError'));
+      }
+    };
+
+    if (signal) {
+      if (signal.aborted) {
+        reject(new DOMException('The operation was aborted', 'AbortError'));
+        return;
+      }
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+
     const timer = setTimeout(() => {
       if (!settled) {
         settled = true;
         request.abort();
+        signal?.removeEventListener('abort', onAbort);
         logger.warn(`[http] Request timed out after ${timeout}ms: ${url}`);
         reject(new Error(`Request timed out after ${timeout}ms: ${url}`));
       }
@@ -141,17 +160,16 @@ function requestTextRaw(url: string, options: RequestOptions = {}): Promise<stri
       request.setHeader(key, value);
     }
 
-    request.on('response', (response) => {
+    request.on('response', response => {
       const statusCode = response.statusCode;
       const responseHeaders = response.headers as Record<string, string | string[]>;
 
       if (statusCode < 200 || statusCode >= 300) {
         clearTimeout(timer);
         settled = true;
+        signal?.removeEventListener('abort', onAbort);
         logger.warn(`[http] Request failed: ${url} - status ${statusCode}`);
-        reject(
-          new HttpError(url, statusCode, responseHeaders, parseRetryAfter(responseHeaders)),
-        );
+        reject(new HttpError(url, statusCode, responseHeaders, parseRetryAfter(responseHeaders)));
         return;
       }
 
@@ -165,6 +183,7 @@ function requestTextRaw(url: string, options: RequestOptions = {}): Promise<stri
         if (!settled) {
           clearTimeout(timer);
           settled = true;
+          signal?.removeEventListener('abort', onAbort);
           logger.debug(`[http] ${statusCode} ${url} (${Date.now() - startTime}ms)`);
           resolve(Buffer.concat(chunks).toString('utf-8'));
         }
@@ -174,6 +193,7 @@ function requestTextRaw(url: string, options: RequestOptions = {}): Promise<stri
         if (!settled) {
           clearTimeout(timer);
           settled = true;
+          signal?.removeEventListener('abort', onAbort);
           logger.warn(`[http] Response error: ${url}`, err.message);
           reject(err);
         }
@@ -184,6 +204,7 @@ function requestTextRaw(url: string, options: RequestOptions = {}): Promise<stri
       if (!settled) {
         clearTimeout(timer);
         settled = true;
+        signal?.removeEventListener('abort', onAbort);
         logger.warn(`[http] Request error: ${url}`, err.message);
         reject(err);
       }
@@ -195,9 +216,10 @@ function requestTextRaw(url: string, options: RequestOptions = {}): Promise<stri
 
 function requestBufferRaw(
   url: string,
-  options: RequestOptions & { maxBytes?: number } = {},
+  options: RequestOptions & { maxBytes?: number } = {}
 ): Promise<Buffer> {
   const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const { signal } = options;
   const maxBytes = options.maxBytes;
   const startTime = Date.now();
 
@@ -205,10 +227,27 @@ function requestBufferRaw(
     let settled = false;
     const request = net.request(url);
 
+    const onAbort = () => {
+      if (!settled) {
+        settled = true;
+        request.abort();
+        reject(new DOMException('The operation was aborted', 'AbortError'));
+      }
+    };
+
+    if (signal) {
+      if (signal.aborted) {
+        reject(new DOMException('The operation was aborted', 'AbortError'));
+        return;
+      }
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+
     const timer = setTimeout(() => {
       if (!settled) {
         settled = true;
         request.abort();
+        signal?.removeEventListener('abort', onAbort);
         logger.warn(`[http] Request timed out after ${timeout}ms: ${url}`);
         reject(new Error(`Request timed out after ${timeout}ms: ${url}`));
       }
@@ -218,17 +257,16 @@ function requestBufferRaw(
       request.setHeader(key, value);
     }
 
-    request.on('response', (response) => {
+    request.on('response', response => {
       const statusCode = response.statusCode;
       const responseHeaders = response.headers as Record<string, string | string[]>;
 
       if (statusCode < 200 || statusCode >= 300) {
         clearTimeout(timer);
         settled = true;
+        signal?.removeEventListener('abort', onAbort);
         logger.warn(`[http] Request failed: ${url} - status ${statusCode}`);
-        reject(
-          new HttpError(url, statusCode, responseHeaders, parseRetryAfter(responseHeaders)),
-        );
+        reject(new HttpError(url, statusCode, responseHeaders, parseRetryAfter(responseHeaders)));
         return;
       }
 
@@ -242,6 +280,7 @@ function requestBufferRaw(
           clearTimeout(timer);
           settled = true;
           request.abort();
+          signal?.removeEventListener('abort', onAbort);
           reject(new Error(`Response exceeded maxBytes (${maxBytes}): ${url}`));
           return;
         }
@@ -252,6 +291,7 @@ function requestBufferRaw(
         if (!settled) {
           clearTimeout(timer);
           settled = true;
+          signal?.removeEventListener('abort', onAbort);
           logger.debug(`[http] ${statusCode} ${url} (${Date.now() - startTime}ms)`);
           resolve(Buffer.concat(chunks));
         }
@@ -261,6 +301,7 @@ function requestBufferRaw(
         if (!settled) {
           clearTimeout(timer);
           settled = true;
+          signal?.removeEventListener('abort', onAbort);
           logger.warn(`[http] Response error: ${url}`, err.message);
           reject(err);
         }
@@ -271,6 +312,7 @@ function requestBufferRaw(
       if (!settled) {
         clearTimeout(timer);
         settled = true;
+        signal?.removeEventListener('abort', onAbort);
         logger.warn(`[http] Request error: ${url}`, err.message);
         reject(err);
       }
@@ -285,10 +327,7 @@ function requestBufferRaw(
  * by the server's Retry-After (or a 60s fallback) before rethrowing — the
  * caller still gets the rejection, we just don't hammer the host further.
  */
-function runGated<T>(
-  url: string,
-  op: () => Promise<T>,
-): Promise<T> {
+function runGated<T>(url: string, op: () => Promise<T>): Promise<T> {
   let hostname: string;
   try {
     hostname = new URL(url).hostname;
@@ -319,7 +358,7 @@ export function requestText(url: string, options: RequestOptions = {}): Promise<
 
 export function requestBuffer(
   url: string,
-  options: RequestOptions & { maxBytes?: number } = {},
+  options: RequestOptions & { maxBytes?: number } = {}
 ): Promise<Buffer> {
   return runGated(url, () => requestBufferRaw(url, options));
 }

--- a/apps/desktop/src/main/http.ts
+++ b/apps/desktop/src/main/http.ts
@@ -128,11 +128,14 @@ function requestTextRaw(url: string, options: RequestOptions = {}): Promise<stri
 
   return new Promise<string>((resolve, reject) => {
     let settled = false;
+    // eslint-disable-next-line prefer-const
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const request = net.request(url);
 
     const onAbort = () => {
       if (!settled) {
         settled = true;
+        if (timer) clearTimeout(timer);
         request.abort();
         reject(new DOMException('The operation was aborted', 'AbortError'));
       }
@@ -146,7 +149,7 @@ function requestTextRaw(url: string, options: RequestOptions = {}): Promise<stri
       signal.addEventListener('abort', onAbort, { once: true });
     }
 
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       if (!settled) {
         settled = true;
         request.abort();
@@ -225,11 +228,14 @@ function requestBufferRaw(
 
   return new Promise<Buffer>((resolve, reject) => {
     let settled = false;
+    // eslint-disable-next-line prefer-const
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const request = net.request(url);
 
     const onAbort = () => {
       if (!settled) {
         settled = true;
+        if (timer) clearTimeout(timer);
         request.abort();
         reject(new DOMException('The operation was aborted', 'AbortError'));
       }
@@ -243,7 +249,7 @@ function requestBufferRaw(
       signal.addEventListener('abort', onAbort, { once: true });
     }
 
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       if (!settled) {
         settled = true;
         request.abort();

--- a/apps/desktop/src/main/ipc/metadata-enrich.test.ts
+++ b/apps/desktop/src/main/ipc/metadata-enrich.test.ts
@@ -187,8 +187,11 @@ describe('metadata-enrich handlers', () => {
       expect(r.updatedFields.year).toBe(2024);
       expect(r.updatedFields.trackNumber).toBe(3);
 
-      // Cover art should be downloaded and saved to cache
-      expect(mockedDownloadImage).toHaveBeenCalledWith('https://example.com/cover.jpg');
+      // Cover art should be downloaded and saved to cache (signal is passed as second arg)
+      expect(mockedDownloadImage).toHaveBeenCalledWith(
+        'https://example.com/cover.jpg',
+        expect.any(AbortSignal)
+      );
       expect(mockedSaveAlbumArt).toHaveBeenCalled();
       expect(r.updatedFields.albumArt).toBe('shiranami-art://hash');
     });
@@ -421,7 +424,8 @@ describe('metadata-enrich handlers', () => {
           trackNumber: 3,
           coverImageBuffer: expect.any(Buffer),
           coverImageMime: 'image/jpeg',
-        })
+        }),
+        expect.any(AbortSignal)
       );
 
       expect(results[0].updatedFields.albumArt).toBe('shiranami-art://written');
@@ -442,6 +446,61 @@ describe('metadata-enrich handlers', () => {
       expect(ipcHandlers.has('metadata:lookup')).toBe(false);
       expect(ipcHandlers.has('metadata:enrich:cancel')).toBe(false);
       expect(ipcHandlers.has('metadata:enrich:tracks')).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Sequential runs do not share aborted state
+  // ---------------------------------------------------------------
+  describe('sequential runs with cancellation', () => {
+    it('second run completes normally after the first run was cancelled', async () => {
+      vi.useFakeTimers();
+
+      const tracks = [
+        makeTrack({ id: '550e8400-e29b-41d4-a716-446655440001', title: 'Song 1' }),
+        makeTrack({ id: '550e8400-e29b-41d4-a716-446655440002', title: 'Song 2' }),
+      ];
+
+      mockedLookup.mockResolvedValue(makeLookupResult({ coverImageUrl: undefined }));
+
+      const handler = ipcHandlers.get('metadata:enrich:tracks')!;
+      const cancelHandler = ipcHandlers.get('metadata:enrich:cancel')!;
+
+      // --- Run 1: start then cancel ---
+      const run1 = handler(null as never, tracks, {
+        writeToFile: false,
+        onlyMissing: false,
+      }) as Promise<EnrichTrackResult[]>;
+
+      await vi.advanceTimersByTimeAsync(0);
+      await cancelHandler(null as never);
+      await vi.advanceTimersByTimeAsync(1000);
+      await run1;
+
+      vi.clearAllMocks();
+      win.webContents.send.mockClear();
+
+      // --- Run 2: fresh run, must not see the previous controller's aborted state ---
+      const run2 = handler(null as never, [makeTrack({ title: 'Fresh Song' })], {
+        writeToFile: false,
+        onlyMissing: false,
+      }) as Promise<EnrichTrackResult[]>;
+
+      await vi.advanceTimersByTimeAsync(0);
+      const results2 = await run2;
+
+      expect(results2).toHaveLength(1);
+      expect(results2[0].success).toBe(true);
+
+      const progressCalls2 = win.webContents.send.mock.calls.filter(
+        (c: unknown[]) => c[0] === 'metadata:enrich:progress'
+      );
+      const cancelledEvent = progressCalls2.find(
+        (c: unknown[]) => (c[1] as { status: string }).status === 'cancelled'
+      );
+      expect(cancelledEvent).toBeUndefined();
+
+      vi.useRealTimers();
     });
   });
 

--- a/apps/desktop/src/main/ipc/metadata-enrich.test.ts
+++ b/apps/desktop/src/main/ipc/metadata-enrich.test.ts
@@ -240,6 +240,38 @@ describe('metadata-enrich handlers', () => {
   });
 
   // ---------------------------------------------------------------
+  // cancel-while-idle is a no-op
+  // ---------------------------------------------------------------
+  describe('cancel-while-idle', () => {
+    it('does not affect the next run when cancel is called with no active enrichment', async () => {
+      mockedLookup.mockResolvedValue(makeLookupResult({ coverImageUrl: undefined }));
+
+      // Fire cancel before any run has started
+      const cancelHandler = ipcHandlers.get('metadata:enrich:cancel')!;
+      await cancelHandler(null as never);
+
+      // Start a run — it should complete normally, not see itself as already-cancelled
+      const handler = ipcHandlers.get('metadata:enrich:tracks')!;
+      const results = (await handler(null as never, [makeTrack()], {
+        writeToFile: false,
+        onlyMissing: false,
+      })) as EnrichTrackResult[];
+
+      expect(results).toHaveLength(1);
+      expect(results[0].success).toBe(true);
+
+      // No cancelled progress event should have been emitted
+      const progressCalls = win.webContents.send.mock.calls.filter(
+        (c: unknown[]) => c[0] === 'metadata:enrich:progress'
+      );
+      const cancelledProgress = progressCalls.find(
+        (c: unknown[]) => (c[1] as { status: string }).status === 'cancelled'
+      );
+      expect(cancelledProgress).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------
   // Track with no metadata match (source: 'none')
   // ---------------------------------------------------------------
   describe('no metadata match', () => {

--- a/apps/desktop/src/main/ipc/metadata-enrich.ts
+++ b/apps/desktop/src/main/ipc/metadata-enrich.ts
@@ -45,7 +45,13 @@ export interface EnrichProgress {
   status: 'searching' | 'downloading' | 'writing' | 'done' | 'error' | 'cancelled';
 }
 
-let enrichCancelled = false;
+/**
+ * Active enrichment AbortController. Set when a batch run starts and cleared
+ * on exit. The `metadata:enrich:cancel` IPC aborts whichever is current.
+ * Concurrent enrichment runs are not supported (the renderer gates them) so a
+ * single slot is enough.
+ */
+let activeEnrichAbort: AbortController | null = null;
 
 export function registerMetadataEnrichHandlers(): void {
   // Look up metadata for a single track (for preview / confirmation)
@@ -57,12 +63,17 @@ export function registerMetadataEnrichHandlers(): void {
     { schema: metadataLookupArgs }
   );
 
-  // Cancel ongoing enrichment
+  // Cancel ongoing enrichment. No-op when idle — avoids leaving stale state
+  // that would poison the next run (which the old boolean flag could not prevent).
   handle(
     'metadata:enrich:cancel',
     async () => {
-      enrichCancelled = true;
-      logger.info('[metadata:enrich] Cancellation requested');
+      if (activeEnrichAbort) {
+        logger.info('[metadata:enrich] Cancellation requested');
+        activeEnrichAbort.abort('user-cancelled');
+      } else {
+        logger.info('[metadata:enrich] Cancel requested with no active enrichment');
+      }
     },
     { schema: metadataEnrichCancelArgs }
   );
@@ -79,7 +90,9 @@ export function registerMetadataEnrichHandlers(): void {
         `[metadata:enrich] Starting batch enrichment: ${tracks.length} tracks (writeToFile: ${options.writeToFile}, onlyMissing: ${options.onlyMissing})`
       );
 
-      enrichCancelled = false;
+      const abort = new AbortController();
+      activeEnrichAbort = abort;
+      const { signal } = abort;
       const results: EnrichTrackResult[] = [];
 
       const sendProgress = (progress: EnrichProgress) => {
@@ -90,7 +103,7 @@ export function registerMetadataEnrichHandlers(): void {
       };
 
       for (let i = 0; i < tracks.length; i++) {
-        if (enrichCancelled) {
+        if (signal.aborted) {
           logger.info(`[metadata:enrich] Cancelled at track ${i + 1}/${tracks.length}`);
           sendProgress({
             current: i + 1,
@@ -112,7 +125,7 @@ export function registerMetadataEnrichHandlers(): void {
 
         try {
           // Look up metadata
-          const lookup = await lookupMetadata(track.title, track.artist);
+          const lookup = await lookupMetadata(track.title, track.artist, signal);
 
           if (lookup.source === 'none') {
             logger.info(
@@ -177,7 +190,7 @@ export function registerMetadataEnrichHandlers(): void {
             });
 
             try {
-              coverImageBuffer = await downloadImage(lookup.coverImageUrl);
+              coverImageBuffer = await downloadImage(lookup.coverImageUrl, signal);
               // Determine MIME from URL or default to JPEG
               coverImageMime = lookup.coverImageUrl.toLowerCase().includes('.png')
                 ? 'image/png'
@@ -205,7 +218,7 @@ export function registerMetadataEnrichHandlers(): void {
               coverImageMime,
             };
 
-            const albumArtUrl = await writeMetadataToFile(track.filePath, writeOptions);
+            const albumArtUrl = await writeMetadataToFile(track.filePath, writeOptions, signal);
             if (albumArtUrl) {
               updatedFields.albumArt = albumArtUrl;
             }
@@ -260,8 +273,10 @@ export function registerMetadataEnrichHandlers(): void {
       const successCount = results.filter(r => r.success).length;
       const failedCount = results.filter(r => !r.success).length;
       logger.info(
-        `[metadata:enrich] Batch complete: ${successCount} updated, ${failedCount} failed/no-results out of ${tracks.length} tracks${enrichCancelled ? ' (cancelled)' : ''}`
+        `[metadata:enrich] Batch complete: ${successCount} updated, ${failedCount} failed/no-results out of ${tracks.length} tracks${signal.aborted ? ' (cancelled)' : ''}`
       );
+
+      if (activeEnrichAbort === abort) activeEnrichAbort = null;
 
       return results;
     },

--- a/apps/desktop/src/main/ipc/metadata-enrich.ts
+++ b/apps/desktop/src/main/ipc/metadata-enrich.ts
@@ -250,6 +250,15 @@ export function registerMetadataEnrichHandlers(): void {
             status: 'done',
           });
         } catch (error) {
+          if (signal.aborted || (error instanceof Error && error.name === 'AbortError')) {
+            sendProgress({
+              current: i + 1,
+              total: tracks.length,
+              trackName: track.title,
+              status: 'cancelled',
+            });
+            break;
+          }
           const errorMessage = error instanceof Error ? error.message : 'Unknown error';
           logger.error(`[metadata:enrich] Failed to enrich "${track.title}":`, error);
 

--- a/apps/desktop/src/main/metadata-lookup.ts
+++ b/apps/desktop/src/main/metadata-lookup.ts
@@ -24,7 +24,10 @@ export function cleanTitleForSearch(title: string, artist: string): string {
   // Strip common YouTube/video noise
   cleaned = cleaned
     // Parenthetical noise: (Official Video), (Lyrics), (Prod. xyz), (feat. xyz) kept
-    .replace(/\s*\((?:Official\s*(?:Video|Audio|Lyric\s*Video|Visualizer|Music\s*Video)|Lyrics?|MV|Audio|Visualizer|AMV|Prod\.?\s*[^)]*|MOURN\s*\d*|Male\s*Version|Female\s*Version|Rock\s*(?:Version|Cover)|Cover|Remix|Extended|80s\s*Remix)\)/gi, '')
+    .replace(
+      /\s*\((?:Official\s*(?:Video|Audio|Lyric\s*Video|Visualizer|Music\s*Video)|Lyrics?|MV|Audio|Visualizer|AMV|Prod\.?\s*[^)]*|MOURN\s*\d*|Male\s*Version|Female\s*Version|Rock\s*(?:Version|Cover)|Cover|Remix|Extended|80s\s*Remix)\)/gi,
+      ''
+    )
     // Square bracket noise: [Official Audio], [Looped], [+Lyrics], [male], [NMV], [Wave], etc.
     .replace(/\s*\[[^\]]*\]/g, '')
     // CJK brackets: 「...」【...】
@@ -76,18 +79,18 @@ interface ITunesResult {
  */
 async function searchItunes(
   title: string,
-  artist: string
+  artist: string,
+  signal?: AbortSignal
 ): Promise<MetadataLookupResult | null> {
   try {
     // Build search query: clean title and combine with artist
     const cleanedTitle = cleanTitleForSearch(title, artist);
-    const query = artist && artist !== 'Unknown Artist'
-      ? `${artist} ${cleanedTitle}`
-      : cleanedTitle;
+    const query =
+      artist && artist !== 'Unknown Artist' ? `${artist} ${cleanedTitle}` : cleanedTitle;
 
     const url = `https://itunes.apple.com/search?term=${encodeURIComponent(query)}&media=music&entity=song&limit=5`;
     logger.info(`[metadata-lookup] iTunes search: "${query}"`);
-    const data = await requestJson<ITunesResult>(url);
+    const data = await requestJson<ITunesResult>(url, { signal });
 
     if (!data.results || data.results.length === 0) {
       logger.info(`[metadata-lookup] iTunes: no results for "${query}"`);
@@ -117,7 +120,10 @@ async function searchItunes(
       if (normalizedArtist !== 'unknown artist') {
         if (resultArtist === normalizedArtist) {
           score += 0.5;
-        } else if (resultArtist.includes(normalizedArtist) || normalizedArtist.includes(resultArtist)) {
+        } else if (
+          resultArtist.includes(normalizedArtist) ||
+          normalizedArtist.includes(resultArtist)
+        ) {
           score += 0.3;
         }
       }
@@ -134,11 +140,12 @@ async function searchItunes(
       : undefined;
 
     const releaseDate = bestMatch.releaseDate ? new Date(bestMatch.releaseDate) : null;
-    const releaseYear = releaseDate && !isNaN(releaseDate.getTime())
-      ? releaseDate.getFullYear()
-      : undefined;
+    const releaseYear =
+      releaseDate && !isNaN(releaseDate.getTime()) ? releaseDate.getFullYear() : undefined;
 
-    logger.info(`[metadata-lookup] iTunes match: "${bestMatch.trackName}" by "${bestMatch.artistName}" (score: ${bestScore.toFixed(2)}, album: "${bestMatch.collectionName}")`);
+    logger.info(
+      `[metadata-lookup] iTunes match: "${bestMatch.trackName}" by "${bestMatch.artistName}" (score: ${bestScore.toFixed(2)}, album: "${bestMatch.collectionName}")`
+    );
 
     return {
       title: bestMatch.trackName || undefined,
@@ -163,7 +170,8 @@ async function searchItunes(
  */
 async function searchYouTube(
   title: string,
-  artist: string
+  artist: string,
+  signal?: AbortSignal
 ): Promise<MetadataLookupResult | null> {
   if (!isYtDlpInstalled()) {
     logger.info('[metadata-lookup] YouTube: yt-dlp not installed, skipping');
@@ -172,17 +180,14 @@ async function searchYouTube(
 
   try {
     const cleanedTitle = cleanTitleForSearch(title, artist);
-    const query = artist && artist !== 'Unknown Artist'
-      ? `${artist} - ${cleanedTitle}`
-      : cleanedTitle;
+    const query =
+      artist && artist !== 'Unknown Artist' ? `${artist} - ${cleanedTitle}` : cleanedTitle;
     logger.info(`[metadata-lookup] YouTube search: "${query}"`);
 
-    const { stdout, code } = await spawnYtDlp([
-      '--flat-playlist',
-      '--dump-json',
-      '--no-warnings',
-      `ytsearch1:${query}`,
-    ]);
+    const { stdout, code } = await spawnYtDlp(
+      ['--flat-playlist', '--dump-json', '--no-warnings', `ytsearch1:${query}`],
+      signal
+    );
 
     if (code !== 0 || !stdout.trim()) {
       logger.info(`[metadata-lookup] YouTube: no results (code: ${code})`);
@@ -190,9 +195,10 @@ async function searchYouTube(
     }
 
     const data = JSON.parse(stdout.trim().split('\n')[0]);
-    const thumbnailUrl = data.thumbnail
-      || data.thumbnails?.[data.thumbnails.length - 1]?.url
-      || (data.id ? `https://i.ytimg.com/vi/${data.id}/hqdefault.jpg` : undefined);
+    const thumbnailUrl =
+      data.thumbnail ||
+      data.thumbnails?.[data.thumbnails.length - 1]?.url ||
+      (data.id ? `https://i.ytimg.com/vi/${data.id}/hqdefault.jpg` : undefined);
 
     return {
       coverImageUrl: thumbnailUrl,
@@ -205,11 +211,26 @@ async function searchYouTube(
   }
 }
 
-function spawnYtDlp(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+function spawnYtDlp(
+  args: string[],
+  signal?: AbortSignal
+): Promise<{ stdout: string; stderr: string; code: number }> {
   return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('The operation was aborted', 'AbortError'));
+      return;
+    }
+
     const proc = spawn(getYtDlpPath(), args, { env: { ...process.env } });
     let stdout = '';
     let stderr = '';
+
+    const onAbort = () => {
+      proc.kill();
+      reject(new DOMException('The operation was aborted', 'AbortError'));
+    };
+
+    signal?.addEventListener('abort', onAbort, { once: true });
 
     proc.stdout.on('data', (data: Buffer) => {
       stdout += data.toString();
@@ -217,10 +238,12 @@ function spawnYtDlp(args: string[]): Promise<{ stdout: string; stderr: string; c
     proc.stderr.on('data', (data: Buffer) => {
       stderr += data.toString();
     });
-    proc.on('error', (err) => {
+    proc.on('error', err => {
+      signal?.removeEventListener('abort', onAbort);
       reject(err);
     });
-    proc.on('close', (code) => {
+    proc.on('close', code => {
+      signal?.removeEventListener('abort', onAbort);
       resolve({ stdout, stderr, code: code ?? 1 });
     });
   });
@@ -234,10 +257,11 @@ const IMAGE_MAX_SIZE = 10 * 1024 * 1024; // 10 MB
  * Routed through `requestBuffer` so cover-art hosts (e.g. i.ytimg.com,
  * iTunes thumbnails) share the per-host spacing + 429 handling.
  */
-export function downloadImage(url: string): Promise<Buffer> {
+export function downloadImage(url: string, signal?: AbortSignal): Promise<Buffer> {
   return requestBuffer(url, {
     timeoutMs: IMAGE_TIMEOUT_MS,
     maxBytes: IMAGE_MAX_SIZE,
+    signal,
   });
 }
 
@@ -246,17 +270,22 @@ export function downloadImage(url: string): Promise<Buffer> {
  */
 export async function lookupMetadata(
   title: string,
-  artist: string
+  artist: string,
+  signal?: AbortSignal
 ): Promise<MetadataLookupResult> {
   // Non-artist keywords that appear before a dash in titles but aren't real artists
-  const NON_ARTIST_PREFIXES = /^(nightcore|amv|mv|lyrics?|official|hd|hq|full|extended|remix|cover|male|female)\b/i;
+  const NON_ARTIST_PREFIXES =
+    /^(nightcore|amv|mv|lyrics?|official|hd|hq|full|extended|remix|cover|male|female)\b/i;
 
   // If the title contains "Artist - Song" pattern, extract a better artist/title split
   // This handles YouTube downloads where artist = channel name, title = "RealArtist - Song Name"
   let searchTitle = title;
   let searchArtist = artist;
   const dashMatch = title.match(/^(.+?)\s*[-–]\s*(.+)$/);
-  if (dashMatch && (artist === 'Unknown Artist' || !title.toLowerCase().startsWith(artist.toLowerCase()))) {
+  if (
+    dashMatch &&
+    (artist === 'Unknown Artist' || !title.toLowerCase().startsWith(artist.toLowerCase()))
+  ) {
     const candidateArtist = dashMatch[1].trim();
     const candidateTitle = dashMatch[2].trim();
 
@@ -264,25 +293,31 @@ export async function lookupMetadata(
       // "Nightcore - Darkside" → just use "Darkside" as title, keep original artist as Unknown
       searchTitle = candidateTitle;
       searchArtist = 'Unknown Artist';
-      logger.info(`[metadata-lookup] Stripped non-artist prefix "${candidateArtist}", title: "${searchTitle}"`);
+      logger.info(
+        `[metadata-lookup] Stripped non-artist prefix "${candidateArtist}", title: "${searchTitle}"`
+      );
     } else {
       searchArtist = candidateArtist;
       searchTitle = candidateTitle;
-      logger.info(`[metadata-lookup] Extracted artist/title from title: "${searchArtist}" - "${searchTitle}"`);
+      logger.info(
+        `[metadata-lookup] Extracted artist/title from title: "${searchArtist}" - "${searchTitle}"`
+      );
     }
   }
 
   logger.info(`[metadata-lookup] Looking up: "${searchTitle}" by "${searchArtist}"`);
 
   // Try iTunes first (structured metadata + album art)
-  const itunesResult = await searchItunes(searchTitle, searchArtist);
+  const itunesResult = await searchItunes(searchTitle, searchArtist, signal);
   if (itunesResult && itunesResult.confidence >= 0.3) {
-    logger.info(`[metadata-lookup] Using iTunes result (confidence: ${itunesResult.confidence.toFixed(2)})`);
+    logger.info(
+      `[metadata-lookup] Using iTunes result (confidence: ${itunesResult.confidence.toFixed(2)})`
+    );
     return itunesResult;
   }
 
   // Fall back to YouTube for at least a thumbnail
-  const youtubeResult = await searchYouTube(searchTitle, searchArtist);
+  const youtubeResult = await searchYouTube(searchTitle, searchArtist, signal);
   if (youtubeResult) {
     // Merge: if iTunes had some low-confidence data, use it for text fields
     if (itunesResult) {

--- a/apps/desktop/src/main/metadata-writer.ts
+++ b/apps/desktop/src/main/metadata-writer.ts
@@ -19,10 +19,15 @@ export interface WriteMetadataOptions {
 /**
  * Write metadata and/or cover art into an audio file.
  * Returns the shiranami-art:// URL if cover art was saved, or null.
+ *
+ * When `signal` is provided it is forwarded to the ffmpeg child process
+ * so cancellation terminates the encode promptly. node-id3 and flac-tagger
+ * use synchronous writes and cannot be interrupted mid-call.
  */
 export async function writeMetadataToFile(
   filePath: string,
-  options: WriteMetadataOptions
+  options: WriteMetadataOptions,
+  signal?: AbortSignal
 ): Promise<string | null> {
   const ext = path.extname(filePath).toLowerCase();
   const fileName = path.basename(filePath);
@@ -50,7 +55,7 @@ export async function writeMetadataToFile(
       case '.wma':
       case '.weba':
       case '.webm':
-        await writeTagsWithFFmpeg(filePath, options);
+        await writeTagsWithFFmpeg(filePath, options, signal);
         break;
       default:
         logger.warn(`[metadata-writer] Unsupported format for writing: ${ext}`);
@@ -122,7 +127,11 @@ async function writeFlacTags(filePath: string, options: WriteMetadataOptions): P
   await writeFlac(tags, filePath);
 }
 
-async function writeTagsWithFFmpeg(filePath: string, options: WriteMetadataOptions): Promise<void> {
+async function writeTagsWithFFmpeg(
+  filePath: string,
+  options: WriteMetadataOptions,
+  signal?: AbortSignal
+): Promise<void> {
   if (!isFFmpegInstalled()) {
     logger.warn('[metadata-writer] ffmpeg not installed, skipping tag write for:', filePath);
     return;
@@ -164,10 +173,23 @@ async function writeTagsWithFFmpeg(filePath: string, options: WriteMetadataOptio
 
   try {
     await new Promise<void>((resolve, reject) => {
-      execFile(getFFmpegPath(), args, { timeout: 30000 }, err => {
+      if (signal?.aborted) {
+        reject(new DOMException('The operation was aborted', 'AbortError'));
+        return;
+      }
+
+      const proc = execFile(getFFmpegPath(), args, { timeout: 30000 }, err => {
+        signal?.removeEventListener('abort', onAbort);
         if (err) reject(err);
         else resolve();
       });
+
+      const onAbort = () => {
+        proc.kill();
+        reject(new DOMException('The operation was aborted', 'AbortError'));
+      };
+
+      signal?.addEventListener('abort', onAbort, { once: true });
     });
 
     // Atomic replace: rename temp over original


### PR DESCRIPTION
## Summary

- Replaces the module-level `let enrichCancelled = false` boolean in `metadata-enrich.ts` with a per-run `AbortController` stored in `activeEnrichAbort`, mirroring the `activeScanAbort` pattern in `library.ts:296`.
- Cancel-while-idle is now a no-op (fixes the sticky `true` bug where calling cancel with no active run would poison the next batch).
- Threads `AbortSignal` all the way into in-flight work: iTunes HTTP request (`requestJson`), YouTube `yt-dlp` spawn (`proc.kill()`), cover image download (`requestBuffer`), and ffmpeg tag write (`execFile` + `proc.kill()`).
- Updates existing mock assertions in the test file and adds two new test scenarios.

## AbortSignal propagation

| Path | Cancellable? | Mechanism |
|------|-------------|-----------|
| iTunes search (`requestJson` via `requestTextRaw`) | Yes | `signal.addEventListener('abort')` calls `request.abort()` and rejects with `AbortError` |
| yt-dlp spawn (`spawnYtDlp`) | Yes | `signal.addEventListener('abort')` calls `proc.kill()` and rejects with `AbortError` |
| Cover image download (`requestBuffer` via `requestBufferRaw`) | Yes | Same as `requestTextRaw` |
| ffmpeg tag write (`writeTagsWithFFmpeg`) | Yes | `signal.addEventListener('abort')` calls `proc.kill()` and rejects with `AbortError` |
| node-id3 `update()` (MP3 writes) | No - sync call | Cannot be interrupted mid-call; documented in `writeMetadataToFile` JSDoc |
| flac-tagger `writeFlacTags` (FLAC writes) | No - async-wrapped sync | Same as node-id3 |

For non-cancellable paths the per-track loop's `signal.aborted` check fires on the next iteration boundary, so the batch still terminates promptly after the current track finishes.

## Test plan

- [x] `pnpm typecheck` passes (all packages clean)
- [x] `vitest run --project desktop` passes (622/622)
- [x] New test: cancel-while-idle does not poison next run
- [x] New test: sequential runs don't share aborted state
- [x] Existing cancel mid-run test continues to pass
- [x] Existing mock assertions updated for the new `signal` argument

## Notes

- Branched from master (not from PR #167) so it can be reviewed independently.
- If a rebase conflict appears in `metadata-enrich.ts` after PR #167 merges (cancelled status rendering + sleep removal), it will be trivial to resolve since the touched lines are non-overlapping.

Closes: part of the metadata-enrich chain (priority 9 from `docs/chain/2026-05-04-metadata-enrich-chain.md`)