### PR TITLE
feat(web): first-run onboarding wizard

### DIFF
--- a/apps/desktop/src/main/ipc/schemas/store.ts
+++ b/apps/desktop/src/main/ipc/schemas/store.ts
@@ -19,6 +19,7 @@ const RENDERER_STORE_KEYS = [
   'theme',
   'window-bounds',
   'app.language',
+  'app.onboardingCompleted',
   'metadata-enrich.skippedIds',
 ] as const;
 

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -34,6 +34,7 @@ export interface StoreSchema {
   'player.isMuted': boolean;
   theme: 'light' | 'dark' | 'system';
   'app.language': string;
+  'app.onboardingCompleted': boolean;
   'metadata-enrich.skippedIds': string[];
 
   // Main-only (downloader.ts).

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
-import { IS_ELECTRON } from '@/lib/platform';
+import { IS_ELECTRON, IS_E2E } from '@/lib/platform';
 import { PLAYER_BAR_HEIGHT, VISUALIZER_HEIGHT, PLAYER_BAR_PLUS_VIZ } from '@/lib/layout';
 import { Sidebar } from '@/components/shared/Sidebar';
 import { TopBar } from '@/components/shared/TopBar';
@@ -65,11 +65,14 @@ function App() {
 
   const onboardingCompleted = useOnboardingStore(s => s.hasCompletedOnboarding);
   const hydrateOnboarding = useOnboardingStore(s => s.hydrateOnboarding);
-  const [onboardingDone, setOnboardingDone] = useState(onboardingCompleted);
+  // Under the e2e harness, treat onboarding as done so specs land on the app
+  // shell instead of the first-run wizard (fresh userDataDir → never completed).
+  const [onboardingDone, setOnboardingDone] = useState(onboardingCompleted || IS_E2E);
   // Mirror the durable store flag locally so the wizard appears/disappears in
   // step with it — covers both replay (true→false from Settings) and boot-time
   // hydration (false→true from the electron-store mirror).
   useEffect(() => {
+    if (IS_E2E) return;
     setOnboardingDone(onboardingCompleted);
   }, [onboardingCompleted]);
   const handleOnboardingComplete = useCallback(() => setOnboardingDone(true), []);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -66,10 +66,11 @@ function App() {
   const onboardingCompleted = useOnboardingStore(s => s.hasCompletedOnboarding);
   const hydrateOnboarding = useOnboardingStore(s => s.hydrateOnboarding);
   const [onboardingDone, setOnboardingDone] = useState(onboardingCompleted);
-  // Replay (reset from Settings) flips the store flag back to false; mirror it
-  // locally so the wizard re-appears immediately over the running app.
+  // Mirror the durable store flag locally so the wizard appears/disappears in
+  // step with it — covers both replay (true→false from Settings) and boot-time
+  // hydration (false→true from the electron-store mirror).
   useEffect(() => {
-    if (!onboardingCompleted) setOnboardingDone(false);
+    setOnboardingDone(onboardingCompleted);
   }, [onboardingCompleted]);
   const handleOnboardingComplete = useCallback(() => setOnboardingDone(true), []);
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -36,6 +36,7 @@ const DebugOverlay = import.meta.env.DEV
 const KeyboardShortcutsHelp = lazy(() => import('@/components/shared/KeyboardShortcutsHelp'));
 const ShareDialogManager = lazy(() => import('@/components/shared/ShareDialogManager'));
 const TrackEnrichDialogManager = lazy(() => import('@/components/shared/TrackEnrichDialogManager'));
+const OnboardingWizard = lazy(() => import('@/components/onboarding/OnboardingWizard'));
 import { useAudioEngine } from '@/hooks/useAudioEngine';
 import { useMediaSession } from '@/hooks/useMediaSession';
 import { useLibraryActions } from '@/hooks/useLibraryActions';
@@ -53,6 +54,7 @@ import { useViewStore } from '@/stores/useViewStore';
 import { useDownloadStore } from '@/stores/useDownloadStore';
 import { useMetadataEnrichStore } from '@/stores/useMetadataEnrichStore';
 import { useLibraryStore } from '@/stores/useLibraryStore';
+import { useOnboardingStore } from '@/stores/useOnboardingStore';
 import { AmbientColorProvider } from '@/hooks/useAmbientColor';
 import { CommandPalette } from '@/components/shared/CommandPalette';
 import { hydrateLanguageFromStore } from '@/lib/i18n';
@@ -60,6 +62,16 @@ import { hydrateLanguageFromStore } from '@/lib/i18n';
 function App() {
   const [splashDone, setSplashDone] = useState(false);
   const handleSplashDismissed = useCallback(() => setSplashDone(true), []);
+
+  const onboardingCompleted = useOnboardingStore(s => s.hasCompletedOnboarding);
+  const hydrateOnboarding = useOnboardingStore(s => s.hydrateOnboarding);
+  const [onboardingDone, setOnboardingDone] = useState(onboardingCompleted);
+  // Replay (reset from Settings) flips the store flag back to false; mirror it
+  // locally so the wizard re-appears immediately over the running app.
+  useEffect(() => {
+    if (!onboardingCompleted) setOnboardingDone(false);
+  }, [onboardingCompleted]);
+  const handleOnboardingComplete = useCallback(() => setOnboardingDone(true), []);
 
   const { t } = useTranslation();
 
@@ -92,6 +104,10 @@ function App() {
   useEffect(() => {
     hydrateLanguageFromStore();
   }, []);
+
+  useEffect(() => {
+    void hydrateOnboarding();
+  }, [hydrateOnboarding]);
 
   // Auto-collapse sidebar on narrow viewports
   const setSidebarCollapsed = useUIStore(s => s.setSidebarCollapsed);
@@ -154,7 +170,13 @@ function App() {
         onDismissed={handleSplashDismissed}
       />
 
-      {splashDone && (
+      {splashDone && !onboardingDone && (
+        <Suspense fallback={null}>
+          <OnboardingWizard onComplete={handleOnboardingComplete} />
+        </Suspense>
+      )}
+
+      {splashDone && onboardingDone && (
         <AmbientColorProvider>
           <div
             className={cn(

--- a/apps/web/src/components/onboarding/OnboardingKanji.tsx
+++ b/apps/web/src/components/onboarding/OnboardingKanji.tsx
@@ -1,0 +1,27 @@
+interface OnboardingKanjiProps {
+  /** Per-step glyph, e.g. 白波 / 蔵 / 夜 / 波. Not translated — it's brand art. */
+  glyph: string;
+}
+
+/**
+ * Faint kanji watermark behind the left narrative pane. Purely decorative —
+ * derived from --primary at very low alpha so it reads as a textural wash, not
+ * legible copy. Mirrors the splash wordmark's role without any animation.
+ */
+export function OnboardingKanji({ glyph }: OnboardingKanjiProps) {
+  return (
+    <span
+      aria-hidden="true"
+      className="pointer-events-none absolute -left-2 top-1/2 -translate-y-1/2 select-none leading-none"
+      style={{
+        fontFamily: "'Shippori Mincho', 'Noto Sans JP', 'Hiragino Sans', serif",
+        fontWeight: 800,
+        fontSize: 'clamp(160px, 30vw, 340px)',
+        color: 'oklch(from var(--primary) l c h / 0.05)',
+        textShadow: '0 0 80px oklch(from var(--primary) l c h / 0.08)',
+      }}
+    >
+      {glyph}
+    </span>
+  );
+}

--- a/apps/web/src/components/onboarding/OnboardingScene.tsx
+++ b/apps/web/src/components/onboarding/OnboardingScene.tsx
@@ -1,0 +1,32 @@
+import { SplashScene } from '@/components/splash/SplashScene';
+import { SplashGlass } from '@/components/splash/SplashGlass';
+import { SplashDroplets } from '@/components/splash/SplashDroplets';
+
+interface OnboardingSceneProps {
+  /** When true, the scene's only animated sub-layer (window flicker) is frozen. */
+  reducedMotion: boolean;
+}
+
+/**
+ * Rainy-window backdrop for the onboarding wizard, composed from the splash's
+ * already-tuned static layers (night scene + clinging droplets + wet glass)
+ * rather than authoring a new rAF loop. The animated rain/steam/lamp layers are
+ * deliberately omitted — onboarding is a longer-lived overlay than the 2.5s
+ * splash, so we keep it cheap. The droplets' running streaks self-degrade to
+ * static under reduced-motion / low-perf via their globals.css class guards.
+ */
+export function OnboardingScene({ reducedMotion }: OnboardingSceneProps) {
+  return (
+    <div className="absolute inset-0 overflow-hidden bg-background" aria-hidden="true">
+      <div className="absolute inset-0 z-[1]">
+        <SplashScene reducedMotion={reducedMotion} />
+      </div>
+      <div className="absolute inset-0 z-[2]">
+        <SplashDroplets />
+      </div>
+      <div className="absolute inset-0 z-[3]">
+        <SplashGlass />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/onboarding/OnboardingStepLayout.tsx
+++ b/apps/web/src/components/onboarding/OnboardingStepLayout.tsx
@@ -34,8 +34,10 @@ export function OnboardingStepLayout({
 }: OnboardingStepLayoutProps) {
   return (
     <div className="grid h-full w-full gap-8 md:grid-cols-[1.05fr_1fr] md:gap-12">
-      {/* Left — narrative */}
-      <div className="relative flex min-w-0 flex-col justify-center overflow-hidden">
+      {/* Left — narrative. Content block is centered within its pane so the copy
+          never hugs the window edge on wide/full-screen displays, while the
+          grid itself still spans the full width (no dead side-bands). */}
+      <div className="relative flex min-w-0 flex-col items-center justify-center overflow-hidden">
         <OnboardingKanji glyph={kanji} />
         {/* AA contrast scrim behind the copy */}
         <div
@@ -62,9 +64,13 @@ export function OnboardingStepLayout({
         </div>
       </div>
 
-      {/* Right — interactive control */}
-      <div className="relative flex min-w-0 flex-col justify-center">
-        <div className="glass rounded-2xl border border-border/30 bg-surface/50 p-5 shadow-[0_8px_40px_-12px_oklch(from_var(--background)_calc(l*0.4)_c_h_/_0.6)]">
+      {/* Right — interactive control. Centered in its pane with a comfortable
+          max width: never shrinks below its natural size at normal window
+          widths, just stops stretching too wide on full-screen displays. The
+          card scrolls inside itself (max-h-full) so tall steps like Appearance
+          stay reachable on short windows instead of clipping off-screen. */}
+      <div className="relative flex min-h-0 min-w-0 flex-col items-center justify-center">
+        <div className="glass max-h-full w-full max-w-xl overflow-y-auto scrollbar-thin rounded-2xl border border-border/30 bg-surface/50 p-5 shadow-[0_8px_40px_-12px_oklch(from_var(--background)_calc(l*0.4)_c_h_/_0.6)]">
           {children}
         </div>
       </div>

--- a/apps/web/src/components/onboarding/OnboardingStepLayout.tsx
+++ b/apps/web/src/components/onboarding/OnboardingStepLayout.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode, RefObject } from 'react';
+import { OnboardingKanji } from './OnboardingKanji';
+
+interface OnboardingStepLayoutProps {
+  /** Per-step kanji watermark glyph. */
+  kanji: string;
+  /** Mono uppercase eyebrow, e.g. "01 · POINT IT AT YOUR FILES". */
+  stepMarker: ReactNode;
+  /** Headline — supports an <em> accent emphasis via <Trans>. */
+  headline: ReactNode;
+  description: ReactNode;
+  /** The real, working control for this step. */
+  children: ReactNode;
+  /** Wires the left-pane heading id so the wizard can move focus to it. */
+  headingId?: string;
+  /** Ref the wizard focuses on each step change for a11y. */
+  headingRef?: RefObject<HTMLHeadingElement | null>;
+}
+
+/**
+ * Two-pane magazine split shared by every onboarding step. Left pane carries
+ * the kanji watermark + eyebrow + headline + body narrative; right pane hosts
+ * the real interactive control. A subtle scrim sits behind the left pane so the
+ * muted body copy clears WCAG AA over the blurred rainy scene (§7).
+ */
+export function OnboardingStepLayout({
+  kanji,
+  stepMarker,
+  headline,
+  description,
+  children,
+  headingId,
+  headingRef,
+}: OnboardingStepLayoutProps) {
+  return (
+    <div className="grid h-full w-full gap-8 md:grid-cols-[1.05fr_1fr] md:gap-12">
+      {/* Left — narrative */}
+      <div className="relative flex min-w-0 flex-col justify-center overflow-hidden">
+        <OnboardingKanji glyph={kanji} />
+        {/* AA contrast scrim behind the copy */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 -m-6 rounded-3xl"
+          style={{
+            background: 'oklch(from var(--background) calc(l * 0.6) c h / 0.35)',
+            backdropFilter: 'blur(22px)',
+          }}
+        />
+        <div className="relative max-w-md">
+          <p className="mb-5 font-mono text-[11px] uppercase tracking-[0.22em] text-primary">
+            {stepMarker}
+          </p>
+          <h2
+            ref={headingRef}
+            id={headingId}
+            tabIndex={-1}
+            className="m-0 font-serif text-[clamp(30px,4.4vw,46px)] italic leading-[1.05] tracking-[-0.015em] text-foreground focus:outline-none"
+          >
+            {headline}
+          </h2>
+          <p className="mt-5 text-[15px] leading-[1.7] text-muted-foreground">{description}</p>
+        </div>
+      </div>
+
+      {/* Right — interactive control */}
+      <div className="relative flex min-w-0 flex-col justify-center">
+        <div className="glass rounded-2xl border border-border/30 bg-surface/50 p-5 shadow-[0_8px_40px_-12px_oklch(from_var(--background)_calc(l*0.4)_c_h_/_0.6)]">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -115,12 +115,14 @@ export default function OnboardingWizard({ onComplete }: OnboardingWizardProps) 
   }, [isExiting, disableMotion, completeOnboarding, onComplete]);
 
   const goNext = useCallback(() => {
+    if (isExiting) return;
     setStepIndex(i => (i >= STEPS.length - 1 ? i : i + 1));
-  }, []);
+  }, [isExiting]);
 
   const goBack = useCallback(() => {
+    if (isExiting) return;
     setStepIndex(i => (i <= 0 ? i : i - 1));
-  }, []);
+  }, [isExiting]);
 
   const handlePrimary = useCallback(() => {
     if (isLast) {
@@ -135,13 +137,14 @@ export default function OnboardingWizard({ onComplete }: OnboardingWizardProps) 
     headingRef.current?.focus();
   }, [stepIndex]);
 
-  // Keyboard: → / Enter advance (or finish), ← back, Esc skips. Never hijack
-  // while a text input is focused, nor while a layered Radix dialog (e.g. the
-  // subfolder-playlist prompt at z-9999) is open — that overlay owns the keys.
-  // Sliders (UI scale, crossfade) consume Arrow keys for value adjustment, so a
-  // focused slider must also keep its keys instead of changing steps.
+  // Keyboard: → / Enter advance (or finish), ← back, Esc skips. Defers to
+  // focused buttons/links/selects/radios so Enter on "Add folder"/Back/Skip
+  // fires the control and arrows on a theme radio navigate the radiogroup.
+  // Never hijacks while a text input is focused, a Radix dialog is open, a
+  // slider has focus, or the wizard is in its exit animation.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      if (isExiting) return;
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName;
       const isRangeInput = tag === 'INPUT' && (target as HTMLInputElement).type === 'range';
@@ -153,16 +156,18 @@ export default function OnboardingWizard({ onComplete }: OnboardingWizardProps) 
         e.preventDefault();
         finish();
       } else if (e.key === 'ArrowRight' || e.key === 'Enter') {
+        if (target?.closest('button, a, select, [role="radio"]')) return;
         e.preventDefault();
         handlePrimary();
       } else if (e.key === 'ArrowLeft') {
+        if (target?.closest('button, a, select, [role="radio"]')) return;
         e.preventDefault();
         if (!isFirst) goBack();
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [finish, handlePrimary, goBack, isFirst]);
+  }, [finish, handlePrimary, goBack, isFirst, isExiting]);
 
   const primaryLabel = isLast
     ? t('wizard.finish')
@@ -251,7 +256,7 @@ export default function OnboardingWizard({ onComplete }: OnboardingWizardProps) 
                   type="button"
                   aria-label={t('wizard.stepDotAria', { number: i + 1, id: s.id })}
                   aria-current={active ? 'step' : undefined}
-                  onClick={() => setStepIndex(i)}
+                  onClick={() => !isExiting && setStepIndex(i)}
                   className={cn(
                     'h-1.5 rounded-full transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
                     active ? 'w-6 bg-primary' : 'w-1.5 bg-foreground/25 hover:bg-foreground/40'

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -138,10 +138,14 @@ export default function OnboardingWizard({ onComplete }: OnboardingWizardProps) 
   // Keyboard: → / Enter advance (or finish), ← back, Esc skips. Never hijack
   // while a text input is focused, nor while a layered Radix dialog (e.g. the
   // subfolder-playlist prompt at z-9999) is open — that overlay owns the keys.
+  // Sliders (UI scale, crossfade) consume Arrow keys for value adjustment, so a
+  // focused slider must also keep its keys instead of changing steps.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName;
+      const isRangeInput = tag === 'INPUT' && (target as HTMLInputElement).type === 'range';
+      if (target?.getAttribute('role') === 'slider' || isRangeInput) return;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
       if (document.querySelector('[role="dialog"][data-state="open"]')) return;
 

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -17,6 +17,7 @@ import { useFoldersQuery } from '@/hooks/queries/useFolders';
 import { Button } from '@/components/ui/button';
 import { OnboardingScene } from './OnboardingScene';
 import { OnboardingStepContext } from './stepContext';
+import { useFocusTrap } from './useFocusTrap';
 import { WelcomeStep } from './steps/WelcomeStep';
 import { FoldersStep } from './steps/FoldersStep';
 import { ThemeStep } from './steps/ThemeStep';
@@ -57,7 +58,9 @@ export default function OnboardingWizard({ onComplete }: OnboardingWizardProps) 
 
   const [stepIndex, setStepIndex] = useState(0);
   const [isExiting, setIsExiting] = useState(false);
+  const [isEntering, setIsEntering] = useState(true);
   const headingRef = useRef<HTMLHeadingElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   // Cached at mount — the OS preference doesn't change mid-wizard.
   const reducedMotion = useMemo(
@@ -65,6 +68,18 @@ export default function OnboardingWizard({ onComplete }: OnboardingWizardProps) 
     []
   );
   const disableMotion = reducedMotion || lowPerformanceMode;
+
+  useFocusTrap(containerRef, !isExiting);
+
+  // Entrance fade-in (skipped under reduced-motion / low-perf).
+  useEffect(() => {
+    if (disableMotion) {
+      setIsEntering(false);
+      return;
+    }
+    const id = window.requestAnimationFrame(() => setIsEntering(false));
+    return () => window.cancelAnimationFrame(id);
+  }, [disableMotion]);
 
   const step = STEPS[stepIndex];
   const isFirst = stepIndex === 0;
@@ -108,13 +123,14 @@ export default function OnboardingWizard({ onComplete }: OnboardingWizardProps) 
   }, [stepIndex]);
 
   // Keyboard: → / Enter advance (or finish), ← back, Esc skips. Never hijack
-  // while a text input is focused (the folder step has none today, but keep
-  // the guard for safety).
+  // while a text input is focused, nor while a layered Radix dialog (e.g. the
+  // subfolder-playlist prompt at z-9999) is open — that overlay owns the keys.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+      if (document.querySelector('[role="dialog"][data-state="open"]')) return;
 
       if (e.key === 'Escape') {
         e.preventDefault();
@@ -141,6 +157,7 @@ export default function OnboardingWizard({ onComplete }: OnboardingWizardProps) 
 
   return (
     <div
+      ref={containerRef}
       role="dialog"
       aria-modal="true"
       aria-label={t('wizard.ariaLabel')}
@@ -149,8 +166,9 @@ export default function OnboardingWizard({ onComplete }: OnboardingWizardProps) 
         IS_ELECTRON && 'rounded-t-[10px]'
       )}
       style={{
-        transition: isExiting ? 'opacity 520ms ease-out, filter 520ms ease-out' : undefined,
-        opacity: isExiting ? 0 : 1,
+        transition:
+          isExiting || !disableMotion ? 'opacity 520ms ease-out, filter 520ms ease-out' : undefined,
+        opacity: isExiting || isEntering ? 0 : 1,
         filter: isExiting && !disableMotion ? 'blur(8px)' : 'blur(0px)',
       }}
     >

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -24,12 +24,20 @@ import { ToolsStep } from './steps/ToolsStep';
 import { AppearanceStep } from './steps/AppearanceStep';
 import { PlaybackStep } from './steps/PlaybackStep';
 import { VisualizerStep } from './steps/VisualizerStep';
+import { SummaryStep } from './steps/SummaryStep';
 
 interface OnboardingWizardProps {
   onComplete: () => void;
 }
 
-type StepId = 'welcome' | 'folders' | 'tools' | 'appearance' | 'playback' | 'visualizer';
+type StepId =
+  | 'welcome'
+  | 'folders'
+  | 'tools'
+  | 'appearance'
+  | 'playback'
+  | 'visualizer'
+  | 'summary';
 
 interface StepDef {
   id: StepId;
@@ -44,6 +52,7 @@ const STEPS: readonly StepDef[] = [
   { id: 'appearance', kanji: '夜', Component: AppearanceStep },
   { id: 'playback', kanji: '音', Component: PlaybackStep },
   { id: 'visualizer', kanji: '波', Component: VisualizerStep },
+  { id: 'summary', kanji: '締', Component: SummaryStep },
 ];
 
 const HEADING_ID = 'onboarding-step-heading';

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -23,13 +23,13 @@ import { FoldersStep } from './steps/FoldersStep';
 import { ToolsStep } from './steps/ToolsStep';
 import { AppearanceStep } from './steps/AppearanceStep';
 import { PlaybackStep } from './steps/PlaybackStep';
-import { ReadyStep } from './steps/ReadyStep';
+import { VisualizerStep } from './steps/VisualizerStep';
 
 interface OnboardingWizardProps {
   onComplete: () => void;
 }
 
-type StepId = 'welcome' | 'folders' | 'tools' | 'appearance' | 'playback' | 'ready';
+type StepId = 'welcome' | 'folders' | 'tools' | 'appearance' | 'playback' | 'visualizer';
 
 interface StepDef {
   id: StepId;
@@ -43,7 +43,7 @@ const STEPS: readonly StepDef[] = [
   { id: 'tools', kanji: '取', Component: ToolsStep },
   { id: 'appearance', kanji: '夜', Component: AppearanceStep },
   { id: 'playback', kanji: '音', Component: PlaybackStep },
-  { id: 'ready', kanji: '波', Component: ReadyStep },
+  { id: 'visualizer', kanji: '波', Component: VisualizerStep },
 ];
 
 const HEADING_ID = 'onboarding-step-heading';

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -20,6 +20,7 @@ import { OnboardingStepContext } from './stepContext';
 import { useFocusTrap } from './useFocusTrap';
 import { WelcomeStep } from './steps/WelcomeStep';
 import { FoldersStep } from './steps/FoldersStep';
+import { ToolsStep } from './steps/ToolsStep';
 import { ThemeStep } from './steps/ThemeStep';
 import { ReadyStep } from './steps/ReadyStep';
 
@@ -27,7 +28,7 @@ interface OnboardingWizardProps {
   onComplete: () => void;
 }
 
-type StepId = 'welcome' | 'folders' | 'theme' | 'ready';
+type StepId = 'welcome' | 'folders' | 'tools' | 'theme' | 'ready';
 
 interface StepDef {
   id: StepId;
@@ -38,6 +39,7 @@ interface StepDef {
 const STEPS: readonly StepDef[] = [
   { id: 'welcome', kanji: '白波', Component: WelcomeStep },
   { id: 'folders', kanji: '蔵', Component: FoldersStep },
+  { id: 'tools', kanji: '取', Component: ToolsStep },
   { id: 'theme', kanji: '夜', Component: ThemeStep },
   { id: 'ready', kanji: '波', Component: ReadyStep },
 ];
@@ -46,7 +48,7 @@ const HEADING_ID = 'onboarding-step-heading';
 
 /**
  * First-run setup wizard. Full-screen overlay shown once after the splash on a
- * user's first launch. Four skippable steps; Skip == complete (we never show
+ * user's first launch. Skippable steps; Skip == complete (we never show
  * onboarding twice). Lazy-loaded by App.tsx so it never ships to returning
  * users — hence the default export.
  */

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,263 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft, ArrowRight, Play, SkipForward } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { IS_ELECTRON } from '@/lib/platform';
+import { useUIStore } from '@/stores/useUIStore';
+import { useOnboardingStore } from '@/stores/useOnboardingStore';
+import { useFoldersQuery } from '@/hooks/queries/useFolders';
+import { Button } from '@/components/ui/button';
+import { OnboardingScene } from './OnboardingScene';
+import { OnboardingStepContext } from './stepContext';
+import { WelcomeStep } from './steps/WelcomeStep';
+import { FoldersStep } from './steps/FoldersStep';
+import { ThemeStep } from './steps/ThemeStep';
+import { ReadyStep } from './steps/ReadyStep';
+
+interface OnboardingWizardProps {
+  onComplete: () => void;
+}
+
+type StepId = 'welcome' | 'folders' | 'theme' | 'ready';
+
+interface StepDef {
+  id: StepId;
+  kanji: string;
+  Component: () => React.ReactNode;
+}
+
+const STEPS: readonly StepDef[] = [
+  { id: 'welcome', kanji: '白波', Component: WelcomeStep },
+  { id: 'folders', kanji: '蔵', Component: FoldersStep },
+  { id: 'theme', kanji: '夜', Component: ThemeStep },
+  { id: 'ready', kanji: '波', Component: ReadyStep },
+];
+
+const HEADING_ID = 'onboarding-step-heading';
+
+/**
+ * First-run setup wizard. Full-screen overlay shown once after the splash on a
+ * user's first launch. Four skippable steps; Skip == complete (we never show
+ * onboarding twice). Lazy-loaded by App.tsx so it never ships to returning
+ * users — hence the default export.
+ */
+export default function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
+  const { t } = useTranslation('onboarding');
+  const lowPerformanceMode = useUIStore(s => s.lowPerformanceMode);
+  const completeOnboarding = useOnboardingStore(s => s.completeOnboarding);
+  const { data: folders = [] } = useFoldersQuery();
+
+  const [stepIndex, setStepIndex] = useState(0);
+  const [isExiting, setIsExiting] = useState(false);
+  const headingRef = useRef<HTMLHeadingElement | null>(null);
+
+  // Cached at mount — the OS preference doesn't change mid-wizard.
+  const reducedMotion = useMemo(
+    () => window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    []
+  );
+  const disableMotion = reducedMotion || lowPerformanceMode;
+
+  const step = STEPS[stepIndex];
+  const isFirst = stepIndex === 0;
+  const isLast = stepIndex === STEPS.length - 1;
+  const isFoldersStep = step.id === 'folders';
+  const folderNudge = isFoldersStep && folders.length === 0;
+
+  const finish = useCallback(() => {
+    if (isExiting) return;
+    setIsExiting(true);
+    const done = () => {
+      completeOnboarding();
+      onComplete();
+    };
+    if (disableMotion) {
+      done();
+    } else {
+      window.setTimeout(done, 520);
+    }
+  }, [isExiting, disableMotion, completeOnboarding, onComplete]);
+
+  const goNext = useCallback(() => {
+    setStepIndex(i => (i >= STEPS.length - 1 ? i : i + 1));
+  }, []);
+
+  const goBack = useCallback(() => {
+    setStepIndex(i => (i <= 0 ? i : i - 1));
+  }, []);
+
+  const handlePrimary = useCallback(() => {
+    if (isLast) {
+      finish();
+    } else {
+      goNext();
+    }
+  }, [isLast, finish, goNext]);
+
+  // Move focus to the step heading on each step change (a11y).
+  useEffect(() => {
+    headingRef.current?.focus();
+  }, [stepIndex]);
+
+  // Keyboard: → / Enter advance (or finish), ← back, Esc skips. Never hijack
+  // while a text input is focused (the folder step has none today, but keep
+  // the guard for safety).
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        finish();
+      } else if (e.key === 'ArrowRight' || e.key === 'Enter') {
+        e.preventDefault();
+        handlePrimary();
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        if (!isFirst) goBack();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [finish, handlePrimary, goBack, isFirst]);
+
+  const primaryLabel = isLast
+    ? t('wizard.finish')
+    : folderNudge
+      ? t('wizard.skipForNow')
+      : t('wizard.next');
+
+  const StepComponent = step.Component;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('wizard.ariaLabel')}
+      className={cn(
+        'fixed inset-0 z-[9998] overflow-hidden bg-background',
+        IS_ELECTRON && 'rounded-t-[10px]'
+      )}
+      style={{
+        transition: isExiting ? 'opacity 520ms ease-out, filter 520ms ease-out' : undefined,
+        opacity: isExiting ? 0 : 1,
+        filter: isExiting && !disableMotion ? 'blur(8px)' : 'blur(0px)',
+      }}
+    >
+      {/* Drag strip — keeps the frameless window movable */}
+      {IS_ELECTRON && <div className="absolute inset-x-0 top-0 h-8 drag" />}
+
+      {/* Rainy-window backdrop */}
+      <OnboardingScene reducedMotion={disableMotion} />
+
+      {/* Skip — always visible, top-right, never hover-gated */}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={finish}
+        className="no-drag absolute right-6 top-5 z-20 gap-1.5 text-muted-foreground hover:text-foreground"
+      >
+        <SkipForward className="h-3.5 w-3.5" />
+        {t('wizard.skip')}
+      </Button>
+
+      {/* Step content */}
+      <div className="relative z-10 flex h-full flex-col px-6 pb-6 pt-16 md:px-12 md:pb-10 md:pt-16">
+        <div className="flex min-h-0 flex-1 items-center">
+          <StepLayoutHost
+            stepId={step.id}
+            kanji={step.kanji}
+            headingId={HEADING_ID}
+            headingRef={headingRef}
+          >
+            <StepComponent />
+          </StepLayoutHost>
+        </div>
+
+        {/* Footer nav */}
+        <footer className="no-drag relative z-10 mt-6 flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            {!isFirst && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={goBack}
+                className="gap-1.5 text-muted-foreground hover:text-foreground"
+              >
+                <ArrowLeft className="h-3.5 w-3.5" />
+                {t('wizard.back')}
+              </Button>
+            )}
+          </div>
+
+          {/* Progress dots */}
+          <div
+            role="group"
+            aria-label={t('wizard.progressAria')}
+            className="flex items-center gap-2"
+          >
+            {STEPS.map((s, i) => {
+              const active = i === stepIndex;
+              return (
+                <button
+                  key={s.id}
+                  type="button"
+                  aria-label={t('wizard.stepDotAria', { number: i + 1, id: s.id })}
+                  aria-current={active ? 'step' : undefined}
+                  onClick={() => setStepIndex(i)}
+                  className={cn(
+                    'h-1.5 rounded-full transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                    active ? 'w-6 bg-primary' : 'w-1.5 bg-foreground/25 hover:bg-foreground/40'
+                  )}
+                />
+              );
+            })}
+          </div>
+
+          <Button type="button" onClick={handlePrimary} className="gap-1.5">
+            {primaryLabel}
+            {isLast ? <Play className="h-4 w-4" /> : <ArrowRight className="h-4 w-4" />}
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Bridges the wizard's per-step kanji/heading wiring into each step's own
+ * OnboardingStepLayout. Steps consume `useOnboardingStepContext` to read the
+ * shell-owned glyph + heading id, keeping the copy + control inside the step
+ * file while the shell stays presentation-agnostic.
+ */
+function StepLayoutHost({
+  stepId,
+  kanji,
+  headingId,
+  headingRef,
+  children,
+}: {
+  stepId: StepId;
+  kanji: string;
+  headingId: string;
+  headingRef: RefObject<HTMLHeadingElement | null>;
+  children: ReactNode;
+}) {
+  const value = useMemo(
+    () => ({ stepId, kanji, headingId, headingRef }),
+    [stepId, kanji, headingId, headingRef]
+  );
+  return <OnboardingStepContext.Provider value={value}>{children}</OnboardingStepContext.Provider>;
+}

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -189,8 +189,7 @@ export default function OnboardingWizard({ onComplete }: OnboardingWizardProps) 
         IS_ELECTRON && 'rounded-t-[10px]'
       )}
       style={{
-        transition:
-          isExiting || !disableMotion ? 'opacity 520ms ease-out, filter 520ms ease-out' : undefined,
+        transition: disableMotion ? undefined : 'opacity 520ms ease-out, filter 520ms ease-out',
         opacity: isExiting || isEntering ? 0 : 1,
         filter: isExiting && !disableMotion ? 'blur(8px)' : 'blur(0px)',
       }}

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -22,13 +22,14 @@ import { WelcomeStep } from './steps/WelcomeStep';
 import { FoldersStep } from './steps/FoldersStep';
 import { ToolsStep } from './steps/ToolsStep';
 import { AppearanceStep } from './steps/AppearanceStep';
+import { PlaybackStep } from './steps/PlaybackStep';
 import { ReadyStep } from './steps/ReadyStep';
 
 interface OnboardingWizardProps {
   onComplete: () => void;
 }
 
-type StepId = 'welcome' | 'folders' | 'tools' | 'appearance' | 'ready';
+type StepId = 'welcome' | 'folders' | 'tools' | 'appearance' | 'playback' | 'ready';
 
 interface StepDef {
   id: StepId;
@@ -41,6 +42,7 @@ const STEPS: readonly StepDef[] = [
   { id: 'folders', kanji: '蔵', Component: FoldersStep },
   { id: 'tools', kanji: '取', Component: ToolsStep },
   { id: 'appearance', kanji: '夜', Component: AppearanceStep },
+  { id: 'playback', kanji: '音', Component: PlaybackStep },
   { id: 'ready', kanji: '波', Component: ReadyStep },
 ];
 

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -21,14 +21,14 @@ import { useFocusTrap } from './useFocusTrap';
 import { WelcomeStep } from './steps/WelcomeStep';
 import { FoldersStep } from './steps/FoldersStep';
 import { ToolsStep } from './steps/ToolsStep';
-import { ThemeStep } from './steps/ThemeStep';
+import { AppearanceStep } from './steps/AppearanceStep';
 import { ReadyStep } from './steps/ReadyStep';
 
 interface OnboardingWizardProps {
   onComplete: () => void;
 }
 
-type StepId = 'welcome' | 'folders' | 'tools' | 'theme' | 'ready';
+type StepId = 'welcome' | 'folders' | 'tools' | 'appearance' | 'ready';
 
 interface StepDef {
   id: StepId;
@@ -40,7 +40,7 @@ const STEPS: readonly StepDef[] = [
   { id: 'welcome', kanji: '白波', Component: WelcomeStep },
   { id: 'folders', kanji: '蔵', Component: FoldersStep },
   { id: 'tools', kanji: '取', Component: ToolsStep },
-  { id: 'theme', kanji: '夜', Component: ThemeStep },
+  { id: 'appearance', kanji: '夜', Component: AppearanceStep },
   { id: 'ready', kanji: '波', Component: ReadyStep },
 ];
 

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -10,11 +10,12 @@ import {
 import { useTranslation } from 'react-i18next';
 import { ArrowLeft, ArrowRight, Play, SkipForward } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { IS_ELECTRON } from '@/lib/platform';
+import { IS_ELECTRON, IS_MAC } from '@/lib/platform';
 import { useUIStore } from '@/stores/useUIStore';
 import { useOnboardingStore } from '@/stores/useOnboardingStore';
 import { useFoldersQuery } from '@/hooks/queries/useFolders';
 import { Button } from '@/components/ui/button';
+import { WindowControls } from '@/components/shared/WindowControls';
 import { OnboardingScene } from './OnboardingScene';
 import { OnboardingStepContext } from './stepContext';
 import { useFocusTrap } from './useFocusTrap';
@@ -197,16 +198,27 @@ export default function OnboardingWizard({ onComplete }: OnboardingWizardProps) 
       {/* Drag strip — keeps the frameless window movable */}
       {IS_ELECTRON && <div className="absolute inset-x-0 top-0 h-8 drag" />}
 
+      {/* Window controls — frameless chrome (Windows only; no-ops on mac/web).
+          The wizard sits above the shell, so it owns its own controls here. */}
+      <div className="absolute right-0 top-0 z-30 flex h-8 items-center pr-1">
+        <WindowControls />
+      </div>
+
       {/* Rainy-window backdrop */}
       <OnboardingScene reducedMotion={disableMotion} />
 
-      {/* Skip — always visible, top-right, never hover-gated */}
+      {/* Skip — always visible, top-right. Shifts left to clear the window
+          controls when they're present (Windows/Linux); hugs the corner on
+          macOS and web where the wizard draws no custom controls. */}
       <Button
         type="button"
         variant="ghost"
         size="sm"
         onClick={finish}
-        className="no-drag absolute right-6 top-5 z-20 gap-1.5 text-muted-foreground hover:text-foreground"
+        className={cn(
+          'no-drag absolute top-0 z-30 h-8 gap-1.5 text-muted-foreground hover:text-foreground',
+          IS_ELECTRON && !IS_MAC ? 'right-[8.5rem]' : 'right-4'
+        )}
       >
         <SkipForward className="h-3.5 w-3.5" />
         {t('wizard.skip')}

--- a/apps/web/src/components/onboarding/SummaryRow.tsx
+++ b/apps/web/src/components/onboarding/SummaryRow.tsx
@@ -16,14 +16,19 @@ interface SummaryRowProps {
  */
 export function SummaryRow({ icon, label, value, highlight }: SummaryRowProps) {
   return (
-    <div className="flex items-center justify-between gap-3 rounded-lg border border-border/30 bg-foreground/[0.02] px-3 py-2.5 text-xs">
-      <span className="flex items-center gap-2 text-muted-foreground">
-        <span className="text-primary [&_svg]:h-4 [&_svg]:w-4">{icon}</span>
+    <div
+      role="listitem"
+      className="flex items-center justify-between gap-3 rounded-lg border border-border/30 bg-foreground/[0.02] px-3 py-2.5 text-xs"
+    >
+      <span className="flex shrink-0 items-center gap-2 text-muted-foreground">
+        <span aria-hidden="true" className="text-primary [&_svg]:h-4 [&_svg]:w-4">
+          {icon}
+        </span>
         {label}
       </span>
       <span
         className={cn(
-          'font-mono text-[10.5px] font-semibold tracking-[0.05em]',
+          'min-w-0 text-right font-mono text-[10.5px] font-semibold tracking-[0.05em]',
           highlight ? 'text-primary' : 'text-foreground'
         )}
       >

--- a/apps/web/src/components/onboarding/SummaryRow.tsx
+++ b/apps/web/src/components/onboarding/SummaryRow.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+interface SummaryRowProps {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  /** Tints the value with the accent color (e.g. an enabled integration). */
+  highlight?: boolean;
+}
+
+/**
+ * Single read-only recap row for the onboarding Summary step (icon · label ·
+ * value). Local to onboarding — single-use, so it lives beside SummaryStep
+ * rather than in components/shared. Static: no effects, no rAF.
+ */
+export function SummaryRow({ icon, label, value, highlight }: SummaryRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg border border-border/30 bg-foreground/[0.02] px-3 py-2.5 text-xs">
+      <span className="flex items-center gap-2 text-muted-foreground">
+        <span className="text-primary [&_svg]:h-4 [&_svg]:w-4">{icon}</span>
+        {label}
+      </span>
+      <span
+        className={cn(
+          'font-mono text-[10.5px] font-semibold tracking-[0.05em]',
+          highlight ? 'text-primary' : 'text-foreground'
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/components/onboarding/index.ts
+++ b/apps/web/src/components/onboarding/index.ts
@@ -1,0 +1,1 @@
+export { default as OnboardingWizard } from './OnboardingWizard';

--- a/apps/web/src/components/onboarding/stepContext.ts
+++ b/apps/web/src/components/onboarding/stepContext.ts
@@ -1,0 +1,24 @@
+import { createContext, useContext, type RefObject } from 'react';
+
+export type OnboardingStepId = 'welcome' | 'folders' | 'theme' | 'ready';
+
+export interface OnboardingStepContextValue {
+  stepId: OnboardingStepId;
+  /** Per-step kanji watermark glyph supplied by the wizard shell. */
+  kanji: string;
+  /** Stable id the wizard uses to label the dialog's current heading. */
+  headingId: string;
+  /** Ref the wizard focuses on each step change for a11y. */
+  headingRef: RefObject<HTMLHeadingElement | null>;
+}
+
+export const OnboardingStepContext = createContext<OnboardingStepContextValue | null>(null);
+
+/** Read the shell-owned step chrome (kanji, heading wiring) from inside a step. */
+export function useOnboardingStepContext(): OnboardingStepContextValue {
+  const ctx = useContext(OnboardingStepContext);
+  if (!ctx) {
+    throw new Error('useOnboardingStepContext must be used within an OnboardingWizard step');
+  }
+  return ctx;
+}

--- a/apps/web/src/components/onboarding/stepContext.ts
+++ b/apps/web/src/components/onboarding/stepContext.ts
@@ -6,7 +6,8 @@ export type OnboardingStepId =
   | 'tools'
   | 'appearance'
   | 'playback'
-  | 'visualizer';
+  | 'visualizer'
+  | 'summary';
 
 export interface OnboardingStepContextValue {
   stepId: OnboardingStepId;

--- a/apps/web/src/components/onboarding/stepContext.ts
+++ b/apps/web/src/components/onboarding/stepContext.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext, type RefObject } from 'react';
 
-export type OnboardingStepId = 'welcome' | 'folders' | 'tools' | 'theme' | 'ready';
+export type OnboardingStepId = 'welcome' | 'folders' | 'tools' | 'appearance' | 'ready';
 
 export interface OnboardingStepContextValue {
   stepId: OnboardingStepId;

--- a/apps/web/src/components/onboarding/stepContext.ts
+++ b/apps/web/src/components/onboarding/stepContext.ts
@@ -6,7 +6,7 @@ export type OnboardingStepId =
   | 'tools'
   | 'appearance'
   | 'playback'
-  | 'ready';
+  | 'visualizer';
 
 export interface OnboardingStepContextValue {
   stepId: OnboardingStepId;

--- a/apps/web/src/components/onboarding/stepContext.ts
+++ b/apps/web/src/components/onboarding/stepContext.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext, type RefObject } from 'react';
 
-export type OnboardingStepId = 'welcome' | 'folders' | 'theme' | 'ready';
+export type OnboardingStepId = 'welcome' | 'folders' | 'tools' | 'theme' | 'ready';
 
 export interface OnboardingStepContextValue {
   stepId: OnboardingStepId;

--- a/apps/web/src/components/onboarding/stepContext.ts
+++ b/apps/web/src/components/onboarding/stepContext.ts
@@ -1,6 +1,12 @@
 import { createContext, useContext, type RefObject } from 'react';
 
-export type OnboardingStepId = 'welcome' | 'folders' | 'tools' | 'appearance' | 'ready';
+export type OnboardingStepId =
+  | 'welcome'
+  | 'folders'
+  | 'tools'
+  | 'appearance'
+  | 'playback'
+  | 'ready';
 
 export interface OnboardingStepContextValue {
   stepId: OnboardingStepId;

--- a/apps/web/src/components/onboarding/steps/AppearanceStep.tsx
+++ b/apps/web/src/components/onboarding/steps/AppearanceStep.tsx
@@ -1,6 +1,17 @@
 import { useTranslation, Trans } from 'react-i18next';
 import { useThemeStore } from '@/stores/useThemeStore';
+import {
+  useUIStore,
+  UI_SCALE_MIN,
+  UI_SCALE_MAX,
+  UI_SCALE_STEP,
+  UI_SCALE_DEFAULT,
+  UI_SCALE_PRESETS,
+} from '@/stores/useUIStore';
 import { ThemeTileGrid } from '@/components/shared/theme/ThemeTileGrid';
+import { SettingsToggleRow } from '@/components/settings/SettingsCard';
+import { Slider } from '@/components/ui/slider';
+import { cn } from '@/lib/utils';
 import { OnboardingStepLayout } from '../OnboardingStepLayout';
 import { useOnboardingStepContext } from '../stepContext';
 
@@ -9,6 +20,12 @@ export function AppearanceStep() {
   const { kanji, headingId, headingRef } = useOnboardingStepContext();
   const theme = useThemeStore(s => s.theme);
   const setTheme = useThemeStore(s => s.setTheme);
+
+  const uiScale = useUIStore(s => s.uiScale);
+  const setUiScale = useUIStore(s => s.setUiScale);
+  const resetUiScale = useUIStore(s => s.resetUiScale);
+  const lowPerformanceMode = useUIStore(s => s.lowPerformanceMode);
+  const setLowPerformanceMode = useUIStore(s => s.setLowPerformanceMode);
 
   return (
     <OnboardingStepLayout
@@ -25,12 +42,73 @@ export function AppearanceStep() {
       }
       description={t('appearance.description')}
     >
-      <div className="space-y-3">
-        <p className="text-xs font-medium text-foreground">{t('appearance.themeTitle')}</p>
-        <ThemeTileGrid value={theme} onSelect={setTheme} columns={2} />
-        <p className="text-center text-[11px] text-muted-foreground/70">
-          {t('appearance.themeHint')}
-        </p>
+      <div className="space-y-4">
+        <div className="space-y-3">
+          <p className="text-xs font-medium text-foreground">{t('appearance.themeTitle')}</p>
+          <ThemeTileGrid value={theme} onSelect={setTheme} columns={2} />
+          <p className="text-center text-[11px] text-muted-foreground/70">
+            {t('appearance.themeHint')}
+          </p>
+        </div>
+
+        <div className="space-y-3 border-t border-border/30 pt-4">
+          <p className="text-xs font-medium text-foreground">{t('appearance.comfortTitle')}</p>
+
+          <div>
+            <div className="mb-2 flex items-center justify-between">
+              <p id="onboarding-ui-scale-label" className="text-sm text-muted-foreground">
+                {t('appearance.uiScale')}
+              </p>
+              <div className="flex items-center gap-2">
+                {uiScale !== UI_SCALE_DEFAULT && (
+                  <button
+                    type="button"
+                    onClick={resetUiScale}
+                    className="rounded-md px-1.5 py-0.5 text-[10px] font-medium text-primary/80 transition-colors hover:bg-primary/10 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    {t('appearance.uiScaleReset', { value: UI_SCALE_DEFAULT })}
+                  </button>
+                )}
+                <span className="text-xs tabular-nums text-muted-foreground">{uiScale}%</span>
+              </div>
+            </div>
+            <Slider
+              aria-labelledby="onboarding-ui-scale-label"
+              min={UI_SCALE_MIN}
+              max={UI_SCALE_MAX}
+              step={UI_SCALE_STEP}
+              value={[uiScale]}
+              onValueChange={([v]) => setUiScale(v)}
+            />
+            <div className="mt-2 flex items-center justify-between gap-1.5">
+              {UI_SCALE_PRESETS.map(preset => (
+                <button
+                  key={preset}
+                  type="button"
+                  aria-pressed={uiScale === preset}
+                  onClick={() => setUiScale(preset)}
+                  className={cn(
+                    'flex-1 rounded-md py-1 text-[11px] font-medium tabular-nums transition-colors',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+                    uiScale === preset
+                      ? 'border border-primary/40 bg-primary/15 text-primary'
+                      : 'border border-transparent text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+                  )}
+                >
+                  {preset}%
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <SettingsToggleRow
+            divider
+            label={t('appearance.reduceEffects')}
+            description={t('appearance.reduceEffectsDesc')}
+            checked={lowPerformanceMode}
+            onCheckedChange={setLowPerformanceMode}
+          />
+        </div>
       </div>
     </OnboardingStepLayout>
   );

--- a/apps/web/src/components/onboarding/steps/AppearanceStep.tsx
+++ b/apps/web/src/components/onboarding/steps/AppearanceStep.tsx
@@ -88,7 +88,7 @@ export function AppearanceStep() {
                   aria-pressed={uiScale === preset}
                   onClick={() => setUiScale(preset)}
                   className={cn(
-                    'flex-1 rounded-md py-1 text-[11px] font-medium tabular-nums transition-colors',
+                    'flex-1 rounded-md py-1.5 text-[11px] font-medium tabular-nums transition-colors',
                     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
                     uiScale === preset
                       ? 'border border-primary/40 bg-primary/15 text-primary'

--- a/apps/web/src/components/onboarding/steps/AppearanceStep.tsx
+++ b/apps/web/src/components/onboarding/steps/AppearanceStep.tsx
@@ -4,7 +4,7 @@ import { ThemeTileGrid } from '@/components/shared/theme/ThemeTileGrid';
 import { OnboardingStepLayout } from '../OnboardingStepLayout';
 import { useOnboardingStepContext } from '../stepContext';
 
-export function ThemeStep() {
+export function AppearanceStep() {
   const { t } = useTranslation('onboarding');
   const { kanji, headingId, headingRef } = useOnboardingStepContext();
   const theme = useThemeStore(s => s.theme);
@@ -15,20 +15,22 @@ export function ThemeStep() {
       kanji={kanji}
       headingId={headingId}
       headingRef={headingRef}
-      stepMarker={t('theme.eyebrow')}
+      stepMarker={t('appearance.eyebrow')}
       headline={
         <Trans
           t={t}
-          i18nKey="theme.headline"
+          i18nKey="appearance.headline"
           components={{ 1: <em className="not-italic text-primary" /> }}
         />
       }
-      description={t('theme.description')}
+      description={t('appearance.description')}
     >
       <div className="space-y-3">
-        <p className="text-xs font-medium text-foreground">{t('theme.title')}</p>
+        <p className="text-xs font-medium text-foreground">{t('appearance.themeTitle')}</p>
         <ThemeTileGrid value={theme} onSelect={setTheme} columns={2} />
-        <p className="text-center text-[11px] text-muted-foreground/70">{t('theme.hint')}</p>
+        <p className="text-center text-[11px] text-muted-foreground/70">
+          {t('appearance.themeHint')}
+        </p>
       </div>
     </OnboardingStepLayout>
   );

--- a/apps/web/src/components/onboarding/steps/FoldersStep.tsx
+++ b/apps/web/src/components/onboarding/steps/FoldersStep.tsx
@@ -1,3 +1,125 @@
+import { useEffect, useState } from 'react';
+import { useTranslation, Trans } from 'react-i18next';
+import { FolderOpen, Plus, Loader2, X } from 'lucide-react';
+import { IS_ELECTRON } from '@/lib/platform';
+import { isScanLocked } from '@/lib/scanLock';
+import { useFoldersQuery } from '@/hooks/queries/useFolders';
+import { useLibraryFolders } from '@/hooks/useLibraryFolders';
+import { useSubfolderPlaylistConfirm } from '@/hooks/useSubfolderPlaylistConfirm';
+import { Button } from '@/components/ui/button';
+import { IconButton } from '@/components/ui/icon-button';
+import { ScanProgressCard } from '@/components/library/ScanProgressCard';
+import { SubfolderPlaylistDialog } from '@/components/settings/SubfolderPlaylistDialog';
+import { OnboardingStepLayout } from '../OnboardingStepLayout';
+import { useOnboardingStepContext } from '../stepContext';
+
 export function FoldersStep() {
-  return null;
+  const { t } = useTranslation('onboarding');
+  const { kanji, headingId, headingRef } = useOnboardingStepContext();
+
+  const { data: folders = [] } = useFoldersQuery();
+  const {
+    isScanning,
+    addFolder,
+    removeFolder,
+    detectedSubfolders,
+    existingPlaylistNames,
+    clearDetectedSubfolders,
+  } = useLibraryFolders();
+
+  const handleSubfolderConfirm = useSubfolderPlaylistConfirm();
+  const [subfolderDialogOpen, setSubfolderDialogOpen] = useState(false);
+
+  useEffect(() => {
+    if (detectedSubfolders.length > 0) setSubfolderDialogOpen(true);
+  }, [detectedSubfolders]);
+
+  const handleDialogOpenChange = (open: boolean) => {
+    setSubfolderDialogOpen(open);
+    if (!open) clearDetectedSubfolders();
+  };
+
+  const hasFolders = folders.length > 0;
+  const addDisabled = !IS_ELECTRON || isScanning || isScanLocked();
+
+  return (
+    <>
+      <OnboardingStepLayout
+        kanji={kanji}
+        headingId={headingId}
+        headingRef={headingRef}
+        stepMarker={t('folders.eyebrow')}
+        headline={
+          <Trans
+            t={t}
+            i18nKey="folders.headline"
+            components={{ 1: <em className="not-italic text-primary" /> }}
+          />
+        }
+        description={t('folders.description')}
+      >
+        <div className="space-y-3">
+          <p className="text-xs font-medium text-foreground">{t('folders.title')}</p>
+
+          {!hasFolders ? (
+            <p className="rounded-xl border border-dashed border-border/30 py-6 text-center text-sm text-muted-foreground/70">
+              {t('folders.empty')}
+            </p>
+          ) : (
+            <div className="max-h-44 space-y-2 overflow-y-auto scrollbar-thin pr-0.5">
+              {folders.map(folder => (
+                <div
+                  key={folder.id}
+                  className="group flex items-center gap-3 rounded-xl border border-border/20 bg-background/50 px-3 py-2.5"
+                >
+                  <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="flex-1 truncate font-mono text-sm text-foreground">
+                    {folder.path}
+                  </span>
+                  <IconButton
+                    onClick={() => removeFolder(folder.id)}
+                    className="opacity-0 transition-all hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
+                    title={t('folders.remove')}
+                    aria-label={t('folders.remove')}
+                  >
+                    <X />
+                  </IconButton>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <Button
+            variant="outline"
+            onClick={addFolder}
+            disabled={addDisabled}
+            aria-label={t('folders.addFolder')}
+            className="h-auto w-full rounded-xl border-dashed border-border/40 bg-transparent py-2.5 text-primary shadow-none hover:border-primary/30 hover:bg-primary/10 hover:text-primary"
+          >
+            {isScanning ? <Loader2 className="animate-spin" /> : <Plus />}
+            {isScanning ? t('folders.scanning') : t('folders.addFolder')}
+          </Button>
+
+          <ScanProgressCard />
+
+          {!IS_ELECTRON && (
+            <p className="text-center text-[11px] text-muted-foreground/70">
+              {t('folders.desktopOnly')}
+            </p>
+          )}
+          {hasFolders && !isScanning && (
+            <p className="text-center text-[11px] text-primary/80">{t('folders.doneHint')}</p>
+          )}
+        </div>
+      </OnboardingStepLayout>
+
+      <SubfolderPlaylistDialog
+        open={subfolderDialogOpen}
+        onOpenChange={handleDialogOpenChange}
+        subfolders={detectedSubfolders}
+        onConfirm={handleSubfolderConfirm}
+        existingPlaylistNames={existingPlaylistNames}
+      />
+    </>
+  );
 }

--- a/apps/web/src/components/onboarding/steps/FoldersStep.tsx
+++ b/apps/web/src/components/onboarding/steps/FoldersStep.tsx
@@ -1,0 +1,3 @@
+export function FoldersStep() {
+  return null;
+}

--- a/apps/web/src/components/onboarding/steps/PlaybackStep.tsx
+++ b/apps/web/src/components/onboarding/steps/PlaybackStep.tsx
@@ -1,0 +1,100 @@
+import { useTranslation, Trans } from 'react-i18next';
+import { IS_ELECTRON } from '@/lib/platform';
+import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { useSettingsQuery, useUpdateSettingsMutation } from '@/hooks/queries/useSettings';
+import { SettingsToggleRow } from '@/components/settings/SettingsCard';
+import { Slider } from '@/components/ui/slider';
+import { OnboardingStepLayout } from '../OnboardingStepLayout';
+import { useOnboardingStepContext } from '../stepContext';
+
+/**
+ * Step 04 · Playback. Surfaces the three highest-value first-run playback prefs
+ * over the existing settings query/store — resume position, crossfade (with its
+ * duration slider when on), and Discord Rich Presence (desktop-only, owner add).
+ * Composes primitives directly rather than reusing PlaybackSection's card-shaped
+ * layout, which would drag in the controls onboarding deliberately leaves in
+ * Settings.
+ */
+export function PlaybackStep() {
+  const { t } = useTranslation('onboarding');
+  const { kanji, headingId, headingRef } = useOnboardingStepContext();
+
+  const { data: settings } = useSettingsQuery();
+  const updateSettings = useUpdateSettingsMutation();
+  const rememberPlaybackPosition = settings?.rememberPlaybackPosition ?? false;
+  const discordRpc = settings?.discordRpc ?? false;
+
+  const crossfadeEnabled = usePlaybackStore(s => s.crossfadeEnabled);
+  const crossfadeDuration = usePlaybackStore(s => s.crossfadeDuration);
+  const setCrossfadeEnabled = usePlaybackStore(s => s.setCrossfadeEnabled);
+  const setCrossfadeDuration = usePlaybackStore(s => s.setCrossfadeDuration);
+
+  return (
+    <OnboardingStepLayout
+      kanji={kanji}
+      headingId={headingId}
+      headingRef={headingRef}
+      stepMarker={t('playback.eyebrow')}
+      headline={
+        <Trans
+          t={t}
+          i18nKey="playback.headline"
+          components={{ 1: <em className="not-italic text-primary" /> }}
+        />
+      }
+      description={t('playback.description')}
+    >
+      <div>
+        <SettingsToggleRow
+          label={t('playback.resume')}
+          description={t('playback.resumeDesc')}
+          checked={rememberPlaybackPosition}
+          onCheckedChange={v => updateSettings.mutate({ rememberPlaybackPosition: v })}
+        />
+
+        <SettingsToggleRow
+          divider
+          label={t('playback.crossfade')}
+          description={t('playback.crossfadeDesc')}
+          checked={crossfadeEnabled}
+          onCheckedChange={setCrossfadeEnabled}
+        />
+
+        {crossfadeEnabled && (
+          <div className="px-3 pb-1 pt-3">
+            <div className="mb-2 flex items-center justify-between">
+              <p id="onboarding-crossfade-label" className="text-sm text-muted-foreground">
+                {t('playback.crossfadeDuration')}
+              </p>
+              <span className="text-xs tabular-nums text-muted-foreground">
+                {crossfadeDuration}s
+              </span>
+            </div>
+            <Slider
+              aria-labelledby="onboarding-crossfade-label"
+              min={1}
+              max={12}
+              step={1}
+              value={[crossfadeDuration]}
+              onValueChange={([v]) => setCrossfadeDuration(v)}
+            />
+            <div className="mt-1 flex justify-between">
+              <span className="text-[10px] text-muted-foreground/60">1s</span>
+              <span className="text-[10px] text-muted-foreground/60">12s</span>
+            </div>
+          </div>
+        )}
+
+        {IS_ELECTRON && (
+          <SettingsToggleRow
+            divider
+            label={t('playback.discord')}
+            description={t('playback.discordDesc')}
+            checked={discordRpc}
+            onCheckedChange={v => updateSettings.mutate({ discordRpc: v })}
+          />
+        )}
+      </div>
+    </OnboardingStepLayout>
+  );
+}

--- a/apps/web/src/components/onboarding/steps/ReadyStep.tsx
+++ b/apps/web/src/components/onboarding/steps/ReadyStep.tsx
@@ -1,0 +1,3 @@
+export function ReadyStep() {
+  return null;
+}

--- a/apps/web/src/components/onboarding/steps/ReadyStep.tsx
+++ b/apps/web/src/components/onboarding/steps/ReadyStep.tsx
@@ -1,3 +1,50 @@
+import { useTranslation, Trans } from 'react-i18next';
+import { useUIStore } from '@/stores/useUIStore';
+import { VisualizerStyleGrid } from '@/components/settings/VisualizerStyleGrid';
+import { VisualizerStylePreview } from '@/components/settings/VisualizerStylePreview';
+import { OnboardingStepLayout } from '../OnboardingStepLayout';
+import { useOnboardingStepContext } from '../stepContext';
+
 export function ReadyStep() {
-  return null;
+  const { t } = useTranslation('onboarding');
+  const { kanji, headingId, headingRef } = useOnboardingStepContext();
+  const visualizerStyle = useUIStore(s => s.visualizerStyle);
+  const setVisualizerStyle = useUIStore(s => s.setVisualizerStyle);
+
+  return (
+    <OnboardingStepLayout
+      kanji={kanji}
+      headingId={headingId}
+      headingRef={headingRef}
+      stepMarker={t('ready.eyebrow')}
+      headline={
+        <Trans
+          t={t}
+          i18nKey="ready.headline"
+          components={{ 1: <em className="not-italic text-primary" /> }}
+        />
+      }
+      description={t('ready.description')}
+    >
+      <div className="space-y-4">
+        <VisualizerStylePreview />
+        <div className="space-y-3">
+          <div>
+            <p className="text-xs font-medium text-foreground">{t('ready.title')}</p>
+            <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground/70">
+              {t('ready.hint')}
+            </p>
+          </div>
+          <div className="max-h-40 overflow-y-auto scrollbar-thin pr-0.5">
+            <VisualizerStyleGrid
+              value={visualizerStyle}
+              onSelect={setVisualizerStyle}
+              columns={3}
+              compact
+            />
+          </div>
+        </div>
+      </div>
+    </OnboardingStepLayout>
+  );
 }

--- a/apps/web/src/components/onboarding/steps/SummaryStep.tsx
+++ b/apps/web/src/components/onboarding/steps/SummaryStep.tsx
@@ -1,0 +1,128 @@
+import { useMemo } from 'react';
+import { useTranslation, Trans } from 'react-i18next';
+import { Languages, FolderOpen, ArrowDownToLine, Music2, Palette, Waves } from 'lucide-react';
+import { IS_ELECTRON } from '@/lib/platform';
+import { SUPPORTED_LANGUAGES } from '@/lib/i18n';
+import { useFoldersQuery } from '@/hooks/queries/useFolders';
+import { useSettingsQuery } from '@/hooks/queries/useSettings';
+import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { useUIStore } from '@/stores/useUIStore';
+import { useThemeStore } from '@/stores/useThemeStore';
+import { useDownloadsSettings } from '@/components/settings/downloads/useDownloadsSettings';
+import { THEME_TILES } from '@/components/shared/theme/ThemeTileGrid';
+import { VISUALIZER_STYLES } from '@/components/player/visualizerRegistry';
+import { OnboardingStepLayout } from '../OnboardingStepLayout';
+import { useOnboardingStepContext } from '../stepContext';
+import { SummaryRow } from '../SummaryRow';
+
+/**
+ * Step 06 · Summary. Read-only recap of every choice the wizard touched, read
+ * live from the same stores/queries each step writes to. The primary button
+ * ("Open library") and fog-out finish live in the wizard chrome — this step
+ * adds no actions, no effects.
+ */
+export function SummaryStep() {
+  const { t, i18n } = useTranslation('onboarding');
+  const { kanji, headingId, headingRef } = useOnboardingStepContext();
+
+  const { data: folders = [] } = useFoldersQuery();
+  const { data: settings } = useSettingsQuery();
+  const tools = useDownloadsSettings();
+
+  const crossfadeEnabled = usePlaybackStore(s => s.crossfadeEnabled);
+  const crossfadeDuration = usePlaybackStore(s => s.crossfadeDuration);
+  const theme = useThemeStore(s => s.theme);
+  const visualizerStyle = useUIStore(s => s.visualizerStyle);
+
+  const languageValue = useMemo(() => {
+    const match = SUPPORTED_LANGUAGES.find(l => l.code === i18n.language);
+    return match?.label ?? t('summary.value.none');
+  }, [i18n.language, t]);
+
+  const toolsValue = useMemo(() => {
+    if (!IS_ELECTRON || tools.isCheckingDownloadTools) return t('summary.tools.checking');
+    if (tools.ytdlpInstalled && tools.ffmpegInstalled) return t('summary.tools.both');
+    if (tools.ytdlpInstalled) return t('summary.tools.ytdlpOnly');
+    if (tools.ffmpegInstalled) return t('summary.tools.ffmpegOnly');
+    return t('summary.tools.none');
+  }, [tools.isCheckingDownloadTools, tools.ytdlpInstalled, tools.ffmpegInstalled, t]);
+
+  const playbackValue = useMemo(() => {
+    const parts = [
+      settings?.rememberPlaybackPosition
+        ? t('summary.playback.resumeOn')
+        : t('summary.playback.resumeOff'),
+      crossfadeEnabled
+        ? t('summary.playback.crossfade', { seconds: crossfadeDuration })
+        : t('summary.playback.noCrossfade'),
+    ];
+    if (IS_ELECTRON && settings?.discordRpc) parts.push(t('summary.playback.discordOn'));
+    return parts.join(' · ');
+  }, [
+    settings?.rememberPlaybackPosition,
+    settings?.discordRpc,
+    crossfadeEnabled,
+    crossfadeDuration,
+    t,
+  ]);
+
+  const themeValue = useMemo(() => {
+    const tile = THEME_TILES.find(item => item.id === theme);
+    return tile
+      ? t(`app.theme.names.${tile.nameKey}`, { ns: 'settings' })
+      : t('summary.value.none');
+  }, [theme, t]);
+
+  const visualizerValue = useMemo(() => {
+    const meta = VISUALIZER_STYLES.find(v => v.value === visualizerStyle);
+    return meta ? t(meta.labelKey, { ns: 'settings' }) : t('summary.value.none');
+  }, [visualizerStyle, t]);
+
+  return (
+    <OnboardingStepLayout
+      kanji={kanji}
+      headingId={headingId}
+      headingRef={headingRef}
+      stepMarker={t('summary.eyebrow')}
+      headline={
+        <Trans
+          t={t}
+          i18nKey="summary.headline"
+          components={{ 1: <em className="not-italic text-primary" /> }}
+        />
+      }
+      description={t('summary.description')}
+    >
+      <div className="space-y-3">
+        <p className="text-xs font-medium text-foreground">{t('summary.intro')}</p>
+        <div className="flex flex-col gap-2">
+          <SummaryRow
+            icon={<Languages />}
+            label={t('summary.row.language')}
+            value={languageValue}
+          />
+          <SummaryRow
+            icon={<FolderOpen />}
+            label={t('summary.row.folders')}
+            value={t('summary.folders', { count: folders.length })}
+            highlight={folders.length > 0}
+          />
+          {IS_ELECTRON && (
+            <SummaryRow
+              icon={<ArrowDownToLine />}
+              label={t('summary.row.tools')}
+              value={toolsValue}
+            />
+          )}
+          <SummaryRow icon={<Music2 />} label={t('summary.row.playback')} value={playbackValue} />
+          <SummaryRow icon={<Palette />} label={t('summary.row.theme')} value={themeValue} />
+          <SummaryRow
+            icon={<Waves />}
+            label={t('summary.row.visualizer')}
+            value={visualizerValue}
+          />
+        </div>
+      </div>
+    </OnboardingStepLayout>
+  );
+}

--- a/apps/web/src/components/onboarding/steps/SummaryStep.tsx
+++ b/apps/web/src/components/onboarding/steps/SummaryStep.tsx
@@ -95,7 +95,7 @@ export function SummaryStep() {
     >
       <div className="space-y-3">
         <p className="text-xs font-medium text-foreground">{t('summary.intro')}</p>
-        <div className="flex flex-col gap-2">
+        <div role="list" aria-label={t('summary.listAria')} className="flex flex-col gap-2">
           <SummaryRow
             icon={<Languages />}
             label={t('summary.row.language')}

--- a/apps/web/src/components/onboarding/steps/ThemeStep.tsx
+++ b/apps/web/src/components/onboarding/steps/ThemeStep.tsx
@@ -1,0 +1,3 @@
+export function ThemeStep() {
+  return null;
+}

--- a/apps/web/src/components/onboarding/steps/ThemeStep.tsx
+++ b/apps/web/src/components/onboarding/steps/ThemeStep.tsx
@@ -1,3 +1,35 @@
+import { useTranslation, Trans } from 'react-i18next';
+import { useThemeStore } from '@/stores/useThemeStore';
+import { ThemeTileGrid } from '@/components/shared/theme/ThemeTileGrid';
+import { OnboardingStepLayout } from '../OnboardingStepLayout';
+import { useOnboardingStepContext } from '../stepContext';
+
 export function ThemeStep() {
-  return null;
+  const { t } = useTranslation('onboarding');
+  const { kanji, headingId, headingRef } = useOnboardingStepContext();
+  const theme = useThemeStore(s => s.theme);
+  const setTheme = useThemeStore(s => s.setTheme);
+
+  return (
+    <OnboardingStepLayout
+      kanji={kanji}
+      headingId={headingId}
+      headingRef={headingRef}
+      stepMarker={t('theme.eyebrow')}
+      headline={
+        <Trans
+          t={t}
+          i18nKey="theme.headline"
+          components={{ 1: <em className="not-italic text-primary" /> }}
+        />
+      }
+      description={t('theme.description')}
+    >
+      <div className="space-y-3">
+        <p className="text-xs font-medium text-foreground">{t('theme.title')}</p>
+        <ThemeTileGrid value={theme} onSelect={setTheme} columns={2} />
+        <p className="text-center text-[11px] text-muted-foreground/70">{t('theme.hint')}</p>
+      </div>
+    </OnboardingStepLayout>
+  );
 }

--- a/apps/web/src/components/onboarding/steps/ToolsStep.tsx
+++ b/apps/web/src/components/onboarding/steps/ToolsStep.tsx
@@ -80,7 +80,7 @@ export function ToolsStep() {
               <ToolsInstaller s={s} />
             ) : (
               <div className="flex items-start gap-2.5 rounded-xl border border-primary/25 bg-primary/[0.06] px-3 py-2.5">
-                <Check className="mt-0.5 h-4 w-4 shrink-0 text-green-400" />
+                <Check aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-green-400" />
                 <p className="text-sm leading-snug text-foreground">{t('tools.allSet')}</p>
               </div>
             )}
@@ -153,7 +153,7 @@ function ToolsCheckingSkeleton({ label }: { label: string }) {
           key={i}
           className="flex items-center gap-3 rounded-xl border border-border/20 bg-background/50 px-3 py-2.5"
         >
-          <Download className="h-4 w-4 shrink-0 text-muted-foreground/40" />
+          <Download aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground/40" />
           <Skeleton className="h-4 w-32" />
           <Skeleton className="ml-auto h-3 w-16" />
         </div>

--- a/apps/web/src/components/onboarding/steps/ToolsStep.tsx
+++ b/apps/web/src/components/onboarding/steps/ToolsStep.tsx
@@ -1,0 +1,164 @@
+import { useEffect } from 'react';
+import { useTranslation, Trans } from 'react-i18next';
+import { ArrowDownToLine, Check, Download } from 'lucide-react';
+import { IS_ELECTRON } from '@/lib/platform';
+import { useDownloadStore } from '@/stores/useDownloadStore';
+import { useDownloadsSettings } from '@/components/settings/downloads/useDownloadsSettings';
+import { ToolStatusRow } from '@/components/settings/downloads/ToolStatusRow';
+import { InstallProgressBar } from '@/components/settings/downloads/InstallProgressBar';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { OnboardingStepLayout } from '../OnboardingStepLayout';
+import { useOnboardingStepContext } from '../stepContext';
+
+/**
+ * Step 02 · Tools. Optional first-run installer for yt-dlp + ffmpeg so a user
+ * can download and import straight away. Wraps the existing `useDownloadsSettings`
+ * hook and reuses the settings download primitives verbatim — no new install
+ * logic. Installs never gate `goNext`; the step is fully skippable.
+ *
+ * The "Install both" overall-progress event (`onDependencyInstallProgress`) is
+ * normally subscribed in `App.tsx`, which is NOT mounted during onboarding, so
+ * we register the same subscription locally (idempotent — App re-subscribes once
+ * mounted post-finish) to keep the dependency-install bar animating.
+ */
+export function ToolsStep() {
+  const { t } = useTranslation('onboarding');
+  const { kanji, headingId, headingRef } = useOnboardingStepContext();
+  const updateDependencyInstall = useDownloadStore(s => s.updateDependencyInstall);
+  const s = useDownloadsSettings();
+
+  useEffect(() => {
+    if (!IS_ELECTRON) return;
+    const cleanup = window.electronAPI.downloader.onDependencyInstallProgress(progress => {
+      updateDependencyInstall(progress);
+    });
+    return cleanup;
+  }, [updateDependencyInstall]);
+
+  return (
+    <OnboardingStepLayout
+      kanji={kanji}
+      headingId={headingId}
+      headingRef={headingRef}
+      stepMarker={t('tools.eyebrow')}
+      headline={
+        <Trans
+          t={t}
+          i18nKey="tools.headline"
+          components={{ 1: <em className="not-italic text-primary" /> }}
+        />
+      }
+      description={t('tools.description')}
+    >
+      <div className="space-y-3">
+        <p className="text-xs font-medium text-foreground">{t('tools.title')}</p>
+
+        {!IS_ELECTRON ? (
+          <p className="rounded-xl border border-dashed border-border/30 py-6 text-center text-sm text-muted-foreground/70">
+            {t('tools.desktopOnly')}
+          </p>
+        ) : s.isCheckingDownloadTools ? (
+          <ToolsCheckingSkeleton label={t('tools.checking')} />
+        ) : (
+          <>
+            <ToolStatusRow
+              installed={Boolean(s.ytdlpInstalled)}
+              installedTitle={t('dl.ytdlpInstalled', { ns: 'settings' })}
+              notInstalledTitle={t('dl.ytdlpNotInstalled', { ns: 'settings' })}
+              updateAvailable={s.ytdlpUpdateAvailable}
+            />
+            <ToolStatusRow
+              installed={Boolean(s.ffmpegInstalled)}
+              installedTitle={t('dl.ffmpegInstalled', { ns: 'settings' })}
+              notInstalledTitle={t('dl.ffmpegNotInstalled', { ns: 'settings' })}
+              updateAvailable={s.ffmpegUpdateAvailable}
+              notInstalledRight={t('dl.recommended', { ns: 'settings' })}
+            />
+
+            {s.hasMissingDownloadTools ? (
+              <ToolsInstaller s={s} />
+            ) : (
+              <div className="flex items-start gap-2.5 rounded-xl border border-primary/25 bg-primary/[0.06] px-3 py-2.5">
+                <Check className="mt-0.5 h-4 w-4 shrink-0 text-green-400" />
+                <p className="text-sm leading-snug text-foreground">{t('tools.allSet')}</p>
+              </div>
+            )}
+          </>
+        )}
+
+        {IS_ELECTRON && (
+          <p className="text-center text-[11px] text-muted-foreground/70">{t('tools.skipHint')}</p>
+        )}
+      </div>
+    </OnboardingStepLayout>
+  );
+}
+
+/**
+ * The install affordance once we know a tool is missing. Prefers the one-pass
+ * "Install both" path (with its overall-progress bar) and falls back to per-tool
+ * bars whenever a single tool install is streaming progress.
+ */
+function ToolsInstaller({ s }: { s: ReturnType<typeof useDownloadsSettings> }) {
+  const { t } = useTranslation('onboarding');
+
+  if (s.dependenciesInstalling) {
+    return (
+      <InstallProgressBar
+        percent={s.dependencyInstallProgress}
+        caption={`${s.dependencyInstallLabel}… ${s.dependencyInstallProgress}%`}
+        className="px-1"
+      />
+    );
+  }
+
+  if (s.ytdlpInstalling) {
+    return (
+      <InstallProgressBar
+        percent={s.ytdlpInstallProgress}
+        caption={`${t('dl.downloadingYtdlp', { ns: 'settings' })} ${s.ytdlpInstallProgress}%`}
+        className="px-1"
+      />
+    );
+  }
+
+  if (s.ffmpegInstalling) {
+    return (
+      <InstallProgressBar
+        percent={s.ffmpegInstallProgress}
+        caption={`${t('dl.downloadingFfmpeg', { ns: 'settings' })} ${s.ffmpegInstallProgress}%`}
+        className="px-1"
+      />
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      onClick={s.handleInstallMissingTools}
+      className="w-full rounded-xl [&_svg]:size-3.5"
+    >
+      <ArrowDownToLine />
+      {t('tools.installAll')}
+    </Button>
+  );
+}
+
+function ToolsCheckingSkeleton({ label }: { label: string }) {
+  return (
+    <div className="space-y-3" role="status" aria-live="polite">
+      {[0, 1].map(i => (
+        <div
+          key={i}
+          className="flex items-center gap-3 rounded-xl border border-border/20 bg-background/50 px-3 py-2.5"
+        >
+          <Download className="h-4 w-4 shrink-0 text-muted-foreground/40" />
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="ml-auto h-3 w-16" />
+        </div>
+      ))}
+      <p className="text-center text-[11px] text-muted-foreground/70">{label}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/onboarding/steps/VisualizerStep.tsx
+++ b/apps/web/src/components/onboarding/steps/VisualizerStep.tsx
@@ -35,14 +35,12 @@ export function VisualizerStep() {
               {t('visualizer.hint')}
             </p>
           </div>
-          <div className="max-h-40 overflow-y-auto scrollbar-thin pr-0.5">
-            <VisualizerStyleGrid
-              value={visualizerStyle}
-              onSelect={setVisualizerStyle}
-              columns={3}
-              compact
-            />
-          </div>
+          <VisualizerStyleGrid
+            value={visualizerStyle}
+            onSelect={setVisualizerStyle}
+            columns={3}
+            compact
+          />
         </div>
       </div>
     </OnboardingStepLayout>

--- a/apps/web/src/components/onboarding/steps/VisualizerStep.tsx
+++ b/apps/web/src/components/onboarding/steps/VisualizerStep.tsx
@@ -5,7 +5,7 @@ import { VisualizerStylePreview } from '@/components/settings/VisualizerStylePre
 import { OnboardingStepLayout } from '../OnboardingStepLayout';
 import { useOnboardingStepContext } from '../stepContext';
 
-export function ReadyStep() {
+export function VisualizerStep() {
   const { t } = useTranslation('onboarding');
   const { kanji, headingId, headingRef } = useOnboardingStepContext();
   const visualizerStyle = useUIStore(s => s.visualizerStyle);
@@ -16,23 +16,23 @@ export function ReadyStep() {
       kanji={kanji}
       headingId={headingId}
       headingRef={headingRef}
-      stepMarker={t('ready.eyebrow')}
+      stepMarker={t('visualizer.eyebrow')}
       headline={
         <Trans
           t={t}
-          i18nKey="ready.headline"
+          i18nKey="visualizer.headline"
           components={{ 1: <em className="not-italic text-primary" /> }}
         />
       }
-      description={t('ready.description')}
+      description={t('visualizer.description')}
     >
       <div className="space-y-4">
         <VisualizerStylePreview />
         <div className="space-y-3">
           <div>
-            <p className="text-xs font-medium text-foreground">{t('ready.title')}</p>
+            <p className="text-xs font-medium text-foreground">{t('visualizer.title')}</p>
             <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground/70">
-              {t('ready.hint')}
+              {t('visualizer.hint')}
             </p>
           </div>
           <div className="max-h-40 overflow-y-auto scrollbar-thin pr-0.5">

--- a/apps/web/src/components/onboarding/steps/WelcomeStep.tsx
+++ b/apps/web/src/components/onboarding/steps/WelcomeStep.tsx
@@ -1,3 +1,97 @@
+import { useTranslation, Trans } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import { useAppVersion } from '@/hooks/useAppVersion';
+import { SUPPORTED_LANGUAGES, persistLanguage, type SupportedLanguage } from '@/lib/i18n';
+import { OnboardingStepLayout } from '../OnboardingStepLayout';
+import { useOnboardingStepContext } from '../stepContext';
+
 export function WelcomeStep() {
-  return null;
+  const { t, i18n } = useTranslation('onboarding');
+  const { kanji, headingId, headingRef } = useOnboardingStepContext();
+  const version = useAppVersion();
+
+  function handleLanguageChange(lang: SupportedLanguage) {
+    i18n.changeLanguage(lang);
+    persistLanguage(lang);
+  }
+
+  return (
+    <OnboardingStepLayout
+      kanji={kanji}
+      headingId={headingId}
+      headingRef={headingRef}
+      stepMarker={t('welcome.eyebrow', { version: version ?? '…' })}
+      headline={
+        <Trans
+          t={t}
+          i18nKey="welcome.headline"
+          components={{ 1: <em className="not-italic text-primary" /> }}
+        />
+      }
+      description={t('welcome.description')}
+    >
+      <div className="flex flex-col items-center gap-6 py-2 text-center">
+        {/* Brand ring — breathing mascot, dropped under reduced-motion */}
+        <div className="relative grid h-32 w-32 place-items-center">
+          <span
+            aria-hidden="true"
+            className="float-mascot absolute inset-0 rounded-full"
+            style={{
+              background:
+                'radial-gradient(circle, oklch(from var(--primary) l c h / 0.22), transparent 70%)',
+            }}
+          />
+          <span
+            aria-hidden="true"
+            className="absolute inset-2 rounded-full border border-primary/30"
+          />
+          <img
+            src="./mascot.png"
+            alt={t('abt.altMascot', { ns: 'settings' })}
+            className="relative h-20 w-20 object-contain"
+            draggable={false}
+          />
+        </div>
+
+        <div className="flex flex-col items-center gap-1">
+          <h3 className="m-0 font-serif text-3xl italic leading-none tracking-[-0.015em] text-foreground">
+            Shira<em className="not-italic text-primary">nami</em>
+          </h3>
+          <span
+            className="select-none text-sm tracking-[0.05em] text-primary"
+            style={{ fontFamily: "'Shippori Mincho', 'Noto Sans JP', 'Hiragino Sans', serif" }}
+          >
+            白波
+          </span>
+        </div>
+
+        {/* Language switch */}
+        <div className="flex w-full flex-col items-center gap-2 border-t border-border/30 pt-5">
+          <p className="text-xs font-medium text-foreground">{t('welcome.language.label')}</p>
+          <div className="flex items-center gap-1.5">
+            {SUPPORTED_LANGUAGES.map(lang => (
+              <button
+                key={lang.code}
+                type="button"
+                aria-pressed={i18n.language === lang.code}
+                onClick={() => handleLanguageChange(lang.code)}
+                className={cn(
+                  'rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+                  i18n.language === lang.code
+                    ? 'border border-primary/40 bg-primary/15 text-primary'
+                    : 'border border-transparent text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+                )}
+              >
+                {lang.label}
+              </button>
+            ))}
+          </div>
+          <p className="max-w-[18rem] text-[11px] leading-snug text-muted-foreground/70">
+            {t('welcome.language.hint')}
+          </p>
+        </div>
+      </div>
+    </OnboardingStepLayout>
+  );
 }

--- a/apps/web/src/components/onboarding/steps/WelcomeStep.tsx
+++ b/apps/web/src/components/onboarding/steps/WelcomeStep.tsx
@@ -1,0 +1,3 @@
+export function WelcomeStep() {
+  return null;
+}

--- a/apps/web/src/components/onboarding/useFocusTrap.ts
+++ b/apps/web/src/components/onboarding/useFocusTrap.ts
@@ -1,0 +1,50 @@
+import { useEffect, type RefObject } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'textarea:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+/**
+ * Confines Tab/Shift+Tab focus to the elements inside `containerRef` while
+ * `active`. The onboarding wizard is a modal overlay, but unlike a Radix dialog
+ * it doesn't render an inert backdrop, so without this a Tab could reach the
+ * app/toasts behind it. Cheap and dependency-free — queries the focusables on
+ * each Tab rather than maintaining a live list.
+ */
+export function useFocusTrap(containerRef: RefObject<HTMLElement | null>, active: boolean) {
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const focusable = Array.from(
+        container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ).filter(el => el.offsetParent !== null || el === document.activeElement);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const activeEl = document.activeElement as HTMLElement | null;
+
+      if (e.shiftKey) {
+        if (activeEl === first || !container.contains(activeEl)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (activeEl === last || !container.contains(activeEl)) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    container.addEventListener('keydown', onKeyDown);
+    return () => container.removeEventListener('keydown', onKeyDown);
+  }, [containerRef, active]);
+}

--- a/apps/web/src/components/settings/AboutSection.tsx
+++ b/apps/web/src/components/settings/AboutSection.tsx
@@ -1,15 +1,17 @@
 import { useTranslation } from 'react-i18next';
-import { Globe, BookOpen, FolderOpen, Music2 } from 'lucide-react';
+import { Globe, BookOpen, FolderOpen, Music2, Sparkles } from 'lucide-react';
 import { IS_ELECTRON } from '@/lib/platform';
 import { SettingsCard } from '@/components/settings/SettingsCard';
 import { Button } from '@/components/ui/button';
 import { useAppVersion } from '@/hooks/useAppVersion';
 import { useAbout } from '@/hooks/useAbout';
+import { useOnboardingStore } from '@/stores/useOnboardingStore';
 
 export function AboutSection() {
   const { t } = useTranslation('settings');
   const version = useAppVersion();
   const { openLogsFolder } = useAbout();
+  const resetOnboarding = useOnboardingStore(s => s.resetOnboarding);
 
   const heroIcon = (
     <div className="w-[42px] h-[42px] rounded-xl bg-primary/10 border border-border/30 flex items-center justify-center overflow-hidden flex-shrink-0">
@@ -93,6 +95,19 @@ export function AboutSection() {
           </Button>
         </SettingsCard>
       )}
+
+      {/* Card 4: Replay onboarding */}
+      <SettingsCard icon={Sparkles} title={t('abt.replayTitle')} subtitle={t('abt.replaySubtitle')}>
+        <Button
+          variant="outline"
+          size="sm"
+          className="border-border/40"
+          onClick={() => resetOnboarding()}
+        >
+          <Sparkles className="w-3.5 h-3.5" />
+          {t('abt.replayButton')}
+        </Button>
+      </SettingsCard>
     </div>
   );
 }

--- a/apps/web/src/components/settings/AppearanceSection.tsx
+++ b/apps/web/src/components/settings/AppearanceSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Languages, Sparkles, LayoutGrid, Palette, Check } from 'lucide-react';
+import { Languages, Sparkles, LayoutGrid, Palette } from 'lucide-react';
 import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsCard';
 import { Slider } from '@/components/ui/slider';
 import {
@@ -10,22 +10,11 @@ import {
   UI_SCALE_DEFAULT,
   UI_SCALE_PRESETS,
 } from '@/stores/useUIStore';
-import { useThemeStore, type ThemeId } from '@/stores/useThemeStore';
+import { useThemeStore } from '@/stores/useThemeStore';
 import type { AppView } from '@/stores/useViewStore';
 import { cn } from '@/lib/utils';
+import { ThemeTileGrid } from '@/components/shared/theme/ThemeTileGrid';
 import { SUPPORTED_LANGUAGES, persistLanguage, type SupportedLanguage } from '@/lib/i18n';
-
-// Drives the theme picker grid. `thumb` reuses the same committed WebP the
-// background uses, downscaled by CSS object-fit. The "none" tile has no thumb
-// and renders a solid swatch so the default reads as "no photo".
-const THEME_TILES: Array<{ id: ThemeId; nameKey: string; thumb?: string }> = [
-  { id: 'none', nameKey: 'none' },
-  { id: 'lofi-night', nameKey: 'lofiNight', thumb: './themes/lofi-night.webp' },
-  { id: 'snow', nameKey: 'snow', thumb: './themes/snow.webp' },
-  { id: 'summer', nameKey: 'summer', thumb: './themes/summer.webp' },
-  { id: 'sunset', nameKey: 'sunset', thumb: './themes/sunset.webp' },
-  { id: 'wisteria', nameKey: 'wisteria', thumb: './themes/wisteria.webp' },
-];
 
 const TOGGLEABLE_SIDEBAR_ITEMS: Array<{ id: AppView; key: string }> = [
   { id: 'library', key: 'library' },
@@ -172,54 +161,7 @@ export function AppearanceSection() {
 
       {/* Card 3 — Theme */}
       <SettingsCard icon={Palette} title={t('app.theme.title')} subtitle={t('app.theme.desc')}>
-        <div
-          role="radiogroup"
-          aria-label={t('app.theme.title')}
-          className="grid grid-cols-3 gap-2.5"
-        >
-          {THEME_TILES.map(tile => {
-            const isActive = theme === tile.id;
-            const name = t(`app.theme.names.${tile.nameKey}`);
-            return (
-              <button
-                key={tile.id}
-                role="radio"
-                aria-checked={isActive}
-                aria-label={t('app.theme.apply', { name })}
-                onClick={() => setTheme(tile.id)}
-                className={cn(
-                  'group relative aspect-video rounded-xl overflow-hidden border text-left transition-all',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-                  isActive
-                    ? 'border-primary/60 ring-1 ring-primary/40 shadow-[0_0_18px_-4px_rgba(var(--primary-rgb),0.5)]'
-                    : 'border-border/40 hover:border-border/60'
-                )}
-              >
-                {tile.thumb ? (
-                  <img
-                    src={tile.thumb}
-                    alt=""
-                    aria-hidden="true"
-                    loading="lazy"
-                    decoding="async"
-                    className="absolute inset-0 w-full h-full object-cover"
-                    draggable={false}
-                  />
-                ) : (
-                  <div className="absolute inset-0 bg-background" />
-                )}
-                <span className="absolute bottom-1.5 left-1.5 right-1.5 truncate rounded-md bg-black/45 px-1.5 py-0.5 text-[11px] font-medium text-white backdrop-blur-sm">
-                  {name}
-                </span>
-                {isActive && (
-                  <span className="absolute top-1.5 right-1.5 grid place-items-center w-5 h-5 rounded-full bg-primary text-primary-foreground shadow">
-                    <Check className="w-3 h-3" />
-                  </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
+        <ThemeTileGrid value={theme} onSelect={setTheme} />
       </SettingsCard>
 
       {/* Card 4 — Sidebar */}

--- a/apps/web/src/components/settings/VisualizerSection.tsx
+++ b/apps/web/src/components/settings/VisualizerSection.tsx
@@ -1,9 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsCard';
-import { cn } from '@/lib/utils';
 import { AudioLines } from 'lucide-react';
 import { useUIStore } from '@/stores/useUIStore';
-import { VISUALIZER_STYLES } from '@/components/player/visualizerRegistry';
+import { VisualizerStyleGrid } from '@/components/settings/VisualizerStyleGrid';
 import { VisualizerStylePreview } from '@/components/settings/VisualizerStylePreview';
 
 export function VisualizerSection() {
@@ -29,35 +28,7 @@ export function VisualizerSection() {
 
             <div className="px-3">
               <p className="text-xs text-muted-foreground mb-3">{t('vis.style')}</p>
-              <div className="grid grid-cols-2 gap-3">
-                {VISUALIZER_STYLES.map(opt => {
-                  const selected = visualizerStyle === opt.value;
-                  return (
-                    <button
-                      key={opt.value}
-                      type="button"
-                      aria-pressed={selected}
-                      onClick={() => setVisualizerStyle(opt.value)}
-                      className={cn(
-                        'flex-1 px-4 py-3 rounded-xl border text-left transition-all',
-                        selected
-                          ? 'border-primary/40 bg-primary/10'
-                          : 'border-border/30 hover:border-border/50 hover:bg-accent/30'
-                      )}
-                    >
-                      <p
-                        className={cn(
-                          'text-sm font-medium',
-                          selected ? 'text-foreground' : 'text-muted-foreground'
-                        )}
-                      >
-                        {t(opt.labelKey)}
-                      </p>
-                      <p className="text-xs text-muted-foreground/70 mt-0.5">{t(opt.descKey)}</p>
-                    </button>
-                  );
-                })}
-              </div>
+              <VisualizerStyleGrid value={visualizerStyle} onSelect={setVisualizerStyle} />
             </div>
           </>
         )}

--- a/apps/web/src/components/settings/VisualizerStyleGrid.tsx
+++ b/apps/web/src/components/settings/VisualizerStyleGrid.tsx
@@ -1,0 +1,63 @@
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import type { VisualizerStyle } from '@/stores/useUIStore';
+import { VISUALIZER_STYLES } from '@/components/player/visualizerRegistry';
+
+interface VisualizerStyleGridProps {
+  value: VisualizerStyle;
+  onSelect: (style: VisualizerStyle) => void;
+  /** Tailwind grid-column count (default 2, matching Settings · Visualizer). */
+  columns?: 2 | 3;
+  /** Condensed variant — drops the per-style description line. */
+  compact?: boolean;
+}
+
+/**
+ * Presentational visualizer style picker grid shared by Settings · Visualizer
+ * and the first-run onboarding wizard so the two can never visually drift.
+ * Keeps the aria-pressed a11y wiring intact.
+ */
+export function VisualizerStyleGrid({
+  value,
+  onSelect,
+  columns = 2,
+  compact = false,
+}: VisualizerStyleGridProps) {
+  const { t } = useTranslation('settings');
+
+  return (
+    <div className={cn('grid gap-3', columns === 3 ? 'grid-cols-3' : 'grid-cols-2')}>
+      {VISUALIZER_STYLES.map(opt => {
+        const selected = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            aria-pressed={selected}
+            onClick={() => onSelect(opt.value)}
+            className={cn(
+              'flex-1 rounded-xl border text-left transition-all',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+              compact ? 'px-3 py-2' : 'px-4 py-3',
+              selected
+                ? 'border-primary/40 bg-primary/10'
+                : 'border-border/30 hover:border-border/50 hover:bg-accent/30'
+            )}
+          >
+            <p
+              className={cn(
+                'text-sm font-medium',
+                selected ? 'text-foreground' : 'text-muted-foreground'
+              )}
+            >
+              {t(opt.labelKey)}
+            </p>
+            {!compact && (
+              <p className="text-xs text-muted-foreground/70 mt-0.5">{t(opt.descKey)}</p>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/shared/TopBar.tsx
+++ b/apps/web/src/components/shared/TopBar.tsx
@@ -1,10 +1,9 @@
 import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Minus, Square, Copy, X, Plus, FolderOpen, File, RefreshCw, Loader2 } from 'lucide-react';
+import { Plus, FolderOpen, File, RefreshCw, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { IS_ELECTRON, IS_MAC } from '@/lib/platform';
 import { useViewStore } from '@/stores/useViewStore';
-import { useWindowControls } from '@/hooks/useWindowControls';
+import { WindowControls } from '@/components/shared/WindowControls';
 import { useLibraryRescan } from '@/hooks/useLibraryRescan';
 import { isScanLocked } from '@/lib/scanLock';
 import { SUPPORTED_LANGUAGES, persistLanguage, type SupportedLanguage } from '@/lib/i18n';
@@ -30,7 +29,6 @@ interface TopBarProps {
 export function TopBar({ onAddFile, onAddFolder, isScanning }: TopBarProps) {
   const { t, i18n } = useTranslation('topbar');
   const activeView = useViewStore(s => s.activeView);
-  const { isMaximized, minimize, maximize, close } = useWindowControls();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { isScanning: isRescanning, rescan } = useLibraryRescan();
@@ -146,38 +144,7 @@ export function TopBar({ onAddFile, onAddFolder, isScanning }: TopBarProps) {
       </div>
 
       {/* Window controls (Windows only) */}
-      {IS_ELECTRON && !IS_MAC && (
-        <div className="no-drag flex h-full items-center gap-1 pr-1.5">
-          <button
-            type="button"
-            onClick={minimize}
-            className="flex h-8 w-10 items-center justify-center rounded-md text-muted-foreground/55 transition-colors hover:bg-accent hover:text-foreground"
-            aria-label={t('minimize')}
-          >
-            <Minus className="h-3.5 w-3.5" />
-          </button>
-          <button
-            type="button"
-            onClick={maximize}
-            className="flex h-8 w-10 items-center justify-center rounded-md text-muted-foreground/55 transition-colors hover:bg-accent hover:text-foreground"
-            aria-label={isMaximized ? t('restore') : t('maximize')}
-          >
-            {isMaximized ? <Copy className="h-3.5 w-3.5" /> : <Square className="h-3.5 w-3.5" />}
-          </button>
-          <button
-            type="button"
-            onClick={close}
-            className={cn(
-              'flex h-8 w-10 items-center justify-center rounded-md',
-              'text-muted-foreground/55 transition-colors',
-              'hover:bg-red-500/85 hover:text-white'
-            )}
-            aria-label={t('close')}
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
-        </div>
-      )}
+      <WindowControls className="pr-1.5" />
     </div>
   );
 }

--- a/apps/web/src/components/shared/WindowControls.tsx
+++ b/apps/web/src/components/shared/WindowControls.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from 'react-i18next';
+import { Minus, Square, Copy, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { IS_ELECTRON, IS_MAC } from '@/lib/platform';
+import { useWindowControls } from '@/hooks/useWindowControls';
+
+interface WindowControlsProps {
+  /** Extra classes for the wrapper (e.g. corner padding per host). */
+  className?: string;
+}
+
+/**
+ * Windows-only minimize / maximize / close cluster for the frameless window.
+ * Rendered both in the app shell's TopBar and in the first-run onboarding
+ * overlay — the overlay sits above the shell, so without this it would have no
+ * window chrome at all. Renders nothing on macOS (native traffic lights) or in
+ * the browser. Close maps to `window.close()` (quits), matching the shell.
+ */
+export function WindowControls({ className }: WindowControlsProps) {
+  const { t } = useTranslation('topbar');
+  const { isMaximized, minimize, maximize, close } = useWindowControls();
+
+  if (!IS_ELECTRON || IS_MAC) return null;
+
+  return (
+    <div className={cn('no-drag flex h-full items-center gap-1', className)}>
+      <button
+        type="button"
+        onClick={minimize}
+        className="flex h-8 w-10 items-center justify-center rounded-md text-muted-foreground/55 transition-colors hover:bg-accent hover:text-foreground"
+        aria-label={t('minimize')}
+      >
+        <Minus className="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={maximize}
+        className="flex h-8 w-10 items-center justify-center rounded-md text-muted-foreground/55 transition-colors hover:bg-accent hover:text-foreground"
+        aria-label={isMaximized ? t('restore') : t('maximize')}
+      >
+        {isMaximized ? <Copy className="h-3.5 w-3.5" /> : <Square className="h-3.5 w-3.5" />}
+      </button>
+      <button
+        type="button"
+        onClick={close}
+        className={cn(
+          'flex h-8 w-10 items-center justify-center rounded-md',
+          'text-muted-foreground/55 transition-colors',
+          'hover:bg-red-500/85 hover:text-white'
+        )}
+        aria-label={t('close')}
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/shared/theme/ThemeTileGrid.tsx
+++ b/apps/web/src/components/shared/theme/ThemeTileGrid.tsx
@@ -1,0 +1,83 @@
+import { useTranslation } from 'react-i18next';
+import { Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { ThemeId } from '@/stores/useThemeStore';
+
+// Drives the theme picker grid. `thumb` reuses the same committed WebP the
+// background uses, downscaled by CSS object-fit. The "none" tile has no thumb
+// and renders a solid swatch so the default reads as "no photo".
+export const THEME_TILES: Array<{ id: ThemeId; nameKey: string; thumb?: string }> = [
+  { id: 'none', nameKey: 'none' },
+  { id: 'lofi-night', nameKey: 'lofiNight', thumb: './themes/lofi-night.webp' },
+  { id: 'snow', nameKey: 'snow', thumb: './themes/snow.webp' },
+  { id: 'summer', nameKey: 'summer', thumb: './themes/summer.webp' },
+  { id: 'sunset', nameKey: 'sunset', thumb: './themes/sunset.webp' },
+  { id: 'wisteria', nameKey: 'wisteria', thumb: './themes/wisteria.webp' },
+];
+
+interface ThemeTileGridProps {
+  value: ThemeId;
+  onSelect: (id: ThemeId) => void;
+  /** Tailwind grid-column count (default 3, matching Settings · Appearance). */
+  columns?: 2 | 3;
+}
+
+/**
+ * Presentational theme picker grid shared by Settings · Appearance and the
+ * first-run onboarding wizard so the two can never visually drift. Keeps the
+ * radiogroup/radio/aria-checked a11y wiring intact.
+ */
+export function ThemeTileGrid({ value, onSelect, columns = 3 }: ThemeTileGridProps) {
+  const { t } = useTranslation('settings');
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={t('app.theme.title')}
+      className={cn('grid gap-2.5', columns === 2 ? 'grid-cols-2' : 'grid-cols-3')}
+    >
+      {THEME_TILES.map(tile => {
+        const isActive = value === tile.id;
+        const name = t(`app.theme.names.${tile.nameKey}`);
+        return (
+          <button
+            key={tile.id}
+            role="radio"
+            aria-checked={isActive}
+            aria-label={t('app.theme.apply', { name })}
+            onClick={() => onSelect(tile.id)}
+            className={cn(
+              'group relative aspect-video rounded-xl overflow-hidden border text-left transition-all',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+              isActive
+                ? 'border-primary/60 ring-1 ring-primary/40 shadow-[0_0_18px_-4px_rgba(var(--primary-rgb),0.5)]'
+                : 'border-border/40 hover:border-border/60'
+            )}
+          >
+            {tile.thumb ? (
+              <img
+                src={tile.thumb}
+                alt=""
+                aria-hidden="true"
+                loading="lazy"
+                decoding="async"
+                className="absolute inset-0 w-full h-full object-cover"
+                draggable={false}
+              />
+            ) : (
+              <div className="absolute inset-0 bg-background" />
+            )}
+            <span className="absolute bottom-1.5 left-1.5 right-1.5 truncate rounded-md bg-black/45 px-1.5 py-0.5 text-[11px] font-medium text-white backdrop-blur-sm">
+              {name}
+            </span>
+            {isActive && (
+              <span className="absolute top-1.5 right-1.5 grid place-items-center w-5 h-5 rounded-full bg-primary text-primary-foreground shadow">
+                <Check className="w-3 h-3" />
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/shared/theme/ThemeTileGrid.tsx
+++ b/apps/web/src/components/shared/theme/ThemeTileGrid.tsx
@@ -30,10 +30,26 @@ interface ThemeTileGridProps {
 export function ThemeTileGrid({ value, onSelect, columns = 3 }: ThemeTileGridProps) {
   const { t } = useTranslation('settings');
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (
+      e.key !== 'ArrowRight' &&
+      e.key !== 'ArrowDown' &&
+      e.key !== 'ArrowLeft' &&
+      e.key !== 'ArrowUp'
+    )
+      return;
+    e.preventDefault();
+    const currentIndex = THEME_TILES.findIndex(tile => tile.id === value);
+    const delta = e.key === 'ArrowRight' || e.key === 'ArrowDown' ? 1 : -1;
+    const nextIndex = (currentIndex + delta + THEME_TILES.length) % THEME_TILES.length;
+    onSelect(THEME_TILES[nextIndex].id);
+  };
+
   return (
     <div
       role="radiogroup"
       aria-label={t('app.theme.title')}
+      onKeyDown={handleKeyDown}
       className={cn('grid gap-2.5', columns === 2 ? 'grid-cols-2' : 'grid-cols-3')}
     >
       {THEME_TILES.map(tile => {
@@ -42,9 +58,11 @@ export function ThemeTileGrid({ value, onSelect, columns = 3 }: ThemeTileGridPro
         return (
           <button
             key={tile.id}
+            type="button"
             role="radio"
             aria-checked={isActive}
             aria-label={t('app.theme.apply', { name })}
+            tabIndex={isActive ? 0 : -1}
             onClick={() => onSelect(tile.id)}
             className={cn(
               'group relative aspect-video rounded-xl overflow-hidden border text-left transition-all',

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -29,6 +29,7 @@ import nowPlayingEn from '@/locales/en/nowPlaying.json';
 import errorBoundaryEn from '@/locales/en/errorBoundary.json';
 import equalizerEn from '@/locales/en/equalizer.json';
 import enrichDialogEn from '@/locales/en/enrichDialog.json';
+import onboardingEn from '@/locales/en/onboarding.json';
 
 import commonPl from '@/locales/pl/common.json';
 import sidebarPl from '@/locales/pl/sidebar.json';
@@ -57,6 +58,7 @@ import nowPlayingPl from '@/locales/pl/nowPlaying.json';
 import errorBoundaryPl from '@/locales/pl/errorBoundary.json';
 import equalizerPl from '@/locales/pl/equalizer.json';
 import enrichDialogPl from '@/locales/pl/enrichDialog.json';
+import onboardingPl from '@/locales/pl/onboarding.json';
 
 export const SUPPORTED_LANGUAGES = [
   { code: 'en', label: 'English' },
@@ -111,6 +113,7 @@ const namespaces = [
   'errorBoundary',
   'equalizer',
   'enrichDialog',
+  'onboarding',
 ] as const;
 
 i18n.use(initReactI18next).init({
@@ -143,6 +146,7 @@ i18n.use(initReactI18next).init({
       errorBoundary: errorBoundaryEn,
       equalizer: equalizerEn,
       enrichDialog: enrichDialogEn,
+      onboarding: onboardingEn,
     },
     pl: {
       common: commonPl,
@@ -172,6 +176,7 @@ i18n.use(initReactI18next).init({
       errorBoundary: errorBoundaryPl,
       equalizer: equalizerPl,
       enrichDialog: enrichDialogPl,
+      onboarding: onboardingPl,
     },
   },
   lng: getInitialLanguage(),

--- a/apps/web/src/lib/platform.ts
+++ b/apps/web/src/lib/platform.ts
@@ -1,6 +1,13 @@
 /** Whether we're running inside Electron (vs plain browser) */
 export const IS_ELECTRON = typeof window !== 'undefined' && !!window.electronAPI;
 
+/**
+ * True only under the Playwright e2e harness (main process launched with
+ * SHIRANAMI_E2E=1, surfaced via the preload bridge). Used to skip first-run-only
+ * UI like the onboarding wizard so specs land directly on the app shell.
+ */
+export const IS_E2E = IS_ELECTRON && window.electronAPI?.__e2e === true;
+
 const platform = IS_ELECTRON ? window.electronAPI?.platform : undefined;
 
 /** Whether the app is running on Windows inside Electron */

--- a/apps/web/src/locales/en/onboarding.json
+++ b/apps/web/src/locales/en/onboarding.json
@@ -78,6 +78,13 @@
     "discord": "Show what I'm playing on Discord",
     "discordDesc": "Your now-playing track appears on your Discord profile."
   },
+  "visualizer": {
+    "eyebrow": "05 · The rhythm",
+    "headline": "Give the sound a <1>shape</1>.",
+    "description": "An audio-reactive scene rides above your now-playing bar. Pick one you like — or none. Change it any time.",
+    "title": "Choose a visualizer",
+    "hint": "Optional — preview updates live."
+  },
   "ready": {
     "eyebrow": "03 · Ready",
     "headline": "Open the door. <1>Press play</1>.",

--- a/apps/web/src/locales/en/onboarding.json
+++ b/apps/web/src/locales/en/onboarding.json
@@ -54,12 +54,12 @@
     "skipHint": "Optional — only needed for downloading and importing.",
     "desktopOnly": "Downloading is available in the desktop app."
   },
-  "theme": {
-    "eyebrow": "02 · Pick your room",
+  "appearance": {
+    "eyebrow": "03 · Make it yours",
     "headline": "The window dresses for your <1>mood</1>.",
     "description": "One quiet theme with five scenes. The whole interface — accent color, glow, surfaces — shifts to match. Swap any time from Settings · Appearance.",
-    "title": "Theme",
-    "hint": "Tap any scene · the rain stays."
+    "themeTitle": "Theme",
+    "themeHint": "Tap any scene · the rain stays."
   },
   "ready": {
     "eyebrow": "03 · Ready",

--- a/apps/web/src/locales/en/onboarding.json
+++ b/apps/web/src/locales/en/onboarding.json
@@ -1,0 +1,57 @@
+{
+  "wizard": {
+    "ariaLabel": "First-run setup",
+    "skip": "Skip",
+    "back": "Back",
+    "next": "Next",
+    "skipForNow": "Skip for now",
+    "finish": "Open library",
+    "progressAria": "Setup progress",
+    "stepDotAria": "Go to step {{number}}: {{id}}",
+    "stepCounter": "Step · {{current}} · of {{total}}",
+    "crumb": "Welcome"
+  },
+  "welcome": {
+    "eyebrow": "Vol · NS · {{version}} · late night build",
+    "headline": "A softer place for your <1>music library</1>.",
+    "description": "Shiranami plays the files you already own. Folders you point it at. Nothing streamed, nothing watched, nothing recommended over your shoulder.",
+    "language": {
+      "label": "Language",
+      "hint": "You can change this any time in Settings · Appearance."
+    },
+    "stats": {
+      "free": "Source-available",
+      "platforms": "Win · macOS",
+      "noTelemetry": "No telemetry"
+    }
+  },
+  "folders": {
+    "eyebrow": "01 · Point it at your files",
+    "headline": "Your folders are the <1>catalog</1>.",
+    "description": "Drop in directories. Shiranami scans your files, reads the tags, lifts cover art, and quietly hands you back a real library — no upload, no account, no maybe-it-syncs.",
+    "title": "Music folders",
+    "empty": "No folders yet. Add one to start building your library.",
+    "addFolder": "Add folder",
+    "scanning": "Scanning…",
+    "remove": "Remove folder",
+    "trackCount_one": "{{count}} track",
+    "trackCount_other": "{{count}} tracks",
+    "desktopOnly": "Adding folders is available in the desktop app.",
+    "doneHint": "Nice — your library is filling up. Add more or continue."
+  },
+  "theme": {
+    "eyebrow": "02 · Pick your room",
+    "headline": "The window dresses for your <1>mood</1>.",
+    "description": "One quiet theme with five scenes. The whole interface — accent color, glow, surfaces — shifts to match. Swap any time from Settings · Appearance.",
+    "title": "Theme",
+    "hint": "Tap any scene · the rain stays."
+  },
+  "ready": {
+    "eyebrow": "03 · Ready",
+    "headline": "Open the door. <1>Press play</1>.",
+    "description": "That's it. The library is waiting. We'll keep your queue, run your radio, hand you the lyrics, and resume the song you left at 2:47 a.m.",
+    "title": "Choose a visualizer",
+    "hint": "Optional — the rhythm behind your now-playing bar. Change it any time.",
+    "cta": "Press play."
+  }
+}

--- a/apps/web/src/locales/en/onboarding.json
+++ b/apps/web/src/locales/en/onboarding.json
@@ -39,6 +39,21 @@
     "desktopOnly": "Adding folders is available in the desktop app.",
     "doneHint": "Nice — your library is filling up. Add more or continue."
   },
+  "tools": {
+    "eyebrow": "02 · Bring the tools",
+    "headline": "Pull tracks <1>straight in</1>.",
+    "description": "Shiranami can fetch and import from a link — it just needs two small helpers: yt-dlp to fetch, ffmpeg to convert. Skip this if you only play files you already have; you can grab them later in Settings · Downloads.",
+    "title": "Download helpers",
+    "installAll": "Install both",
+    "installing": "Installing…",
+    "ytdlp": "yt-dlp",
+    "ffmpeg": "ffmpeg",
+    "updateBoth": "Update available",
+    "checking": "Checking for helpers…",
+    "allSet": "Both helpers are installed — you're ready to import.",
+    "skipHint": "Optional — only needed for downloading and importing.",
+    "desktopOnly": "Downloading is available in the desktop app."
+  },
   "theme": {
     "eyebrow": "02 · Pick your room",
     "headline": "The window dresses for your <1>mood</1>.",

--- a/apps/web/src/locales/en/onboarding.json
+++ b/apps/web/src/locales/en/onboarding.json
@@ -85,12 +85,35 @@
     "title": "Choose a visualizer",
     "hint": "Optional — preview updates live."
   },
-  "ready": {
-    "eyebrow": "03 · Ready",
-    "headline": "Open the door. <1>Press play</1>.",
-    "description": "That's it. The library is waiting. We'll keep your queue, run your radio, hand you the lyrics, and resume the song you left at 2:47 a.m.",
-    "title": "Choose a visualizer",
-    "hint": "Optional — the rhythm behind your now-playing bar. Change it any time.",
-    "cta": "Press play."
+  "summary": {
+    "eyebrow": "06 · All set",
+    "headline": "Your room is <1>ready</1>.",
+    "description": "Here's what you chose. Tweak any of it later from Settings.",
+    "intro": "A quick recap before the library opens.",
+    "row": {
+      "language": "Language",
+      "folders": "Music folders",
+      "tools": "Download helpers",
+      "playback": "Playback",
+      "theme": "Theme",
+      "visualizer": "Visualizer"
+    },
+    "folders_one": "{{count}} folder",
+    "folders_other": "{{count}} folders",
+    "tools": {
+      "both": "yt-dlp + ffmpeg",
+      "ytdlpOnly": "yt-dlp only",
+      "ffmpegOnly": "ffmpeg only",
+      "none": "Not installed",
+      "checking": "—"
+    },
+    "playback": {
+      "resumeOn": "Resume on",
+      "resumeOff": "Resume off",
+      "crossfade": "Crossfade {{seconds}}s",
+      "noCrossfade": "No crossfade",
+      "discordOn": "Discord on"
+    },
+    "value": { "none": "—" }
   }
 }

--- a/apps/web/src/locales/en/onboarding.json
+++ b/apps/web/src/locales/en/onboarding.json
@@ -28,7 +28,7 @@
   "folders": {
     "eyebrow": "01 · Point it at your files",
     "headline": "Your folders are the <1>catalog</1>.",
-    "description": "Drop in directories. Shiranami scans your files, reads the tags, lifts cover art, and quietly hands you back a real library — no upload, no account, no maybe-it-syncs.",
+    "description": "Drop in directories. Shiranami scans your files, reads the tags, lifts cover art, and quietly hands you back a real library. No upload, no account, no maybe-it-syncs.",
     "title": "Music folders",
     "empty": "No folders yet. Add one to start building your library.",
     "addFolder": "Add folder",
@@ -37,12 +37,12 @@
     "trackCount_one": "{{count}} track",
     "trackCount_other": "{{count}} tracks",
     "desktopOnly": "Adding folders is available in the desktop app.",
-    "doneHint": "Nice — your library is filling up. Add more or continue."
+    "doneHint": "Nice. Your library is filling up. Add more or continue."
   },
   "tools": {
     "eyebrow": "02 · Bring the tools",
     "headline": "Pull tracks <1>straight in</1>.",
-    "description": "Shiranami can fetch and import from a link — it just needs two small helpers: yt-dlp to fetch, ffmpeg to convert. Skip this if you only play files you already have; you can grab them later in Settings · Downloads.",
+    "description": "Shiranami can fetch and import from a link. It just needs two small helpers: yt-dlp to fetch, ffmpeg to convert. Skip this if you only play files you already have; you can grab them later in Settings · Downloads.",
     "title": "Download helpers",
     "installAll": "Install both",
     "installing": "Installing…",
@@ -50,8 +50,8 @@
     "ffmpeg": "ffmpeg",
     "updateBoth": "Update available",
     "checking": "Checking for helpers…",
-    "allSet": "Both helpers are installed — you're ready to import.",
-    "skipHint": "Optional — only needed for downloading and importing.",
+    "allSet": "Both helpers are installed. You're ready to import.",
+    "skipHint": "Optional. Only needed for downloading and importing.",
     "desktopOnly": "Downloading is available in the desktop app."
   },
   "appearance": {
@@ -81,9 +81,9 @@
   "visualizer": {
     "eyebrow": "05 · The rhythm",
     "headline": "Give the sound a <1>shape</1>.",
-    "description": "An audio-reactive scene rides above your now-playing bar. Pick one you like — or none. Change it any time.",
+    "description": "An audio-reactive scene rides above your now-playing bar. Pick one you like, or none. Change it any time.",
     "title": "Choose a visualizer",
-    "hint": "Optional — preview updates live."
+    "hint": "Optional. Preview updates live."
   },
   "summary": {
     "eyebrow": "06 · All set",
@@ -106,7 +106,7 @@
       "ytdlpOnly": "yt-dlp only",
       "ffmpegOnly": "ffmpeg only",
       "none": "Not installed",
-      "checking": "—"
+      "checking": "Checking…"
     },
     "playback": {
       "resumeOn": "Resume on",
@@ -115,6 +115,6 @@
       "noCrossfade": "No crossfade",
       "discordOn": "Discord on"
     },
-    "value": { "none": "—" }
+    "value": { "none": "None" }
   }
 }

--- a/apps/web/src/locales/en/onboarding.json
+++ b/apps/web/src/locales/en/onboarding.json
@@ -57,9 +57,14 @@
   "appearance": {
     "eyebrow": "03 · Make it yours",
     "headline": "The window dresses for your <1>mood</1>.",
-    "description": "One quiet theme with five scenes. The whole interface — accent color, glow, surfaces — shifts to match. Swap any time from Settings · Appearance.",
+    "description": "Pick a scene, then size it to your screen. Everything here is reversible from Settings · Appearance.",
     "themeTitle": "Theme",
-    "themeHint": "Tap any scene · the rain stays."
+    "themeHint": "Tap any scene · the rain stays.",
+    "comfortTitle": "Comfort",
+    "uiScale": "Interface size",
+    "uiScaleReset": "Reset to {{value}}%",
+    "reduceEffects": "Reduce effects",
+    "reduceEffectsDesc": "Lighter animations and blur for slower machines."
   },
   "ready": {
     "eyebrow": "03 · Ready",

--- a/apps/web/src/locales/en/onboarding.json
+++ b/apps/web/src/locales/en/onboarding.json
@@ -66,6 +66,18 @@
     "reduceEffects": "Reduce effects",
     "reduceEffectsDesc": "Lighter animations and blur for slower machines."
   },
+  "playback": {
+    "eyebrow": "04 · How it plays",
+    "headline": "Set the <1>flow</1> of the room.",
+    "description": "A couple of touches for how music carries from one track to the next. Change any of it later in Settings · Playback.",
+    "resume": "Resume where I left off",
+    "resumeDesc": "Reopen to the song and spot you stopped at.",
+    "crossfade": "Crossfade tracks",
+    "crossfadeDesc": "Blend the end of one song into the start of the next.",
+    "crossfadeDuration": "Crossfade length",
+    "discord": "Show what I'm playing on Discord",
+    "discordDesc": "Your now-playing track appears on your Discord profile."
+  },
   "ready": {
     "eyebrow": "03 · Ready",
     "headline": "Open the door. <1>Press play</1>.",

--- a/apps/web/src/locales/en/onboarding.json
+++ b/apps/web/src/locales/en/onboarding.json
@@ -90,6 +90,7 @@
     "headline": "Your room is <1>ready</1>.",
     "description": "Here's what you chose. Tweak any of it later from Settings.",
     "intro": "A quick recap before the library opens.",
+    "listAria": "Your setup choices",
     "row": {
       "language": "Language",
       "folders": "Music folders",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -339,6 +339,9 @@
     "storyP3Post": ".",
     "logsTitle": "Application logs",
     "logsSubtitle": "Open the log folder in your file explorer",
-    "openLogs": "Open logs folder"
+    "openLogs": "Open logs folder",
+    "replayTitle": "Replay onboarding",
+    "replaySubtitle": "Step through the first-run setup again",
+    "replayButton": "Replay setup"
   }
 }

--- a/apps/web/src/locales/pl/onboarding.json
+++ b/apps/web/src/locales/pl/onboarding.json
@@ -1,0 +1,59 @@
+{
+  "wizard": {
+    "ariaLabel": "Pierwsze uruchomienie",
+    "skip": "Pomiń",
+    "back": "Wstecz",
+    "next": "Dalej",
+    "skipForNow": "Pomiń na razie",
+    "finish": "Otwórz bibliotekę",
+    "progressAria": "Postęp konfiguracji",
+    "stepDotAria": "Przejdź do kroku {{number}}: {{id}}",
+    "stepCounter": "Krok · {{current}} · z {{total}}",
+    "crumb": "Witaj"
+  },
+  "welcome": {
+    "eyebrow": "Vol · NS · {{version}} · nocny build",
+    "headline": "Spokojniejsze miejsce dla Twojej <1>biblioteki muzycznej</1>.",
+    "description": "Shiranami odtwarza pliki, które już masz. Foldery, które wskażesz. Nic ze streamingu, nic śledzonego, nic podpowiadanego przez ramię.",
+    "language": {
+      "label": "Język",
+      "hint": "Możesz to zmienić w każdej chwili w Ustawienia · Wygląd."
+    },
+    "stats": {
+      "free": "Kod dostępny",
+      "platforms": "Win · macOS",
+      "noTelemetry": "Bez telemetrii"
+    }
+  },
+  "folders": {
+    "eyebrow": "01 · Wskaż swoje pliki",
+    "headline": "Twoje foldery to <1>katalog</1>.",
+    "description": "Dodaj katalogi. Shiranami przeskanuje pliki, odczyta tagi, pobierze okładki i po cichu zbuduje prawdziwą bibliotekę — bez przesyłania, bez konta, bez „może-się-zsynchronizuje”.",
+    "title": "Foldery muzyczne",
+    "empty": "Brak folderów. Dodaj pierwszy, aby zbudować bibliotekę.",
+    "addFolder": "Dodaj folder",
+    "scanning": "Skanowanie…",
+    "remove": "Usuń folder",
+    "trackCount_one": "{{count}} utwór",
+    "trackCount_few": "{{count}} utwory",
+    "trackCount_many": "{{count}} utworów",
+    "trackCount_other": "{{count}} utworu",
+    "desktopOnly": "Dodawanie folderów jest dostępne w aplikacji desktopowej.",
+    "doneHint": "Świetnie — biblioteka się zapełnia. Dodaj więcej lub kontynuuj."
+  },
+  "theme": {
+    "eyebrow": "02 · Wybierz nastrój",
+    "headline": "Okno ubiera się pod Twój <1>nastrój</1>.",
+    "description": "Jeden spokojny motyw, pięć scenerii. Cały interfejs — kolor akcentu, poświata, powierzchnie — dopasowuje się. Zmień w dowolnej chwili w Ustawienia · Wygląd.",
+    "title": "Motyw",
+    "hint": "Dotknij dowolnej scenerii · deszcz zostaje."
+  },
+  "ready": {
+    "eyebrow": "03 · Gotowe",
+    "headline": "Otwórz drzwi. <1>Naciśnij play</1>.",
+    "description": "I to wszystko. Biblioteka czeka. Zachowamy kolejkę, uruchomimy radio, podamy teksty i wznowimy utwór porzucony o 2:47 w nocy.",
+    "title": "Wybierz wizualizację",
+    "hint": "Opcjonalne — rytm za paskiem odtwarzania. Zmień w dowolnej chwili.",
+    "cta": "Naciśnij play."
+  }
+}

--- a/apps/web/src/locales/pl/onboarding.json
+++ b/apps/web/src/locales/pl/onboarding.json
@@ -92,6 +92,7 @@
     "headline": "Twój pokój jest <1>gotowy</1>.",
     "description": "Oto, co wybrałeś. Wszystko możesz dostroić później w Ustawieniach.",
     "intro": "Szybkie podsumowanie, zanim otworzy się biblioteka.",
+    "listAria": "Twoje wybory konfiguracji",
     "row": {
       "language": "Język",
       "folders": "Foldery muzyczne",

--- a/apps/web/src/locales/pl/onboarding.json
+++ b/apps/web/src/locales/pl/onboarding.json
@@ -41,6 +41,21 @@
     "desktopOnly": "Dodawanie folderów jest dostępne w aplikacji desktopowej.",
     "doneHint": "Świetnie — biblioteka się zapełnia. Dodaj więcej lub kontynuuj."
   },
+  "tools": {
+    "eyebrow": "02 · Dorzuć narzędzia",
+    "headline": "Pobieraj utwory <1>prosto do środka</1>.",
+    "description": "Shiranami pobiera i importuje z linku — potrzebuje tylko dwóch małych pomocników: yt-dlp do pobierania i ffmpeg do konwersji. Pomiń, jeśli odtwarzasz tylko własne pliki; możesz je dodać później w Ustawienia · Pobieranie.",
+    "title": "Pomocnicy do pobierania",
+    "installAll": "Zainstaluj oba",
+    "installing": "Instalowanie…",
+    "ytdlp": "yt-dlp",
+    "ffmpeg": "ffmpeg",
+    "updateBoth": "Dostępna aktualizacja",
+    "checking": "Sprawdzanie pomocników…",
+    "allSet": "Oba pomocniki są zainstalowane — możesz importować.",
+    "skipHint": "Opcjonalne — potrzebne tylko do pobierania i importu.",
+    "desktopOnly": "Pobieranie jest dostępne w aplikacji desktopowej."
+  },
   "theme": {
     "eyebrow": "02 · Wybierz nastrój",
     "headline": "Okno ubiera się pod Twój <1>nastrój</1>.",

--- a/apps/web/src/locales/pl/onboarding.json
+++ b/apps/web/src/locales/pl/onboarding.json
@@ -80,6 +80,13 @@
     "discord": "Pokaż na Discordzie, co gram",
     "discordDesc": "Aktualnie odtwarzany utwór pojawi się na Twoim profilu Discord."
   },
+  "visualizer": {
+    "eyebrow": "05 · Rytm",
+    "headline": "Nadaj dźwiękowi <1>kształt</1>.",
+    "description": "Scena reagująca na dźwięk unosi się nad paskiem odtwarzania. Wybierz tę, którą lubisz — albo żadną. Zmień w dowolnej chwili.",
+    "title": "Wybierz wizualizację",
+    "hint": "Opcjonalne — podgląd aktualizuje się na żywo."
+  },
   "ready": {
     "eyebrow": "03 · Gotowe",
     "headline": "Otwórz drzwi. <1>Naciśnij play</1>.",

--- a/apps/web/src/locales/pl/onboarding.json
+++ b/apps/web/src/locales/pl/onboarding.json
@@ -68,6 +68,18 @@
     "reduceEffects": "Ogranicz efekty",
     "reduceEffectsDesc": "Lżejsze animacje i rozmycie dla wolniejszych maszyn."
   },
+  "playback": {
+    "eyebrow": "04 · Jak odtwarza",
+    "headline": "Ustaw <1>przepływ</1> dźwięku.",
+    "description": "Kilka drobiazgów dotyczących tego, jak muzyka przechodzi z utworu na utwór. Zmień w dowolnej chwili w Ustawienia · Odtwarzanie.",
+    "resume": "Wznów tam, gdzie skończyłem",
+    "resumeDesc": "Otwórz ponownie na utworze i w miejscu, gdzie przerwałeś.",
+    "crossfade": "Płynne przejścia",
+    "crossfadeDesc": "Płynnie połącz koniec jednego utworu z początkiem następnego.",
+    "crossfadeDuration": "Długość przejścia",
+    "discord": "Pokaż na Discordzie, co gram",
+    "discordDesc": "Aktualnie odtwarzany utwór pojawi się na Twoim profilu Discord."
+  },
   "ready": {
     "eyebrow": "03 · Gotowe",
     "headline": "Otwórz drzwi. <1>Naciśnij play</1>.",

--- a/apps/web/src/locales/pl/onboarding.json
+++ b/apps/web/src/locales/pl/onboarding.json
@@ -59,9 +59,14 @@
   "appearance": {
     "eyebrow": "03 · Dopasuj do siebie",
     "headline": "Okno ubiera się pod Twój <1>nastrój</1>.",
-    "description": "Jeden spokojny motyw, pięć scenerii. Cały interfejs — kolor akcentu, poświata, powierzchnie — dopasowuje się. Zmień w dowolnej chwili w Ustawienia · Wygląd.",
+    "description": "Wybierz scenerię, a potem dopasuj rozmiar do ekranu. Wszystko tutaj można cofnąć w Ustawienia · Wygląd.",
     "themeTitle": "Motyw",
-    "themeHint": "Dotknij dowolnej scenerii · deszcz zostaje."
+    "themeHint": "Dotknij dowolnej scenerii · deszcz zostaje.",
+    "comfortTitle": "Komfort",
+    "uiScale": "Rozmiar interfejsu",
+    "uiScaleReset": "Przywróć {{value}}%",
+    "reduceEffects": "Ogranicz efekty",
+    "reduceEffectsDesc": "Lżejsze animacje i rozmycie dla wolniejszych maszyn."
   },
   "ready": {
     "eyebrow": "03 · Gotowe",

--- a/apps/web/src/locales/pl/onboarding.json
+++ b/apps/web/src/locales/pl/onboarding.json
@@ -87,12 +87,37 @@
     "title": "Wybierz wizualizację",
     "hint": "Opcjonalne — podgląd aktualizuje się na żywo."
   },
-  "ready": {
-    "eyebrow": "03 · Gotowe",
-    "headline": "Otwórz drzwi. <1>Naciśnij play</1>.",
-    "description": "I to wszystko. Biblioteka czeka. Zachowamy kolejkę, uruchomimy radio, podamy teksty i wznowimy utwór porzucony o 2:47 w nocy.",
-    "title": "Wybierz wizualizację",
-    "hint": "Opcjonalne — rytm za paskiem odtwarzania. Zmień w dowolnej chwili.",
-    "cta": "Naciśnij play."
+  "summary": {
+    "eyebrow": "06 · Gotowe",
+    "headline": "Twój pokój jest <1>gotowy</1>.",
+    "description": "Oto, co wybrałeś. Wszystko możesz dostroić później w Ustawieniach.",
+    "intro": "Szybkie podsumowanie, zanim otworzy się biblioteka.",
+    "row": {
+      "language": "Język",
+      "folders": "Foldery muzyczne",
+      "tools": "Pomocnicy do pobierania",
+      "playback": "Odtwarzanie",
+      "theme": "Motyw",
+      "visualizer": "Wizualizacja"
+    },
+    "folders_one": "{{count}} folder",
+    "folders_few": "{{count}} foldery",
+    "folders_many": "{{count}} folderów",
+    "folders_other": "{{count}} folderu",
+    "tools": {
+      "both": "yt-dlp + ffmpeg",
+      "ytdlpOnly": "tylko yt-dlp",
+      "ffmpegOnly": "tylko ffmpeg",
+      "none": "Nie zainstalowano",
+      "checking": "—"
+    },
+    "playback": {
+      "resumeOn": "Wznawianie wł.",
+      "resumeOff": "Wznawianie wył.",
+      "crossfade": "Przejścia {{seconds}}s",
+      "noCrossfade": "Bez przejść",
+      "discordOn": "Discord wł."
+    },
+    "value": { "none": "—" }
   }
 }

--- a/apps/web/src/locales/pl/onboarding.json
+++ b/apps/web/src/locales/pl/onboarding.json
@@ -28,7 +28,7 @@
   "folders": {
     "eyebrow": "01 · Wskaż swoje pliki",
     "headline": "Twoje foldery to <1>katalog</1>.",
-    "description": "Dodaj katalogi. Shiranami przeskanuje pliki, odczyta tagi, pobierze okładki i po cichu zbuduje prawdziwą bibliotekę — bez przesyłania, bez konta, bez „może-się-zsynchronizuje”.",
+    "description": "Dodaj katalogi. Shiranami przeskanuje pliki, odczyta tagi, pobierze okładki i po cichu zbuduje prawdziwą bibliotekę. Bez przesyłania, bez konta, bez „może-się-zsynchronizuje”.",
     "title": "Foldery muzyczne",
     "empty": "Brak folderów. Dodaj pierwszy, aby zbudować bibliotekę.",
     "addFolder": "Dodaj folder",
@@ -39,12 +39,12 @@
     "trackCount_many": "{{count}} utworów",
     "trackCount_other": "{{count}} utworu",
     "desktopOnly": "Dodawanie folderów jest dostępne w aplikacji desktopowej.",
-    "doneHint": "Świetnie — biblioteka się zapełnia. Dodaj więcej lub kontynuuj."
+    "doneHint": "Świetnie. Biblioteka się zapełnia. Dodaj więcej lub kontynuuj."
   },
   "tools": {
     "eyebrow": "02 · Dorzuć narzędzia",
     "headline": "Pobieraj utwory <1>prosto do środka</1>.",
-    "description": "Shiranami pobiera i importuje z linku — potrzebuje tylko dwóch małych pomocników: yt-dlp do pobierania i ffmpeg do konwersji. Pomiń, jeśli odtwarzasz tylko własne pliki; możesz je dodać później w Ustawienia · Pobieranie.",
+    "description": "Shiranami pobiera i importuje z linku. Potrzebuje tylko dwóch małych pomocników: yt-dlp do pobierania i ffmpeg do konwersji. Pomiń, jeśli odtwarzasz tylko własne pliki; możesz je dodać później w Ustawienia · Pobieranie.",
     "title": "Pomocnicy do pobierania",
     "installAll": "Zainstaluj oba",
     "installing": "Instalowanie…",
@@ -52,8 +52,8 @@
     "ffmpeg": "ffmpeg",
     "updateBoth": "Dostępna aktualizacja",
     "checking": "Sprawdzanie pomocników…",
-    "allSet": "Oba pomocniki są zainstalowane — możesz importować.",
-    "skipHint": "Opcjonalne — potrzebne tylko do pobierania i importu.",
+    "allSet": "Oba pomocniki są zainstalowane. Możesz importować.",
+    "skipHint": "Opcjonalne. Potrzebne tylko do pobierania i importu.",
     "desktopOnly": "Pobieranie jest dostępne w aplikacji desktopowej."
   },
   "appearance": {
@@ -83,9 +83,9 @@
   "visualizer": {
     "eyebrow": "05 · Rytm",
     "headline": "Nadaj dźwiękowi <1>kształt</1>.",
-    "description": "Scena reagująca na dźwięk unosi się nad paskiem odtwarzania. Wybierz tę, którą lubisz — albo żadną. Zmień w dowolnej chwili.",
+    "description": "Scena reagująca na dźwięk unosi się nad paskiem odtwarzania. Wybierz tę, którą lubisz, albo żadną. Zmień w dowolnej chwili.",
     "title": "Wybierz wizualizację",
-    "hint": "Opcjonalne — podgląd aktualizuje się na żywo."
+    "hint": "Opcjonalne. Podgląd aktualizuje się na żywo."
   },
   "summary": {
     "eyebrow": "06 · Gotowe",
@@ -110,7 +110,7 @@
       "ytdlpOnly": "tylko yt-dlp",
       "ffmpegOnly": "tylko ffmpeg",
       "none": "Nie zainstalowano",
-      "checking": "—"
+      "checking": "Sprawdzanie…"
     },
     "playback": {
       "resumeOn": "Wznawianie wł.",
@@ -119,6 +119,6 @@
       "noCrossfade": "Bez przejść",
       "discordOn": "Discord wł."
     },
-    "value": { "none": "—" }
+    "value": { "none": "Brak" }
   }
 }

--- a/apps/web/src/locales/pl/onboarding.json
+++ b/apps/web/src/locales/pl/onboarding.json
@@ -56,12 +56,12 @@
     "skipHint": "Opcjonalne — potrzebne tylko do pobierania i importu.",
     "desktopOnly": "Pobieranie jest dostępne w aplikacji desktopowej."
   },
-  "theme": {
-    "eyebrow": "02 · Wybierz nastrój",
+  "appearance": {
+    "eyebrow": "03 · Dopasuj do siebie",
     "headline": "Okno ubiera się pod Twój <1>nastrój</1>.",
     "description": "Jeden spokojny motyw, pięć scenerii. Cały interfejs — kolor akcentu, poświata, powierzchnie — dopasowuje się. Zmień w dowolnej chwili w Ustawienia · Wygląd.",
-    "title": "Motyw",
-    "hint": "Dotknij dowolnej scenerii · deszcz zostaje."
+    "themeTitle": "Motyw",
+    "themeHint": "Dotknij dowolnej scenerii · deszcz zostaje."
   },
   "ready": {
     "eyebrow": "03 · Gotowe",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -339,6 +339,9 @@
     "storyP3Post": ".",
     "logsTitle": "Logi aplikacji",
     "logsSubtitle": "Otw\u00f3rz folder z logami w eksploratorze plik\u00f3w",
-    "openLogs": "Otw\u00f3rz folder log\u00f3w"
+    "openLogs": "Otw\u00f3rz folder log\u00f3w",
+    "replayTitle": "Powt\u00f3rz wprowadzenie",
+    "replaySubtitle": "Przejd\u017a ponownie przez konfiguracj\u0119 pierwszego uruchomienia",
+    "replayButton": "Powt\u00f3rz konfiguracj\u0119"
   }
 }

--- a/apps/web/src/stores/useOnboardingStore.test.ts
+++ b/apps/web/src/stores/useOnboardingStore.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useOnboardingStore } from './useOnboardingStore';
+
+vi.mock('@/lib/platform', () => ({
+  IS_ELECTRON: true,
+  IS_WINDOWS: false,
+  IS_MAC: false,
+}));
+
+const STORE_KEY = 'shiranami.onboarding';
+const ELECTRON_KEY = 'app.onboardingCompleted';
+
+function readPersisted(): Record<string, unknown> {
+  const raw = localStorage.getItem(STORE_KEY);
+  if (!raw) return {};
+  const parsed = JSON.parse(raw) as { state?: Record<string, unknown> };
+  return parsed.state ?? {};
+}
+
+describe('useOnboardingStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useOnboardingStore.setState({ hasCompletedOnboarding: false });
+    vi.mocked(window.electronAPI.store.set).mockResolvedValue(undefined);
+    vi.mocked(window.electronAPI.store.delete).mockResolvedValue(undefined);
+    vi.mocked(window.electronAPI.store.get).mockResolvedValue(undefined);
+    vi.clearAllMocks();
+  });
+
+  it('defaults to not completed on a fresh install', () => {
+    expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(false);
+  });
+
+  it('completeOnboarding flips the flag, persists it, and mirrors to electron-store', () => {
+    useOnboardingStore.getState().completeOnboarding();
+
+    expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(true);
+    expect(readPersisted().hasCompletedOnboarding).toBe(true);
+    expect(window.electronAPI.store.set).toHaveBeenCalledWith(ELECTRON_KEY, true);
+  });
+
+  it('resetOnboarding clears the flag and deletes the electron-store mirror', () => {
+    useOnboardingStore.getState().completeOnboarding();
+    vi.clearAllMocks();
+
+    useOnboardingStore.getState().resetOnboarding();
+
+    expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(false);
+    expect(readPersisted().hasCompletedOnboarding).toBe(false);
+    expect(window.electronAPI.store.delete).toHaveBeenCalledWith(ELECTRON_KEY);
+  });
+
+  it('hydrateOnboarding marks completed when the electron-store mirror is true', async () => {
+    vi.mocked(window.electronAPI.store.get).mockResolvedValueOnce(true);
+
+    await useOnboardingStore.getState().hydrateOnboarding();
+
+    expect(window.electronAPI.store.get).toHaveBeenCalledWith(ELECTRON_KEY);
+    expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(true);
+  });
+
+  it('hydrateOnboarding leaves the flag untouched when the mirror is absent', async () => {
+    vi.mocked(window.electronAPI.store.get).mockResolvedValueOnce(undefined);
+
+    await useOnboardingStore.getState().hydrateOnboarding();
+
+    expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(false);
+  });
+
+  it('hydrateOnboarding swallows electron-store read failures', async () => {
+    vi.mocked(window.electronAPI.store.get).mockRejectedValueOnce(new Error('ipc failed'));
+
+    await expect(useOnboardingStore.getState().hydrateOnboarding()).resolves.toBeUndefined();
+    expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(false);
+  });
+
+  it('coerces a malformed persisted value to false on merge', () => {
+    localStorage.setItem(
+      STORE_KEY,
+      JSON.stringify({ state: { hasCompletedOnboarding: 'yes' }, version: 1 })
+    );
+
+    const merged = useOnboardingStore.persist
+      .getOptions()
+      .merge?.(
+        { hasCompletedOnboarding: 'yes' },
+        useOnboardingStore.getState()
+      ) as OnboardingMergeResult;
+
+    expect(merged.hasCompletedOnboarding).toBe(false);
+  });
+});
+
+interface OnboardingMergeResult {
+  hasCompletedOnboarding: boolean;
+}

--- a/apps/web/src/stores/useOnboardingStore.ts
+++ b/apps/web/src/stores/useOnboardingStore.ts
@@ -17,7 +17,9 @@ interface OnboardingState {
   completeOnboarding: () => void;
   /** Re-show the wizard (replay from Settings) + clear the electron-store mirror. */
   resetOnboarding: () => void;
-  /** Reconcile from electron-store on boot — the durable source of truth. */
+  /** One-way sync from electron-store on boot: upgrades a cleared/un-migrated
+   *  localStorage to completed when the mirror says so. localStorage is the
+   *  working source of truth; the mirror only upgrades it, never downgrades. */
   hydrateOnboarding: () => Promise<void>;
 }
 

--- a/apps/web/src/stores/useOnboardingStore.ts
+++ b/apps/web/src/stores/useOnboardingStore.ts
@@ -1,0 +1,78 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { IS_ELECTRON } from '@/lib/platform';
+
+/** localStorage key — matches the shiranami.* store convention. */
+const STORE_KEY = 'shiranami.onboarding';
+/** electron-store mirror key — matches the app.language convention. */
+const ELECTRON_KEY = 'app.onboardingCompleted';
+
+function coerceCompleted(v: unknown): boolean {
+  return v === true;
+}
+
+interface OnboardingState {
+  hasCompletedOnboarding: boolean;
+  /** Mark the first-run wizard as done + mirror to electron-store. */
+  completeOnboarding: () => void;
+  /** Re-show the wizard (replay from Settings) + clear the electron-store mirror. */
+  resetOnboarding: () => void;
+  /** Reconcile from electron-store on boot — the durable source of truth. */
+  hydrateOnboarding: () => Promise<void>;
+}
+
+export const useOnboardingStore = create<OnboardingState>()(
+  persist(
+    set => ({
+      hasCompletedOnboarding: false,
+      completeOnboarding: () => {
+        set({ hasCompletedOnboarding: true });
+        if (IS_ELECTRON) {
+          window.electronAPI.store.set(ELECTRON_KEY, true).catch(() => {});
+        }
+      },
+      resetOnboarding: () => {
+        set({ hasCompletedOnboarding: false });
+        if (IS_ELECTRON) {
+          window.electronAPI.store.delete(ELECTRON_KEY).catch(() => {});
+        }
+      },
+      hydrateOnboarding: async () => {
+        if (!IS_ELECTRON) return;
+        try {
+          const stored = await window.electronAPI.store.get(ELECTRON_KEY);
+          if (stored === true) {
+            set({ hasCompletedOnboarding: true });
+          }
+        } catch {
+          // Ignore store read failures — localStorage stays the fallback.
+        }
+      },
+    }),
+    {
+      name: STORE_KEY,
+      version: 1,
+      storage: createJSONStorage(() => localStorage),
+      partialize: s => ({ hasCompletedOnboarding: s.hasCompletedOnboarding }),
+      merge: (persisted, current) => ({
+        ...current,
+        hasCompletedOnboarding: coerceCompleted(
+          (persisted as Partial<OnboardingState> | undefined)?.hasCompletedOnboarding
+        ),
+      }),
+    }
+  )
+);
+
+if (import.meta.hot) {
+  type HmrData = { store?: typeof useOnboardingStore };
+  const hot = import.meta.hot;
+  const data = (hot.data ?? {}) as HmrData;
+  if (data.store) {
+    useOnboardingStore.setState({
+      hasCompletedOnboarding: coerceCompleted(data.store.getState().hasCompletedOnboarding),
+    });
+  }
+  data.store = useOnboardingStore;
+  hot.accept();
+}


### PR DESCRIPTION
## Summary

Adds a **7-step first-run onboarding wizard** for new Shiranami users. Previously the app dropped users straight into an empty library with no guidance. The wizard overlays the app once after the splash on first launch, gets the user to the "aha moment" (a populated library) fast, and is **fully skippable** at every step.

Designed against `design/Shiranami Onboarding.html`, architecture adapted from shiroani's onboarding, built research-first (`/kirei`) with the `/impeccable:onboard` methodology baked in. Full spec + addendum: `docs/ui/2026-05-21-onboarding-flow*.md` (local).

## The flow (7 steps · skippable)

| # | Step | Kanji | What it does |
|---|------|-------|--------------|
| 1 | **Welcome** | 白波 | Product frame + language toggle (en/pl) |
| 2 | **Folders** | 蔵 | **Core success step** — real add-folder + scan flow (`useLibraryFolders`). Zero-folder state nudges with "Skip for now" instead of hard-blocking |
| 3 | **Tools** | 取 | Install yt-dlp / ffmpeg so you can download + import playlists right away. Optional; reuses the real `useDownloadsSettings` flow |
| 4 | **Appearance** | 夜 | Live theme grid + UI scale + reduce-effects |
| 5 | **Playback** | 音 | Resume-where-I-left-off + crossfade (with duration) + Discord Rich Presence |
| 6 | **Visualizer** | 波 | Pick a visualizer with a live preview |
| 7 | **Summary** | 締 | Read-only recap of every choice → "Open library" |

Every step uses the app's **real working controls** (not screenshots), so onboarding produces real, durable value. Skip is always visible; skip == complete (won't reappear). Replayable from **Settings · About**.

## Architecture & DRY

- New `useOnboardingStore` — persists `hasCompletedOnboarding` via zustand `persist`(localStorage `shiranami.onboarding`), mirrored to electron-store `app.onboardingCompleted` for durability. Step nav stays local to the wizard.
- Two zero-behavior-change extractions so settings and onboarding can't drift: `ThemeTileGrid` (from `AppearanceSection`) and `VisualizerStyleGrid` (from `VisualizerSection`).
- Tools/Playback steps **reuse existing settings logic verbatim** (`useDownloadsSettings`, `usePlaybackStore`, `useSettingsQuery`/`useUpdateSettingsMutation`) — zero duplicated download/playback logic.
- Wizard is `React.lazy`'d (default export) → its own **32.68 kB / 10.26 kB gzip** chunk holding all 7 steps, off the returning-user path.
- New `onboarding` i18n namespace (en + pl, Polish CLDR plurals) + `abt.replay*` settings keys.

## Accessibility & performance

- `role="dialog"` + `aria-modal`, focus trap (`useFocusTrap`), keyboard nav (→/Enter/←/Esc), real `<button>` progress dots with `aria-current`.
- Keyboard guard so Arrow keys on a focused slider (UI scale / crossfade) adjust the value instead of changing steps.
- Install progress reuses `InstallProgressBar` (`role="status"`/`progressbar`). Tools installs never block navigation.
- All motion collapses under `prefers-reduced-motion` / low-perf; the scene reuses the splash's already-degraded static layers — no new rAF loops.

## Verification

- `pnpm typecheck` clean (web + desktop) · `pnpm lint` clean
- `pnpm test` — **web 604 passed** (incl. 7 `useOnboardingStore` tests)
- `pnpm build` clean — wizard confirmed as a single lazy chunk; main bundle unchanged
- Live walkthrough of all 7 steps + finish + returning-user (no re-show) path; slider keyboard-guard confirmed

## Notes

- The Electron-only Discord toggle and the "Install both" streaming progress mirror the proven `PlaybackSection`/`App.tsx` paths and were verified structurally in the web build — a 30-second desktop sanity pass before merge is worthwhile since only a real launch exercises live IPC.
- Tightening the `LibraryView` empty-state copy toward "add a folder" (the safety net for skip-users) is a tracked, out-of-scope follow-up — `LibraryView` was not touched.