### PR TITLE
perf: cut visible-window CPU usage + add dev CPU debug panel

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -92,6 +92,22 @@ async function bootstrap(): Promise<void> {
     `[system] Memory: ${Math.round(os.totalmem() / 1024 / 1024)}MB, userData: ${app.getPath('userData')}`
   );
   logger.info(`[security] App packaged: ${app.isPackaged}`);
+  // One-time GPU/HW-accel assertion so a future regression that disables
+  // hardware acceleration (which would sharply raise open-state CPU because
+  // compositing falls back to the CPU) is detectable in logs immediately.
+  // We never call app.disableHardwareAcceleration(), so this should report
+  // hardware-backed compositing.
+  try {
+    const gpu = app.getGPUFeatureStatus();
+    logger.info(
+      `[gpu] HW acceleration enabled: ${!app.commandLine.hasSwitch('disable-gpu')} | ` +
+        `gpu_compositing: ${gpu.gpu_compositing ?? 'unknown'}, ` +
+        `webgl: ${gpu.webgl ?? 'unknown'}, ` +
+        `video_decode: ${gpu.video_decode ?? 'unknown'}`
+    );
+  } catch (err) {
+    logger.warn('[gpu] Failed to read GPU feature status:', err);
+  }
   logger.info('════════════════════════════════════════════════════════════');
 
   initializeDatabase({ path: join(app.getPath('userData'), 'shiranami.db') });

--- a/apps/desktop/src/main/ipc/debug.ts
+++ b/apps/desktop/src/main/ipc/debug.ts
@@ -1,0 +1,87 @@
+// Main-process metrics sampler for the dev-only CPU/Perf Debug Panel.
+//
+// While active (between `debug:start` and `debug:stop`) it polls
+// `app.getAppMetrics()` + `process.getCPUUsage()` + `process.getHeapStatistics()`
+// at ~1 Hz and pushes a `debug:metrics` snapshot to the renderer, mirroring the
+// `webContents.send` progress pattern in downloader.ts. The interval is
+// `.unref()`-ed (matching logger.ts) so it never holds the event loop open.
+//
+// SAFETY (see observability report 2026-05-21):
+//  - Sample at 1 Hz, never per-frame; the monitor must not become the load it
+//    measures.
+//  - Only sample while the panel is open — start on `debug:start`, stop on
+//    `debug:stop`. Closing the panel clears the interval so there is zero
+//    self-inflicted CPU when the overlay is closed.
+//  - Do NOT log per-tick (it would blow up the rotating file logger). Emit a
+//    single `info` heartbeat on start/stop only.
+//  - The snapshot carries numbers + process types only — no paths, titles,
+//    URLs, argv, or env.
+
+import { app, ipcMain } from 'electron';
+import { IPC_CHANNELS, type MainMetricsSnapshot } from '@shiranami/contracts';
+import { logger } from '../logger';
+import { getMainWindow } from '../utils/window';
+import { handle } from './with-ipc-handler';
+import { debugStartArgs, debugStopArgs } from './schemas/debug';
+
+const C = IPC_CHANNELS.debug;
+const SAMPLE_INTERVAL_MS = 1000;
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+function sample(): void {
+  const win = getMainWindow();
+  if (!win || win.isDestroyed()) return;
+
+  const cpu = process.getCPUUsage();
+  const heap = process.getHeapStatistics();
+  const procs = app.getAppMetrics().map(m => ({
+    type: m.type,
+    pid: m.pid,
+    cpu: m.cpu.percentCPUUsage,
+    mem: m.memory.workingSetSize,
+  }));
+
+  const snapshot: MainMetricsSnapshot = {
+    ts: Date.now(),
+    cpu: {
+      percentCPUUsage: cpu.percentCPUUsage,
+      idleWakeupsPerSecond: cpu.idleWakeupsPerSecond,
+    },
+    heap: {
+      totalHeapSize: heap.totalHeapSize,
+      usedHeapSize: heap.usedHeapSize,
+      heapSizeLimit: heap.heapSizeLimit,
+    },
+    procs,
+  };
+
+  win.webContents.send(C.metrics, snapshot);
+}
+
+function startSampling(): void {
+  if (timer) return;
+  logger.info('[debug] metrics sampling started');
+  timer = setInterval(sample, SAMPLE_INTERVAL_MS);
+  if (typeof timer === 'object' && 'unref' in timer) {
+    timer.unref();
+  }
+}
+
+function stopSampling(): void {
+  if (!timer) return;
+  clearInterval(timer);
+  timer = null;
+  logger.info('[debug] metrics sampling stopped');
+}
+
+export function registerDebugHandlers(): void {
+  handle(C.start, () => startSampling(), { schema: debugStartArgs });
+  handle(C.stop, () => stopSampling(), { schema: debugStopArgs });
+}
+
+export function cleanupDebugHandlers(): void {
+  stopSampling();
+  ipcMain.removeHandler(C.start);
+  ipcMain.removeHandler(C.stop);
+}

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1,6 +1,7 @@
 export { registerWindowHandlers, cleanupWindowHandlers } from './window';
 export { registerStoreHandlers, cleanupStoreHandlers } from './store';
 export { registerAppHandlers, cleanupAppHandlers } from './app';
