### PR TITLE
perf(library): fix track-row re-render storm + overlay play counts

### DIFF
--- a/apps/web/src/components/mixes/MixesView.tsx
+++ b/apps/web/src/components/mixes/MixesView.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLibraryStore } from '@/stores/useLibraryStore';
+import { useMergedLibrary } from '@/hooks/useMergedLibrary';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 import { Sparkles, Play, Shuffle, ArrowLeft } from 'lucide-react';
@@ -17,7 +18,9 @@ import { MixesViewSkeleton } from './MixesViewSkeleton';
 
 export function MixesView() {
   const { t } = useTranslation('mixes');
-  const library = useLibraryStore(s => s.library);
+  // Merged so the mix previews / counts (`most-played`, `never-played`) reflect
+  // play counts bumped this session via the overlay store.
+  const library = useMergedLibrary();
   const libraryLoaded = useLibraryStore(s => s.libraryLoaded);
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const isPlaying = usePlaybackStore(s => s.isPlaying);

--- a/apps/web/src/components/shared/TrackRow.tsx
+++ b/apps/web/src/components/shared/TrackRow.tsx
@@ -1,4 +1,3 @@
-import { memo } from 'react';
 import { type Track } from '@/stores/types';
 import { type RowComponentProps } from 'react-window';
 import { TrackRowContent } from './TrackRowContent';
@@ -13,7 +12,18 @@ export interface TrackRowProps {
   showAddToPlaylist?: boolean;
 }
 
-function TrackRowImpl(props: RowComponentProps<TrackRowProps>) {
+/**
+ * Row adapter for `react-window`'s `List`. Renders a positioned wrapper and
+ * delegates all content to `TrackRowContent` (which is memoised and handles
+ * its own re-render gating via narrowed store subscriptions).
+ *
+ * `memo` is intentionally absent here: `react-window` constructs a fresh
+ * `style` object literal and fresh `ariaAttributes` on every list render, so a
+ * default shallow comparison always fails — the wrapper adds cost with no
+ * benefit. `memo(TrackRowContent)` one level down is what prevents the content
+ * subtree from re-rendering when only the wrapper's positional props change.
+ */
+export function TrackRow(props: RowComponentProps<TrackRowProps>) {
   const {
     index,
     style,
@@ -45,18 +55,3 @@ function TrackRowImpl(props: RowComponentProps<TrackRowProps>) {
     </div>
   );
 }
-
-/**
- * Memoised so a list-level re-render of `react-window`'s `List` doesn't
- * re-render every mounted row. `LibraryView` builds `rowProps` from stable
- * refs (memoised `filteredLibrary`, `useCallback` handlers, the stable
- * Zustand action ref); `react-window` spreads those keys plus `index`/`style`
- * onto the row, so the only props that change per render are `index`, `style`,
- * and the now-playing flags (`currentTrack`/`isPlaying`) — a default shallow
- * comparison handles all of them correctly.
- *
- * Cast back to the plain function signature so it satisfies `react-window`'s
- * `rowComponent` prop type (which expects `(props) => ReactElement | null`,
- * not a `MemoExoticComponent`); `memo` is transparent at runtime.
- */
-export const TrackRow = memo(TrackRowImpl) as unknown as typeof TrackRowImpl;

--- a/apps/web/src/components/shared/TrackRow.tsx
+++ b/apps/web/src/components/shared/TrackRow.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { type Track } from '@/stores/types';
 import { type RowComponentProps } from 'react-window';
 import { TrackRowContent } from './TrackRowContent';
@@ -12,7 +13,7 @@ export interface TrackRowProps {
   showAddToPlaylist?: boolean;
 }
 
-export function TrackRow(props: RowComponentProps<TrackRowProps>) {
+function TrackRowImpl(props: RowComponentProps<TrackRowProps>) {
   const {
     index,
     style,
@@ -44,3 +45,18 @@ export function TrackRow(props: RowComponentProps<TrackRowProps>) {
     </div>
   );
 }
+
+/**
+ * Memoised so a list-level re-render of `react-window`'s `List` doesn't
+ * re-render every mounted row. `LibraryView` builds `rowProps` from stable
+ * refs (memoised `filteredLibrary`, `useCallback` handlers, the stable
+ * Zustand action ref); `react-window` spreads those keys plus `index`/`style`
+ * onto the row, so the only props that change per render are `index`, `style`,
+ * and the now-playing flags (`currentTrack`/`isPlaying`) — a default shallow
+ * comparison handles all of them correctly.
+ *
+ * Cast back to the plain function signature so it satisfies `react-window`'s
+ * `rowComponent` prop type (which expects `(props) => ReactElement | null`,
+ * not a `MemoExoticComponent`); `memo` is transparent at runtime.
+ */
+export const TrackRow = memo(TrackRowImpl) as unknown as typeof TrackRowImpl;

--- a/apps/web/src/components/shared/TrackRowContent.tsx
+++ b/apps/web/src/components/shared/TrackRowContent.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState, useCallback } from 'react';
+import { type ReactNode, memo, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { type Track } from '@/stores/types';
 import { useSelectionStore } from '@/stores/useSelectionStore';
@@ -25,7 +25,7 @@ export interface TrackRowContentProps {
   dragHandle?: ReactNode;
 }
 
-export function TrackRowContent({
+function TrackRowContentImpl({
   track,
   index,
   queue,
@@ -43,30 +43,30 @@ export function TrackRowContent({
 
   const isSelected = useSelectionStore(s => s.selectedTrackIds.has(track.id));
   const hasSelection = useSelectionStore(s => s.selectedTrackIds.size > 0);
-  const selectedTrackIds = useSelectionStore(s => s.selectedTrackIds);
   const toggleTrack = useSelectionStore(s => s.toggleTrack);
   const selectRange = useSelectionStore(s => s.selectRange);
   const clearSelection = useSelectionStore(s => s.clearSelection);
 
-  // Heart icon reads the live overlay value so a toggle anywhere in the app
-  // (player bar, context menu, this row) reflects on every surface without
-  // reallocating the library array. Falls back to the seed value on the
-  // passed-in `track` when no overlay entry exists.
-  const overlayVersion = useTrackOverlayStore(s => s.version);
-  void overlayVersion;
-  const overlayFavorite = useTrackOverlayStore.getState().overlays.get(track.id)?.isFavorite;
+  // Heart icon subscribes to *this row's* overlay favorite value only — a
+  // toggle anywhere in the app (player bar, context menu, this row) updates
+  // the overlay store, and Zustand's Object.is comparison re-renders just the
+  // toggled row instead of every mounted virtual row. Falls back to the seed
+  // value on the passed-in `track` when no overlay entry exists.
+  const overlayFavorite = useTrackOverlayStore(s => s.overlays.get(track.id)?.isFavorite);
   const isFavorite = overlayFavorite ?? track.isFavorite;
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
-      if (hasSelection && !selectedTrackIds.has(track.id)) {
+      // Read the live Set via getState() instead of subscribing to it — the
+      // row only cares whether *it* is in the current selection at click time.
+      if (hasSelection && !useSelectionStore.getState().selectedTrackIds.has(track.id)) {
         clearSelection();
       }
       setContextMenu({ x: e.clientX, y: e.clientY });
     },
-    [hasSelection, track.id, selectedTrackIds, clearSelection]
+    [hasSelection, track.id, clearSelection]
   );
 
   const handleCloseContextMenu = useCallback(() => {
@@ -207,3 +207,13 @@ export function TrackRowContent({
     </>
   );
 }
+
+/**
+ * Memoised so a list re-render (e.g. `react-window` re-rendering all mounted
+ * rows when its `rowProps` object identity changes, or the now-playing row's
+ * `currentTrack`/`isPlaying` flipping) doesn't propagate into every row. The
+ * row's volatile state (its selection flag, its overlay favorite) is read via
+ * row-scoped Zustand selectors above, so a default shallow prop comparison is
+ * enough — only the now-playing flags legitimately change per row.
+ */
+export const TrackRowContent = memo(TrackRowContentImpl);

--- a/apps/web/src/hooks/queries/useMixTracks.ts
+++ b/apps/web/src/hooks/queries/useMixTracks.ts
@@ -1,11 +1,13 @@
 import { useMemo } from 'react';
-import { useLibraryStore } from '@/stores/useLibraryStore';
+import { useMergedLibrary } from '@/hooks/useMergedLibrary';
 import type { Track } from '@/stores/types';
 import { useHistoryQuery } from '@/hooks/queries/useHistory';
 import { MIX_LIMIT, type MixId } from '@/components/mixes/mixDefinitions';
 
 export function useMixTracks(mixId: MixId | null): Track[] {
-  const library = useLibraryStore((s) => s.library);
+  // Merged so `most-played` / `never-played` see the overlay-bumped play count
+  // recorded this session, not the stale canonical-library seed value.
+  const library = useMergedLibrary();
   const { data: historyData } = useHistoryQuery('all');
 
   return useMemo(() => {

--- a/apps/web/src/hooks/useLibraryRescan.ts
+++ b/apps/web/src/hooks/useLibraryRescan.ts
@@ -145,7 +145,9 @@ export function useLibraryRescan(): UseLibraryRescanResult {
         await window.electronAPI.db.tracks.removeMany(allTracks.map(t => t.id));
       }
       clearQueue();
-      useLibraryStore.setState({ library: [] });
+      // Go through the action (not setState) so the mutation overlay is
+      // cleared alongside the canonical array.
+      useLibraryStore.getState().setLibrary([]);
       queryClient.invalidateQueries({ queryKey: libraryKeys.all });
       queryClient.invalidateQueries({ queryKey: playlistKeys.all });
       setConfirmClear(false);

--- a/apps/web/src/hooks/useLibrarySync.ts
+++ b/apps/web/src/hooks/useLibrarySync.ts
@@ -35,7 +35,9 @@ export function useLibrarySync() {
   useEffect(() => {
     if (!data || data.length === 0) return;
     if (useLibraryStore.getState().library.length === 0) {
-      useLibraryStore.setState({ library: data });
+      // Through the action so the mutation overlay is reconciled away — the
+      // freshly-fetched array carries the latest DB-side isFavorite/playCount.
+      useLibraryStore.getState().setLibrary(data);
     }
     // Drop the React-Query copy after seeding Zustand. Zustand is the runtime
     // source of truth; keeping the cache around is ~20 MB of dead state at 50k

--- a/apps/web/src/hooks/useMergedLibrary.ts
+++ b/apps/web/src/hooks/useMergedLibrary.ts
@@ -12,10 +12,16 @@ import type { Track } from '@/stores/types';
  * overlay entries exist, allocates a single new array and patches only the
  * matching ids; the rest are reused by reference.
  *
+ * Merges every overlay field (`isFavorite`, `playCount`) on top of the seed
+ * via a shallow spread, so an overlay-carried play-count bump or favorite
+ * toggle is reflected here without the canonical `library` array changing
+ * identity.
+ *
  * Memoised over `(library, overlay-version)`. Re-runs on every overlay
  * mutation but the cost is O(n) once per mutation — sub-1Hz for favorite
- * toggles, much cheaper than the full `library.map(...)` reallocation that
- * the previous `toggleFavorite` performed.
+ * toggles and recorded plays, much cheaper than the full `library.map(...)`
+ * reallocation the previous `toggleFavorite` / `incrementTrackPlayCount`
+ * performed.
  */
 export function useMergedLibrary(): Track[] {
   const library = useLibraryStore(s => s.library);

--- a/apps/web/src/stores/useLibraryStore.test.ts
+++ b/apps/web/src/stores/useLibraryStore.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
 import { useLibraryStore } from './useLibraryStore';
 import { usePlaybackStore } from './usePlaybackStore';
 import { useTrackOverlayStore } from './useTrackOverlayStore';
+import { useMergedLibrary } from '@/hooks/useMergedLibrary';
 import type { Track } from './types';
 
 vi.mock('@/lib/platform', () => ({
@@ -51,6 +53,22 @@ describe('useLibraryStore', () => {
       useLibraryStore.getState().setLibrary([makeTrack('a', { isFavorite: true, playCount: 9 })]);
 
       expect(useTrackOverlayStore.getState().overlays.size).toBe(0);
+    });
+
+    it('yields the DB value from useMergedLibrary after re-seed with a bumped count, not the stale overlay value', () => {
+      // Simulate a play-count bump accumulating in the overlay during the session.
+      useLibraryStore.getState().setLibrary([makeTrack('a', { playCount: 2 })]);
+      useLibraryStore.getState().incrementTrackPlayCount('a');
+      expect(useTrackOverlayStore.getState().overlays.get('a')?.playCount).toBe(3);
+
+      // A full library re-seed (e.g. from applyEnrichResults) brings the
+      // authoritative DB value. setLibrary clears the overlay, so useMergedLibrary
+      // must return the DB value (4), not the stale overlay value (3).
+      useLibraryStore.getState().setLibrary([makeTrack('a', { playCount: 4 })]);
+
+      expect(useTrackOverlayStore.getState().overlays.size).toBe(0);
+      const { result } = renderHook(() => useMergedLibrary());
+      expect(result.current[0].playCount).toBe(4);
     });
   });
 

--- a/apps/web/src/stores/useLibraryStore.test.ts
+++ b/apps/web/src/stores/useLibraryStore.test.ts
@@ -43,6 +43,15 @@ describe('useLibraryStore', () => {
       useLibraryStore.getState().setLibrary([makeTrack('a'), makeTrack('b')]);
       expect(useLibraryStore.getState().library).toHaveLength(2);
     });
+
+    it('clears the mutation overlay so a fresh canonical array supersedes session deltas', () => {
+      useLibraryStore.setState({ library: [makeTrack('a')] });
+      useTrackOverlayStore.getState().setOverlay('a', { isFavorite: true, playCount: 9 });
+
+      useLibraryStore.getState().setLibrary([makeTrack('a', { isFavorite: true, playCount: 9 })]);
+
+      expect(useTrackOverlayStore.getState().overlays.size).toBe(0);
+    });
   });
 
   describe('addToLibrary', () => {
@@ -50,6 +59,15 @@ describe('useLibraryStore', () => {
       useLibraryStore.setState({ library: [makeTrack('a')] });
       useLibraryStore.getState().addToLibrary([makeTrack('b'), makeTrack('c')]);
       expect(useLibraryStore.getState().library.map(t => t.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('does not touch the overlay (existing tracks keep their session deltas)', () => {
+      useLibraryStore.setState({ library: [makeTrack('a')] });
+      useTrackOverlayStore.getState().setOverlay('a', { playCount: 4 });
+
+      useLibraryStore.getState().addToLibrary([makeTrack('b')]);
+
+      expect(useTrackOverlayStore.getState().overlays.get('a')).toEqual({ playCount: 4 });
     });
   });
 
@@ -60,6 +78,19 @@ describe('useLibraryStore', () => {
       });
       useLibraryStore.getState().removeFromLibrary(['b']);
       expect(useLibraryStore.getState().library.map(t => t.id)).toEqual(['a', 'c']);
+    });
+
+    it('drops overlay entries for removed tracks but keeps them for survivors', () => {
+      useLibraryStore.setState({
+        library: [makeTrack('a'), makeTrack('b')],
+      });
+      useTrackOverlayStore.getState().setOverlay('a', { playCount: 2 });
+      useTrackOverlayStore.getState().setOverlay('b', { isFavorite: true });
+
+      useLibraryStore.getState().removeFromLibrary(['a']);
+
+      expect(useTrackOverlayStore.getState().overlays.has('a')).toBe(false);
+      expect(useTrackOverlayStore.getState().overlays.get('b')).toEqual({ isFavorite: true });
     });
 
     it('removes from library and prunes queue + currentTrack when currently playing', () => {
@@ -303,9 +334,10 @@ describe('useLibraryStore', () => {
   // --- incrementTrackPlayCount ---
 
   describe('incrementTrackPlayCount', () => {
-    it('increments across library, queue, and currentTrack', () => {
+    it('writes the bumped count to the overlay and leaves the library array reference stable', () => {
       const t = makeTrack('x', { playCount: 2 });
-      useLibraryStore.setState({ library: [t] });
+      const libraryRefBefore = [t];
+      useLibraryStore.setState({ library: libraryRefBefore });
       usePlaybackStore.setState({
         queue: [t],
         currentTrack: t,
@@ -314,16 +346,50 @@ describe('useLibraryStore', () => {
 
       useLibraryStore.getState().incrementTrackPlayCount('x');
 
-      expect(useLibraryStore.getState().library[0].playCount).toBe(3);
+      // Overlay carries the absolute bumped count (seed 2 -> 3).
+      expect(useTrackOverlayStore.getState().overlays.get('x')).toEqual({ playCount: 3 });
+      // Canonical library array reference is unchanged — the whole point of
+      // routing play counts through the overlay store.
+      expect(useLibraryStore.getState().library).toBe(libraryRefBefore);
+      expect(useLibraryStore.getState().library[0].playCount).toBe(2);
+      // Playback queue + currentTrack still get the new value (cross-store sync
+      // remains library's responsibility — they're not overlay-aware).
       expect(usePlaybackStore.getState().queue[0].playCount).toBe(3);
       expect(usePlaybackStore.getState().currentTrack!.playCount).toBe(3);
     });
 
-    it('defaults from undefined playCount to 1', () => {
+    it('defaults from undefined playCount to 1 in the overlay', () => {
       const t = makeTrack('x');
       useLibraryStore.setState({ library: [t] });
       useLibraryStore.getState().incrementTrackPlayCount('x');
-      expect(useLibraryStore.getState().library[0].playCount).toBe(1);
+      expect(useTrackOverlayStore.getState().overlays.get('x')).toEqual({ playCount: 1 });
+    });
+
+    it('reads the current count from the overlay if one already exists (no double-count on refetch-free bumps)', () => {
+      const t = makeTrack('x', { playCount: 5 });
+      useLibraryStore.setState({ library: [t] });
+      // First bump: 5 -> 6.
+      useLibraryStore.getState().incrementTrackPlayCount('x');
+      expect(useTrackOverlayStore.getState().overlays.get('x')).toEqual({ playCount: 6 });
+      // Second bump reads the overlay (6), not the stale library seed (5) -> 7.
+      useLibraryStore.getState().incrementTrackPlayCount('x');
+      expect(useTrackOverlayStore.getState().overlays.get('x')).toEqual({ playCount: 7 });
+    });
+
+    it('bumps a track that lives only in the playback queue (radio/preview case)', () => {
+      const radioTrack = makeTrack('radio', { playCount: 3 });
+      useLibraryStore.setState({ library: [] });
+      usePlaybackStore.setState({
+        queue: [radioTrack],
+        currentTrack: radioTrack,
+        queueIndex: 0,
+      });
+
+      useLibraryStore.getState().incrementTrackPlayCount('radio');
+
+      expect(useTrackOverlayStore.getState().overlays.get('radio')).toEqual({ playCount: 4 });
+      expect(usePlaybackStore.getState().queue[0].playCount).toBe(4);
+      expect(usePlaybackStore.getState().currentTrack!.playCount).toBe(4);
     });
 
     it('persists to the DB via electronAPI', () => {

--- a/apps/web/src/stores/useLibraryStore.ts
+++ b/apps/web/src/stores/useLibraryStore.ts
@@ -88,12 +88,25 @@ export const useLibraryStore = create<LibraryStore>()((set, get) => ({
   scanState: 'idle',
   scanProgress: null,
 
-  setLibrary: tracks => set({ library: tracks }),
+  setLibrary: tracks => {
+    // A fresh canonical array carries the latest DB-side isFavorite/playCount
+    // for the whole world, so any session-scoped overlay deltas are now folded
+    // into `tracks` — drop them. In practice this only fires on cold boot
+    // (`useLibrarySync` seeds when the library is empty) and on HMR, where the
+    // overlay is already empty; it's the correct reconciliation point either
+    // way and keeps the invariant explicit.
+    useTrackOverlayStore.getState().clearAll();
+    set({ library: tracks });
+  },
 
   addToLibrary: tracks => set(s => ({ library: [...s.library, ...tracks] })),
 
   removeFromLibrary: trackIds => {
     const ids = new Set(trackIds);
+    // Drop overlay entries for tracks leaving the library so they don't linger
+    // as dead weight (and can't pollute a future re-import that reuses an id).
+    const overlayStore = useTrackOverlayStore.getState();
+    for (const id of ids) overlayStore.clearOverlay(id);
     set(s => ({ library: s.library.filter(t => !ids.has(t.id)) }));
 
     const playback = usePlaybackStore.getState();
@@ -165,16 +178,36 @@ export const useLibraryStore = create<LibraryStore>()((set, get) => ({
   },
 
   incrementTrackPlayCount: trackId => {
+    const overlayStore = useTrackOverlayStore.getState();
+    const overlayEntry = overlayStore.overlays.get(trackId);
     const { library } = get();
-    const increment = (t: Track) => ({ ...t, playCount: (t.playCount ?? 0) + 1 });
+    const target = library.find(t => t.id === trackId);
 
-    const hasInLibrary = library.some(t => t.id === trackId);
-    if (hasInLibrary) {
-      set({
-        library: library.map(t => (t.id === trackId ? increment(t) : t)),
-      });
-    }
-    syncPlaybackTrack(trackId, increment);
+    // Resolve the current effective play count: overlay-first (carries any
+    // earlier bump this session), then the library seed, then the playback
+    // queue / currentTrack (radio / preview tracks that never enter the
+    // library). The overlay stores the absolute value, mirroring how
+    // `isFavorite` is modeled — `useMergedLibrary` / `useTrack` merge it on
+    // top of the seed, so the effective value is always correct.
+    const playback = usePlaybackStore.getState();
+    const queueTrack = playback.queue.find(t => t.id === trackId);
+    const currentTrack = playback.currentTrack;
+    const currentCount =
+      overlayEntry?.playCount ??
+      target?.playCount ??
+      queueTrack?.playCount ??
+      (currentTrack?.id === trackId ? currentTrack.playCount : undefined) ??
+      0;
+    const nextCount = currentCount + 1;
+
+    // Library array reference is intentionally NOT touched — the overlay
+    // carries the new count until the next full library refetch (rescan /
+    // import) reseeds canonical state and `clearAll()` drops the session
+    // deltas. Skipping the reallocation here is the entire point: AlbumGrid's
+    // groupTracksByAlbum memo and LibraryView's filteredLibrary memo no longer
+    // invalidate on a recorded play.
+    overlayStore.setOverlay(trackId, { playCount: nextCount });
+    syncPlaybackTrack(trackId, t => ({ ...t, playCount: nextCount }));
 
     if (IS_ELECTRON) {
       window.electronAPI.db.tracks.incrementPlayCount(trackId).catch(err => {

--- a/apps/web/src/stores/useMetadataEnrichStore.ts
+++ b/apps/web/src/stores/useMetadataEnrichStore.ts
@@ -117,7 +117,7 @@ async function applyEnrichResults(results: EnrichTrackResult[]): Promise<void> {
   const allDbTracks = await window.electronAPI.db.tracks.getAll();
   const { mapDbTracksToTracks } = await import('@/lib/trackMapper');
   const refreshedTracks = mapDbTracksToTracks(allDbTracks as Record<string, unknown>[]);
-  useLibraryStore.setState({ library: refreshedTracks });
+  useLibraryStore.getState().setLibrary(refreshedTracks);
 
   // Patch playback store if the affected track is currently playing or queued —
   // otherwise the player bar / queue panel would render stale fields until the


### PR DESCRIPTION
## Summary

Findings #1 and #5 from the 2026-05-11 perf audit (`docs/perf/2026-05-11-app-wide-perf-audit.md`).

**Track-row re-render storm.** `react-window` keeps ~30-50 `TrackRowContent` rows mounted; toggling one selection or one favorite used to re-render all of them, because the row subscribed to the whole `selectedTrackIds` Set and to the global `useTrackOverlayStore.version`.
- The favorite heart now subscribes to a row-scoped selector (`s.overlays.get(track.id)?.isFavorite`) instead of `s.version` - Zustand's `Object.is` then re-renders only the toggled row.
- The range-select / context-menu path reads `selectedTrackIds` via `useSelectionStore.getState()` inside the callback instead of subscribing to the Set.
- `TrackRowContent` is wrapped in `React.memo` so a `react-window` list re-render (fresh `style` prop) does not propagate into the content subtree. (`TrackRow` itself is intentionally not memoized - react-window hands it a fresh `style` + `ariaAttributes` every render, so a memo there would never short-circuit; the gating that matters is the narrowed subscriptions plus `memo(TrackRowContent)`.)
- Out of scope, tracked as a follow-up: a track change still re-renders all rows because `currentTrack` flows as a prop; switching each row to `usePlaybackStore(s => s.currentTrack?.id === track.id)` is a separate change.

**Play counts via the mutation overlay store.** `useLibraryStore.incrementTrackPlayCount` used to `set({ library: library.map(...) })`, reallocating the canonical `library` array on every recorded play and re-running `AlbumGrid`'s `groupTracksByAlbum` memo, `LibraryView`'s `filteredLibrary` memo, etc. Favorites already avoided this via `useTrackOverlayStore`; play counts now do too.
- `incrementTrackPlayCount` writes the bumped absolute count to `useTrackOverlayStore` (reading overlay-first, then library seed, then the playback queue/current as fallback). `useMergedLibrary`'s `{ ...t, ...overlay }` shallow merge already folds `playCount` in.
- The overlay is reconciled against canonical-library changes: `setLibrary` calls `useTrackOverlayStore.clearAll()`, `removeFromLibrary` clears the removed ids. All full-refetch paths (`useLibrarySync` cold start, `useLibraryRescan` clear, and the metadata-enrich post-apply re-seed) now route through the `setLibrary` action rather than raw `setState`, so there is a single reconciliation point.
- `useMixTracks` / `MixesView` now read `useMergedLibrary()` so the `most-played` / `never-played` mixes see session play counts. History / listening-stats surfaces read DB aggregation rows, not `Track.playCount`, so they were already correct.

## Commits

- `perf(library): narrow track-row favorite + selection subscriptions to the row's own state`
- `perf(library): memo TrackRow and TrackRowContent so list re-renders don't propagate`
- `perf(library): route play counts through the mutation overlay store`
- `refactor(library): reconcile the mutation overlay against canonical-library changes`
- `test(library): cover play-count overlay routing and overlay reconciliation`
- `perf(library): drop the no-op memo wrapper on TrackRow` (review follow-up)
- `fix(metadata): re-seed library via setLibrary so the overlay reconciles` (review follow-up)

## Test plan

- [x] `pnpm typecheck` - passes (web + desktop + packages)
- [x] `pnpm lint` - passes (one pre-existing warning in `apps/mobile/.expo/types/router.d.ts`, mobile is excluded from the workspace)
- [x] `pnpm test` - 1253 tests pass; new coverage for the play-count overlay routing (absolute bump, stable `library` reference, no double-count), overlay reconciliation on `setLibrary` / `addToLibrary` / `removeFromLibrary`, and the merged read yielding the DB value after a re-seed
- [x] `pnpm build` - succeeds (vite renderer + esbuild main/preload)
- [ ] Manual UI smoke (not run - dev server is not started in this environment): React DevTools Profiler confirming ~50 row commits down to 1 per selection move / favorite toggle on a tall Library view; drag-reorder in playlists still feels right; "Most Played" mix updates live as a session plays without an AlbumGrid remount; favorite heart stays in sync across player bar / context menu / row

## Reviewed

`kirei-review` pass: verdict ship-with-changes, no blockers; the two "Important" findings (the no-op `memo(TrackRow)` and the metadata-enrich re-seed bypassing `setLibrary`) are addressed in the last two commits. Full review at `docs/review/2026-05-11-branch-track-row-rerender-overlay-playcount.md`.