### PR TITLE
feat(appearance): add background customization sliders (opacity, blur, dim)

### DIFF
--- a/apps/web/src/components/onboarding/steps/AppearanceStep.tsx
+++ b/apps/web/src/components/onboarding/steps/AppearanceStep.tsx
@@ -8,6 +8,18 @@ import {
   UI_SCALE_DEFAULT,
   UI_SCALE_PRESETS,
 } from '@/stores/useUIStore';
+import {
+  useThemeBgStore,
+  THEME_BG_OPACITY_MIN,
+  THEME_BG_OPACITY_MAX,
+  THEME_BG_OPACITY_STEP,
+  THEME_BG_BLUR_MIN,
+  THEME_BG_BLUR_MAX,
+  THEME_BG_BLUR_STEP,
+  THEME_BG_DIM_MIN,
+  THEME_BG_DIM_MAX,
+  THEME_BG_DIM_STEP,
+} from '@/stores/useThemeBgStore';
 import { ThemeTileGrid } from '@/components/shared/theme/ThemeTileGrid';
 import { SettingsToggleRow } from '@/components/settings/SettingsCard';
 import { Slider } from '@/components/ui/slider';
@@ -26,6 +38,13 @@ export function AppearanceStep() {
   const resetUiScale = useUIStore(s => s.resetUiScale);
   const lowPerformanceMode = useUIStore(s => s.lowPerformanceMode);
   const setLowPerformanceMode = useUIStore(s => s.setLowPerformanceMode);
+
+  const bgOpacity = useThemeBgStore(s => s.bgOpacity);
+  const setBgOpacity = useThemeBgStore(s => s.setBgOpacity);
+  const bgBlur = useThemeBgStore(s => s.bgBlur);
+  const setBgBlur = useThemeBgStore(s => s.setBgBlur);
+  const bgDim = useThemeBgStore(s => s.bgDim);
+  const setBgDim = useThemeBgStore(s => s.setBgDim);
 
   return (
     <OnboardingStepLayout
@@ -109,6 +128,67 @@ export function AppearanceStep() {
             onCheckedChange={setLowPerformanceMode}
           />
         </div>
+
+        {theme !== 'none' && (
+          <div className="space-y-4 border-t border-border/30 pt-4">
+            <p className="text-xs font-medium text-foreground">{t('appearance.bgAdjustTitle')}</p>
+
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <p id="onboarding-bg-opacity-label" className="text-sm text-muted-foreground">
+                  {t('appearance.bgOpacity')}
+                </p>
+                <span className="text-xs tabular-nums text-muted-foreground">
+                  {Math.round(bgOpacity * 100)}%
+                </span>
+              </div>
+              <Slider
+                aria-labelledby="onboarding-bg-opacity-label"
+                min={THEME_BG_OPACITY_MIN}
+                max={THEME_BG_OPACITY_MAX}
+                step={THEME_BG_OPACITY_STEP}
+                value={[bgOpacity]}
+                onValueChange={([v]) => setBgOpacity(v)}
+              />
+            </div>
+
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <p id="onboarding-bg-blur-label" className="text-sm text-muted-foreground">
+                  {t('appearance.bgBlur')}
+                </p>
+                <span className="text-xs tabular-nums text-muted-foreground">{bgBlur}px</span>
+              </div>
+              <Slider
+                aria-labelledby="onboarding-bg-blur-label"
+                min={THEME_BG_BLUR_MIN}
+                max={THEME_BG_BLUR_MAX}
+                step={THEME_BG_BLUR_STEP}
+                value={[bgBlur]}
+                onValueChange={([v]) => setBgBlur(v)}
+              />
+            </div>
+
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <p id="onboarding-bg-dim-label" className="text-sm text-muted-foreground">
+                  {t('appearance.bgDim')}
+                </p>
+                <span className="text-xs tabular-nums text-muted-foreground">
+                  {Math.round(bgDim * 100)}%
+                </span>
+              </div>
+              <Slider
+                aria-labelledby="onboarding-bg-dim-label"
+                min={THEME_BG_DIM_MIN}
+                max={THEME_BG_DIM_MAX}
+                step={THEME_BG_DIM_STEP}
+                value={[bgDim]}
+                onValueChange={([v]) => setBgDim(v)}
+              />
+            </div>
+          </div>
+        )}
       </div>
     </OnboardingStepLayout>
   );

--- a/apps/web/src/components/settings/AppearanceSection.tsx
+++ b/apps/web/src/components/settings/AppearanceSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Languages, Sparkles, LayoutGrid, Palette } from 'lucide-react';
+import { Languages, Sparkles, LayoutGrid, Palette, RotateCcw } from 'lucide-react';
 import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsCard';
 import { Slider } from '@/components/ui/slider';
 import {
@@ -11,6 +11,21 @@ import {
   UI_SCALE_PRESETS,
 } from '@/stores/useUIStore';
 import { useThemeStore } from '@/stores/useThemeStore';
+import {
+  useThemeBgStore,
+  THEME_BG_OPACITY_MIN,
+  THEME_BG_OPACITY_MAX,
+  THEME_BG_OPACITY_STEP,
+  THEME_BG_OPACITY_DEFAULT,
+  THEME_BG_BLUR_MIN,
+  THEME_BG_BLUR_MAX,
+  THEME_BG_BLUR_STEP,
+  THEME_BG_BLUR_DEFAULT,
+  THEME_BG_DIM_MIN,
+  THEME_BG_DIM_MAX,
+  THEME_BG_DIM_STEP,
+  THEME_BG_DIM_DEFAULT,
+} from '@/stores/useThemeBgStore';
 import type { AppView } from '@/stores/useViewStore';
 import { cn } from '@/lib/utils';
 import { ThemeTileGrid } from '@/components/shared/theme/ThemeTileGrid';
@@ -48,6 +63,18 @@ export function AppearanceSection() {
   const setSidebarPlaylistsVisible = useUIStore(s => s.setSidebarPlaylistsVisible);
   const theme = useThemeStore(s => s.theme);
   const setTheme = useThemeStore(s => s.setTheme);
+  const bgOpacity = useThemeBgStore(s => s.bgOpacity);
+  const setBgOpacity = useThemeBgStore(s => s.setBgOpacity);
+  const bgBlur = useThemeBgStore(s => s.bgBlur);
+  const setBgBlur = useThemeBgStore(s => s.setBgBlur);
+  const bgDim = useThemeBgStore(s => s.bgDim);
+  const setBgDim = useThemeBgStore(s => s.setBgDim);
+  const resetBg = useThemeBgStore(s => s.resetBg);
+
+  const isBgModified =
+    bgOpacity !== THEME_BG_OPACITY_DEFAULT ||
+    bgBlur !== THEME_BG_BLUR_DEFAULT ||
+    bgDim !== THEME_BG_DIM_DEFAULT;
 
   function handleLanguageChange(lang: SupportedLanguage) {
     i18n.changeLanguage(lang);
@@ -162,6 +189,76 @@ export function AppearanceSection() {
       {/* Card 3 — Theme */}
       <SettingsCard icon={Palette} title={t('app.theme.title')} subtitle={t('app.theme.desc')}>
         <ThemeTileGrid value={theme} onSelect={setTheme} />
+
+        {theme !== 'none' && (
+          <div className="px-3 pt-4 border-t border-border/40 space-y-5">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-foreground">{t('app.bgAdjust.title')}</p>
+              {isBgModified && (
+                <button
+                  onClick={resetBg}
+                  className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  aria-label={t('app.bgAdjust.reset')}
+                >
+                  <RotateCcw className="size-3" />
+                  {t('app.bgAdjust.reset')}
+                </button>
+              )}
+            </div>
+
+            {/* Opacity */}
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <p className="text-sm font-medium text-foreground">{t('app.bgAdjust.opacity')}</p>
+                <span className="text-xs tabular-nums text-muted-foreground">
+                  {Math.round(bgOpacity * 100)}%
+                </span>
+              </div>
+              <p className="text-xs text-muted-foreground mb-3">{t('app.bgAdjust.opacityDesc')}</p>
+              <Slider
+                min={THEME_BG_OPACITY_MIN}
+                max={THEME_BG_OPACITY_MAX}
+                step={THEME_BG_OPACITY_STEP}
+                value={[bgOpacity]}
+                onValueChange={([v]) => setBgOpacity(v)}
+              />
+            </div>
+
+            {/* Blur */}
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <p className="text-sm font-medium text-foreground">{t('app.bgAdjust.blur')}</p>
+                <span className="text-xs tabular-nums text-muted-foreground">{bgBlur}px</span>
+              </div>
+              <p className="text-xs text-muted-foreground mb-3">{t('app.bgAdjust.blurDesc')}</p>
+              <Slider
+                min={THEME_BG_BLUR_MIN}
+                max={THEME_BG_BLUR_MAX}
+                step={THEME_BG_BLUR_STEP}
+                value={[bgBlur]}
+                onValueChange={([v]) => setBgBlur(v)}
+              />
+            </div>
+
+            {/* Dim */}
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <p className="text-sm font-medium text-foreground">{t('app.bgAdjust.dim')}</p>
+                <span className="text-xs tabular-nums text-muted-foreground">
+                  {Math.round(bgDim * 100)}%
+                </span>
+              </div>
+              <p className="text-xs text-muted-foreground mb-3">{t('app.bgAdjust.dimDesc')}</p>
+              <Slider
+                min={THEME_BG_DIM_MIN}
+                max={THEME_BG_DIM_MAX}
+                step={THEME_BG_DIM_STEP}
+                value={[bgDim]}
+                onValueChange={([v]) => setBgDim(v)}
+              />
+            </div>
+          </div>
+        )}
       </SettingsCard>
 
       {/* Card 4 — Sidebar */}

--- a/apps/web/src/components/shared/ThemeBackground.tsx
+++ b/apps/web/src/components/shared/ThemeBackground.tsx
@@ -1,4 +1,5 @@
 import { useThemeStore } from '@/stores/useThemeStore';
+import { useThemeBgStore } from '@/stores/useThemeBgStore';
 
 /**
  * Full-bleed theme image + contrast scrim painted at z-0, beneath the ambient
@@ -20,15 +21,22 @@ import { useThemeStore } from '@/stores/useThemeStore';
  */
 export function ThemeBackground() {
   const theme = useThemeStore(s => s.theme);
+  // Importing the store here triggers its onRehydrate, which applies
+  // --theme-bg-opacity / --theme-bg-blur / --theme-bg-dim to the DOM.
+  useThemeBgStore();
   if (theme === 'none') return null;
 
   return (
-    <div className="fixed inset-0 z-0 pointer-events-none" aria-hidden="true">
+    <div className="fixed inset-0 z-0 overflow-hidden pointer-events-none" aria-hidden="true">
       <div
         className="theme-bg-image absolute inset-0"
         style={{ backgroundImage: `url(./themes/${theme}.webp)` }}
       />
       <div className="theme-bg-scrim absolute inset-0" />
+      <div
+        className="absolute inset-0 bg-background"
+        style={{ opacity: 'var(--theme-bg-dim, 0)' }}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/shared/ThemeBackground.tsx
+++ b/apps/web/src/components/shared/ThemeBackground.tsx
@@ -21,9 +21,11 @@ import { useThemeBgStore } from '@/stores/useThemeBgStore';
  */
 export function ThemeBackground() {
   const theme = useThemeStore(s => s.theme);
-  // Importing the store here triggers its onRehydrate, which applies
-  // --theme-bg-opacity / --theme-bg-blur / --theme-bg-dim to the DOM.
-  useThemeBgStore();
+  // No-op selector: keep the store import alive (so its onRehydrate applies
+  // --theme-bg-opacity / --theme-bg-blur / --theme-bg-dim to the DOM) WITHOUT
+  // subscribing this full-bleed layer to state. The values are consumed purely
+  // as CSS variables, so re-rendering on every slider tick would be wasted work.
+  useThemeBgStore(() => null);
   if (theme === 'none') return null;
 
   return (

--- a/apps/web/src/locales/en/onboarding.json
+++ b/apps/web/src/locales/en/onboarding.json
@@ -64,7 +64,11 @@
     "uiScale": "Interface size",
     "uiScaleReset": "Reset to {{value}}%",
     "reduceEffects": "Reduce effects",
-    "reduceEffectsDesc": "Lighter animations and blur for slower machines."
+    "reduceEffectsDesc": "Lighter animations and blur for slower machines.",
+    "bgAdjustTitle": "Background adjustments",
+    "bgOpacity": "Image opacity",
+    "bgBlur": "Blur",
+    "bgDim": "Dim overlay"
   },
   "playback": {
     "eyebrow": "04 · How it plays",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -261,6 +261,16 @@
         "sunset": "Sunset",
         "wisteria": "Wisteria"
       }
+    },
+    "bgAdjust": {
+      "title": "Background adjustments",
+      "opacity": "Image opacity",
+      "opacityDesc": "How visible the background image is",
+      "blur": "Blur",
+      "blurDesc": "Soften the background image edges",
+      "dim": "Dim overlay",
+      "dimDesc": "Dark layer over the image to keep text readable",
+      "reset": "Reset"
     }
   },
   "dl": {

--- a/apps/web/src/locales/pl/onboarding.json
+++ b/apps/web/src/locales/pl/onboarding.json
@@ -66,7 +66,11 @@
     "uiScale": "Rozmiar interfejsu",
     "uiScaleReset": "Przywróć {{value}}%",
     "reduceEffects": "Ogranicz efekty",
-    "reduceEffectsDesc": "Lżejsze animacje i rozmycie dla wolniejszych maszyn."
+    "reduceEffectsDesc": "Lżejsze animacje i rozmycie dla wolniejszych maszyn.",
+    "bgAdjustTitle": "Regulacja tła",
+    "bgOpacity": "Widoczność obrazu",
+    "bgBlur": "Rozmycie",
+    "bgDim": "Przyciemnienie"
   },
   "playback": {
     "eyebrow": "04 · Jak odtwarza",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -261,6 +261,16 @@
         "sunset": "Zachód słońca",
         "wisteria": "Glicynia"
       }
+    },
+    "bgAdjust": {
+      "title": "Regulacja tła",
+      "opacity": "Widoczność obrazu",
+      "opacityDesc": "Jak wyraźny jest obraz tła",
+      "blur": "Rozmycie",
+      "blurDesc": "Zmiękczenie krawędzi obrazu tła",
+      "dim": "Przyciemnienie",
+      "dimDesc": "Ciemna warstwa nad obrazem poprawiająca czytelność tekstu",
+      "reset": "Przywróć domyślne"
     }
   },
   "dl": {

--- a/apps/web/src/stores/useThemeBgStore.test.ts
+++ b/apps/web/src/stores/useThemeBgStore.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  useThemeBgStore,
+  THEME_BG_OPACITY_DEFAULT,
+  THEME_BG_OPACITY_MIN,
+  THEME_BG_OPACITY_MAX,
+  THEME_BG_BLUR_DEFAULT,
+  THEME_BG_BLUR_MIN,
+  THEME_BG_BLUR_MAX,
+  THEME_BG_DIM_DEFAULT,
+  THEME_BG_DIM_MIN,
+  THEME_BG_DIM_MAX,
+} from './useThemeBgStore';
+
+const STORE_KEY = 'shiranami.theme-bg-store';
+
+function readPersisted(): Record<string, unknown> {
+  const raw = localStorage.getItem(STORE_KEY);
+  if (!raw) return {};
+  const parsed = JSON.parse(raw) as { state?: Record<string, unknown> };
+  return parsed.state ?? {};
+}
+
+describe('useThemeBgStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useThemeBgStore.setState({
+      bgOpacity: THEME_BG_OPACITY_DEFAULT,
+      bgBlur: THEME_BG_BLUR_DEFAULT,
+      bgDim: THEME_BG_DIM_DEFAULT,
+    });
+  });
+
+  it('ships defaults that leave the built-in background visually unchanged', () => {
+    // opacity=1, blur=0px, dim=0 means the new vars are no-ops: the background
+    // looks identical to before the customization feature shipped.
+    expect(THEME_BG_OPACITY_DEFAULT).toBe(1);
+    expect(THEME_BG_BLUR_DEFAULT).toBe(0);
+    expect(THEME_BG_DIM_DEFAULT).toBe(0);
+  });
+
+  it('clamps opacity above max and persists', () => {
+    useThemeBgStore.getState().setBgOpacity(2);
+    expect(useThemeBgStore.getState().bgOpacity).toBe(THEME_BG_OPACITY_MAX);
+    expect(readPersisted().bgOpacity).toBe(THEME_BG_OPACITY_MAX);
+  });
+
+  it('clamps opacity below min', () => {
+    useThemeBgStore.getState().setBgOpacity(-1);
+    expect(useThemeBgStore.getState().bgOpacity).toBe(THEME_BG_OPACITY_MIN);
+  });
+
+  it('coerces non-finite opacity to the default', () => {
+    // @ts-expect-error — runtime guard test
+    useThemeBgStore.getState().setBgOpacity('broken');
+    expect(useThemeBgStore.getState().bgOpacity).toBe(THEME_BG_OPACITY_DEFAULT);
+  });
+
+  it('clamps blur above max and persists', () => {
+    useThemeBgStore.getState().setBgBlur(99);
+    expect(useThemeBgStore.getState().bgBlur).toBe(THEME_BG_BLUR_MAX);
+    expect(readPersisted().bgBlur).toBe(THEME_BG_BLUR_MAX);
+  });
+
+  it('clamps blur below min', () => {
+    useThemeBgStore.getState().setBgBlur(-5);
+    expect(useThemeBgStore.getState().bgBlur).toBe(THEME_BG_BLUR_MIN);
+  });
+
+  it('clamps dim to both ends of its range and persists', () => {
+    useThemeBgStore.getState().setBgDim(5);
+    expect(useThemeBgStore.getState().bgDim).toBe(THEME_BG_DIM_MAX);
+    expect(readPersisted().bgDim).toBe(THEME_BG_DIM_MAX);
+    useThemeBgStore.getState().setBgDim(-1);
+    expect(useThemeBgStore.getState().bgDim).toBe(THEME_BG_DIM_MIN);
+  });
+
+  it('writes the CSS custom properties on the document root', () => {
+    useThemeBgStore.getState().setBgOpacity(0.5);
+    useThemeBgStore.getState().setBgBlur(8);
+    useThemeBgStore.getState().setBgDim(0.3);
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--theme-bg-opacity')).toBe('0.5');
+    expect(root.style.getPropertyValue('--theme-bg-blur')).toBe('8px');
+    expect(root.style.getPropertyValue('--theme-bg-dim')).toBe('0.3');
+  });
+
+  it('resetBg restores all three values to defaults', () => {
+    useThemeBgStore.getState().setBgOpacity(0.4);
+    useThemeBgStore.getState().setBgBlur(12);
+    useThemeBgStore.getState().setBgDim(0.7);
+    useThemeBgStore.getState().resetBg();
+    expect(useThemeBgStore.getState().bgOpacity).toBe(THEME_BG_OPACITY_DEFAULT);
+    expect(useThemeBgStore.getState().bgBlur).toBe(THEME_BG_BLUR_DEFAULT);
+    expect(useThemeBgStore.getState().bgDim).toBe(THEME_BG_DIM_DEFAULT);
+  });
+});
+
+describe('useThemeBgStore rehydration sanitizing', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it('clamps malformed persisted values on load', async () => {
+    localStorage.setItem(
+      STORE_KEY,
+      JSON.stringify({ state: { bgOpacity: 5, bgBlur: 'broken', bgDim: -3 }, version: 1 })
+    );
+
+    const mod = await import('./useThemeBgStore');
+    const state = mod.useThemeBgStore.getState();
+    expect(state.bgOpacity).toBe(mod.THEME_BG_OPACITY_MAX); // 5 -> clamped to 1
+    expect(state.bgBlur).toBe(mod.THEME_BG_BLUR_DEFAULT); // 'broken' -> default
+    expect(state.bgDim).toBe(mod.THEME_BG_DIM_MIN); // -3 -> clamped to 0
+  });
+});