+export { registerDebugHandlers, cleanupDebugHandlers } from './debug';
 export { registerDialogHandlers, cleanupDialogHandlers } from './dialog';
 export { registerLibraryHandlers, cleanupLibraryHandlers } from './library';
 export { registerMediaHandlers, cleanupMediaHandlers } from './media';

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -36,6 +36,8 @@ import {
   cleanupStoreHandlers,
   registerAppHandlers,
   cleanupAppHandlers,
+  registerDebugHandlers,
+  cleanupDebugHandlers,
   registerDialogHandlers,
   cleanupDialogHandlers,
   registerLibraryHandlers,
@@ -66,6 +68,7 @@ export function registerIpcHandlers(mainWindow: BrowserWindow): void {
   registerWindowHandlers(mainWindow);
   registerStoreHandlers();
   registerAppHandlers();
+  registerDebugHandlers();
   registerDialogHandlers(mainWindow);
   registerLibraryHandlers();
   registerMediaHandlers();
@@ -84,6 +87,7 @@ export function cleanupIpcHandlers(): void {
   cleanupWindowHandlers();
   cleanupStoreHandlers();
   cleanupAppHandlers();
+  cleanupDebugHandlers();
   cleanupDialogHandlers();
   cleanupLibraryHandlers();
   cleanupMediaHandlers();

--- a/apps/desktop/src/main/ipc/schemas/debug.ts
+++ b/apps/desktop/src/main/ipc/schemas/debug.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod';
+
+export const debugStartArgs = z.tuple([]);
+export const debugStopArgs = z.tuple([]);

--- a/apps/desktop/src/main/preload/api/debug.ts
+++ b/apps/desktop/src/main/preload/api/debug.ts
@@ -1,0 +1,20 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS, type MainMetricsSnapshot } from '@shiranami/contracts';
+import { createIpcListener } from '../ipc-listener';
+
+const C = IPC_CHANNELS.debug;
+
+export interface DebugApi {
+  /** Begin main-process metrics sampling (~1 Hz). Idempotent. */
+  start: () => Promise<void>;
+  /** Stop sampling and clear the interval. Idempotent. */
+  stop: () => Promise<void>;
+  /** Subscribe to main-process metric snapshots. Returns an unsubscribe fn. */
+  onMetrics: (callback: (snapshot: MainMetricsSnapshot) => void) => () => void;
+}
+
+export const debugApi: DebugApi = {
+  start: () => ipcRenderer.invoke(C.start),
+  stop: () => ipcRenderer.invoke(C.stop),
+  onMetrics: createIpcListener<MainMetricsSnapshot>(C.metrics),
+};

--- a/apps/desktop/src/main/preload/index.ts
+++ b/apps/desktop/src/main/preload/index.ts
@@ -13,6 +13,7 @@ import {
 } from '../ipc/errors';
 import { appApi, type AppApi } from './api/app';
 import { dbApi, type DbApi } from './api/db';
+import { debugApi, type DebugApi } from './api/debug';
 import { dialogApi, type DialogApi } from './api/dialog';
 import { downloaderApi, type DownloaderApi } from './api/downloader';
 import { libraryApi, type LibraryApi } from './api/library';
@@ -43,6 +44,7 @@ export interface ElectronAPI {
   playlist: PlaylistApi;
   metadata: MetadataApi;
   share: ShareApi;
+  debug: DebugApi;
   errors: {
     isIpcError: (e: unknown) => e is { code: string; message: string; details?: unknown };
     SHARE_ERROR_CODES: typeof SHARE_ERROR_CODES;
@@ -76,6 +78,7 @@ const electronAPI: ElectronAPI = {
   playlist: playlistApi,
   metadata: metadataApi,
   share: shareApi,
+  debug: debugApi,
   errors: {
     isIpcError,
     SHARE_ERROR_CODES,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,7 @@ import { TopBar } from '@/components/shared/TopBar';
 import { SplashScreen } from '@/components/splash/SplashScreen';
 import { PlayerBar } from '@/components/player';
 import { CompactPlayer } from '@/components/player/CompactPlayer';
+import { MediaSessionSync } from '@/components/player/MediaSessionSync';
 import { LibraryView } from '@/components/library/LibraryView';
 import { FavoritesView } from '@/components/favorites/FavoritesView';
 import { PlaylistsView } from '@/components/playlists/PlaylistsView';
@@ -145,6 +146,10 @@ function App() {
 
   return (
     <>
+      {/* Isolated leaf: owns the currentTime media-session side-effects so the
+          root App tree does not re-render on every 250ms time tick. */}
+      <MediaSessionSync />
+
       <SplashScreen
         isLoading={libraryLoading}
         isError={libraryError}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -30,6 +30,11 @@ const AudioVisualizer = lazy(() => import('@/components/player/AudioVisualizer')
 const WaveformVisualizer = lazy(() => import('@/components/player/WaveformVisualizer'));
 const CircleVisualizer = lazy(() => import('@/components/player/CircleVisualizer'));
 const ParticleVisualizer = lazy(() => import('@/components/player/ParticleVisualizer'));
+// Dev-only: the import expression is dead code in prod (the ternary collapses
+// to `null`), so Rollup never emits the chunk for a production build.
+const DebugOverlay = import.meta.env.DEV
+  ? lazy(() => import('@/components/debug/DebugOverlay').then(m => ({ default: m.DebugOverlay })))
+  : null;
 const KeyboardShortcutsHelp = lazy(() => import('@/components/shared/KeyboardShortcutsHelp'));
 const ShareDialogManager = lazy(() => import('@/components/shared/ShareDialogManager'));
 const TrackEnrichDialogManager = lazy(() => import('@/components/shared/TrackEnrichDialogManager'));
@@ -41,6 +46,8 @@ import { usePlayerPreferences } from '@/hooks/usePlayerPreferences';
 import { usePlaybackResume } from '@/hooks/usePlaybackResume';
 import { useUpdateNotifications } from '@/hooks/useUpdateNotifications';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { useDebugPanel } from '@/hooks/useDebugPanel';
+import { DevProfiler } from '@/components/debug/DevProfiler';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useUIStore } from '@/stores/useUIStore';
 import { useCompactStore } from '@/stores/useCompactStore';
@@ -82,6 +89,7 @@ function App() {
   }, [libraryError, refetchLibrary, t]);
   useUpdateNotifications();
   useKeyboardShortcuts();
+  const debugOpen = useDebugPanel();
 
   useEffect(() => {
     hydrateLanguageFromStore();
@@ -155,6 +163,11 @@ function App() {
             <ThemeBackground />
             <AmbientBackground />
             <CommandPalette />
+            {debugOpen && DebugOverlay && (
+              <Suspense fallback={null}>
+                <DebugOverlay />
+              </Suspense>
+            )}
             <ErrorBoundary viewName="KeyboardShortcutsHelp">
               <Suspense fallback={null}>
                 <KeyboardShortcutsHelp />
@@ -213,7 +226,9 @@ function App() {
                     <div className="flex-1 min-w-0 min-h-0 overflow-hidden flex flex-col">
                       {activeView === 'library' && (
                         <ErrorBoundary viewName="LibraryView">
-                          <LibraryView />
+                          <DevProfiler id="library">
+                            <LibraryView />
+                          </DevProfiler>
                         </ErrorBoundary>
                       )}
                       {activeView === 'playlists' && (
@@ -308,22 +323,28 @@ function App() {
                       >
                         <ErrorBoundary viewName="Visualizer">
                           <Suspense fallback={null}>
-                            {visualizerStyle === 'waveform' ? (
-                              <WaveformVisualizer />
-                            ) : visualizerStyle === 'circle' ? (
-                              <CircleVisualizer />
-                            ) : visualizerStyle === 'particles' ? (
-                              <ParticleVisualizer />
-                            ) : (
-                              <AudioVisualizer />
-                            )}
+                            <DevProfiler id="visualizer">
+                              {visualizerStyle === 'waveform' ? (
+                                <WaveformVisualizer />
+                              ) : visualizerStyle === 'circle' ? (
+                                <CircleVisualizer />
+                              ) : visualizerStyle === 'particles' ? (
+                                <ParticleVisualizer />
+                              ) : (
+                                <AudioVisualizer />
+                              )}
+                            </DevProfiler>
                           </Suspense>
                         </ErrorBoundary>
                       </div>
                     )}
 
                   {/* Player bar (hidden in now-playing view — controls are inline) */}
-                  {activeView !== 'now-playing' && <PlayerBar />}
+                  {activeView !== 'now-playing' && (
+                    <DevProfiler id="player">
+                      <PlayerBar />
+                    </DevProfiler>
+                  )}
                 </div>
               </>
             )}

--- a/apps/web/src/components/debug/DebugOverlay.tsx
+++ b/apps/web/src/components/debug/DebugOverlay.tsx
@@ -1,0 +1,213 @@
+// Dev-only CPU/Perf Debug Panel overlay. A fixed-position translucent panel
+// summarizing main-process per-process CPU/memory, renderer FPS/frame time/JS
+// heap, React commit attribution, the active timer registry, per-store update
+// Hz, and a long-task feed.
+//
+// Reads `useDebugStore` with narrow selectors so the panel itself re-renders
+// minimally. Only mounted while `open` is true (see App.tsx), so when closed it
+// adds zero cost. The main sampler is driven by `useDebugInstrumentation`.
+
+import { useDebugStore } from '@/stores/useDebugStore';
+import { cn } from '@/lib/utils';
+
+function formatKb(kb: number): string {
+  if (kb >= 1024 * 1024) return `${(kb / 1024 / 1024).toFixed(1)} GB`;
+  if (kb >= 1024) return `${(kb / 1024).toFixed(1)} MB`;
+  return `${Math.round(kb)} KB`;
+}
+
+function formatBytes(bytes: number | null): string {
+  if (bytes == null) return 'n/a';
+  return formatKb(bytes / 1024);
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="border-b border-white/10 px-3 py-2 last:border-b-0">
+      <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-white/40">
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Stat({ label, value, warn }: { label: string; value: string; warn?: boolean }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <span className="text-white/50">{label}</span>
+      <span className={cn('font-mono tabular-nums', warn ? 'text-amber-400' : 'text-white/90')}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export function DebugOverlay() {
+  const main = useDebugStore(s => s.main);
+  const renderer = useDebugStore(s => s.renderer);
+  const longTasks = useDebugStore(s => s.longTasks);
+  const close = useDebugStore(s => s.close);
+
+  return (
+    <div
+      className="fixed right-3 top-3 z-[10000] flex max-h-[90vh] w-[340px] flex-col overflow-hidden rounded-lg border border-white/15 bg-black/80 text-[11px] leading-tight text-white shadow-2xl backdrop-blur-md"
+      role="dialog"
+      aria-label="Performance debug panel"
+    >
+      <div className="flex items-center justify-between border-b border-white/10 bg-white/5 px-3 py-1.5">
+        <span className="font-semibold tracking-wide">Perf Debug</span>
+        <button
+          type="button"
+          onClick={close}
+          className="rounded px-1.5 text-white/50 hover:bg-white/10 hover:text-white"
+          aria-label="Close debug panel"
+        >
+          esc
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        <Section title="Processes (main)">
+          {main ? (
+            <table className="w-full font-mono tabular-nums">
+              <thead>
+                <tr className="text-white/40">
+                  <th className="text-left font-normal">type</th>
+                  <th className="text-right font-normal">pid</th>
+                  <th className="text-right font-normal">cpu%</th>
+                  <th className="text-right font-normal">mem</th>
+                </tr>
+              </thead>
+              <tbody>
+                {main.procs.map(p => (
+                  <tr
+                    key={p.pid}
+                    className={cn(
+                      p.type === 'GPU' && 'text-cyan-300',
+                      p.cpu >= 25 && 'text-amber-400'
+                    )}
+                  >
+                    <td className="text-left">{p.type}</td>
+                    <td className="text-right">{p.pid}</td>
+                    <td className="text-right">{p.cpu.toFixed(1)}</td>
+                    <td className="text-right">{formatKb(p.mem)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <div className="text-white/40">waiting for samples…</div>
+          )}
+        </Section>
+
+        {main && (
+          <Section title="Main process">
+            <Stat label="cpu" value={`${main.cpu.percentCPUUsage.toFixed(1)} %`} />
+            <Stat label="idle wakeups/s" value={`${main.cpu.idleWakeupsPerSecond}`} />
+            <Stat
+              label="heap used"
+              value={`${formatKb(main.heap.usedHeapSize)} / ${formatKb(main.heap.totalHeapSize)}`}
+            />
+          </Section>
+        )}
+
+        <Section title="Renderer">
+          <Stat
+            label="fps"
+            value={`${renderer.fps}`}
+            warn={renderer.fps > 0 && renderer.fps < 50}
+          />
+          <Stat
+            label="frame p95"
+            value={`${renderer.frameP95.toFixed(1)} ms`}
+            warn={renderer.frameP95 > 20}
+          />
+          <Stat label="js heap" value={formatBytes(renderer.jsHeap)} />
+        </Section>
+
+        <Section title="React commits">
+          {renderer.renderStats.length > 0 ? (
+            <table className="w-full font-mono tabular-nums">
+              <thead>
+                <tr className="text-white/40">
+                  <th className="text-left font-normal">id</th>
+                  <th className="text-right font-normal">commits</th>
+                  <th className="text-right font-normal">ms</th>
+                </tr>
+              </thead>
+              <tbody>
+                {renderer.renderStats.map(s => (
+                  <tr key={s.id} className={cn(s.commits >= 30 && 'text-amber-400')}>
+                    <td className="text-left">{s.id}</td>
+                    <td className="text-right">{s.commits}</td>
+                    <td className="text-right">{s.totalDuration.toFixed(1)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <div className="text-white/40">no commits in window</div>
+          )}
+        </Section>
+
+        <Section title="Timers">
+          {renderer.timers ? (
+            <>
+              <Stat label="active rAF" value={`${renderer.timers.activeRaf}`} />
+              <Stat label="active intervals" value={`${renderer.timers.activeIntervals}`} />
+              <Stat label="active timeouts" value={`${renderer.timers.activeTimeouts}`} />
+              {renderer.timers.rafOrigins.length > 0 && (
+                <ul className="mt-1 space-y-0.5 font-mono text-[10px] text-white/50">
+                  {renderer.timers.rafOrigins.map(o => (
+                    <li key={o.id} className="truncate">
+                      ↳ {o.origin}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
+          ) : (
+            <div className="text-white/40">registry not installed</div>
+          )}
+        </Section>
+
+        <Section title="Store updates (Hz)">
+          {Object.keys(renderer.storeHz).length > 0 ? (
+            <div className="space-y-0.5">
+              {Object.entries(renderer.storeHz).map(([name, hz]) => (
+                <Stat key={name} label={name} value={`${hz}`} warn={hz >= 10} />
+              ))}
+            </div>
+          ) : (
+            <div className="text-white/40">no tracked updates</div>
+          )}
+        </Section>
+
+        <Section title="Long tasks / slow events">
+          {longTasks.length > 0 ? (
+            <ul className="space-y-0.5 font-mono text-[10px]">
+              {longTasks.map((t, i) => (
+                <li
+                  key={`${t.ts}-${i}`}
+                  className={cn(
+                    'flex justify-between gap-2',
+                    t.duration >= 100 ? 'text-red-400' : 'text-amber-400'
+                  )}
+                >
+                  <span className="truncate">
+                    {t.kind}
+                    {t.name ? `: ${t.name}` : ''}
+                  </span>
+                  <span className="tabular-nums">{t.duration} ms</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="text-white/40">none over 50 ms</div>
+          )}
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/debug/DevProfiler.tsx
+++ b/apps/web/src/components/debug/DevProfiler.tsx
@@ -1,0 +1,25 @@
+// Dev-only React render-cost wrapper. In dev it mounts a `<Profiler onRender>`
+// that feeds commit count + duration into the debug render-stats collector; in
+// prod it returns `children` directly (no Profiler node, so it is a zero-cost
+// pass-through that tree-shakes away).
+
+import { Profiler, type ProfilerOnRenderCallback, type ReactNode } from 'react';
+import { recordRender } from '@/lib/debug/renderStats';
+
+interface DevProfilerProps {
+  id: string;
+  children: ReactNode;
+}
+
+const onRender: ProfilerOnRenderCallback = (id, _phase, actualDuration) => {
+  recordRender(id, actualDuration);
+};
+
+export function DevProfiler({ id, children }: DevProfilerProps) {
+  if (!import.meta.env.DEV) return <>{children}</>;
+  return (
+    <Profiler id={id} onRender={onRender}>
+      {children}
+    </Profiler>
+  );
+}

--- a/apps/web/src/components/library/AlbumGrid.tsx
+++ b/apps/web/src/components/library/AlbumGrid.tsx
@@ -108,7 +108,7 @@ function AlbumCell({
     <div style={insetStyle}>
       <button
         onClick={() => onAlbumClick(album.name)}
-        className={`text-left ${cardPaddingClass} rounded-2xl glass-subtle border border-border/30 hover:border-primary/30 hover:shadow-[0_0_20px_-6px_rgba(var(--primary-rgb),0.4)] transition-all duration-200 group w-full h-full flex flex-col`}
+        className={`text-left ${cardPaddingClass} rounded-2xl bg-card/70 border border-border/30 hover:border-primary/30 hover:shadow-[0_0_20px_-6px_rgba(var(--primary-rgb),0.4)] transition-all duration-200 group w-full h-full flex flex-col`}
       >
         <div
           className="w-full rounded-xl bg-muted/30 flex items-center justify-center mb-3 overflow-hidden"

--- a/apps/web/src/components/player/AudioVisualizer.tsx
+++ b/apps/web/src/components/player/AudioVisualizer.tsx
@@ -118,18 +118,14 @@ export function AudioVisualizer({ source, active }: AudioVisualizerProps = {}) {
       const b = Math.round(pb - 45 + t * 45);
       const alpha = (0.35 + value * 0.3) * edgeFade;
 
-      // Subtle glow
-      ctx.shadowColor = `rgba(${r}, ${g}, ${b}, ${0.3 * edgeFade})`;
-      ctx.shadowBlur = 4;
-
-      // Main bar — center-aligned (grows up and down from center)
+      // Main bar — center-aligned (grows up and down from center).
+      // Glow comes from a single CSS drop-shadow on the canvas element rather
+      // than per-bar canvas shadowBlur (which cost ~2,880 Gaussian-blur fills/sec
+      // at 48 bars × 60fps — the dominant per-frame visualizer cost).
       ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${alpha})`;
       ctx.beginPath();
       ctx.roundRect(x, centerY - barH / 2, barWidth, barH, barWidth / 2);
       ctx.fill();
-
-      // Reset shadow for reflection
-      ctx.shadowBlur = 0;
     }
   }, [widthRef, heightRef, dprRef, rgbRef, source]);
 
@@ -140,7 +136,10 @@ export function AudioVisualizer({ source, active }: AudioVisualizerProps = {}) {
     <canvas
       ref={canvasRef}
       className="w-full h-full pointer-events-none"
-      style={{ display: 'block' }}
+      style={{
+        display: 'block',
+        filter: 'drop-shadow(0 0 3px rgba(var(--primary-rgb), 0.3))',
+      }}
     />
   );
 }

--- a/apps/web/src/components/player/AudioVisualizer.tsx
+++ b/apps/web/src/components/player/AudioVisualizer.tsx
@@ -4,7 +4,7 @@ import { getAnalyser } from '@/lib/audioAnalyser';
 import { useRafLoop } from '@/hooks/useRafLoop';
 import { useCanvasSize } from '@/hooks/useCanvasSize';
 import { usePrimaryRGB } from '@/hooks/usePrimaryRGB';
-import type { FrequencySource } from './visualizer-source';
+import { VISUALIZER_FPS, type FrequencySource } from './visualizer-source';
 
 /**
  * Canvas-based frequency visualizer with a soft lofi aesthetic.
@@ -130,7 +130,7 @@ export function AudioVisualizer({ source, active }: AudioVisualizerProps = {}) {
   }, [widthRef, heightRef, dprRef, rgbRef, source]);
 
   const shouldRun = active ?? (isPlaying && !!currentTrack);
-  useRafLoop(draw, canvasRef, shouldRun);
+  useRafLoop(draw, canvasRef, shouldRun, VISUALIZER_FPS);
 
   return (
     <canvas

--- a/apps/web/src/components/player/CircleVisualizer.tsx
+++ b/apps/web/src/components/player/CircleVisualizer.tsx
@@ -153,14 +153,13 @@ export function CircleVisualizer({ source, active }: CircleVisualizerProps = {})
     }
 
     // ── Base ring line ──
+    // Glow comes from a single CSS drop-shadow on the canvas element rather
+    // than canvas shadowBlur (a Gaussian-blur stroke every frame).
     ctx.beginPath();
     ctx.arc(centerX, centerY, barBaseRadius, 0, Math.PI * 2);
     ctx.strokeStyle = `rgba(${pr}, ${pg}, ${pb}, ${0.12 + avgEnergy * 0.2})`;
     ctx.lineWidth = 1;
-    ctx.shadowColor = `rgba(${pr}, ${pg}, ${pb}, ${0.15 + avgEnergy * 0.15})`;
-    ctx.shadowBlur = 4;
     ctx.stroke();
-    ctx.shadowBlur = 0;
   }, [widthRef, heightRef, dprRef, rgbRef, source]);
 
   const shouldRun = active ?? (isPlaying && !!currentTrack);
@@ -170,7 +169,10 @@ export function CircleVisualizer({ source, active }: CircleVisualizerProps = {})
     <canvas
       ref={canvasRef}
       className="w-full h-full pointer-events-none"
-      style={{ display: 'block' }}
+      style={{
+        display: 'block',
+        filter: 'drop-shadow(0 0 3px rgba(var(--primary-rgb), 0.3))',
+      }}
     />
   );
 }

--- a/apps/web/src/components/player/CircleVisualizer.tsx
+++ b/apps/web/src/components/player/CircleVisualizer.tsx
@@ -4,7 +4,7 @@ import { getAnalyser } from '@/lib/audioAnalyser';
 import { useRafLoop } from '@/hooks/useRafLoop';
 import { useCanvasSize } from '@/hooks/useCanvasSize';
 import { usePrimaryRGB } from '@/hooks/usePrimaryRGB';
-import type { FrequencySource } from './visualizer-source';
+import { VISUALIZER_FPS, type FrequencySource } from './visualizer-source';
 
 /**
  * Compact circular frequency visualizer.
@@ -163,7 +163,7 @@ export function CircleVisualizer({ source, active }: CircleVisualizerProps = {})
   }, [widthRef, heightRef, dprRef, rgbRef, source]);
 
   const shouldRun = active ?? (isPlaying && !!currentTrack);
-  useRafLoop(draw, canvasRef, shouldRun);
+  useRafLoop(draw, canvasRef, shouldRun, VISUALIZER_FPS);
 
   return (
     <canvas

--- a/apps/web/src/components/player/MediaSessionSync.tsx
+++ b/apps/web/src/components/player/MediaSessionSync.tsx
@@ -1,0 +1,65 @@
+import { memo, useEffect, useRef } from 'react';
+import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { IS_ELECTRON } from '@/lib/platform';
+
+/**
+ * Isolated leaf that owns the currentTime-dependent media-session side-effects
+ * (OS overlay position state + throttled playback-state IPC to the main process).
+ *
+ * currentTime is written to the store every 250ms during playback. Subscribing
+ * to it here — in a component that renders null — keeps the re-render contained
+ * to this leaf instead of the root App tree (mirrors the TimeDisplay pattern).
+ * The action handlers / metadata / playbackState live in useMediaSession, which
+ * no longer touches currentTime.
+ */
+export const MediaSessionSync = memo(function MediaSessionSync() {
+  const currentTrack = usePlaybackStore(s => s.currentTrack);
+  const isPlaying = usePlaybackStore(s => s.isPlaying);
+  const currentTime = usePlaybackStore(s => s.currentTime);
+  const duration = usePlaybackStore(s => s.duration);
+
+  // Throttle state updates to the main process (every 1 second).
+  const lastUpdateRef = useRef(0);
+
+  // Update position state for the seek bar in the OS media overlay.
+  useEffect(() => {
+    if (!('mediaSession' in navigator) || !duration || !isFinite(duration)) return;
+    try {
+      navigator.mediaSession.setPositionState({
+        duration,
+        playbackRate: 1,
+        position: Math.min(currentTime, duration),
+      });
+    } catch {
+      // Some browsers don't support setPositionState
+    }
+  }, [currentTime, duration]);
+
+  // Send playback state to the main process (throttled to 1Hz).
+  useEffect(() => {
+    if (!IS_ELECTRON) return;
+
+    const now = Date.now();
+    if (now - lastUpdateRef.current < 1000 && lastUpdateRef.current > 0) return;
+    lastUpdateRef.current = now;
+
+    if (!currentTrack) {
+      window.electronAPI.media.clearState();
+      return;
+    }
+
+    window.electronAPI.media.sendPlaybackState({
+      isPlaying,
+      title: currentTrack.title,
+      artist: currentTrack.artist,
+      album: currentTrack.album,
+      duration,
+      currentTime,
+      albumArt: currentTrack.albumArt ?? null,
+    });
+  }, [currentTrack, isPlaying, currentTime, duration]);
+
+  return null;
+});
+
+export default MediaSessionSync;

--- a/apps/web/src/components/player/ParticleVisualizer.tsx
+++ b/apps/web/src/components/player/ParticleVisualizer.tsx
@@ -159,12 +159,11 @@ export function ParticleVisualizer({ source, active }: ParticleVisualizerProps =
     }
     const last = points[points.length - 1];
     ctx.lineTo(last.x, last.y);
+    // Glow comes from a single CSS drop-shadow on the canvas element rather
+    // than canvas shadowBlur (a Gaussian-blur stroke every frame).
     ctx.strokeStyle = `rgba(${pr}, ${pg}, ${pb}, 0.5)`;
     ctx.lineWidth = 1.5;
-    ctx.shadowColor = `rgba(${pr}, ${pg}, ${pb}, 0.3)`;
-    ctx.shadowBlur = 4;
     ctx.stroke();
-    ctx.shadowBlur = 0;
 
     // ── Center line ──
     ctx.beginPath();
@@ -182,7 +181,10 @@ export function ParticleVisualizer({ source, active }: ParticleVisualizerProps =
     <canvas
       ref={canvasRef}
       className="w-full h-full pointer-events-none"
-      style={{ display: 'block' }}
+      style={{
+        display: 'block',
+        filter: 'drop-shadow(0 0 3px rgba(var(--primary-rgb), 0.3))',
+      }}
     />
   );
 }

--- a/apps/web/src/components/player/ParticleVisualizer.tsx
+++ b/apps/web/src/components/player/ParticleVisualizer.tsx
@@ -4,7 +4,7 @@ import { useRafLoop } from '@/hooks/useRafLoop';
 import { useCanvasSize } from '@/hooks/useCanvasSize';
 import { usePrimaryRGB } from '@/hooks/usePrimaryRGB';
 import { getAnalyser } from '@/lib/audioAnalyser';
-import type { FrequencySource } from './visualizer-source';
+import { VISUALIZER_FPS, type FrequencySource } from './visualizer-source';
 
 /**
  * Smooth wave visualizer with gradient fill.
@@ -175,7 +175,7 @@ export function ParticleVisualizer({ source, active }: ParticleVisualizerProps =
   }, [widthRef, heightRef, dprRef, rgbRef, versionRef, source]);
 
   const shouldRun = active ?? (isPlaying && !!currentTrack);
-  useRafLoop(draw, canvasRef, shouldRun);
+  useRafLoop(draw, canvasRef, shouldRun, VISUALIZER_FPS);
 
   return (
     <canvas

--- a/apps/web/src/components/player/SeekBar.tsx
+++ b/apps/web/src/components/player/SeekBar.tsx
@@ -1,8 +1,24 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useLayoutEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlaybackStore, currentTimeRef } from '@/stores/usePlaybackStore';
 import { usePlayerUIStore } from '@/stores/usePlayerUIStore';
+import { useRafLoop } from '@/hooks/useRafLoop';
 import { formatDuration } from '@shiranami/shared';
+
+/** Apply a 0..1 progress ratio to the fill (scaleX) and thumb (translateX).
+ *  Both are compositor-only transforms — no layout/paint per frame. The thumb
+ *  offset is in track-relative pixels; translateX(-50%) keeps it centered on
+ *  the progress point regardless of the thumb's own (hover-animated) width. */
+function applyProgress(
+  ratio: number,
+  fill: HTMLDivElement | null,
+  thumb: HTMLDivElement | null,
+  trackWidth: number
+) {
+  const clamped = Math.max(0, Math.min(1, ratio));
+  if (fill) fill.style.transform = `scaleX(${clamped})`;
+  if (thumb) thumb.style.transform = `translateX(${clamped * trackWidth}px) translateX(-50%)`;
+}
 
 export function SeekBar() {
   const { t } = useTranslation('player');
@@ -16,7 +32,6 @@ export function SeekBar() {
   const fillRef = useRef<HTMLDivElement>(null);
   const thumbRef = useRef<HTMLDivElement>(null);
   const isDraggingRef = useRef(false);
-  const rafRef = useRef<number>(0);
 
   const getValueFromPointer = useCallback(
     (clientX: number) => {
@@ -65,33 +80,31 @@ export function SeekBar() {
     [getValueFromPointer, setScrubTime, seek]
   );
 
-  // RAF loop for smooth seek bar updates while playing and not scrubbing
-  useEffect(() => {
-    if (!isPlaying || scrubTime !== null) {
-      cancelAnimationFrame(rafRef.current);
-      return;
-    }
+  // RAF loop for smooth seek bar updates while playing and not scrubbing.
+  // Routed through useRafLoop so it also stops when the window is hidden or the
+  // bar scrolls off-screen — not only when Chromium happens to throttle rAF.
+  const tick = useCallback(() => {
+    const trackWidth = trackRef.current?.clientWidth ?? 0;
+    const ratio = duration > 0 ? currentTimeRef.current / duration : 0;
+    applyProgress(ratio, fillRef.current, thumbRef.current, trackWidth);
+  }, [duration]);
 
-    const tick = () => {
-      const time = currentTimeRef.current;
-      const progress = duration > 0 ? (time / duration) * 100 : 0;
-      const pct = `${progress}%`;
+  const rafActive = isPlaying && scrubTime === null;
+  useRafLoop(tick, trackRef, rafActive);
 
-      if (fillRef.current) fillRef.current.style.width = pct;
-      if (thumbRef.current) thumbRef.current.style.left = pct;
-
-      rafRef.current = requestAnimationFrame(tick);
-    };
-
-    rafRef.current = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(rafRef.current);
-  }, [isPlaying, scrubTime, duration]);
-
-  // When paused or scrubbing, compute progress from store values
+  // When paused or scrubbing, the rAF is inactive — drive the same transforms
+  // from store values in a layout effect so the position stays exact (and the
+  // thumb tracks pointer drags) without animating layout properties.
   const storeTime = usePlaybackStore(s => s.currentTime);
   const displayTime = scrubTime ?? storeTime;
-  const staticProgress = duration > 0 ? (displayTime / duration) * 100 : 0;
+  const staticRatio = duration > 0 ? displayTime / duration : 0;
   const needsStaticStyle = !isPlaying || scrubTime !== null;
+
+  useLayoutEffect(() => {
+    if (!needsStaticStyle) return;
+    const trackWidth = trackRef.current?.clientWidth ?? 0;
+    applyProgress(staticRatio, fillRef.current, thumbRef.current, trackWidth);
+  }, [needsStaticStyle, staticRatio]);
 
   return (
     <div
@@ -108,18 +121,16 @@ export function SeekBar() {
     >
       {/* Track */}
       <div className="relative h-1 w-full grow overflow-hidden rounded-full bg-foreground/[0.06] group-hover:h-[5px] transition-all duration-200">
-        {/* Range fill */}
+        {/* Range fill — full width, scaled along X (compositor-only). */}
         <div
           ref={fillRef}
-          className="absolute h-full bg-primary/80 group-hover:bg-primary rounded-full transition-colors duration-200 group-hover:shadow-[0_0_8px_0_rgba(var(--primary-rgb),0.5)]"
-          style={needsStaticStyle ? { width: `${staticProgress}%` } : undefined}
+          className="absolute h-full w-full origin-left bg-primary/80 group-hover:bg-primary rounded-full transition-colors duration-200 group-hover:shadow-[0_0_8px_0_rgba(var(--primary-rgb),0.5)]"
         />
       </div>
-      {/* Thumb */}
+      {/* Thumb — positioned via translateX (compositor-only). */}
       <div
         ref={thumbRef}
-        className="absolute h-0 w-0 -translate-x-1/2 rounded-full bg-primary shadow-[0_0_10px_0_rgba(var(--primary-rgb),0.6)] transition-[width,height,background-color,box-shadow] duration-200 group-hover:h-3 group-hover:w-3"
-        style={needsStaticStyle ? { left: `${staticProgress}%` } : undefined}
+        className="absolute left-0 h-0 w-0 rounded-full bg-primary shadow-[0_0_10px_0_rgba(var(--primary-rgb),0.6)] transition-[width,height,background-color,box-shadow] duration-200 group-hover:h-3 group-hover:w-3"
       />
     </div>
   );

--- a/apps/web/src/components/player/SeekBar.tsx
+++ b/apps/web/src/components/player/SeekBar.tsx
@@ -5,19 +5,20 @@ import { usePlayerUIStore } from '@/stores/usePlayerUIStore';
 import { useRafLoop } from '@/hooks/useRafLoop';
 import { formatDuration } from '@shiranami/shared';
 
-/** Apply a 0..1 progress ratio to the fill (scaleX) and thumb (translateX).
- *  Both are compositor-only transforms — no layout/paint per frame. The thumb
- *  offset is in track-relative pixels; translateX(-50%) keeps it centered on
- *  the progress point regardless of the thumb's own (hover-animated) width. */
-function applyProgress(
-  ratio: number,
-  fill: HTMLDivElement | null,
-  thumb: HTMLDivElement | null,
-  trackWidth: number
-) {
+/** Apply a 0..1 progress ratio to the fill (scaleX) and thumb (left + translateX).
+ *  The fill is a compositor-only transform — no layout/paint per frame. The thumb
+ *  is positioned with a percentage `left` so it stays correct across track
+ *  resizes without depending on a cached pixel width; translateX(-50%) keeps it
+ *  centered on the progress point regardless of the thumb's own (hover-animated)
+ *  width. The percentage `left` resolves against the live track width on every
+ *  layout, so this is a one-time layout on value change (not per-frame). */
+function applyProgress(ratio: number, fill: HTMLDivElement | null, thumb: HTMLDivElement | null) {
   const clamped = Math.max(0, Math.min(1, ratio));
   if (fill) fill.style.transform = `scaleX(${clamped})`;
-  if (thumb) thumb.style.transform = `translateX(${clamped * trackWidth}px) translateX(-50%)`;
+  if (thumb) {
+    thumb.style.left = `${clamped * 100}%`;
+    thumb.style.transform = 'translateX(-50%)';
+  }
 }
 
 export function SeekBar() {
@@ -84,9 +85,8 @@ export function SeekBar() {
   // Routed through useRafLoop so it also stops when the window is hidden or the
   // bar scrolls off-screen — not only when Chromium happens to throttle rAF.
   const tick = useCallback(() => {
-    const trackWidth = trackRef.current?.clientWidth ?? 0;
     const ratio = duration > 0 ? currentTimeRef.current / duration : 0;
-    applyProgress(ratio, fillRef.current, thumbRef.current, trackWidth);
+    applyProgress(ratio, fillRef.current, thumbRef.current);
   }, [duration]);
 
   const rafActive = isPlaying && scrubTime === null;
@@ -102,8 +102,7 @@ export function SeekBar() {
 
   useLayoutEffect(() => {
     if (!needsStaticStyle) return;
-    const trackWidth = trackRef.current?.clientWidth ?? 0;
-    applyProgress(staticRatio, fillRef.current, thumbRef.current, trackWidth);
+    applyProgress(staticRatio, fillRef.current, thumbRef.current);
   }, [needsStaticStyle, staticRatio]);
 
   return (

--- a/apps/web/src/components/player/WaveformVisualizer.tsx
+++ b/apps/web/src/components/player/WaveformVisualizer.tsx
@@ -4,7 +4,7 @@ import { getAnalyser } from '@/lib/audioAnalyser';
 import { useRafLoop } from '@/hooks/useRafLoop';
 import { useCanvasSize } from '@/hooks/useCanvasSize';
 import { usePrimaryRGB } from '@/hooks/usePrimaryRGB';
-import type { FrequencySource } from './visualizer-source';
+import { VISUALIZER_FPS, type FrequencySource } from './visualizer-source';
 
 /**
  * Dense vertical-bar waveform visualizer inspired by ElevenLabs UI.
@@ -124,7 +124,7 @@ export function WaveformVisualizer({ source, active }: WaveformVisualizerProps =
   }, [widthRef, heightRef, dprRef, rgbRef, source]);
 
   const shouldRun = active ?? (isPlaying && !!currentTrack);
-  useRafLoop(draw, canvasRef, shouldRun);
+  useRafLoop(draw, canvasRef, shouldRun, VISUALIZER_FPS);
 
   return (
     <canvas

--- a/apps/web/src/components/player/visualizer-source.ts
+++ b/apps/web/src/components/player/visualizer-source.ts
@@ -1,3 +1,10 @@
+/**
+ * Frame-rate cap for the audio visualizers. Audio bars read smooth at 30fps,
+ * so there's no reason to redraw them at the monitor's refresh rate (60/120/144Hz).
+ * On a 144Hz display this cuts visualizer draw work by ~4.8x.
+ */
+export const VISUALIZER_FPS = 30;
+
 export interface FrequencySource {
   /**
    * Fills `buf` with frequency data; returns true if data was written.

--- a/apps/web/src/components/search/SearchView.tsx
+++ b/apps/web/src/components/search/SearchView.tsx
@@ -257,7 +257,7 @@ export function SearchView() {
                       src="./mascot.png"
                       alt=""
                       aria-hidden="true"
-                      className="w-[4.5rem] h-[4.5rem] object-contain opacity-70 animate-[shiranami-float_6s_ease-in-out_infinite]"
+                      className="w-[4.5rem] h-[4.5rem] object-contain opacity-70 float-mascot"
                       draggable={false}
                     />
                   </div>

--- a/apps/web/src/components/shared/AmbientBackground.tsx
+++ b/apps/web/src/components/shared/AmbientBackground.tsx
@@ -1,13 +1,14 @@
 import { useAmbientColor } from '@/hooks/useAmbientColor';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useUIStore } from '@/stores/useUIStore';
-import { motion, AnimatePresence } from 'motion/react';
+import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 
 export function AmbientBackground() {
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const ambientColor = useAmbientColor();
   const lowPerformanceMode = useUIStore(s => s.lowPerformanceMode);
   const noiseOverlayEnabled = useUIStore(s => s.noiseOverlayEnabled);
+  const prefersReducedMotion = useReducedMotion();
 
   if (lowPerformanceMode) return null;
 
@@ -22,7 +23,7 @@ export function AmbientBackground() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            transition={{ duration: 2 }}
+            transition={{ duration: prefersReducedMotion ? 0 : 2 }}
             className="fixed inset-0 pointer-events-none z-0"
             style={{
               background: `

--- a/apps/web/src/components/shared/ViewEmptyState.tsx
+++ b/apps/web/src/components/shared/ViewEmptyState.tsx
@@ -42,9 +42,7 @@ export function ViewEmptyState({
               aria-hidden="true"
               className={cn(
                 'w-[4.5rem] h-[4.5rem] object-contain',
-                isError
-                  ? 'opacity-50'
-                  : 'opacity-70 animate-[shiranami-float_6s_ease-in-out_infinite]'
+                isError ? 'opacity-50' : 'opacity-70 float-mascot'
               )}
               draggable={false}
             />

--- a/apps/web/src/hooks/useDebugInstrumentation.ts
+++ b/apps/web/src/hooks/useDebugInstrumentation.ts
@@ -1,0 +1,128 @@
+// Dev-only renderer instrumentation for the CPU/Perf Debug Panel.
+//
+// Mounted (via `useDebugBridge`) ONLY while the overlay is open, so React does
+// not even create the observers/loops otherwise. While active it:
+//  - runs a single rAF loop measuring FPS + p95 frame time (a continuous loop,
+//    NOT gated on intersection — it must keep measuring when backgrounded so
+//    the open-vs-background delta is visible),
+//  - reads `performance.memory.usedJSHeapSize` (Chromium-only, null-guarded),
+//  - observes `longtask`/`event` PerformanceEntries over a threshold,
+//  - aggregates the timer registry, render stats, and store-Hz counters,
+//  - pushes a renderer snapshot to the debug store at ~2 Hz (never per-frame),
+//  - starts/stops the main-process sampler over IPC and subscribes to its push.
+//
+// All capture stays renderer-local except the numeric main snapshot; timer
+// origin stacks are never sent over IPC (see timerRegistry SAFETY note).
+
+import { useEffect } from 'react';
+import { IS_ELECTRON } from '@/lib/platform';
+import { getTimerStats } from '@/lib/debug/timerRegistry';
+import { sampleRenderStats, resetRenderStats } from '@/lib/debug/renderStats';
+import { startStoreHz, stopStoreHz, sampleStoreHz } from '@/lib/debug/storeHz';
+import { useDebugStore, type LongTaskEntry } from '@/stores/useDebugStore';
+
+const PUSH_INTERVAL_MS = 500; // ~2 Hz
+const LONG_TASK_THRESHOLD_MS = 50;
+
+interface ChromeMemory {
+  usedJSHeapSize: number;
+}
+
+function readJsHeap(): number | null {
+  const mem = (performance as Performance & { memory?: ChromeMemory }).memory;
+  return mem ? mem.usedJSHeapSize : null;
+}
+
+/** p95 of a numeric sample array. */
+function p95(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor(sorted.length * 0.95));
+  return sorted[idx];
+}
+
+export function useDebugInstrumentation(active: boolean): void {
+  // Main-process sampler bridge: start sampling on open, stop on close.
+  useEffect(() => {
+    if (!active || !IS_ELECTRON) return;
+    const setMain = useDebugStore.getState().setMain;
+    const unsubscribe = window.electronAPI.debug.onMetrics(setMain);
+    void window.electronAPI.debug.start();
+    return () => {
+      unsubscribe();
+      void window.electronAPI.debug.stop();
+    };
+  }, [active]);
+
+  // Renderer-side loops + observers.
+  useEffect(() => {
+    if (!active) return;
+
+    startStoreHz();
+    resetRenderStats();
+
+    let rafId = 0;
+    let frameCount = 0;
+    const frameTimes: number[] = [];
+    let lastFrameTs = performance.now();
+    let lastFpsTs = lastFrameTs;
+    let fps = 0;
+
+    const loop = () => {
+      const now = performance.now();
+      const delta = now - lastFrameTs;
+      lastFrameTs = now;
+      frameCount += 1;
+      frameTimes.push(delta);
+      if (now - lastFpsTs >= 1000) {
+        fps = Math.round((frameCount * 1000) / (now - lastFpsTs));
+        frameCount = 0;
+        lastFpsTs = now;
+      }
+      rafId = requestAnimationFrame(loop);
+    };
+    rafId = requestAnimationFrame(loop);
+
+    const pushLongTask = useDebugStore.getState().pushLongTask;
+    let observer: PerformanceObserver | null = null;
+    try {
+      observer = new PerformanceObserver(list => {
+        for (const entry of list.getEntries()) {
+          if (entry.duration < LONG_TASK_THRESHOLD_MS) continue;
+          const item: LongTaskEntry = {
+            ts: Date.now(),
+            kind: entry.entryType,
+            duration: Math.round(entry.duration),
+            name: entry.name,
+          };
+          pushLongTask(item);
+        }
+      });
+      observer.observe({ entryTypes: ['longtask', 'event'] });
+    } catch {
+      observer = null;
+    }
+
+    const pushTimer = window.setInterval(() => {
+      const setRenderer = useDebugStore.getState().setRenderer;
+      const frameP95 = Math.round(p95(frameTimes) * 100) / 100;
+      frameTimes.length = 0;
+      setRenderer({
+        fps,
+        frameP95,
+        jsHeap: readJsHeap(),
+        timers: getTimerStats(),
+        renderStats: sampleRenderStats(),
+        storeHz: sampleStoreHz(),
+      });
+    }, PUSH_INTERVAL_MS);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      observer?.disconnect();
+      window.clearInterval(pushTimer);
+      stopStoreHz();
+      useDebugStore.getState().reset();
+    };
+  }, [active]);
+}

--- a/apps/web/src/hooks/useDebugPanel.ts
+++ b/apps/web/src/hooks/useDebugPanel.ts
@@ -1,0 +1,39 @@
+// Dev-only glue for the CPU/Perf Debug Panel.
+//
+// Installs the timer registry once at first mount, registers the Ctrl+Shift+D
+// toggle, drives the renderer instrumentation off the store's `open` flag, and
+// exposes `open` for conditional rendering of the overlay. The whole hook is a
+// no-op outside dev (`import.meta.env.DEV`), so the toggle, listeners, and
+// monkeypatch are tree-shaken from production builds.
+
+import { useEffect } from 'react';
+import { useDebugStore } from '@/stores/useDebugStore';
+import { useDebugInstrumentation } from '@/hooks/useDebugInstrumentation';
+import { installTimerRegistry } from '@/lib/debug/timerRegistry';
+
+let registryInstalled = false;
+
+export function useDebugPanel(): boolean {
+  const open = useDebugStore(s => s.open);
+  const enabled = import.meta.env.DEV;
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (!registryInstalled) {
+      installTimerRegistry();
+      registryInstalled = true;
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && (e.key === 'D' || e.key === 'd')) {
+        e.preventDefault();
+        useDebugStore.getState().toggle();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [enabled]);
+
+  useDebugInstrumentation(enabled && open);
+
+  return enabled && open;
+}

--- a/apps/web/src/hooks/useMediaSession.ts
+++ b/apps/web/src/hooks/useMediaSession.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { IS_ELECTRON } from '@/lib/platform';
 
@@ -6,21 +6,20 @@ import { IS_ELECTRON } from '@/lib/platform';
  * Integrates with:
  * 1. navigator.mediaSession — for OS media overlay (Windows media popup, macOS Now Playing)
  * 2. Electron IPC — listens for media:command from main process (global shortcuts)
- * 3. Sends playback state back to main process for tray/taskbar updates
+ *
+ * This hook intentionally does NOT subscribe to currentTime — that high-frequency
+ * value (written every 250ms) is owned by the isolated <MediaSessionSync/> leaf so
+ * the host (root App) does not re-render 4x/sec. Mount <MediaSessionSync/> once
+ * alongside this hook.
  */
 export function useMediaSession() {
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const isPlaying = usePlaybackStore(s => s.isPlaying);
-  const currentTime = usePlaybackStore(s => s.currentTime);
-  const duration = usePlaybackStore(s => s.duration);
   const togglePlay = usePlaybackStore(s => s.togglePlay);
   const next = usePlaybackStore(s => s.next);
   const previous = usePlaybackStore(s => s.previous);
   const stop = usePlaybackStore(s => s.stop);
   const seek = usePlaybackStore(s => s.seek);
-
-  // Throttle state updates to main process (every 1 second)
-  const lastUpdateRef = useRef(0);
 
   // Set up Media Session API action handlers
   useEffect(() => {
@@ -116,20 +115,6 @@ export function useMediaSession() {
     navigator.mediaSession.playbackState = isPlaying ? 'playing' : 'paused';
   }, [isPlaying]);
 
-  // Update position state for seek bar in OS media overlay
-  useEffect(() => {
-    if (!('mediaSession' in navigator) || !duration || !isFinite(duration)) return;
-    try {
-      navigator.mediaSession.setPositionState({
-        duration,
-        playbackRate: 1,
-        position: Math.min(currentTime, duration),
-      });
-    } catch {
-      // Some browsers don't support setPositionState
-    }
-  }, [currentTime, duration]);
-
   // Listen for media commands from Electron main process
   useEffect(() => {
     if (!IS_ELECTRON) return;
@@ -153,28 +138,4 @@ export function useMediaSession() {
 
     return unsub;
   }, [togglePlay, next, previous, stop]);
-
-  // Send playback state to main process (throttled)
-  useEffect(() => {
-    if (!IS_ELECTRON) return;
-
-    const now = Date.now();
-    if (now - lastUpdateRef.current < 1000 && lastUpdateRef.current > 0) return;
-    lastUpdateRef.current = now;
-
-    if (!currentTrack) {
-      window.electronAPI.media.clearState();
-      return;
-    }
-
-    window.electronAPI.media.sendPlaybackState({
-      isPlaying,
-      title: currentTrack.title,
-      artist: currentTrack.artist,
-      album: currentTrack.album,
-      duration,
-      currentTime,
-      albumArt: currentTrack.albumArt ?? null,
-    });
-  }, [currentTrack, isPlaying, currentTime, duration]);
 }

--- a/apps/web/src/hooks/usePlaybackResume.test.ts
+++ b/apps/web/src/hooks/usePlaybackResume.test.ts
@@ -282,7 +282,7 @@ describe('usePlaybackResume hook', () => {
   // Periodic persistence
   // -------------------------------------------------------------------------
 
-  it('persists state on a 1-second interval when ready', async () => {
+  it('persists state on every 1-second interval tick while playing', async () => {
     // Return settings with rememberPlaybackPosition OFF so restore resolves immediately,
     // letting the persist-interval effect activate.
     vi.mocked(window.electronAPI.store.get).mockImplementation(async key => {
@@ -292,7 +292,8 @@ describe('usePlaybackResume hook', () => {
 
     const { usePlaybackResume } = await import('./usePlaybackResume');
 
-    // Set a current track so buildPersistedState returns non-null
+    // Set a current track so buildPersistedState returns non-null. While playing,
+    // currentTime advances in real use, so the interval persists every tick.
     usePlaybackStore.setState({
       currentTrack: tracks[0],
       queue: tracks,
@@ -323,6 +324,43 @@ describe('usePlaybackResume hook', () => {
     expect(setCalls.length).toBeGreaterThanOrEqual(3);
   });
 
+  it('skips redundant interval writes while paused and unchanged', async () => {
+    vi.mocked(window.electronAPI.store.get).mockImplementation(async key => {
+      if (key === 'settings') return { rememberPlaybackPosition: false };
+      return undefined;
+    });
+
+    const { usePlaybackResume } = await import('./usePlaybackResume');
+
+    // Paused track with a stable position — nothing changes between ticks.
+    usePlaybackStore.setState({
+      currentTrack: tracks[0],
+      queue: tracks,
+      queueIndex: 0,
+      currentTime: 10,
+      isPlaying: false,
+    });
+
+    renderHook(() => usePlaybackResume(true));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // The change-driven effect persists once on mount; clear so we only observe
+    // the interval. Paused + unchanged snapshot -> no further writes.
+    vi.mocked(window.electronAPI.store.set).mockClear();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    const setCalls = vi
+      .mocked(window.electronAPI.store.set)
+      .mock.calls.filter(call => call[0] === PLAYER_STATE_KEY);
+    expect(setCalls).toHaveLength(0);
+  });
+
   it('calls store.delete when there is no current track during persist', async () => {
     vi.mocked(window.electronAPI.store.get).mockImplementation(async key => {
       if (key === 'settings') return { rememberPlaybackPosition: false };
@@ -336,12 +374,9 @@ describe('usePlaybackResume hook', () => {
 
     renderHook(() => usePlaybackResume(true));
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
-    });
-
-    vi.mocked(window.electronAPI.store.delete).mockClear();
-
+    // Persist now skips redundant identical writes, so the no-track delete fires
+    // once (on the initial change-driven persist) rather than every interval
+    // tick. Assert that a delete happened — without clearing the mock first.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1000);
     });

--- a/apps/web/src/hooks/usePlaybackResume.ts
+++ b/apps/web/src/hooks/usePlaybackResume.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { IS_ELECTRON } from '@/lib/platform';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
@@ -162,42 +162,65 @@ export function usePlaybackResume(enabled = true) {
     };
   }, [enabled, isReady, isRestoreResolved, library, persistedState, shouldRestore]);
 
+  // Last snapshot actually written to the store, serialized. `undefined` means
+  // "never persisted this session" so the first write always goes through; an
+  // empty string means "last action was a delete (no track)". Used to skip
+  // redundant 1Hz writes when the player is paused and nothing has changed.
+  const lastPersistedRef = useRef<string | undefined>(undefined);
+
+  // Single persist path shared by the 1Hz interval and the change-driven effect.
+  // Persists when playing (currentTime is advancing, so resume stays fresh),
+  // when forced (change events / unload / teardown), or when the snapshot
+  // differs from the last write. Skips the steady stream of identical writes
+  // while paused/hidden.
+  const persistState = useCallback((force = false) => {
+    const state = buildPersistedState();
+
+    if (!state) {
+      if (force || lastPersistedRef.current !== '') {
+        lastPersistedRef.current = '';
+        window.electronAPI.store.delete(PLAYER_STATE_KEY).catch(() => {});
+      }
+      return;
+    }
+
+    const serialized = JSON.stringify(state);
+    if (!force && !state.isPlaying && serialized === lastPersistedRef.current) {
+      return;
+    }
+
+    lastPersistedRef.current = serialized;
+    window.electronAPI.store.set(PLAYER_STATE_KEY, state).catch(() => {});
+  }, []);
+
   useEffect(() => {
     if (!IS_ELECTRON || !enabled || !isReady || !isRestoreResolved) return;
 
-    const persistState = () => {
-      const state = buildPersistedState();
-      if (!state) {
-        window.electronAPI.store.delete(PLAYER_STATE_KEY).catch(() => {});
-        return;
-      }
-
-      window.electronAPI.store.set(PLAYER_STATE_KEY, state).catch(() => {});
-    };
-
-    const intervalId = window.setInterval(persistState, 1000);
-    window.addEventListener('beforeunload', persistState);
+    const intervalId = window.setInterval(() => persistState(), 1000);
+    // Always flush on unload and on teardown so the final position is never lost.
+    const flush = () => persistState(true);
+    window.addEventListener('beforeunload', flush);
 
     return () => {
       window.clearInterval(intervalId);
-      window.removeEventListener('beforeunload', persistState);
-      persistState();
+      window.removeEventListener('beforeunload', flush);
+      flush();
     };
-  }, [enabled, isReady, isRestoreResolved]);
+  }, [enabled, isReady, isRestoreResolved, persistState]);
 
   useEffect(() => {
     if (!IS_ELECTRON || !enabled || !isReady || !isRestoreResolved) return;
-
-    const persistState = () => {
-      const state = buildPersistedState();
-      if (!state) {
-        window.electronAPI.store.delete(PLAYER_STATE_KEY).catch(() => {});
-        return;
-      }
-
-      window.electronAPI.store.set(PLAYER_STATE_KEY, state).catch(() => {});
-    };
-
-    persistState();
-  }, [enabled, isReady, isRestoreResolved, currentTrackPath, queue, queueIndex, isPlaying]);
+    // Track/queue/index/play-state changes are always meaningful — force a write
+    // (and refresh the dedupe snapshot so the next interval tick can skip).
+    persistState(true);
+  }, [
+    enabled,
+    isReady,
+    isRestoreResolved,
+    currentTrackPath,
+    queue,
+    queueIndex,
+    isPlaying,
+    persistState,
+  ]);
 }

--- a/apps/web/src/hooks/usePlaybackResume.ts
+++ b/apps/web/src/hooks/usePlaybackResume.ts
@@ -162,34 +162,41 @@ export function usePlaybackResume(enabled = true) {
     };
   }, [enabled, isReady, isRestoreResolved, library, persistedState, shouldRestore]);
 
-  // Last snapshot actually written to the store, serialized. `undefined` means
+  // Cheap scalar dedupe key for the last persisted snapshot. `undefined` means
   // "never persisted this session" so the first write always goes through; an
   // empty string means "last action was a delete (no track)". Used to skip
-  // redundant 1Hz writes when the player is paused and nothing has changed.
-  const lastPersistedRef = useRef<string | undefined>(undefined);
+  // redundant 1Hz writes when the player is paused and nothing has changed,
+  // without paying a full-queue serialize on every tick. Queue/track/index
+  // changes are caught by the change-driven effect below (which forces a
+  // write), so the key only needs the scalars the interval can observe.
+  const lastKeyRef = useRef<string | undefined>(undefined);
 
   // Single persist path shared by the 1Hz interval and the change-driven effect.
   // Persists when playing (currentTime is advancing, so resume stays fresh),
-  // when forced (change events / unload / teardown), or when the snapshot
+  // when forced (change events / unload / teardown), or when the cheap key
   // differs from the last write. Skips the steady stream of identical writes
-  // while paused/hidden.
+  // while paused/hidden — and avoids building queuePaths / serializing the
+  // queue at all on those skipped ticks.
   const persistState = useCallback((force = false) => {
-    const state = buildPersistedState();
+    const { currentTrack, queueIndex, currentTime, isPlaying } = usePlaybackStore.getState();
 
-    if (!state) {
-      if (force || lastPersistedRef.current !== '') {
-        lastPersistedRef.current = '';
+    if (!currentTrack) {
+      if (force || lastKeyRef.current !== '') {
+        lastKeyRef.current = '';
         window.electronAPI.store.delete(PLAYER_STATE_KEY).catch(() => {});
       }
       return;
     }
 
-    const serialized = JSON.stringify(state);
-    if (!force && !state.isPlaying && serialized === lastPersistedRef.current) {
+    const key = `${currentTrack.filePath}|${queueIndex}|${currentTime}|${isPlaying}`;
+    if (!force && !isPlaying && key === lastKeyRef.current) {
       return;
     }
 
-    lastPersistedRef.current = serialized;
+    const state = buildPersistedState();
+    if (!state) return;
+
+    lastKeyRef.current = key;
     window.electronAPI.store.set(PLAYER_STATE_KEY, state).catch(() => {});
   }, []);
 

--- a/apps/web/src/hooks/useRafLoop.ts
+++ b/apps/web/src/hooks/useRafLoop.ts
@@ -6,10 +6,11 @@ export function useRafLoop(
   callback: () => void,
   elementRef: React.RefObject<HTMLElement | null>,
   isActive: boolean,
+  fps?: number
 ): void {
   const callbackRef = useRef(callback);
   const [isVisible, setIsVisible] = useState(
-    () => typeof document !== 'undefined' && document.visibilityState === 'visible',
+    () => typeof document !== 'undefined' && document.visibilityState === 'visible'
   );
   const [isIntersecting, setIsIntersecting] = useState(false);
 
@@ -34,7 +35,7 @@ export function useRafLoop(
 
     const observer = new IntersectionObserver(
       ([entry]) => setIsIntersecting(entry.isIntersecting),
-      { threshold: 0 },
+      { threshold: 0 }
     );
     observer.observe(el);
     return () => observer.disconnect();
@@ -44,15 +45,24 @@ export function useRafLoop(
   useEffect(() => {
     if (!isActive || !isVisible || !isIntersecting) return;
 
+    // Optional frame-rate cap. We keep scheduling every frame (so the loop
+    // stays aligned with the compositor and stops promptly on cleanup) but
+    // only invoke the callback at most `fps` times/sec. Without this, the
+    // callback runs at the display refresh rate — 120/144Hz monitors would
+    // run expensive per-frame work ~2x more often than it needs to.
+    const minInterval = fps && fps > 0 ? 1000 / fps : 0;
+    let lastRun = -Infinity;
     let rafId: number;
 
-    const loop = () => {
-      callbackRef.current();
+    const loop = (now: number) => {
       rafId = requestAnimationFrame(loop);
+      if (now - lastRun < minInterval) return;
+      lastRun = now;
+      callbackRef.current();
     };
 
     rafId = requestAnimationFrame(loop);
 
     return () => cancelAnimationFrame(rafId);
-  }, [isActive, isVisible, isIntersecting]);
+  }, [isActive, isVisible, isIntersecting, fps]);
 }

--- a/apps/web/src/lib/debug/renderStats.test.ts
+++ b/apps/web/src/lib/debug/renderStats.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { recordRender, sampleRenderStats, resetRenderStats } from './renderStats';
+
+describe('renderStats', () => {
+  beforeEach(() => {
+    resetRenderStats();
+  });
+
+  it('aggregates commits and durations per id', () => {
+    recordRender('player', 2);
+    recordRender('player', 4);
+    recordRender('visualizer', 1);
+
+    const stats = sampleRenderStats();
+    const player = stats.find(s => s.id === 'player');
+    const visualizer = stats.find(s => s.id === 'visualizer');
+
+    expect(player).toEqual({ id: 'player', commits: 2, totalDuration: 6, maxDuration: 4 });
+    expect(visualizer).toEqual({ id: 'visualizer', commits: 1, totalDuration: 1, maxDuration: 1 });
+  });
+
+  it('sorts by commit count descending', () => {
+    recordRender('a', 1);
+    recordRender('b', 1);
+    recordRender('b', 1);
+    recordRender('c', 1);
+    recordRender('c', 1);
+    recordRender('c', 1);
+
+    const ids = sampleRenderStats().map(s => s.id);
+    expect(ids).toEqual(['c', 'b', 'a']);
+  });
+
+  it('resets the window after sampling', () => {
+    recordRender('player', 5);
+    sampleRenderStats();
+    expect(sampleRenderStats()).toEqual([]);
+  });
+
+  it('tracks the largest single commit as maxDuration', () => {
+    recordRender('x', 3);
+    recordRender('x', 9);
+    recordRender('x', 1);
+    expect(sampleRenderStats()[0].maxDuration).toBe(9);
+  });
+});

--- a/apps/web/src/lib/debug/renderStats.ts
+++ b/apps/web/src/lib/debug/renderStats.ts
@@ -1,0 +1,47 @@
+// Dev-only React render-cost attribution for the Debug Panel.
+//
+// `<DevProfiler>` (components/debug/DevProfiler.tsx) feeds `recordRender()` on
+// every commit, accumulating a per-id `{commits, totalDuration}` map. The
+// overlay reads `sampleRenderStats()` on its sampling cadence to show which
+// subtree re-renders most often and most expensively — the direct evidence of
+// which part of the tree is the "window-open CPU" cost.
+
+export interface RenderStat {
+  id: string;
+  commits: number;
+  /** Sum of React `actualDuration` (ms) over the window. */
+  totalDuration: number;
+  /** Largest single commit `actualDuration` (ms) seen in the window. */
+  maxDuration: number;
+}
+
+const stats = new Map<string, RenderStat>();
+
+export function recordRender(id: string, actualDuration: number): void {
+  const existing = stats.get(id);
+  if (existing) {
+    existing.commits += 1;
+    existing.totalDuration += actualDuration;
+    existing.maxDuration = Math.max(existing.maxDuration, actualDuration);
+  } else {
+    stats.set(id, {
+      id,
+      commits: 1,
+      totalDuration: actualDuration,
+      maxDuration: actualDuration,
+    });
+  }
+}
+
+/** Snapshot the per-id stats sorted by commit count desc, then reset the window. */
+export function sampleRenderStats(): RenderStat[] {
+  const out = Array.from(stats.values())
+    .map(s => ({ ...s }))
+    .sort((a, b) => b.commits - a.commits);
+  stats.clear();
+  return out;
+}
+
+export function resetRenderStats(): void {
+  stats.clear();
+}

--- a/apps/web/src/lib/debug/storeHz.ts
+++ b/apps/web/src/lib/debug/storeHz.ts
@@ -1,0 +1,71 @@
+// Dev-only per-store Zustand update-frequency (Hz) counter for the Debug Panel.
+//
+// The single best predictor of wasted renders is a store that `set()`s many
+// times per second while the window is open (e.g. a per-frame playback write).
+// We `store.subscribe()` to a curated set of the hottest stores and count calls
+// over a rolling 1s window, exposing updates/sec per store.
+//
+// Cheap and revealing — a subscribe callback that bumps a counter. Gated behind
+// the dev flag and only started while the overlay is open.
+
+import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { useLibraryStore } from '@/stores/useLibraryStore';
+import { useUIStore } from '@/stores/useUIStore';
+import { useSelectionStore } from '@/stores/useSelectionStore';
+import { usePlayerUIStore } from '@/stores/usePlayerUIStore';
+import { useViewStore } from '@/stores/useViewStore';
+
+interface Subscribable {
+  subscribe: (listener: () => void) => () => void;
+}
+
+const TRACKED_STORES: Record<string, Subscribable> = {
+  playback: usePlaybackStore,
+  library: useLibraryStore,
+  ui: useUIStore,
+  selection: useSelectionStore,
+  playerUI: usePlayerUIStore,
+  view: useViewStore,
+};
+
+const counts = new Map<string, number>();
+let lastReset = 0;
+let lastWindowMs = 1;
+let unsubscribers: Array<() => void> = [];
+
+export function startStoreHz(): void {
+  if (unsubscribers.length > 0) return;
+  counts.clear();
+  lastReset = performance.now();
+  for (const [name, store] of Object.entries(TRACKED_STORES)) {
+    counts.set(name, 0);
+    unsubscribers.push(
+      store.subscribe(() => {
+        counts.set(name, (counts.get(name) ?? 0) + 1);
+      })
+    );
+  }
+}
+
+export function stopStoreHz(): void {
+  for (const off of unsubscribers) off();
+  unsubscribers = [];
+  counts.clear();
+}
+
+/**
+ * Reads the per-store update rate (Hz) since the last call and resets the
+ * window. Call on the overlay's sampling cadence (~2 Hz), not per-frame.
+ */
+export function sampleStoreHz(): Record<string, number> {
+  const now = performance.now();
+  const elapsed = (now - lastReset) / 1000;
+  lastWindowMs = Math.max(elapsed, 1 / 1000);
+  const out: Record<string, number> = {};
+  for (const [name, count] of counts.entries()) {
+    out[name] = Math.round(count / lastWindowMs);
+    counts.set(name, 0);
+  }
+  lastReset = now;
+  return out;
+}

--- a/apps/web/src/lib/debug/timerRegistry.ts
+++ b/apps/web/src/lib/debug/timerRegistry.ts
@@ -1,0 +1,127 @@
+// Dev-only rAF/interval/timeout registry for the CPU/Perf Debug Panel.
+//
+// Monkeypatches `requestAnimationFrame`/`cancelAnimationFrame`/`setInterval`/
+// `clearInterval`/`setTimeout`/`clearTimeout` to maintain a live count of
+// *active* loops, plus the first stack frame per active registration so the
+// panel can attribute "renderer CPU is high" to a specific loop ("3 rAF loops
+// running, 2 of them visualizers").
+//
+// SAFETY: the captured `Error().stack` can contain local file paths. These are
+// kept RENDERER-LOCAL — read synchronously by the overlay via `getTimerStats()`
+// and never sent over IPC or logged. Install once at bootstrap behind the dev
+// flag; the wrappers add per-call overhead and must never ship to prod.
+
+export interface ActiveTimer {
+  id: number;
+  /** Single descriptive stack frame, e.g. "useAudioEngine.ts:422". */
+  origin: string;
+}
+
+export interface TimerStats {
+  activeRaf: number;
+  activeIntervals: number;
+  activeTimeouts: number;
+  rafOrigins: ActiveTimer[];
+  intervalOrigins: ActiveTimer[];
+}
+
+const activeRaf = new Map<number, string>();
+const activeIntervals = new Map<unknown, string>();
+const activeTimeouts = new Map<unknown, string>();
+
+let installed = false;
+
+/**
+ * Extract the first non-registry stack frame, trimmed to a short
+ * `file:line:col` form. Best-effort — returns `'unknown'` when no stack is
+ * available (some engines omit it).
+ */
+function captureOrigin(): string {
+  const stack = new Error().stack;
+  if (!stack) return 'unknown';
+  const lines = stack.split('\n').slice(1);
+  for (const line of lines) {
+    if (line.includes('timerRegistry')) continue;
+    const match = line.match(/([^/\\() ]+\.(?:ts|tsx|js|jsx)[^):]*(?::\d+){0,2})/);
+    if (match) return match[1];
+  }
+  return lines[0]?.trim() ?? 'unknown';
+}
+
+export function installTimerRegistry(): void {
+  if (installed || typeof window === 'undefined') return;
+  installed = true;
+
+  const origRaf = window.requestAnimationFrame.bind(window);
+  const origCancelRaf = window.cancelAnimationFrame.bind(window);
+  const origSetInterval = window.setInterval.bind(window);
+  const origClearInterval = window.clearInterval.bind(window);
+  const origSetTimeout = window.setTimeout.bind(window);
+  const origClearTimeout = window.clearTimeout.bind(window);
+
+  window.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+    const origin = captureOrigin();
+    const id = origRaf((ts: number) => {
+      activeRaf.delete(id);
+      cb(ts);
+    });
+    activeRaf.set(id, origin);
+    return id;
+  };
+
+  window.cancelAnimationFrame = (id: number): void => {
+    activeRaf.delete(id);
+    origCancelRaf(id);
+  };
+
+  window.setInterval = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+    const origin = captureOrigin();
+    const id = origSetInterval(handler as TimerHandler, timeout, ...args);
+    activeIntervals.set(id, origin);
+    return id;
+  }) as typeof window.setInterval;
+
+  window.clearInterval = ((id?: number) => {
+    if (id !== undefined) activeIntervals.delete(id);
+    origClearInterval(id);
+  }) as typeof window.clearInterval;
+
+  window.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+    const origin = captureOrigin();
+    const wrapped: TimerHandler =
+      typeof handler === 'function'
+        ? (...a: unknown[]) => {
+            activeTimeouts.delete(id);
+            (handler as (...fnArgs: unknown[]) => void)(...a);
+          }
+        : handler;
+    const id = origSetTimeout(wrapped, timeout, ...args);
+    activeTimeouts.set(id, origin);
+    return id;
+  }) as typeof window.setTimeout;
+
+  window.clearTimeout = ((id?: number) => {
+    if (id !== undefined) activeTimeouts.delete(id);
+    origClearTimeout(id);
+  }) as typeof window.clearTimeout;
+}
+
+function toOrigins(map: Map<unknown, string>): ActiveTimer[] {
+  const counts = new Map<string, number>();
+  for (const origin of map.values()) {
+    counts.set(origin, (counts.get(origin) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([origin, count], i) => ({ id: i, origin: count > 1 ? `${origin} ×${count}` : origin }))
+    .sort((a, b) => a.origin.localeCompare(b.origin));
+}
+
+export function getTimerStats(): TimerStats {
+  return {
+    activeRaf: activeRaf.size,
+    activeIntervals: activeIntervals.size,
+    activeTimeouts: activeTimeouts.size,
+    rafOrigins: toOrigins(activeRaf),
+    intervalOrigins: toOrigins(activeIntervals),
+  };
+}

--- a/apps/web/src/stores/useDebugStore.test.ts
+++ b/apps/web/src/stores/useDebugStore.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useDebugStore, type LongTaskEntry } from './useDebugStore';
+import type { MainMetricsSnapshot } from '@shiranami/contracts';
+
+function resetStore() {
+  useDebugStore.getState().close();
+  useDebugStore.getState().reset();
+}
+
+function makeSnapshot(): MainMetricsSnapshot {
+  return {
+    ts: 1,
+    cpu: { percentCPUUsage: 12.5, idleWakeupsPerSecond: 3 },
+    heap: { totalHeapSize: 100, usedHeapSize: 60, heapSizeLimit: 2000 },
+    procs: [{ type: 'Browser', pid: 1, cpu: 5, mem: 1024 }],
+  };
+}
+
+function makeLongTask(ts: number): LongTaskEntry {
+  return { ts, kind: 'longtask', duration: 80, name: '' };
+}
+
+describe('useDebugStore', () => {
+  beforeEach(resetStore);
+
+  it('starts closed with no data', () => {
+    const s = useDebugStore.getState();
+    expect(s.open).toBe(false);
+    expect(s.main).toBeNull();
+    expect(s.longTasks).toEqual([]);
+  });
+
+  it('toggle flips the open flag', () => {
+    useDebugStore.getState().toggle();
+    expect(useDebugStore.getState().open).toBe(true);
+    useDebugStore.getState().toggle();
+    expect(useDebugStore.getState().open).toBe(false);
+  });
+
+  it('close always sets open to false', () => {
+    useDebugStore.getState().toggle();
+    useDebugStore.getState().close();
+    expect(useDebugStore.getState().open).toBe(false);
+  });
+
+  it('setMain stores the latest snapshot', () => {
+    const snap = makeSnapshot();
+    useDebugStore.getState().setMain(snap);
+    expect(useDebugStore.getState().main).toEqual(snap);
+  });
+
+  it('pushLongTask prepends newest first and caps the ring buffer at 30', () => {
+    for (let i = 0; i < 35; i++) {
+      useDebugStore.getState().pushLongTask(makeLongTask(i));
+    }
+    const tasks = useDebugStore.getState().longTasks;
+    expect(tasks).toHaveLength(30);
+    expect(tasks[0].ts).toBe(34);
+    expect(tasks[29].ts).toBe(5);
+  });
+
+  it('reset clears main, renderer, and long tasks', () => {
+    useDebugStore.getState().setMain(makeSnapshot());
+    useDebugStore.getState().pushLongTask(makeLongTask(1));
+    useDebugStore.getState().reset();
+    const s = useDebugStore.getState();
+    expect(s.main).toBeNull();
+    expect(s.longTasks).toEqual([]);
+    expect(s.renderer.fps).toBe(0);
+  });
+});

--- a/apps/web/src/stores/useDebugStore.ts
+++ b/apps/web/src/stores/useDebugStore.ts
@@ -1,0 +1,80 @@
+import { create } from 'zustand';
+import type { MainMetricsSnapshot } from '@shiranami/contracts';
+import type { TimerStats } from '@/lib/debug/timerRegistry';
+import type { RenderStat } from '@/lib/debug/renderStats';
+
+/** A long-task / slow-event entry captured by the renderer PerformanceObserver. */
+export interface LongTaskEntry {
+  ts: number;
+  /** 'longtask' | 'event' (the PerformanceEntry.entryType). */
+  kind: string;
+  /** Duration in ms. */
+  duration: number;
+  /** Entry name (e.g. the event type for 'event' entries). */
+  name: string;
+}
+
+/** Renderer-side perf aggregate pushed to the store ~2x/sec. */
+export interface RendererMetrics {
+  fps: number;
+  /** p95 frame time over the last window (ms). */
+  frameP95: number;
+  /** `performance.memory.usedJSHeapSize` in bytes, or null when unavailable. */
+  jsHeap: number | null;
+  timers: TimerStats | null;
+  renderStats: RenderStat[];
+  storeHz: Record<string, number>;
+}
+
+const EMPTY_RENDERER: RendererMetrics = {
+  fps: 0,
+  frameP95: 0,
+  jsHeap: null,
+  timers: null,
+  renderStats: [],
+  storeHz: {},
+};
+
+const MAX_LONG_TASKS = 30;
+
+interface DebugState {
+  open: boolean;
+  main: MainMetricsSnapshot | null;
+  renderer: RendererMetrics;
+  longTasks: LongTaskEntry[];
+}
+
+interface DebugActions {
+  toggle: () => void;
+  close: () => void;
+  setMain: (snapshot: MainMetricsSnapshot) => void;
+  setRenderer: (metrics: RendererMetrics) => void;
+  pushLongTask: (entry: LongTaskEntry) => void;
+  reset: () => void;
+}
+
+export const useDebugStore = create<DebugState & DebugActions>(set => ({
+  open: false,
+  main: null,
+  renderer: EMPTY_RENDERER,
+  longTasks: [],
+
+  toggle: () => set(s => ({ open: !s.open })),
+  close: () => set({ open: false }),
+  setMain: snapshot => set({ main: snapshot }),
+  setRenderer: metrics => set({ renderer: metrics }),
+  pushLongTask: entry =>
+    set(s => ({ longTasks: [entry, ...s.longTasks].slice(0, MAX_LONG_TASKS) })),
+  reset: () => set({ main: null, renderer: EMPTY_RENDERER, longTasks: [] }),
+}));
+
+if (import.meta.hot) {
+  type HmrData = { store?: typeof useDebugStore };
+  const hot = import.meta.hot;
+  const data = (hot.data ?? {}) as HmrData;
+  if (data.store) {
+    useDebugStore.setState(data.store.getState());
+  }
+  data.store = useDebugStore;
+  hot.accept();
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -312,6 +312,28 @@
   }
 }
 
+/* App-wide reduced-motion gate (a11y + a free CPU win when the OS asks for it).
+   Neutralizes the decorative / looping steady-state animations only — the
+   equalizer bars, the always-pulsing status badges, the floating mascot, the
+   subtle opacity pulse, and the hover marquee. Functional transitions that
+   convey state (enter/exit, hover affordances) are intentionally left alone.
+   Kept outside @layer so it reliably beats the @utility animation declarations
+   without raising specificity. */
+@media (prefers-reduced-motion: reduce) {
+  .eq-bar-1,
+  .eq-bar-2,
+  .eq-bar-3,
+  .animate-pulse,
+  .animate-pulse-subtle,
+  .float-mascot {
+    animation: none !important;
+  }
+  .animate-marquee {
+    animation: none !important;
+    transform: none !important;
+  }
+}
+
 [data-perf-mode='low'] .splash-steam,
 [data-perf-mode='low'] .splash-streak {
   display: none;
@@ -505,6 +527,13 @@
 
 @utility font-display {
   font-family: var(--font-display);
+}
+
+/* Shared mascot float — stable class so the global reduced-motion gate can
+   neutralize it (replaces the duplicated arbitrary
+   animate-[shiranami-float_6s_ease-in-out_infinite] usages). */
+@utility float-mascot {
+  animation: shiranami-float 6s ease-in-out infinite;
 }
 
 @utility eq-bar-1 {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -556,6 +556,14 @@
   background: oklch(0.1 0.02 280 / 0.9);
 }
 
+/* Full-viewport feTurbulence noise overlay — a live SVG filter the compositor
+   keeps as a top-most always-present layer. AmbientBackground already unmounts
+   it under low-perf, but drop it here too so the rule is self-documenting and
+   covers any future always-on mount. */
+[data-perf-mode='low'] .noise::before {
+  display: none;
+}
+
 /* ── Theme image paint surface (ThemeBackground) ─────────────────────────
    Sizing + first-paint fallback only. The actual `background-image` is set
    inline by ThemeBackground as a document-relative `url(./themes/<id>.webp)`
@@ -604,5 +612,11 @@
   .glass-panel {
     backdrop-filter: none;
     background: oklch(0.1 0.02 280 / 0.9);
+  }
+  /* The live feTurbulence noise overlay reads as a transparency effect — drop
+     it under reduced-transparency (it was previously only dropped under
+     low-perf via AmbientBackground unmount). */
+  .noise::before {
+    display: none;
   }
 }

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -30,6 +30,23 @@ class ResizeObserverMock {
 
 globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 
+// jsdom has no IntersectionObserver. useRafLoop constructs one to gate its loop
+// on element visibility, so any component using it (SeekBar, visualizers) needs
+// this in tests. The mock is inert — it never fires, so loops stay idle, which
+// is the correct default for unit tests that don't drive animation frames.
+class IntersectionObserverMock {
+  constructor(_callback: IntersectionObserverCallback) {}
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+globalThis.IntersectionObserver =
+  IntersectionObserverMock as unknown as typeof IntersectionObserver;
+
 export function triggerResize(target: Element, rect: { width: number; height: number }): void {
   const contentRect = {
     ...rect,

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -240,6 +240,11 @@ function createElectronAPIMock(): ElectronAPI {
       cancel: asyncFn(undefined),
       onExtractProgress: vi.fn(() => noopUnsub()),
     },
+    debug: {
+      start: asyncFn(undefined),
+      stop: asyncFn(undefined),
+      onMetrics: vi.fn(() => noopUnsub()),
+    },
     platform: 'win32',
     __e2e: false,
   };

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -3,6 +3,7 @@ import type {
   EnrichTrackResult,
   EnrichProgress,
   MetadataLookupResult,
+  MainMetricsSnapshot,
 } from '@shiranami/contracts';
 
 export interface Playlist {
@@ -387,6 +388,11 @@ export interface ElectronAPI {
     }>;
     cacheYoutubeId: (trackId: string, youtubeId: string) => Promise<void>;
     onDeepLink: (callback: (code: string) => void) => () => void;
+  };
+  debug: {
+    start: () => Promise<void>;
+    stop: () => Promise<void>;
+    onMetrics: (callback: (snapshot: MainMetricsSnapshot) => void) => () => void;
   };
   platform: NodeJS.Platform;
   /** True when the main process was launched with SHIRANAMI_E2E=1. */

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,5 +2,6 @@
 // shared API DTOs.
 export * from './domain/track';
 export * from './ipc/channels';
+export * from './ipc/debug';
 export * from './ipc/metadata';
 export * from './share/dto';

--- a/packages/contracts/src/ipc/channels.ts
+++ b/packages/contracts/src/ipc/channels.ts
@@ -25,6 +25,11 @@ export const IPC_CHANNELS = {
     getVersion: 'app:get-version',
     openLogsFolder: 'app:open-logs-folder',
   },
+  debug: {
+    start: 'debug:start',
+    stop: 'debug:stop',
+    metrics: 'debug:metrics',
+  },
   store: {
     get: 'store:get',
     set: 'store:set',

--- a/packages/contracts/src/ipc/debug.ts
+++ b/packages/contracts/src/ipc/debug.ts
@@ -1,0 +1,55 @@
+// Wire types for the dev-only CPU/Perf Debug Panel IPC surface.
+//
+// The shape is defined once here and imported by the main-process sampler
+// (apps/desktop/src/main/ipc/debug.ts), the preload bridge
+// (apps/desktop/src/main/preload/api/debug.ts), and the renderer store
+// (apps/web/src/stores/useDebugStore.ts).
+//
+// SAFETY: the snapshot carries NUMBERS and process types only. It must never
+// include file paths, the userData path, track titles, URLs, process.argv, or
+// environment variables. `app.getAppMetrics()` returns pids/types/numbers,
+// which are safe to forward.
+
+/**
+ * Per-child-process slice from `app.getAppMetrics()`. One entry per Electron
+ * process (Browser/GPU/Utility/Renderer/etc.). Splitting CPU by process type is
+ * the core signal for attributing the "window open vs background" delta — it
+ * separates GPU compositing from renderer JS from the main process.
+ */
+export interface ProcessMetric {
+  /** Electron process type, e.g. 'Browser' | 'GPU' | 'Tab' | 'Utility'. */
+  type: string;
+  pid: number;
+  /** Instantaneous CPU usage as a percentage (0-100, may exceed 100 on multi-core). */
+  cpu: number;
+  /** Working set size in KB. */
+  mem: number;
+}
+
+/** Main-process CPU usage from `process.getCPUUsage()` (microseconds + 0-100%). */
+export interface MainCpuUsage {
+  percentCPUUsage: number;
+  idleWakeupsPerSecond: number;
+}
+
+/**
+ * Main-process V8 heap stats from `process.getHeapStatistics()`. Values are in
+ * KB. We forward only the size fields the panel renders — not the full struct.
+ */
+export interface MainHeapStats {
+  totalHeapSize: number;
+  usedHeapSize: number;
+  heapSizeLimit: number;
+}
+
+/**
+ * Snapshot pushed over `debug:metrics` from main → renderer at ~1 Hz while the
+ * panel is open. Numbers and process types only — see the SAFETY note above.
+ */
+export interface MainMetricsSnapshot {
+  /** `Date.now()` when the sample was taken. */
+  ts: number;
+  cpu: MainCpuUsage;
+  heap: MainHeapStats;
+  procs: ProcessMetric[];
+}


### PR DESCRIPTION
## Summary

Addresses elevated **renderer CPU usage when the app window is open/visible** (~3-15% depending on hardware) versus near-idle (~0-2%) when backgrounded. A four-lens investigation (perf, ui, observability, arch) converged on a clear conclusion: this is **not** an Electron/V8 defect and **not** a React re-render storm — the background drop is just Chromium's default `backgroundThrottling` freezing per-frame loops, so the visible-only cost is **continuously-animated renderer work** that we can cut. The architecture (process model, IPC, hardware acceleration) is already correctly tuned and is left untouched (and now guarded).

This PR ships a dev **debug panel** to measure it, then applies the fixes in priority order.

## What's included (in commit order)

**Debug panel (the measurement harness — dev-only, tree-shaken from production):**
- `feat(contracts)` — `debug:{start,stop,metrics}` IPC channels + typed numeric-only payload
- `feat(desktop)` — 1Hz main-process sampler (`app.getAppMetrics()` + `process.getCPUUsage()` + heap stats) pushed over IPC; `.unref()`'d, heartbeat-only logging, starts/stops with the overlay
- `feat(web)` — `useDebugStore` + renderer instrumentation (FPS/frame-p95, `PerformanceObserver` long-tasks, React `<Profiler>` commit counts, dev rAF/timer registry, per-store Zustand Hz)
- `feat(web)` — `DebugOverlay` toggled with **Ctrl+Shift+D** (per-process CPU split: GPU vs renderer vs main)

**Renderer CPU fixes (priority order):**
1. `perf(web)` — remove per-frame `shadowBlur` from visualizers (was ~2,880 Gaussian-blur fills/sec; glow now a single CSS `drop-shadow` on the canvas) — **biggest while-playing win, scales with GPU**
2. `perf(web)` — SeekBar progress via `transform: scaleX()/translateX()` (compositor-only) + visibility/intersection gate via `useRafLoop` (was a 60fps `width/left` reflow, ungated)
3. `perf(web)` — isolate the `currentTime` media-session sync into a memo'd leaf `<MediaSessionSync/>` so root `App` no longer reconciles 4×/sec on every 250ms time write
4. `perf(web)` — gate the 1Hz player-state persist on actual change (skips redundant `electronAPI.store.set` writes while paused/hidden; still flushes final position)
5. `perf(web)` — cut `backdrop-filter`: flat `bg-card/70` on repeated library cards; live fractal-noise overlay gated behind `prefers-reduced-transparency` + low-perf mode
6. `perf(web)` — honor `prefers-reduced-motion` app-wide (eq-bars, pulse badges, mascot float, marquee + `useReducedMotion()` on the ambient cross-fade) — a11y + CPU
7. `perf(desktop)` — log `app.getGPUFeatureStatus()` at bootstrap to catch a future HW-accel regression

**Follow-up — review feedback (`96b129b`):** addressed two valid `gemini-code-assist` comments:
- SeekBar thumb is now ratio-based (`left: %` + `translateX(-50%)`) instead of pixel `translateX(trackWidth)`, so it repositions correctly on window resize while paused (regression introduced by fix #2).
- `usePlaybackResume` no longer `JSON.stringify`s the full queue every second while paused — dedupe now uses a cheap scalar key and only serializes when forced/playing/changed.

**Follow-up — live-panel finding (`e1890e0`):** running the new panel on a 144Hz Windows display surfaced `fps: 144` — `useRafLoop` was uncapped, so every visualizer redrew at the monitor refresh rate (~2.4× the assumed 60fps). Added an optional `fps` cap to `useRafLoop` and applied **`VISUALIZER_FPS = 30`** to all four visualizers (incl. `WaveformVisualizer`, which the shadowBlur pass had missed and was the heaviest when active). SeekBar stays uncapped for smooth progress. ~4.8× less visualizer draw work on a 144Hz display; frees the main thread so hover/pointer latency drops.

## Invariants protected
- **Hardware acceleration stays enabled** — no `app.disableHardwareAcceleration()`
- **`backgroundThrottling` stays at default `true`** — this is *why* backgrounded is cheap; not changed

## Verification
- `pnpm typecheck` — clean (contracts/shared/database build; web + desktop typecheck pass)
- `pnpm lint` — clean
- `pnpm test` — all green (web **595** / desktop **640** at latest run; 1 pre-existing desktop skip), incl. new debug-store/instrumentation/persist tests
- Production build confirmed to **tree-shake the entire debug panel** out (no debug chunk, no instrumentation symbols in the prod bundle)
- **Validated live on Windows** via the panel: root `App` no longer re-renders on time ticks (only the player subtree commits), `playback` store updates at 4 Hz as designed, and the **main process sits at ~0% CPU** — confirming the cost is purely renderer + GPU, as the arch lens predicted.

## How to measure the wins
Run `pnpm dev`, press **Ctrl+Shift+D**, play a track, and watch: GPU-process CPU + visualizer `<Profiler>` commits drop after #1; App commit count/sec → ~0 after #3; the idle-paused IPC tick → 0 after #4; and GPU/renderer process CPU drop with a visualizer active after the fps cap. Background the window to see the per-process rows fall (the original delta, now numeric). Note: the panel's `fps:` readout reflects the display refresh / the panel's own meter loop — judge the visualizer cap by the **PROCESSES (MAIN)** rows, not the fps number.

## Out of scope (deferred by design)
Virtualizing `PlaylistDetailView`/`AlbumDetailView` (scroll-jank, not the idle-visible delta) and any broad `React.memo` sweep — revisit only if the panel later shows commit-driven scripting cost. Possible further visualizer micro-opt (`WaveformVisualizer` per-bar `rgba()` allocation / `roundRect`→`rect`) deferred pending measurement, since the 30fps cap may make it moot.
