### PR TITLE
fix(ui): desktop redesign consistency pass

### DIFF
--- a/apps/web/src/components/favorites/FavoritesView.tsx
+++ b/apps/web/src/components/favorites/FavoritesView.tsx
@@ -57,7 +57,7 @@ export function FavoritesView() {
         <ViewEmptyState title={t('emptyTitle')} subtitle={t('emptySubtitle')} icon={Heart} />
       ) : (
         <div className="flex-1 min-h-0 mx-4 mb-4 rounded-2xl glass-panel border border-border/30 overflow-hidden">
-          <div className="h-full px-2">
+          <div className="h-full px-2 py-1.5">
             <List
               rowCount={favorites.length}
               rowHeight={52}

--- a/apps/web/src/components/library/LibraryView.tsx
+++ b/apps/web/src/components/library/LibraryView.tsx
@@ -207,7 +207,7 @@ export function LibraryView() {
         />
       ) : (
         <div className="flex-1 min-h-0 mx-4 mb-4 rounded-2xl glass-panel border border-border/30 overflow-hidden">
-          <div className="h-full px-2">
+          <div className="h-full px-2 py-1.5">
             <VirtualList
               rowCount={filteredLibrary.length}
               rowHeight={52}

--- a/apps/web/src/components/library/LibraryView.tsx
+++ b/apps/web/src/components/library/LibraryView.tsx
@@ -98,7 +98,7 @@ export function LibraryView() {
         <div className="px-6 pt-4 pb-3 shrink-0">
           <div className="flex items-center gap-2">
             <div className="relative flex-1">
-              <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+              <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-foreground/55 pointer-events-none" />
               <Input
                 ref={searchInputRef}
                 data-testid="library-search-input"

--- a/apps/web/src/components/mixes/MixesView.tsx
+++ b/apps/web/src/components/mixes/MixesView.tsx
@@ -129,7 +129,7 @@ export function MixesView() {
           </div>
         ) : (
           <div className="flex-1 min-h-0 mx-4 mb-4 rounded-2xl glass-panel border border-border/30 overflow-hidden">
-            <div className="h-full px-2">
+            <div className="h-full px-2 py-1.5">
               <List
                 rowCount={mixTracks.length}
                 rowHeight={52}

--- a/apps/web/src/components/playlist-import/PlaylistImportView.tsx
+++ b/apps/web/src/components/playlist-import/PlaylistImportView.tsx
@@ -203,7 +203,7 @@ export function PlaylistImportView() {
         </div>
       ) : (
         <div className="flex-1 min-h-0 mx-4 mb-4 rounded-2xl glass-panel border border-border/30 overflow-hidden">
-          <div className="h-full px-2">
+          <div className="h-full px-2 py-1.5">
             <List
               rowCount={tracks.length}
               rowHeight={52}

--- a/apps/web/src/components/playlist-import/PlaylistImportView.tsx
+++ b/apps/web/src/components/playlist-import/PlaylistImportView.tsx
@@ -79,7 +79,7 @@ export function PlaylistImportView() {
       {/* URL input + controls */}
       <div className="px-6 pt-4 pb-3 shrink-0">
         <div className="relative max-w-2xl">
-          <Link className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+          <Link className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-foreground/55 pointer-events-none" />
           <Input
             ref={inputRef}
             type="text"
@@ -89,7 +89,7 @@ export function PlaylistImportView() {
             placeholder={t('urlPlaceholder')}
             disabled={isExtracting || isImporting}
             className={cn(
-              'h-auto w-full pl-10 pr-24 py-2.5 rounded-xl text-sm bg-card border-border/50',
+              'h-auto w-full pl-10 pr-24 py-2.5 rounded-xl text-sm glass-subtle border-border/40',
               'text-foreground placeholder:text-muted-foreground/50',
               'focus-visible:ring-primary/40 focus-visible:border-primary/40',
               'shadow-none'

--- a/apps/web/src/components/playlist-import/PlaylistImportView.tsx
+++ b/apps/web/src/components/playlist-import/PlaylistImportView.tsx
@@ -1,6 +1,7 @@
 import { useRef, useCallback } from 'react';
 import { Link, Loader2, AlertCircle, X, Download, ListMusic } from 'lucide-react';
 import { ViewEmptyState } from '../shared/ViewEmptyState';
+import { PageHeader } from '@/components/shared/PageHeader';
 import { List } from 'react-window';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -74,7 +75,8 @@ export function PlaylistImportView() {
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
-      {/* Header */}
+      <PageHeader title={t('pageTitle')} />
+      {/* URL input + controls */}
       <div className="px-6 pt-4 pb-3 shrink-0">
         <div className="relative max-w-2xl">
           <Link className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />

--- a/apps/web/src/components/playlists/PlaylistTrackList.tsx
+++ b/apps/web/src/components/playlists/PlaylistTrackList.tsx
@@ -61,7 +61,7 @@ export function PlaylistTrackList({
 
   return (
     <div className="flex-1 min-h-0 mx-4 mb-4 rounded-2xl glass-panel border border-border/30 overflow-hidden">
-      <div className="h-full overflow-y-auto px-2 scrollbar-thin">
+      <div className="h-full overflow-y-auto px-2 py-1.5 scrollbar-thin">
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}

--- a/apps/web/src/components/playlists/PlaylistTrackList.tsx
+++ b/apps/web/src/components/playlists/PlaylistTrackList.tsx
@@ -60,33 +60,35 @@ export function PlaylistTrackList({
   }
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto px-4 scrollbar-thin">
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragStart={onDragStart}
-        onDragEnd={onDragEnd}
-        onDragCancel={onDragCancel}
-      >
-        <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
-          {displayTracks.map((track, index) => (
-            <SortableTrackRow
-              key={track.id}
-              track={track}
-              index={index}
-              queue={displayTracks}
-              currentTrack={currentTrack}
-              isPlaying={isPlaying}
-              handlePlayTrack={onPlayTrack}
-              onToggleFavorite={onToggleFavorite}
-              onRemoveFromPlaylist={onRemoveTrack}
-            />
-          ))}
-        </SortableContext>
-        <DragOverlay dropAnimation={null}>
-          {activeTrack ? <DragOverlayContent track={activeTrack} /> : null}
-        </DragOverlay>
-      </DndContext>
+    <div className="flex-1 min-h-0 mx-4 mb-4 rounded-2xl glass-panel border border-border/30 overflow-hidden">
+      <div className="h-full overflow-y-auto px-2 scrollbar-thin">
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+          onDragCancel={onDragCancel}
+        >
+          <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+            {displayTracks.map((track, index) => (
+              <SortableTrackRow
+                key={track.id}
+                track={track}
+                index={index}
+                queue={displayTracks}
+                currentTrack={currentTrack}
+                isPlaying={isPlaying}
+                handlePlayTrack={onPlayTrack}
+                onToggleFavorite={onToggleFavorite}
+                onRemoveFromPlaylist={onRemoveTrack}
+              />
+            ))}
+          </SortableContext>
+          <DragOverlay dropAnimation={null}>
+            {activeTrack ? <DragOverlayContent track={activeTrack} /> : null}
+          </DragOverlay>
+        </DndContext>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/radio/RadioView.tsx
+++ b/apps/web/src/components/radio/RadioView.tsx
@@ -137,7 +137,7 @@ export function RadioView() {
       {/* Search bar */}
       <div className="px-6 pt-4 pb-3 shrink-0">
         <div className="relative max-w-2xl">
-          <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+          <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-foreground/55 pointer-events-none" />
           <Input
             ref={inputRef}
             type="text"

--- a/apps/web/src/components/radio/RadioView.tsx
+++ b/apps/web/src/components/radio/RadioView.tsx
@@ -258,7 +258,7 @@ export function RadioView() {
         )
       ) : (
         <div className="flex-1 min-h-0 mx-4 mb-4 rounded-2xl glass-panel border border-border/30 overflow-hidden">
-          <div className="h-full px-2">
+          <div className="h-full px-2 py-1.5">
             <List
               rowCount={stations.length}
               rowHeight={56}

--- a/apps/web/src/components/search/SearchView.tsx
+++ b/apps/web/src/components/search/SearchView.tsx
@@ -142,7 +142,7 @@ export function SearchView() {
       <PageHeader title={t('pageTitle')} />
       <div className="px-6 pt-4 pb-3 shrink-0">
         <div className="relative max-w-2xl">
-          <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+          <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-foreground/55 pointer-events-none" />
           <Input
             ref={inputRef}
             type="text"

--- a/apps/web/src/components/shared/ViewEmptyState.tsx
+++ b/apps/web/src/components/shared/ViewEmptyState.tsx
@@ -34,19 +34,21 @@ export function ViewEmptyState({
 
   if (compact) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center gap-4 text-center px-6">
-        <Icon className="w-12 h-12 text-muted-foreground/20" strokeWidth={1.5} />
-        <div>
-          <p className="font-display text-base font-medium text-foreground/85">{title}</p>
-          <p className="text-sm text-muted-foreground/60 mt-1.5 max-w-xs mx-auto leading-relaxed">
-            {subtitle}
-          </p>
+      <div className="flex-1 flex flex-col items-center justify-center px-6">
+        <div className="flex flex-col items-center gap-4 text-center glass-subtle rounded-2xl border border-border/30 px-8 py-7">
+          <Icon className="w-12 h-12 text-muted-foreground/20" strokeWidth={1.5} />
+          <div>
+            <p className="font-display text-base font-medium text-foreground/85">{title}</p>
+            <p className="text-sm text-muted-foreground/60 mt-1.5 max-w-xs mx-auto leading-relaxed">
+              {subtitle}
+            </p>
+          </div>
+          {action && (
+            <Button size="sm" onClick={action.onClick} className="rounded-xl px-4 py-2">
+              {action.label}
+            </Button>
+          )}
         </div>
-        {action && (
-          <Button size="sm" onClick={action.onClick} className="rounded-xl px-4 py-2">
-            {action.label}
-          </Button>
-        )}
       </div>
     );
   }

--- a/apps/web/src/locales/en/import.json
+++ b/apps/web/src/locales/en/import.json
@@ -1,4 +1,5 @@
 {
+  "pageTitle": "Import playlist",
   "urlPlaceholder": "Paste a YouTube or Spotify playlist URL...",
   "extract": "Extract",
   "resolvingTrack": "Resolving track {{current}}/{{total}}: {{name}}",

--- a/apps/web/src/locales/pl/import.json
+++ b/apps/web/src/locales/pl/import.json
@@ -1,4 +1,5 @@
 {
+  "pageTitle": "Importuj playlistę",
   "urlPlaceholder": "Wklej link do playlisty YouTube lub Spotify...",
   "extract": "Wczytaj listę",
   "resolvingTrack": "Dopasowywanie utworu {{current}}/{{total}}: {{name}}",


### PR DESCRIPTION
## Summary

Closes a set of consistency gaps in the in-progress desktop redesign (not yet public). Each fix realigns a screen that was ported without inheriting an established new-UI pattern. The renderer lives in `apps/web` (the desktop app loads the built web bundle verbatim), so every change is under `apps/web/src`.

Based on the kirei-ui audit in `docs/ui/2026-05-22-desktop-redesign-consistency-audit.md` (gitignored scratch, not in this PR).

## Changes

| Fix | Severity | What |
|-----|----------|------|
| F1 | High | Wrap the selected-playlist track list in the `glass-panel` scrim. It was the only list view rendering bare on the wallpaper, unlike the library/search/favorites lists. Drag-and-drop preserved. |
| F2 | High | Add the serif `PageHeader` to the import view (it previously showed only the small TopBar title). New `pageTitle` i18n key added in EN and PL. |
| F3 | Medium | Add a `glass-subtle` scrim behind the compact empty state so "no matching tracks" stays legible on bright wallpapers. Benefits the empty-mix states too. |
| F4 | Medium | Add top spacing to the first virtualized row in Library, Favorites, and Import (the virtualized row 0 could not self-pad, so it hugged the search bar). |
| F5 | Medium | Raise the leading search-icon contrast from `text-muted-foreground` to `text-foreground/55` so it does not wash out on bright themes, and switch the import URL input to the canonical `glass-subtle` surface. |

## Note on the reported "missing input icons"

The leading icons were never removed in source (git history confirms they predate the screenshots). The real cause was low contrast: a muted icon over a translucent field disappears on bright wallpaper. F5 addresses it. If the icons still look absent in a running build after this, the next suspect is a stale copied renderer rather than the source.

## Out of scope

F6 from the audit (extracting shared `<ListPanel>` and `<SearchInput>` components to prevent this drift recurring) is intentionally deferred to a follow-up, since it touches 7+ files.

## Verification

- `pnpm --filter @shiranami/web typecheck` passes clean.
- All user-facing copy added in EN and PL.
- Five atomic commits, one per fix.