--- a/apps/web/src/stores/useThemeBgStore.ts
+++ b/apps/web/src/stores/useThemeBgStore.ts
@@ -1,0 +1,136 @@
+import { createPersistedStore, clampNumber, acceptStoreHmr } from '@/lib/createPersistedStore';
+
+export const THEME_BG_OPACITY_MIN = 0;
+export const THEME_BG_OPACITY_MAX = 1;
+export const THEME_BG_OPACITY_STEP = 0.01;
+export const THEME_BG_OPACITY_DEFAULT = 1.0;
+
+export const THEME_BG_BLUR_MIN = 0;
+export const THEME_BG_BLUR_MAX = 20;
+export const THEME_BG_BLUR_STEP = 1;
+export const THEME_BG_BLUR_DEFAULT = 0;
+
+export const THEME_BG_DIM_MIN = 0;
+export const THEME_BG_DIM_MAX = 1;
+export const THEME_BG_DIM_STEP = 0.01;
+export const THEME_BG_DIM_DEFAULT = 0;
+
+const STORE_KEY = 'shiranami.theme-bg-store';
+
+function applyThemeBgToDOM(opacity: number, blur: number, dim: number): void {
+  const root = document.documentElement;
+  root.style.setProperty('--theme-bg-opacity', String(opacity));
+  root.style.setProperty('--theme-bg-blur', `${blur}px`);
+  root.style.setProperty('--theme-bg-dim', String(dim));
+}
+
+interface PersistedThemeBgState {
+  bgOpacity: number;
+  bgBlur: number;
+  bgDim: number;
+}
+
+function sanitize(
+  persisted: Partial<PersistedThemeBgState> | undefined
+): Partial<PersistedThemeBgState> {
+  if (!persisted || typeof persisted !== 'object') return {};
+  const out: Partial<PersistedThemeBgState> = {};
+  if (persisted.bgOpacity !== undefined)
+    out.bgOpacity = clampNumber(
+      persisted.bgOpacity,
+      THEME_BG_OPACITY_MIN,
+      THEME_BG_OPACITY_MAX,
+      THEME_BG_OPACITY_DEFAULT
+    );
+  if (persisted.bgBlur !== undefined)
+    out.bgBlur = clampNumber(
+      persisted.bgBlur,
+      THEME_BG_BLUR_MIN,
+      THEME_BG_BLUR_MAX,
+      THEME_BG_BLUR_DEFAULT
+    );
+  if (persisted.bgDim !== undefined)
+    out.bgDim = clampNumber(
+      persisted.bgDim,
+      THEME_BG_DIM_MIN,
+      THEME_BG_DIM_MAX,
+      THEME_BG_DIM_DEFAULT
+    );
+  return out;
+}
+
+interface ThemeBgState {
+  bgOpacity: number;
+  bgBlur: number;
+  bgDim: number;
+}
+
+interface ThemeBgActions {
+  setBgOpacity: (v: number) => void;
+  setBgBlur: (v: number) => void;
+  setBgDim: (v: number) => void;
+  resetBg: () => void;
+}
+
+export const useThemeBgStore = createPersistedStore<ThemeBgState & ThemeBgActions>(
+  set => ({
+    bgOpacity: THEME_BG_OPACITY_DEFAULT,
+    bgBlur: THEME_BG_BLUR_DEFAULT,
+    bgDim: THEME_BG_DIM_DEFAULT,
+
+    setBgOpacity: v => {
+      const next = clampNumber(
+        v,
+        THEME_BG_OPACITY_MIN,
+        THEME_BG_OPACITY_MAX,
+        THEME_BG_OPACITY_DEFAULT
+      );
+      set({ bgOpacity: next });
+      applyThemeBgToDOM(next, useThemeBgStore.getState().bgBlur, useThemeBgStore.getState().bgDim);
+    },
+    setBgBlur: v => {
+      const next = clampNumber(v, THEME_BG_BLUR_MIN, THEME_BG_BLUR_MAX, THEME_BG_BLUR_DEFAULT);
+      set({ bgBlur: next });
+      applyThemeBgToDOM(
+        useThemeBgStore.getState().bgOpacity,
+        next,
+        useThemeBgStore.getState().bgDim
+      );
+    },
+    setBgDim: v => {
+      const next = clampNumber(v, THEME_BG_DIM_MIN, THEME_BG_DIM_MAX, THEME_BG_DIM_DEFAULT);
+      set({ bgDim: next });
+      applyThemeBgToDOM(
+        useThemeBgStore.getState().bgOpacity,
+        useThemeBgStore.getState().bgBlur,
+        next
+      );
+    },
+    resetBg: () => {
+      set({
+        bgOpacity: THEME_BG_OPACITY_DEFAULT,
+        bgBlur: THEME_BG_BLUR_DEFAULT,
+        bgDim: THEME_BG_DIM_DEFAULT,
+      });
+      applyThemeBgToDOM(THEME_BG_OPACITY_DEFAULT, THEME_BG_BLUR_DEFAULT, THEME_BG_DIM_DEFAULT);
+    },
+  }),
+  {
+    name: STORE_KEY,
+    version: 1,
+    partialize: (s): PersistedThemeBgState => ({
+      bgOpacity: s.bgOpacity,
+      bgBlur: s.bgBlur,
+      bgDim: s.bgDim,
+    }),
+    sanitize: (persisted, current) => ({
+      ...current,
+      ...sanitize(persisted as Partial<PersistedThemeBgState>),
+    }),
+    onRehydrate: state => {
+      applyThemeBgToDOM(state.bgOpacity, state.bgBlur, state.bgDim);
+    },
+  }
+);
+
+acceptStoreHmr(useThemeBgStore, import.meta.hot);

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -619,6 +619,8 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
+  opacity: var(--theme-bg-opacity, 1);
+  filter: blur(var(--theme-bg-blur, 0px));
 }
 
 /* Contrast scrim — a light dark wash that lets the theme photo read as a real


### PR DESCRIPTION
## Summary

Ports ShiroAni's background customization sliders (opacity / blur / dim) onto Shiranami's existing built-in theme backgrounds. No custom image upload is added — Shiranami ships a fixed set of built-in theme backgrounds, and this PR only adds adjustment controls around those.

Defaults are deliberately no-ops (opacity `1.0`, blur `0px`, dim `0`), so the app looks byte-identical to today until the user moves a slider.

## Changes

**Store**
- `apps/web/src/stores/useThemeBgStore.ts` — new persisted store (`shiranami.theme-bg-store`) holding `bgOpacity` / `bgBlur` / `bgDim`, built on `createPersistedStore` + `clampNumber` sanitize + `acceptStoreHmr`, modeled on `useLyricsAppearanceStore`. Writes three CSS custom properties to `:root` on every setter and on rehydrate.
- `apps/web/src/stores/useThemeBgStore.test.ts` — unit tests for clamping, reset, CSS var application, and malformed-persist sanitizing (matches the sibling store test pattern).

**Rendering**
- `apps/web/src/styles/globals.css` — `.theme-bg-image` now reads `--theme-bg-opacity` and `--theme-bg-blur` (fallbacks `1` / `0px`).
- `apps/web/src/components/shared/ThemeBackground.tsx` — container gains `overflow-hidden` to contain blur bleed; a new additive `bg-background` dim layer driven by `--theme-bg-dim` (default `0`) sits above the existing scrim. The existing `.theme-bg-scrim` legibility gradient is left untouched.

**UI**
- `apps/web/src/components/settings/AppearanceSection.tsx` — three sliders + reset inside the Theme card, shown only when `theme !== 'none'`.
- `apps/web/src/components/onboarding/steps/AppearanceStep.tsx` — the same three sliders in the onboarding appearance step.

**i18n**
- `apps/web/src/locales/{en,pl}/settings.json` — `app.bgAdjust.*` keys (EN + PL, proper Polish diacritics).
- `apps/web/src/locales/{en,pl}/onboarding.json` — onboarding slider labels (EN + PL).

## Design notes

- Researched + implemented via the kirei chain: a research agent mapped ShiroAni's `useBackgroundStore` slider mechanics against Shiranami's `ThemeBackground` / `useThemeStore`; the build agent ported only the adjustment controls, dropping all custom-image-upload machinery (file pickers, electron-store image persistence, `BackgroundOverlay`).
- The dim layer is intentionally separate from, and additive to, the existing contrast scrim, so `dim=0` preserves today's exact look while users can darken further for legibility on the brighter themes (summer, sunset).
- Blur is displayed as `{n}px`; opacity and dim are displayed as percentages.

## Verification

- `pnpm --filter web typecheck` — clean
- `pnpm lint` (root) — clean
- `pnpm test` — full web suite green (1311 tests), including 10 new `useThemeBgStore` tests

## Behavior for existing users

On update the background looks identical (all sliders default to no-op values). Adjustments persist to localStorage and reapply on launch via the store's `onRehydrate`.
