### PR TITLE
feat(discord): customizable Discord Rich Presence with dedicated settings section

### DIFF
--- a/apps/desktop/src/main/discord-presence-builder.test.ts
+++ b/apps/desktop/src/main/discord-presence-builder.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_DISCORD_TEMPLATES, type DiscordRpcSettings } from '@shiranami/shared';
+import { buildPresence, resolveActivityType } from './discord-presence-builder';
+
+function makeSettings(overrides: Partial<DiscordRpcSettings> = {}): DiscordRpcSettings {
+  return {
+    enabled: true,
+    showTrackDetails: true,
+    showElapsedTime: true,
+    useCustomTemplates: false,
+    templates: structuredClone(DEFAULT_DISCORD_TEMPLATES),
+    ...overrides,
+  };
+}
+
+const PLAYING = {
+  isPlaying: true,
+  title: 'Idol',
+  artist: 'Yoasobi',
+  album: 'THE BOOK 3',
+  duration: 222,
+  currentTime: 60,
+};
+
+const PAUSED = { ...PLAYING, isPlaying: false };
+
+describe('resolveActivityType', () => {
+  it('returns idle for null activity', () => {
+    expect(resolveActivityType(null)).toBe('idle');
+  });
+
+  it('returns idle for an activity with no title', () => {
+    expect(resolveActivityType({ ...PLAYING, title: '' })).toBe('idle');
+  });
+
+  it('returns playing when a titled track is playing', () => {
+    expect(resolveActivityType(PLAYING)).toBe('playing');
+  });
+
+  it('returns paused when a titled track is not playing', () => {
+    expect(resolveActivityType(PAUSED)).toBe('paused');
+  });
+});
+
+describe('buildPresence — default templates', () => {
+  it('substitutes {title} and {artist} into the state line for playing', () => {
+    const presence = buildPresence(PLAYING, makeSettings());
+    expect(presence.details).toBe('Listening to music');
+    expect(presence.state).toBe('Idol by Yoasobi');
+  });
+
+  it('uses the paused template details for a paused track', () => {
+    const presence = buildPresence(PAUSED, makeSettings());
+    expect(presence.details).toBe('Music paused');
+    expect(presence.state).toBe('Idol by Yoasobi');
+  });
+
+  it('uses the idle template (no state line) for null activity', () => {
+    const presence = buildPresence(null, makeSettings());
+    expect(presence.details).toBe('Idle');
+    expect(presence.state).toBeUndefined();
+  });
+});
+
+describe('buildPresence — large image', () => {
+  it('sets the static asset key and album text when showLargeImage is on', () => {
+    const presence = buildPresence(PLAYING, makeSettings());
+    expect(presence.largeImageKey).toBe('shiranami');
+    expect(presence.largeImageText).toBe('THE BOOK 3');
+  });
+
+  it('falls back to Shiranami for largeImageText when album is missing', () => {
+    const presence = buildPresence({ ...PLAYING, album: '' }, makeSettings());
+    expect(presence.largeImageText).toBe('Shiranami');
+  });
+
+  it('omits the large image entirely when showLargeImage is off', () => {
+    const settings = makeSettings({ useCustomTemplates: true });
+    settings.templates.playing.showLargeImage = false;
+    const presence = buildPresence(PLAYING, settings);
+    expect(presence.largeImageKey).toBeUndefined();
+    expect(presence.largeImageText).toBeUndefined();
+  });
+});
+
+describe('buildPresence — timestamp', () => {
+  it('adds an endTimestamp when playing and showTimestamp is on', () => {
+    const presence = buildPresence(PLAYING, makeSettings());
+    expect(presence.endTimestamp).toBeInstanceOf(Date);
+  });
+
+  it('omits the timestamp for a paused track even though the template allows it', () => {
+    // Paused template has showTimestamp:false; flip it on to prove the
+    // playing-only guard, not the template, suppresses it.
+    const settings = makeSettings({ useCustomTemplates: true });
+    settings.templates.paused.showTimestamp = true;
+    const presence = buildPresence(PAUSED, settings);
+    expect(presence.endTimestamp).toBeUndefined();
+  });
+
+  it('omits the timestamp when showElapsedTime is off (legacy mode)', () => {
+    const presence = buildPresence(PLAYING, makeSettings({ showElapsedTime: false }));
+    expect(presence.endTimestamp).toBeUndefined();
+  });
+
+  it('omits the timestamp when the template disables it (custom mode)', () => {
+    const settings = makeSettings({ useCustomTemplates: true });
+    settings.templates.playing.showTimestamp = false;
+    const presence = buildPresence(PLAYING, settings);
+    expect(presence.endTimestamp).toBeUndefined();
+  });
+
+  it('omits the timestamp when duration is zero', () => {
+    const presence = buildPresence({ ...PLAYING, duration: 0 }, makeSettings());
+    expect(presence.endTimestamp).toBeUndefined();
+  });
+});
+
+describe('buildPresence — button', () => {
+  it('includes the landing button for the playing template', () => {
+    const presence = buildPresence(PLAYING, makeSettings());
+    expect(presence.buttons).toEqual([{ label: 'Get Shiranami', url: 'https://shiranami.app' }]);
+  });
+
+  it('omits the button for the paused template', () => {
+    const presence = buildPresence(PAUSED, makeSettings());
+    expect(presence.buttons).toBeUndefined();
+  });
+});
+
+describe('buildPresence — track details toggle (legacy mode)', () => {
+  it('drops the state line when showTrackDetails is off', () => {
+    const presence = buildPresence(PLAYING, makeSettings({ showTrackDetails: false }));
+    expect(presence.state).toBeUndefined();
+    expect(presence.details).toBe('Listening to music');
+  });
+
+  it('still shows the state line in custom-template mode regardless of showTrackDetails', () => {
+    const presence = buildPresence(
+      PLAYING,
+      makeSettings({ useCustomTemplates: true, showTrackDetails: false })
+    );
+    expect(presence.state).toBe('Idol by Yoasobi');
+  });
+});
+
+describe('buildPresence — custom template substitution', () => {
+  it('substitutes {album} and truncates over-long fields', () => {
+    const settings = makeSettings({ useCustomTemplates: true });
+    settings.templates.playing.state = '{album}';
+    const longAlbum = 'A'.repeat(200);
+    const presence = buildPresence({ ...PLAYING, album: longAlbum }, settings);
+    expect((presence.state as string).length).toBe(128);
+    expect((presence.state as string).endsWith('…')).toBe(true);
+  });
+
+  it('collapses whitespace from empty token substitutions', () => {
+    const settings = makeSettings({ useCustomTemplates: true });
+    settings.templates.playing.state = '{title} by {artist}';
+    const presence = buildPresence({ ...PLAYING, artist: '' }, settings);
+    expect(presence.state).toBe('Idol by');
+  });
+});

--- a/apps/desktop/src/main/discord-presence-builder.ts
+++ b/apps/desktop/src/main/discord-presence-builder.ts
@@ -1,0 +1,108 @@
+// Pure presence-building logic for Discord Rich Presence. Kept free of the
+// xhayper client and electron-store so it stays trivially unit-testable: given
+// a now-playing snapshot and the user's settings, it returns the plain RPC
+// activity object the service hands to `client.user.setActivity`.
+
+import type {
+  DiscordRpcSettings,
+  DiscordMusicActivityType,
+  DiscordMusicPresenceActivity,
+  DiscordPresenceTemplate,
+} from '@shiranami/shared';
+import {
+  DEFAULT_DISCORD_TEMPLATES,
+  DISCORD_LANDING_URL,
+  DISCORD_LARGE_IMAGE_KEY,
+  DISCORD_MAX_FIELD_LENGTH,
+} from '@shiranami/shared';
+
+const MIN_FIELD_LENGTH = 2; // Discord requires string fields to be >= 2 chars.
+
+function truncate(text: string): string {
+  if (text.length <= DISCORD_MAX_FIELD_LENGTH) return text;
+  return text.slice(0, DISCORD_MAX_FIELD_LENGTH - 1) + '…';
+}
+
+/** Determine the activity type for a now-playing snapshot (null = idle). */
+export function resolveActivityType(
+  activity: DiscordMusicPresenceActivity | null
+): DiscordMusicActivityType {
+  if (!activity || !activity.title) return 'idle';
+  return activity.isPlaying ? 'playing' : 'paused';
+}
+
+/** Replace `{title}`/`{artist}`/`{album}` tokens and clean up empty fragments. */
+function substituteVariables(
+  template: string,
+  activity: DiscordMusicPresenceActivity | null
+): string {
+  if (!template) return '';
+
+  let result = template
+    .replace(/\{title\}/g, activity?.title ?? '')
+    .replace(/\{artist\}/g, activity?.artist ?? '')
+    .replace(/\{album\}/g, activity?.album ?? '');
+
+  // Collapse double spaces left by empty substitutions, then trim.
+  result = result.replace(/\s{2,}/g, ' ').trim();
+
+  return truncate(result);
+}
+
+/**
+ * Build the Discord presence payload for the given now-playing snapshot.
+ *
+ * The large image always uses the static `DISCORD_LARGE_IMAGE_KEY` asset —
+ * Shiranami's local album art lives behind the `shiranami-art://` protocol and
+ * is not reachable by Discord, so the app logo stands in. That asset must be
+ * uploaded as a Rich Presence art asset for the registered Discord app, or the
+ * logo slot renders blank.
+ */
+export function buildPresence(
+  activity: DiscordMusicPresenceActivity | null,
+  settings: DiscordRpcSettings
+): Record<string, unknown> {
+  const activityType = resolveActivityType(activity);
+  const template: DiscordPresenceTemplate = settings.useCustomTemplates
+    ? (settings.templates?.[activityType] ?? DEFAULT_DISCORD_TEMPLATES[activityType])
+    : DEFAULT_DISCORD_TEMPLATES[activityType];
+
+  const showTrackText = settings.useCustomTemplates || settings.showTrackDetails;
+  const showTimestamp =
+    (settings.useCustomTemplates ? template.showTimestamp : settings.showElapsedTime) &&
+    template.showTimestamp;
+
+  const details = substituteVariables(template.details, activity);
+  const state = showTrackText ? substituteVariables(template.state, activity) : '';
+
+  const presence: Record<string, unknown> = {};
+
+  if (details.length >= MIN_FIELD_LENGTH) presence.details = details;
+  if (state.length >= MIN_FIELD_LENGTH) presence.state = state;
+
+  if (template.showLargeImage) {
+    presence.largeImageKey = DISCORD_LARGE_IMAGE_KEY;
+    const albumText = activity?.album?.trim();
+    presence.largeImageText =
+      albumText && albumText.length >= MIN_FIELD_LENGTH ? albumText : 'Shiranami';
+  }
+
+  // Show remaining time only while a track is actually playing with a known
+  // duration — a frozen/elapsed bar on a paused track reads as a bug.
+  if (
+    showTimestamp &&
+    activityType === 'playing' &&
+    activity &&
+    activity.duration > 0 &&
+    activity.currentTime >= 0
+  ) {
+    const remainingMs = Math.max(0, (activity.duration - activity.currentTime) * 1000);
+    presence.endTimestamp = new Date(Date.now() + remainingMs);
+  }
+
+  if (template.showButton) {
+    presence.buttons = [{ label: 'Get Shiranami', url: DISCORD_LANDING_URL }];
+  }
+
+  return presence;
+}

--- a/apps/desktop/src/main/discord-rpc.test.ts
+++ b/apps/desktop/src/main/discord-rpc.test.ts
@@ -1,129 +1,225 @@
-import { describe, it, expect, vi } from 'vitest';
-import { truncate, sanitizeField, buildPresence } from './discord-rpc';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DEFAULT_DISCORD_TEMPLATES } from '@shiranami/shared';
 
+// --- Mock electron-store ---
+const storeData = new Map<string, unknown>();
 vi.mock('./store', () => ({
-  store: { get: vi.fn() },
+  store: {
+    get: vi.fn((key: string) => storeData.get(key)),
+    set: vi.fn((key: string, value: unknown) => {
+      storeData.set(key, value);
+    }),
+  },
 }));
+
+vi.mock('./logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// --- Mock the xhayper RPC client ---
+type Listener = () => void;
+
+const { MockClient } = vi.hoisted(() => {
+  class MockClient {
+    static instances: MockClient[] = [];
+    clientId: string;
+    listeners = new Map<string, Listener>();
+    user = { setActivity: vi.fn().mockResolvedValue(undefined), clearActivity: vi.fn() };
+    login = vi.fn().mockResolvedValue(undefined);
+    destroy = vi.fn();
+
+    constructor({ clientId }: { clientId: string }) {
+      this.clientId = clientId;
+      MockClient.instances.push(this);
+    }
+    on(event: string, fn: Listener) {
+      this.listeners.set(event, fn);
+    }
+    /** Simulate Discord signalling the socket is ready. */
+    fireReady() {
+      this.listeners.get('ready')?.();
+    }
+  }
+  return { MockClient };
+});
 
 vi.mock('@xhayper/discord-rpc', () => ({
-  Client: vi.fn(),
+  Client: MockClient,
 }));
 
-describe('truncate', () => {
-  it('returns text when within max', () => {
-    expect(truncate('hello', 10)).toBe('hello');
+// Import after mocks are registered.
+import {
+  getDiscordRpcSettings,
+  updateDiscordRpcSettings,
+  updateDiscordPresence,
+  clearDiscordPresence,
+  initializeDiscordRpc,
+  cleanupDiscordRpc,
+} from './discord-rpc';
+
+const PLAYING = {
+  isPlaying: true,
+  title: 'Idol',
+  artist: 'Yoasobi',
+  album: 'THE BOOK 3',
+  duration: 222,
+  currentTime: 30,
+  albumArt: null,
+};
+
+beforeEach(() => {
+  storeData.clear();
+  MockClient.instances = [];
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanupDiscordRpc();
+  vi.useRealTimers();
+});
+
+describe('getDiscordRpcSettings', () => {
+  it('returns defaults when nothing is stored', () => {
+    const settings = getDiscordRpcSettings();
+    expect(settings.enabled).toBe(false);
+    expect(settings.showTrackDetails).toBe(true);
+    expect(settings.showElapsedTime).toBe(true);
+    expect(settings.useCustomTemplates).toBe(false);
+    expect(settings.templates).toEqual(DEFAULT_DISCORD_TEMPLATES);
   });
 
-  it('truncates with ellipsis when over max', () => {
-    const long = 'a'.repeat(200);
-    const result = truncate(long, 10);
-    expect(result.length).toBe(10);
-    expect(result.endsWith('\u2026')).toBe(true);
+  it('coerces a partial stored blob to the full shape', () => {
+    storeData.set('discord-rpc-settings', { enabled: true });
+    const settings = getDiscordRpcSettings();
+    expect(settings.enabled).toBe(true);
+    expect(settings.showTrackDetails).toBe(true);
+    expect(settings.templates).toEqual(DEFAULT_DISCORD_TEMPLATES);
   });
 
-  it('returns text unchanged at exact max', () => {
-    expect(truncate('hello', 5)).toBe('hello');
+  it('migrates the legacy settings.discordRpc=true flag when no dedicated key exists', () => {
+    storeData.set('settings', { discordRpc: true });
+    const settings = getDiscordRpcSettings();
+    expect(settings.enabled).toBe(true);
+  });
+
+  it('ignores the legacy flag once the dedicated key exists', () => {
+    storeData.set('settings', { discordRpc: true });
+    storeData.set('discord-rpc-settings', { enabled: false });
+    expect(getDiscordRpcSettings().enabled).toBe(false);
   });
 });
 
-describe('sanitizeField', () => {
-  it('returns undefined for null', () => {
-    expect(sanitizeField(null)).toBeUndefined();
+describe('updateDiscordRpcSettings', () => {
+  it('persists the merged settings under the dedicated key', () => {
+    const next = updateDiscordRpcSettings({ enabled: true, showElapsedTime: false });
+    expect(next.enabled).toBe(true);
+    expect(next.showElapsedTime).toBe(false);
+    expect(storeData.get('discord-rpc-settings')).toMatchObject({
+      enabled: true,
+      showElapsedTime: false,
+    });
   });
 
-  it('returns undefined for undefined', () => {
-    expect(sanitizeField(undefined)).toBeUndefined();
+  it('connects a client when enabling', () => {
+    updateDiscordRpcSettings({ enabled: true });
+    expect(MockClient.instances).toHaveLength(1);
+    expect(MockClient.instances[0].login).toHaveBeenCalled();
   });
 
-  it('returns undefined for empty string', () => {
-    expect(sanitizeField('')).toBeUndefined();
+  it('destroys the client when disabling after being connected', async () => {
+    updateDiscordRpcSettings({ enabled: true });
+    const client = MockClient.instances[0];
+    await Promise.resolve();
+    client.fireReady();
+
+    updateDiscordRpcSettings({ enabled: false });
+    await Promise.resolve();
+    expect(client.destroy).toHaveBeenCalled();
   });
 
-  it('returns undefined for single character (too short for Discord)', () => {
-    expect(sanitizeField('a')).toBeUndefined();
+  it('does not open a second client when toggled on while already connecting', () => {
+    updateDiscordRpcSettings({ enabled: true });
+    updateDiscordRpcSettings({ enabled: true, showTrackDetails: false });
+    expect(MockClient.instances).toHaveLength(1);
   });
 
-  it('returns trimmed text for valid input', () => {
-    expect(sanitizeField('  hello  ')).toBe('hello');
-  });
-
-  it('truncates long text', () => {
-    const long = 'a'.repeat(200);
-    const result = sanitizeField(long);
-    expect(result!.length).toBe(128);
+  it('merges per-activity template patches over the current templates', () => {
+    const next = updateDiscordRpcSettings({
+      templates: { playing: { ...DEFAULT_DISCORD_TEMPLATES.playing, details: 'Vibing' } },
+    });
+    expect(next.templates.playing.details).toBe('Vibing');
+    expect(next.templates.paused).toEqual(DEFAULT_DISCORD_TEMPLATES.paused);
   });
 });
 
-describe('buildPresence', () => {
-  it('builds presence with title and artist', () => {
-    const state = {
-      isPlaying: true,
-      title: 'My Song',
-      artist: 'My Artist',
-      album: 'My Album',
-      duration: 180,
-      currentTime: 60,
-      albumArt: null,
-    };
-    const presence = buildPresence(state);
-    expect(presence.details).toBe('My Song');
-    expect(presence.state).toBe('My Artist');
-    expect(presence.largeImageText).toBe('My Album');
+describe('updateDiscordPresence', () => {
+  it('does nothing and opens no client when disabled', () => {
+    updateDiscordPresence(PLAYING);
+    expect(MockClient.instances).toHaveLength(0);
   });
 
-  it('omits artist when not provided', () => {
-    const state = {
-      isPlaying: true,
-      title: 'My Song',
-      artist: '',
-      album: 'My Album',
-      duration: 0,
-      currentTime: 0,
-      albumArt: null,
-    };
-    const presence = buildPresence(state);
-    expect(presence.state).toBeUndefined();
+  it('sends the presence after connecting when enabled', async () => {
+    updateDiscordRpcSettings({ enabled: true });
+    const client = MockClient.instances[0];
+    await Promise.resolve();
+    client.fireReady();
+
+    // The on-ready handler consumes the throttle window (it emits an initial
+    // idle/clear), so advance past it to flush the deferred presence.
+    updateDiscordPresence(PLAYING);
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(client.user.setActivity).toHaveBeenCalled();
+    const payload = client.user.setActivity.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(payload.details).toBe('Listening to music');
+    expect(payload.state).toBe('Idol by Yoasobi');
   });
 
-  it('includes endTimestamp when playing with duration', () => {
-    const state = {
-      isPlaying: true,
-      title: 'My Song',
-      artist: 'Artist',
-      album: 'Album',
-      duration: 180,
-      currentTime: 60,
-      albumArt: null,
-    };
-    const presence = buildPresence(state);
-    expect(presence.endTimestamp).toBeInstanceOf(Date);
+  it('coalesces rapid updates within the 15s window into one deferred send', async () => {
+    updateDiscordRpcSettings({ enabled: true });
+    const client = MockClient.instances[0];
+    await Promise.resolve();
+    // The on-ready emit consumes the throttle window, so the next updates fall
+    // inside it and must be deferred rather than sent immediately. Flush its
+    // async send so `lastUpdateTime` is set before we measure the window.
+    client.fireReady();
+    await vi.advanceTimersByTimeAsync(0);
+    client.user.setActivity.mockClear();
+
+    updateDiscordPresence(PLAYING);
+    updateDiscordPresence({ ...PLAYING, title: 'Racing Into The Night' });
+    await Promise.resolve();
+    expect(client.user.setActivity).not.toHaveBeenCalled(); // both deferred
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(client.user.setActivity).toHaveBeenCalledTimes(1); // coalesced into one
+    const payload = client.user.setActivity.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.state).toBe('Racing Into The Night by Yoasobi'); // the latest activity won
+  });
+});
+
+describe('clearDiscordPresence', () => {
+  it('clears the activity on the connected client', async () => {
+    updateDiscordRpcSettings({ enabled: true });
+    const client = MockClient.instances[0];
+    await Promise.resolve();
+    client.fireReady();
+
+    clearDiscordPresence();
+    expect(client.user.clearActivity).toHaveBeenCalled();
+  });
+});
+
+describe('initializeDiscordRpc', () => {
+  it('connects on startup when persisted settings are enabled', () => {
+    storeData.set('discord-rpc-settings', { enabled: true });
+    initializeDiscordRpc();
+    expect(MockClient.instances).toHaveLength(1);
   });
 
-  it('omits endTimestamp when paused', () => {
-    const state = {
-      isPlaying: false,
-      title: 'My Song',
-      artist: 'Artist',
-      album: 'Album',
-      duration: 180,
-      currentTime: 60,
-      albumArt: null,
-    };
-    const presence = buildPresence(state);
-    expect(presence.endTimestamp).toBeUndefined();
-  });
-
-  it('omits endTimestamp when duration is 0', () => {
-    const state = {
-      isPlaying: true,
-      title: 'My Song',
-      artist: 'Artist',
-      album: 'Album',
-      duration: 0,
-      currentTime: 0,
-      albumArt: null,
-    };
-    const presence = buildPresence(state);
-    expect(presence.endTimestamp).toBeUndefined();
+  it('does not connect on startup when disabled', () => {
+    storeData.set('discord-rpc-settings', { enabled: false });
+    initializeDiscordRpc();
+    expect(MockClient.instances).toHaveLength(0);
   });
 });

--- a/apps/desktop/src/main/discord-rpc.ts
+++ b/apps/desktop/src/main/discord-rpc.ts
@@ -147,7 +147,9 @@ async function sendPresenceUpdate(activity: DiscordMusicPresenceActivity | null)
 
 function throttledUpdate(activity: DiscordMusicPresenceActivity | null): void {
   const now = Date.now();
-  const elapsed = now - lastUpdateTime;
+  // Clamp to >= 0 so a backward clock jump (NTP correction, manual system clock
+  // change) can never make the window look negative and stall the next update.
+  const elapsed = Math.max(0, now - lastUpdateTime);
 
   if (elapsed >= MIN_UPDATE_INTERVAL_MS) {
     sendPresenceUpdate(activity).catch(() => {});
@@ -183,8 +185,9 @@ async function doConnect(): Promise<void> {
     isConnected = true;
     reconnectDelay = RECONNECT_BASE_MS;
     logger.info('[discord-rpc] Connected');
-    // Re-emit the last known activity (or an idle presence) on (re)connect.
-    sendPresenceUpdate(currentActivity).catch(() => {});
+    // Re-emit the last known activity (or an idle presence) on (re)connect,
+    // through the throttle so rapid reconnects cannot trip Discord's rate limit.
+    throttledUpdate(currentActivity);
   });
 
   client.on('disconnected', () => {
@@ -266,8 +269,9 @@ export function updateDiscordRpcSettings(updates: Partial<DiscordRpcSettings>): 
   } else if (!next.enabled) {
     disconnectClient();
   } else if (isConnected) {
-    // Settings changed while connected — re-send presence with new settings.
-    sendPresenceUpdate(currentActivity).catch(() => {});
+    // Settings changed while connected, so re-send presence through the
+    // throttle to reflect the new template without bypassing the rate limit.
+    throttledUpdate(currentActivity);
   }
 
   logger.info(

--- a/apps/desktop/src/main/discord-rpc.ts
+++ b/apps/desktop/src/main/discord-rpc.ts
@@ -1,44 +1,106 @@
 import { Client } from '@xhayper/discord-rpc';
+import {
+  DEFAULT_DISCORD_TEMPLATES,
+  SHIRANAMI_DISCORD_CLIENT_ID,
+  type DiscordRpcSettings,
+  type DiscordMusicPresenceActivity,
+} from '@shiranami/shared';
 import { logger } from './logger';
 import { store } from './store';
 import type { PlaybackState } from './media-controls';
+import { buildPresence } from './discord-presence-builder';
 
-const DISCORD_CLIENT_ID = '1484544721060761610';
+const STORE_KEY = 'discord-rpc-settings';
 const MIN_UPDATE_INTERVAL_MS = 15_000; // Discord rate limit: 1 update per 15s
 const RECONNECT_BASE_MS = 5_000;
 const RECONNECT_MAX_MS = 60_000;
-const MAX_FIELD_LENGTH = 128;
+
+const DEFAULT_SETTINGS: DiscordRpcSettings = {
+  enabled: false,
+  showTrackDetails: true,
+  showElapsedTime: true,
+  useCustomTemplates: false,
+  templates: DEFAULT_DISCORD_TEMPLATES,
+};
 
 let client: Client | null = null;
 let isConnected = false;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectDelay = RECONNECT_BASE_MS;
 let lastUpdateTime = 0;
-let pendingState: PlaybackState | null | undefined = undefined;
+let pendingActivity: DiscordMusicPresenceActivity | null | undefined = undefined;
 let throttleTimer: ReturnType<typeof setTimeout> | null = null;
 let connectPromise: Promise<void> | null = null;
+let currentActivity: DiscordMusicPresenceActivity | null = null;
 
-function isEnabled(): boolean {
+/**
+ * Read persisted settings, filling any missing field from the defaults so an
+ * older or partial blob is always coerced to the full shape.
+ *
+ * Migration: if no `discord-rpc-settings` key exists yet, seed `enabled` from
+ * the legacy `settings.discordRpc` boolean so users who already had Rich
+ * Presence on keep it on. This runs once — the very next `saveSettings` writes
+ * the dedicated key, which then becomes the single source of truth and the
+ * legacy flag is never read again.
+ */
+function getSettings(): DiscordRpcSettings {
+  let stored: Partial<DiscordRpcSettings> | undefined;
   try {
-    const settings = store.get('settings');
-    return settings?.discordRpc === true;
+    stored = store.get(STORE_KEY) as Partial<DiscordRpcSettings> | undefined;
   } catch {
-    return false;
+    stored = undefined;
   }
+
+  if (!stored) {
+    let legacyEnabled = DEFAULT_SETTINGS.enabled;
+    try {
+      const legacy = store.get('settings') as { discordRpc?: boolean } | undefined;
+      if (legacy?.discordRpc === true) legacyEnabled = true;
+    } catch {
+      // ignore — legacy flag is best-effort
+    }
+    return {
+      ...DEFAULT_SETTINGS,
+      enabled: legacyEnabled,
+      templates: { ...DEFAULT_DISCORD_TEMPLATES },
+    };
+  }
+
+  return {
+    enabled: typeof stored.enabled === 'boolean' ? stored.enabled : DEFAULT_SETTINGS.enabled,
+    showTrackDetails:
+      typeof stored.showTrackDetails === 'boolean'
+        ? stored.showTrackDetails
+        : DEFAULT_SETTINGS.showTrackDetails,
+    showElapsedTime:
+      typeof stored.showElapsedTime === 'boolean'
+        ? stored.showElapsedTime
+        : DEFAULT_SETTINGS.showElapsedTime,
+    useCustomTemplates:
+      typeof stored.useCustomTemplates === 'boolean'
+        ? stored.useCustomTemplates
+        : DEFAULT_SETTINGS.useCustomTemplates,
+    templates: stored.templates
+      ? { ...DEFAULT_DISCORD_TEMPLATES, ...stored.templates }
+      : { ...DEFAULT_DISCORD_TEMPLATES },
+  };
 }
 
-const MIN_FIELD_LENGTH = 2; // Discord requires at least 2 characters
-
-export function truncate(text: string, max: number = MAX_FIELD_LENGTH): string {
-  if (text.length <= max) return text;
-  return text.slice(0, max - 1) + '\u2026';
+function saveSettings(settings: DiscordRpcSettings): void {
+  store.set(STORE_KEY, settings);
 }
 
-export function sanitizeField(text: string | undefined | null): string | undefined {
-  if (!text) return undefined;
-  const trimmed = text.trim();
-  if (trimmed.length < MIN_FIELD_LENGTH) return undefined;
-  return truncate(trimmed);
+/** Map the main-process PlaybackState into the builder's snapshot shape. */
+function toActivity(state: PlaybackState | null): DiscordMusicPresenceActivity | null {
+  if (!state) return null;
+  return {
+    isPlaying: state.isPlaying,
+    title: state.title,
+    artist: state.artist,
+    album: state.album,
+    duration: state.duration,
+    currentTime: state.currentTime,
+  };
 }
 
 function clearReconnectTimer(): void {
@@ -57,7 +119,7 @@ function clearThrottleTimer(): void {
 
 function scheduleReconnect(): void {
   clearReconnectTimer();
-  if (!isEnabled()) return;
+  if (!getSettings().enabled) return;
 
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;
@@ -67,37 +129,14 @@ function scheduleReconnect(): void {
   reconnectDelay = Math.min(reconnectDelay * 2, RECONNECT_MAX_MS);
 }
 
-export function buildPresence(state: PlaybackState): Record<string, unknown> {
-  const presence: Record<string, unknown> = {
-    details: sanitizeField(state.title) ?? 'Unknown Track',
-    largeImageKey: 'shiranami',
-    largeImageText: sanitizeField(state.album) ?? 'Shiranami',
-  };
-
-  const artist = sanitizeField(state.artist);
-  if (artist) {
-    presence.state = artist;
-  }
-
-  // Show time remaining when playing
-  if (state.isPlaying && state.duration > 0) {
-    const remainingMs = (state.duration - state.currentTime) * 1000;
-    presence.endTimestamp = new Date(Date.now() + remainingMs);
-  }
-
-  presence.buttons = [{ label: 'Get Shiranami', url: 'https://shiranami.app' }];
-
-  return presence;
-}
-
-async function sendPresenceUpdate(state: PlaybackState | null): Promise<void> {
+async function sendPresenceUpdate(activity: DiscordMusicPresenceActivity | null): Promise<void> {
   if (!client || !isConnected) return;
 
   try {
-    if (!state || !state.isPlaying) {
+    if (!activity) {
       await client.user?.clearActivity();
     } else {
-      const presence = buildPresence(state);
+      const presence = buildPresence(activity, getSettings());
       await client.user?.setActivity(presence as never);
     }
     lastUpdateTime = Date.now();
@@ -106,21 +145,21 @@ async function sendPresenceUpdate(state: PlaybackState | null): Promise<void> {
   }
 }
 
-function throttledUpdate(state: PlaybackState | null): void {
+function throttledUpdate(activity: DiscordMusicPresenceActivity | null): void {
   const now = Date.now();
   const elapsed = now - lastUpdateTime;
 
   if (elapsed >= MIN_UPDATE_INTERVAL_MS) {
-    sendPresenceUpdate(state).catch(() => {});
-    pendingState = undefined;
+    sendPresenceUpdate(activity).catch(() => {});
+    pendingActivity = undefined;
   } else {
-    pendingState = state;
+    pendingActivity = activity;
     if (!throttleTimer) {
       throttleTimer = setTimeout(() => {
         throttleTimer = null;
-        if (pendingState !== undefined) {
-          sendPresenceUpdate(pendingState).catch(() => {});
-          pendingState = undefined;
+        if (pendingActivity !== undefined) {
+          sendPresenceUpdate(pendingActivity).catch(() => {});
+          pendingActivity = undefined;
         }
       }, MIN_UPDATE_INTERVAL_MS - elapsed);
     }
@@ -138,12 +177,14 @@ async function doConnect(): Promise<void> {
     isConnected = false;
   }
 
-  client = new Client({ clientId: DISCORD_CLIENT_ID });
+  client = new Client({ clientId: SHIRANAMI_DISCORD_CLIENT_ID });
 
   client.on('ready', () => {
     isConnected = true;
     reconnectDelay = RECONNECT_BASE_MS;
     logger.info('[discord-rpc] Connected');
+    // Re-emit the last known activity (or an idle presence) on (re)connect.
+    sendPresenceUpdate(currentActivity).catch(() => {});
   });
 
   client.on('disconnected', () => {
@@ -171,7 +212,7 @@ function connectClient(): void {
 async function disconnectClient(): Promise<void> {
   clearReconnectTimer();
   clearThrottleTimer();
-  pendingState = undefined;
+  pendingActivity = undefined;
 
   if (client) {
     try {
@@ -194,32 +235,81 @@ async function disconnectClient(): Promise<void> {
 // ========================================
 
 export function initializeDiscordRpc(): void {
-  const enabled = isEnabled();
-  logger.info(`[discord-rpc] Initialized (enabled: ${enabled})`);
+  const settings = getSettings();
+  logger.info(`[discord-rpc] Initialized (enabled: ${settings.enabled})`);
 
-  if (enabled) {
+  if (settings.enabled) {
     connectClient();
   }
 }
 
+export function getDiscordRpcSettings(): DiscordRpcSettings {
+  return getSettings();
+}
+
+export function updateDiscordRpcSettings(updates: Partial<DiscordRpcSettings>): DiscordRpcSettings {
+  const current = getSettings();
+  const next: DiscordRpcSettings = {
+    enabled: updates.enabled ?? current.enabled,
+    showTrackDetails: updates.showTrackDetails ?? current.showTrackDetails,
+    showElapsedTime: updates.showElapsedTime ?? current.showElapsedTime,
+    useCustomTemplates: updates.useCustomTemplates ?? current.useCustomTemplates,
+    templates: updates.templates
+      ? { ...current.templates, ...updates.templates }
+      : current.templates,
+  };
+  saveSettings(next);
+
+  if (next.enabled && !isConnected && !connectPromise) {
+    reconnectDelay = RECONNECT_BASE_MS;
+    connectClient();
+  } else if (!next.enabled) {
+    disconnectClient();
+  } else if (isConnected) {
+    // Settings changed while connected — re-send presence with new settings.
+    sendPresenceUpdate(currentActivity).catch(() => {});
+  }
+
+  logger.info(
+    `[discord-rpc] Settings updated: enabled=${next.enabled}, showTrackDetails=${next.showTrackDetails}, showElapsedTime=${next.showElapsedTime}, useCustomTemplates=${next.useCustomTemplates}`
+  );
+  return next;
+}
+
 export function updateDiscordPresence(state: PlaybackState | null): void {
-  if (!isEnabled()) {
-    // If disabled but still connected, disconnect
+  if (!getSettings().enabled) {
+    // Disabled but still connected — tear the connection down.
     if (isConnected) {
       disconnectClient();
     }
     return;
   }
 
-  // If enabled but not connected, initiate connection
+  // Enabled but not yet connected — kick off a connection.
   if (!isConnected && !connectPromise && !reconnectTimer) {
     connectClient();
   }
 
-  throttledUpdate(state);
+  currentActivity = toActivity(state);
+  throttledUpdate(currentActivity);
+}
+
+export function clearDiscordPresence(): void {
+  currentActivity = null;
+  clearThrottleTimer();
+  pendingActivity = undefined;
+
+  if (client && isConnected) {
+    try {
+      client.user?.clearActivity();
+    } catch (error) {
+      logger.error('[discord-rpc] Failed to clear presence:', error);
+    }
+  }
 }
 
 export function cleanupDiscordRpc(): void {
   disconnectClient();
+  currentActivity = null;
   logger.info('[discord-rpc] Cleaned up');
 }

--- a/apps/desktop/src/main/ipc/discord-rpc.test.ts
+++ b/apps/desktop/src/main/ipc/discord-rpc.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ipcHandlers } from '../../../test/setup';
+
+const mockService = vi.hoisted(() => ({
+  getDiscordRpcSettings: vi.fn(),
+  updateDiscordRpcSettings: vi.fn(),
+  updateDiscordPresence: vi.fn(),
+  clearDiscordPresence: vi.fn(),
+}));
+vi.mock('../discord-rpc', () => mockService);
+
+vi.mock('../logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { registerDiscordRpcHandlers, cleanupDiscordRpcHandlers } from './discord-rpc';
+
+const ACTIVITY = {
+  isPlaying: true,
+  title: 'Idol',
+  artist: 'Yoasobi',
+  album: 'THE BOOK 3',
+  duration: 222,
+  currentTime: 30,
+};
+
+describe('discord-rpc ipc handlers', () => {
+  beforeEach(() => {
+    ipcHandlers.clear();
+    Object.values(mockService).forEach(fn => fn.mockReset());
+    registerDiscordRpcHandlers();
+  });
+
+  afterEach(() => {
+    cleanupDiscordRpcHandlers();
+  });
+
+  it('discord-rpc:get-settings delegates to the service', async () => {
+    mockService.getDiscordRpcSettings.mockReturnValue({ enabled: true });
+    const handler = ipcHandlers.get('discord-rpc:get-settings')!;
+    const result = await handler(null);
+    expect(mockService.getDiscordRpcSettings).toHaveBeenCalled();
+    expect(result).toEqual({ enabled: true });
+  });
+
+  it('discord-rpc:update-settings delegates with the patch', async () => {
+    const updates = { enabled: false };
+    mockService.updateDiscordRpcSettings.mockReturnValue(updates);
+    const handler = ipcHandlers.get('discord-rpc:update-settings')!;
+    const result = await handler(null, updates);
+    expect(mockService.updateDiscordRpcSettings).toHaveBeenCalledWith(updates);
+    expect(result).toEqual(updates);
+  });
+
+  it('discord-rpc:update-settings rejects a malformed patch', async () => {
+    const handler = ipcHandlers.get('discord-rpc:update-settings')!;
+    await expect(handler(null, { enabled: 'yes' })).rejects.toBeDefined();
+    expect(mockService.updateDiscordRpcSettings).not.toHaveBeenCalled();
+  });
+
+  it('discord-rpc:update-presence pads the activity to a PlaybackState', async () => {
+    const handler = ipcHandlers.get('discord-rpc:update-presence')!;
+    await handler(null, ACTIVITY);
+    expect(mockService.updateDiscordPresence).toHaveBeenCalledWith({
+      ...ACTIVITY,
+      albumArt: null,
+    });
+  });
+
+  it('discord-rpc:update-presence swallows service errors (fallback)', async () => {
+    mockService.updateDiscordPresence.mockImplementation(() => {
+      throw new Error('rpc down');
+    });
+    const handler = ipcHandlers.get('discord-rpc:update-presence')!;
+    await expect(handler(null, ACTIVITY)).resolves.toBeUndefined();
+  });
+
+  it('discord-rpc:clear-presence delegates', async () => {
+    const handler = ipcHandlers.get('discord-rpc:clear-presence')!;
+    await handler(null);
+    expect(mockService.clearDiscordPresence).toHaveBeenCalled();
+  });
+
+  it('cleanupDiscordRpcHandlers removes every discord-rpc handler', () => {
+    cleanupDiscordRpcHandlers();
+    [
+      'discord-rpc:get-settings',
+      'discord-rpc:update-settings',
+      'discord-rpc:update-presence',
+      'discord-rpc:clear-presence',
+    ].forEach(ch => {
+      expect(ipcHandlers.get(ch)).toBeUndefined();
+    });
+  });
+});

--- a/apps/desktop/src/main/ipc/discord-rpc.ts
+++ b/apps/desktop/src/main/ipc/discord-rpc.ts
@@ -1,0 +1,77 @@
+import { ipcMain } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+import type { DiscordRpcSettings } from '@shiranami/shared';
+import {
+  getDiscordRpcSettings,
+  updateDiscordRpcSettings,
+  updateDiscordPresence,
+  clearDiscordPresence,
+} from '../discord-rpc';
+import type { PlaybackState } from '../media-controls';
+import { handle, handleWithFallback } from './with-ipc-handler';
+import {
+  discordGetSettingsArgs,
+  discordUpdateSettingsArgs,
+  discordUpdatePresenceArgs,
+  discordClearPresenceArgs,
+} from './schemas/discord-rpc';
+
+const C = IPC_CHANNELS.discord;
+
+/**
+ * Discord RPC IPC handlers.
+ *
+ * Normal now-playing updates flow through `media:playback-state` (the media
+ * handler calls `updateDiscordPresence` directly), so the renderer does NOT
+ * use `update-presence` for routine playback. `update-presence` exists only to
+ * force a presence refresh after the settings UI saves, and `clear-presence`
+ * for an explicit clear.
+ */
+export function registerDiscordRpcHandlers(): void {
+  handle(
+    C.getSettings,
+    () => {
+      return getDiscordRpcSettings();
+    },
+    { schema: discordGetSettingsArgs }
+  );
+
+  handle(
+    C.updateSettings,
+    (_event, updates) => {
+      // Zod infers `templates` as a Partial<Record<...>> while the canonical
+      // `DiscordRpcSettings.templates` is Record<...>. Cast at the boundary —
+      // the schema already enforces shape.
+      return updateDiscordRpcSettings(updates as Partial<DiscordRpcSettings>);
+    },
+    { schema: discordUpdateSettingsArgs }
+  );
+
+  handleWithFallback(
+    C.updatePresence,
+    (_event, activity) => {
+      // The validated activity carries no album art; the builder doesn't use
+      // it, so pad to the PlaybackState shape with a null cover.
+      const state: PlaybackState = { ...activity, albumArt: null };
+      updateDiscordPresence(state);
+    },
+    () => undefined,
+    { schema: discordUpdatePresenceArgs }
+  );
+
+  handleWithFallback(
+    C.clearPresence,
+    () => {
+      clearDiscordPresence();
+    },
+    () => undefined,
+    { schema: discordClearPresenceArgs }
+  );
+}
+
+export function cleanupDiscordRpcHandlers(): void {
+  ipcMain.removeHandler(C.getSettings);
+  ipcMain.removeHandler(C.updateSettings);
+  ipcMain.removeHandler(C.updatePresence);
+  ipcMain.removeHandler(C.clearPresence);
+}

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -5,6 +5,7 @@ export { registerDebugHandlers, cleanupDebugHandlers } from './debug';
 export { registerDialogHandlers, cleanupDialogHandlers } from './dialog';
 export { registerLibraryHandlers, cleanupLibraryHandlers } from './library';
 export { registerMediaHandlers, cleanupMediaHandlers } from './media';
+export { registerDiscordRpcHandlers, cleanupDiscordRpcHandlers } from './discord-rpc';
 export { registerLyricsHandlers, cleanupLyricsHandlers } from './lyrics';
 export { registerDatabaseHandlers, cleanupDatabaseHandlers } from './database';
 export { registerShellHandlers, cleanupShellHandlers } from './shell';

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -44,6 +44,8 @@ import {
   cleanupLibraryHandlers,
   registerMediaHandlers,
   cleanupMediaHandlers,
+  registerDiscordRpcHandlers,
+  cleanupDiscordRpcHandlers,
   registerLyricsHandlers,
   cleanupLyricsHandlers,
   registerDatabaseHandlers,
@@ -72,6 +74,7 @@ export function registerIpcHandlers(mainWindow: BrowserWindow): void {
   registerDialogHandlers(mainWindow);
   registerLibraryHandlers();
   registerMediaHandlers();
+  registerDiscordRpcHandlers();
   registerLyricsHandlers();
   registerDatabaseHandlers();
   registerShellHandlers();
@@ -91,6 +94,7 @@ export function cleanupIpcHandlers(): void {
   cleanupDialogHandlers();
   cleanupLibraryHandlers();
   cleanupMediaHandlers();
+  cleanupDiscordRpcHandlers();
   cleanupLyricsHandlers();
   cleanupDatabaseHandlers();
   cleanupShellHandlers();

--- a/apps/desktop/src/main/ipc/schemas/discord-rpc.ts
+++ b/apps/desktop/src/main/ipc/schemas/discord-rpc.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+/** Mirrors `DiscordPresenceTemplate` from `@shiranami/shared`. */
+const discordPresenceTemplateSchema = z.object({
+  details: z.string(),
+  state: z.string(),
+  showTimestamp: z.boolean(),
+  showLargeImage: z.boolean(),
+  showButton: z.boolean(),
+});
+
+/** Mirrors `DiscordMusicActivityType` from `@shiranami/shared`. */
+const discordActivityTypeSchema = z.enum(['playing', 'paused', 'idle']);
+
+/**
+ * Partial of `DiscordRpcSettings` — the renderer patches individual fields via
+ * `discord-rpc:update-settings`, so every key is optional.
+ */
+const discordRpcSettingsPartialSchema = z
+  .object({
+    enabled: z.boolean(),
+    showTrackDetails: z.boolean(),
+    showElapsedTime: z.boolean(),
+    useCustomTemplates: z.boolean(),
+    templates: z.record(discordActivityTypeSchema, discordPresenceTemplateSchema),
+  })
+  .partial();
+
+/** Mirrors the now-playing snapshot a forced presence refresh carries. */
+const discordPresenceActivitySchema = z.object({
+  isPlaying: z.boolean(),
+  title: z.string(),
+  artist: z.string(),
+  album: z.string(),
+  duration: z.number(),
+  currentTime: z.number(),
+});
+
+export const discordGetSettingsArgs = z.tuple([]);
+export const discordUpdateSettingsArgs = z.tuple([discordRpcSettingsPartialSchema]);
+export const discordUpdatePresenceArgs = z.tuple([discordPresenceActivitySchema]);
+export const discordClearPresenceArgs = z.tuple([]);

--- a/apps/desktop/src/main/ipc/schemas/index.ts
+++ b/apps/desktop/src/main/ipc/schemas/index.ts
@@ -9,6 +9,7 @@ export * from './db-history';
 export * from './db-playlists';
 export * from './db-tracks';
 export * from './dialog';
+export * from './discord-rpc';
 export * from './downloader';
 export * from './library';
 export * from './lyrics';

--- a/apps/desktop/src/main/ipc/store.ts
+++ b/apps/desktop/src/main/ipc/store.ts
@@ -24,9 +24,9 @@ const C = IPC_CHANNELS.store;
  *   - Main-only (NOT in the enum; accessed via direct import):
  *       'downloads.location'          — downloader.ts
  *       'downloads.toolStatusCache'   — downloader.ts
- *   - Dual-access (enum-listed AND read directly by main):
- *       'settings' — renderer owns the object; discord-rpc.ts reads
- *                    `settings.discordRpc` to decide whether to connect.
+ *       'discord-rpc-settings'        — discord-rpc.ts (RPC service owns it;
+ *                                       the renderer reaches it only through the
+ *                                       dedicated discord-rpc IPC channels).
  *
  * When adding a new key:
  *   1. Add it to the StoreSchema in `../store.ts` with an exact value type.

--- a/apps/desktop/src/main/preload/api/discord.ts
+++ b/apps/desktop/src/main/preload/api/discord.ts
@@ -1,0 +1,20 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '@shiranami/contracts';
+import type { DiscordRpcSettings, DiscordMusicPresenceActivity } from '@shiranami/shared';
+
+const C = IPC_CHANNELS.discord;
+
+export interface DiscordApi {
+  getSettings: () => Promise<DiscordRpcSettings>;
+  updateSettings: (updates: Partial<DiscordRpcSettings>) => Promise<DiscordRpcSettings>;
+  updatePresence: (activity: DiscordMusicPresenceActivity) => Promise<void>;
+  clearPresence: () => Promise<void>;
+}
+
+export const discordApi: DiscordApi = {
+  getSettings: () => ipcRenderer.invoke(C.getSettings) as Promise<DiscordRpcSettings>,
+  updateSettings: updates =>
+    ipcRenderer.invoke(C.updateSettings, updates) as Promise<DiscordRpcSettings>,
+  updatePresence: activity => ipcRenderer.invoke(C.updatePresence, activity) as Promise<void>,
+  clearPresence: () => ipcRenderer.invoke(C.clearPresence) as Promise<void>,
+};

--- a/apps/desktop/src/main/preload/index.ts
+++ b/apps/desktop/src/main/preload/index.ts
@@ -15,6 +15,7 @@ import { appApi, type AppApi } from './api/app';
 import { dbApi, type DbApi } from './api/db';
 import { debugApi, type DebugApi } from './api/debug';
 import { dialogApi, type DialogApi } from './api/dialog';
+import { discordApi, type DiscordApi } from './api/discord';
 import { downloaderApi, type DownloaderApi } from './api/downloader';
 import { libraryApi, type LibraryApi } from './api/library';
 import { lyricsApi, type LyricsApi } from './api/lyrics';
@@ -37,6 +38,7 @@ export interface ElectronAPI {
   db: DbApi;
   lyrics: LyricsApi;
   media: MediaApi;
+  discord: DiscordApi;
   downloader: DownloaderApi;
   updater: UpdaterApi;
   shell: ShellApi;
@@ -71,6 +73,7 @@ const electronAPI: ElectronAPI = {
   db: dbApi,
   lyrics: lyricsApi,
   media: mediaApi,
+  discord: discordApi,
   downloader: downloaderApi,
   updater: updaterApi,
   shell: shellApi,

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -1,4 +1,5 @@
 import Store from 'electron-store';
+import type { DiscordRpcSettings } from '@shiranami/shared';
 import type { ToolStatusCache } from './ipc/downloader';
 
 /**
@@ -17,8 +18,13 @@ import type { ToolStatusCache } from './ipc/downloader';
  * there for the gate/dual-access rules.
  */
 export interface StoreSchema {
-  // Renderer-owned blob; read by discord-rpc.ts for `discordRpc` flag.
+  // Renderer-owned blob of misc app settings.
   settings: Record<string, unknown>;
+
+  // Main-only (discord-rpc.ts): the single source of truth for Discord Rich
+  // Presence settings. Owned by the RPC service; the renderer reads/writes it
+  // only through the dedicated discord-rpc IPC channels, never via store:get/set.
+  'discord-rpc-settings': DiscordRpcSettings;
 
   // Renderer-owned; shape lives in the web package.
   'music-folders': unknown;

--- a/apps/web/src/components/onboarding/steps/PlaybackStep.tsx
+++ b/apps/web/src/components/onboarding/steps/PlaybackStep.tsx
@@ -2,6 +2,10 @@ import { useTranslation, Trans } from 'react-i18next';
 import { IS_ELECTRON } from '@/lib/platform';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useSettingsQuery, useUpdateSettingsMutation } from '@/hooks/queries/useSettings';
+import {
+  useDiscordRpcSettingsQuery,
+  useUpdateDiscordRpcSettingsMutation,
+} from '@/hooks/queries/useDiscordRpc';
 import { SettingsToggleRow } from '@/components/settings/SettingsCard';
 import { Slider } from '@/components/ui/slider';
 import { OnboardingStepLayout } from '../OnboardingStepLayout';
@@ -22,7 +26,10 @@ export function PlaybackStep() {
   const { data: settings } = useSettingsQuery();
   const updateSettings = useUpdateSettingsMutation();
   const rememberPlaybackPosition = settings?.rememberPlaybackPosition ?? false;
-  const discordRpc = settings?.discordRpc ?? false;
+
+  const { data: discordSettings } = useDiscordRpcSettingsQuery();
+  const updateDiscord = useUpdateDiscordRpcSettingsMutation();
+  const discordRpc = discordSettings?.enabled ?? false;
 
   const crossfadeEnabled = usePlaybackStore(s => s.crossfadeEnabled);
   const crossfadeDuration = usePlaybackStore(s => s.crossfadeDuration);
@@ -91,7 +98,7 @@ export function PlaybackStep() {
             label={t('playback.discord')}
             description={t('playback.discordDesc')}
             checked={discordRpc}
-            onCheckedChange={v => updateSettings.mutate({ discordRpc: v })}
+            onCheckedChange={v => updateDiscord.mutate({ enabled: v })}
           />
         )}
       </div>

--- a/apps/web/src/components/onboarding/steps/SummaryStep.tsx
+++ b/apps/web/src/components/onboarding/steps/SummaryStep.tsx
@@ -5,6 +5,7 @@ import { IS_ELECTRON } from '@/lib/platform';
 import { SUPPORTED_LANGUAGES } from '@/lib/i18n';
 import { useFoldersQuery } from '@/hooks/queries/useFolders';
 import { useSettingsQuery } from '@/hooks/queries/useSettings';
+import { useDiscordRpcSettingsQuery } from '@/hooks/queries/useDiscordRpc';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useUIStore } from '@/stores/useUIStore';
 import { useThemeStore } from '@/stores/useThemeStore';
@@ -27,6 +28,7 @@ export function SummaryStep() {
 
   const { data: folders = [] } = useFoldersQuery();
   const { data: settings } = useSettingsQuery();
+  const { data: discordSettings } = useDiscordRpcSettingsQuery();
   const tools = useDownloadsSettings();
 
   const crossfadeEnabled = usePlaybackStore(s => s.crossfadeEnabled);
@@ -56,11 +58,11 @@ export function SummaryStep() {
         ? t('summary.playback.crossfade', { seconds: crossfadeDuration })
         : t('summary.playback.noCrossfade'),
     ];
-    if (IS_ELECTRON && settings?.discordRpc) parts.push(t('summary.playback.discordOn'));
+    if (IS_ELECTRON && discordSettings?.enabled) parts.push(t('summary.playback.discordOn'));
     return parts.join(' · ');
   }, [
     settings?.rememberPlaybackPosition,
-    settings?.discordRpc,
+    discordSettings?.enabled,
     crossfadeEnabled,
     crossfadeDuration,
     t,

--- a/apps/web/src/components/settings/DiscordPreview.tsx
+++ b/apps/web/src/components/settings/DiscordPreview.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from 'react-i18next';
+import { Music2 } from 'lucide-react';
+
+interface DiscordPreviewProps {
+  details: string;
+  state: string;
+  showTimestamp: boolean;
+  showLargeImage: boolean;
+  showButton: boolean;
+}
+
+/** Discord-style presence preview card, adapted for the music now-playing context. */
+export function DiscordPreview({
+  details,
+  state,
+  showTimestamp,
+  showLargeImage,
+  showButton,
+}: DiscordPreviewProps) {
+  const { t } = useTranslation('settings');
+
+  return (
+    <div className="rounded-lg bg-[#2b2d31] p-3 font-sans text-white/90">
+      <p className="mb-2 text-[10px] font-semibold uppercase text-white/60">
+        {t('discord.preview.playingHeader')}
+      </p>
+      <div className="flex gap-3">
+        {showLargeImage && (
+          <div className="flex h-[60px] w-[60px] shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[#1e1f22]">
+            <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/30 to-primary/5">
+              <Music2 className="h-6 w-6 text-white/70" />
+            </div>
+          </div>
+        )}
+
+        <div className="flex min-w-0 flex-col justify-center gap-0.5">
+          <p className="truncate text-xs font-semibold text-white">Shiranami</p>
+          {details && <p className="truncate text-xs text-white/70">{details}</p>}
+          {state && <p className="truncate text-xs text-white/70">{state}</p>}
+          {showTimestamp && <p className="text-xs text-white/50">{t('discord.preview.elapsed')}</p>}
+        </div>
+      </div>
+
+      {showButton && (
+        <div className="mt-2">
+          <div className="w-full rounded bg-[#4e505899] py-1.5 text-center text-xs font-medium text-white/80">
+            {t('discord.preview.landingButton')}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/DiscordSection.tsx
+++ b/apps/web/src/components/settings/DiscordSection.tsx
@@ -1,0 +1,191 @@
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MessageCircle, Check, Info } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsCard';
+import { DiscordPreview } from '@/components/settings/DiscordPreview';
+import { DiscordTemplateEditor } from '@/components/settings/DiscordTemplateEditor';
+import { substitutePreview } from '@/lib/discord-utils';
+import { IS_ELECTRON } from '@/lib/platform';
+import { useUpdateDiscordRpcSettingsMutation } from '@/hooks/queries/useDiscordRpc';
+import type {
+  DiscordRpcSettings,
+  DiscordMusicActivityType,
+  DiscordPresenceTemplate,
+} from '@shiranami/shared';
+import { DEFAULT_DISCORD_TEMPLATES } from '@shiranami/shared';
+
+export function DiscordSection() {
+  const { t } = useTranslation('settings');
+  const updateDiscord = useUpdateDiscordRpcSettingsMutation();
+  const [settings, setSettings] = useState<DiscordRpcSettings | null>(null);
+  const [saved, setSaved] = useState(false);
+  const [selectedActivity, setSelectedActivity] = useState<DiscordMusicActivityType>('playing');
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!IS_ELECTRON) return;
+    window.electronAPI.discord.getSettings().then(s => {
+      if (!mountedRef.current || !s) return;
+      setSettings({
+        ...s,
+        templates: { ...DEFAULT_DISCORD_TEMPLATES, ...s.templates },
+      });
+    });
+  }, []);
+
+  const updateField = useCallback(
+    <K extends keyof DiscordRpcSettings>(key: K, value: DiscordRpcSettings[K]) => {
+      setSettings(prev => (prev ? { ...prev, [key]: value } : prev));
+    },
+    []
+  );
+
+  const updateTemplate = useCallback(
+    (
+      type: DiscordMusicActivityType,
+      field: keyof DiscordPresenceTemplate,
+      value: string | boolean
+    ) => {
+      setSettings(prev => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          templates: {
+            ...prev.templates,
+            [type]: { ...prev.templates[type], [field]: value },
+          },
+        };
+      });
+    },
+    []
+  );
+
+  const handleSave = useCallback(async () => {
+    if (!settings) return;
+    await updateDiscord.mutateAsync(settings);
+    if (!mountedRef.current) return;
+    setSaved(true);
+    setTimeout(() => {
+      if (mountedRef.current) setSaved(false);
+    }, 2000);
+  }, [settings, updateDiscord]);
+
+  const handleResetTemplate = useCallback(() => {
+    setSettings(prev => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        templates: {
+          ...prev.templates,
+          [selectedActivity]: { ...DEFAULT_DISCORD_TEMPLATES[selectedActivity] },
+        },
+      };
+    });
+  }, [selectedActivity]);
+
+  const currentTemplate =
+    settings?.templates?.[selectedActivity] ?? DEFAULT_DISCORD_TEMPLATES[selectedActivity];
+
+  const previewDetails = useMemo(
+    () => substitutePreview(currentTemplate.details, selectedActivity),
+    [currentTemplate.details, selectedActivity]
+  );
+  const previewState = useMemo(
+    () => substitutePreview(currentTemplate.state, selectedActivity),
+    [currentTemplate.state, selectedActivity]
+  );
+
+  if (!settings) return null;
+
+  const showCustomTemplateEditing = settings.enabled && settings.useCustomTemplates;
+
+  return (
+    <div className="space-y-4">
+      <SettingsCard
+        icon={MessageCircle}
+        title={t('discord.main.title')}
+        subtitle={t('discord.main.subtitle')}
+        headerRight={
+          <Switch
+            aria-label={t('discord.main.enableAria')}
+            checked={settings.enabled}
+            onCheckedChange={v => updateField('enabled', v)}
+          />
+        }
+      >
+        {!settings.useCustomTemplates && (
+          <>
+            <SettingsToggleRow
+              label={t('discord.main.showDetailsTitle')}
+              description={t('discord.main.showDetailsDescription')}
+              checked={settings.showTrackDetails}
+              onCheckedChange={v => updateField('showTrackDetails', v)}
+              disabled={!settings.enabled}
+            />
+            <SettingsToggleRow
+              divider
+              label={t('discord.main.showTimeTitle')}
+              description={t('discord.main.showTimeDescription')}
+              checked={settings.showElapsedTime}
+              onCheckedChange={v => updateField('showElapsedTime', v)}
+              disabled={!settings.enabled}
+            />
+          </>
+        )}
+
+        <SettingsToggleRow
+          divider={!settings.useCustomTemplates}
+          label={t('discord.main.useTemplatesTitle')}
+          description={t('discord.main.useTemplatesDescription')}
+          checked={settings.useCustomTemplates}
+          onCheckedChange={v => updateField('useCustomTemplates', v)}
+          disabled={!settings.enabled}
+        />
+
+        <Button size="sm" onClick={handleSave}>
+          {saved ? <Check className="h-4 w-4" /> : null}
+          {saved ? t('discord.main.saved') : t('discord.main.save')}
+        </Button>
+      </SettingsCard>
+
+      {showCustomTemplateEditing && (
+        <>
+          <DiscordTemplateEditor
+            selectedActivity={selectedActivity}
+            onActivityChange={setSelectedActivity}
+            currentTemplate={currentTemplate}
+            onTemplateChange={updateTemplate}
+            onReset={handleResetTemplate}
+          />
+          <SettingsCard
+            icon={MessageCircle}
+            title={t('discord.preview.title')}
+            subtitle={t('discord.preview.subtitle')}
+          >
+            <DiscordPreview
+              details={previewDetails}
+              state={previewState}
+              showTimestamp={currentTemplate.showTimestamp}
+              showLargeImage={currentTemplate.showLargeImage}
+              showButton={currentTemplate.showButton}
+            />
+          </SettingsCard>
+        </>
+      )}
+
+      <div className="flex items-start gap-2.5 rounded-xl border border-border/30 bg-surface/50 p-4 text-xs text-muted-foreground">
+        <Info className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground/80" />
+        <p className="leading-relaxed">{t('discord.info')}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/DiscordTemplateEditor.tsx
+++ b/apps/web/src/components/settings/DiscordTemplateEditor.tsx
@@ -1,0 +1,162 @@
+import { Clock, Image, ExternalLink, MessageCircle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { SettingsCard } from '@/components/settings/SettingsCard';
+import type { DiscordMusicActivityType, DiscordPresenceTemplate } from '@shiranami/shared';
+import { DISCORD_ACTIVITY_TYPES, DISCORD_TEMPLATE_VARIABLES } from '@shiranami/shared';
+
+interface DiscordTemplateEditorProps {
+  selectedActivity: DiscordMusicActivityType;
+  onActivityChange: (activity: DiscordMusicActivityType) => void;
+  currentTemplate: DiscordPresenceTemplate;
+  onTemplateChange: (
+    type: DiscordMusicActivityType,
+    field: keyof DiscordPresenceTemplate,
+    value: string | boolean
+  ) => void;
+  onReset: () => void;
+}
+
+/** Small toggle row for template options. */
+function TemplateToggle({
+  icon: Icon,
+  label,
+  checked,
+  onChange,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between py-1">
+      <div className="flex items-center gap-2">
+        <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+        <span className="text-sm">{label}</span>
+      </div>
+      <Switch aria-label={label} checked={checked} onCheckedChange={onChange} />
+    </div>
+  );
+}
+
+export function DiscordTemplateEditor({
+  selectedActivity,
+  onActivityChange,
+  currentTemplate,
+  onTemplateChange,
+  onReset,
+}: DiscordTemplateEditorProps) {
+  const { t } = useTranslation('settings');
+
+  return (
+    <SettingsCard
+      icon={MessageCircle}
+      title={t('discord.editor.title')}
+      subtitle={t('discord.editor.subtitle')}
+    >
+      {/* Activity type selector */}
+      <div className="space-y-1.5">
+        <label className="text-xs font-medium text-muted-foreground">
+          {t('discord.editor.activityType')}
+        </label>
+        <Select
+          value={selectedActivity}
+          onValueChange={v => onActivityChange(v as DiscordMusicActivityType)}
+        >
+          <SelectTrigger className="h-8 text-sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {DISCORD_ACTIVITY_TYPES.map(type => (
+              <SelectItem key={type} value={type}>
+                {t(`discord.activityLabel.${type}`)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="border-t border-border/50" />
+
+      {/* Template inputs */}
+      <div className="space-y-3">
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">
+            {t('discord.editor.line1')}
+          </label>
+          <Input
+            className="h-8 text-sm"
+            value={currentTemplate.details}
+            onChange={e => onTemplateChange(selectedActivity, 'details', e.target.value)}
+            placeholder={t('discord.editor.line1Placeholder')}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">
+            {t('discord.editor.line2')}
+          </label>
+          <Input
+            className="h-8 text-sm"
+            value={currentTemplate.state}
+            onChange={e => onTemplateChange(selectedActivity, 'state', e.target.value)}
+            placeholder={t('discord.editor.line2Placeholder')}
+          />
+        </div>
+      </div>
+
+      {/* Template toggles */}
+      <div className="space-y-2">
+        <TemplateToggle
+          icon={Clock}
+          label={t('discord.editor.toggles.duration')}
+          checked={currentTemplate.showTimestamp}
+          onChange={v => onTemplateChange(selectedActivity, 'showTimestamp', v)}
+        />
+        <TemplateToggle
+          icon={Image}
+          label={t('discord.editor.toggles.cover')}
+          checked={currentTemplate.showLargeImage}
+          onChange={v => onTemplateChange(selectedActivity, 'showLargeImage', v)}
+        />
+        <TemplateToggle
+          icon={ExternalLink}
+          label={t('discord.editor.toggles.landingButton')}
+          checked={currentTemplate.showButton}
+          onChange={v => onTemplateChange(selectedActivity, 'showButton', v)}
+        />
+      </div>
+
+      {/* Available variables */}
+      <div className="space-y-1.5 rounded-lg bg-muted/30 p-3">
+        <p className="text-xs font-medium text-muted-foreground">
+          {t('discord.editor.variablesLabel')}
+        </p>
+        <div className="flex flex-wrap gap-x-4 gap-y-1">
+          {DISCORD_TEMPLATE_VARIABLES.map(v => (
+            <span key={v.key} className="text-xs text-muted-foreground">
+              <code className="rounded bg-primary/5 px-1 text-[10px] text-primary/80">{v.key}</code>{' '}
+              · {t(v.descriptionKey)}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Reset button */}
+      <div className="flex justify-end">
+        <Button variant="ghost" size="sm" className="text-xs" onClick={onReset}>
+          {t('discord.editor.resetDefaults')}
+        </Button>
+      </div>
+    </SettingsCard>
+  );
+}

--- a/apps/web/src/components/settings/PlaybackSection.tsx
+++ b/apps/web/src/components/settings/PlaybackSection.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from 'react-i18next';
 import { Settings2 } from 'lucide-react';
 import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsCard';
 import { Slider } from '@/components/ui/slider';
-import { IS_ELECTRON } from '@/lib/platform';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useSettingsQuery, useUpdateSettingsMutation } from '@/hooks/queries/useSettings';
 
@@ -12,14 +11,13 @@ export function PlaybackSection() {
   const updateSettings = useUpdateSettingsMutation();
 
   const rememberPlaybackPosition = settings?.rememberPlaybackPosition ?? false;
-  const discordRpc = settings?.discordRpc ?? false;
 
   const crossfadeEnabled = usePlaybackStore(s => s.crossfadeEnabled);
   const crossfadeDuration = usePlaybackStore(s => s.crossfadeDuration);
   const setCrossfadeEnabled = usePlaybackStore(s => s.setCrossfadeEnabled);
   const setCrossfadeDuration = usePlaybackStore(s => s.setCrossfadeDuration);
 
-  const updateSetting = (key: 'rememberPlaybackPosition' | 'discordRpc', value: boolean) => {
+  const updateSetting = (key: 'rememberPlaybackPosition', value: boolean) => {
     updateSettings.mutate({ [key]: value });
   };
 
@@ -61,16 +59,6 @@ export function PlaybackSection() {
               <span className="text-[10px] text-muted-foreground/60">12s</span>
             </div>
           </div>
-        )}
-
-        {IS_ELECTRON && (
-          <SettingsToggleRow
-            divider
-            label={t('play.discordRpc')}
-            description={t('play.discordDesc')}
-            checked={discordRpc}
-            onCheckedChange={v => updateSetting('discordRpc', v)}
-          />
         )}
       </div>
     </SettingsCard>

--- a/apps/web/src/components/settings/SettingsView.tsx
+++ b/apps/web/src/components/settings/SettingsView.tsx
@@ -13,6 +13,7 @@ import {
   RefreshCcw,
   Info,
   Heart,
+  MessageCircle,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { SettingsHeader } from '@/components/settings/SettingsHeader';
@@ -28,6 +29,7 @@ import { LyricsSection } from '@/components/settings/LyricsSection';
 import { CompactSection } from '@/components/settings/CompactSection';
 import { AboutSection } from '@/components/settings/AboutSection';
 import { SupportSection } from '@/components/settings/SupportSection';
+import { DiscordSection } from '@/components/settings/DiscordSection';
 
 type SettingsSection =
   | 'folders'
@@ -39,6 +41,7 @@ type SettingsSection =
   | 'lyrics'
   | 'compact'
   | 'appearance'
+  | 'discord'
   | 'updates'
   | 'about'
   | 'support';
@@ -125,6 +128,13 @@ const SECTIONS: {
     group: 'appearance',
   },
   {
+    id: 'discord',
+    labelKey: 'discord',
+    subtitleKey: 'subtitles.discord',
+    Icon: MessageCircle,
+    group: 'system',
+  },
+  {
     id: 'updates',
     labelKey: 'updates',
     subtitleKey: 'subtitles.updates',
@@ -151,6 +161,7 @@ const SECTION_PANEL: Record<SettingsSection, ComponentType> = {
   lyrics: LyricsSection,
   compact: CompactSection,
   appearance: AppearanceSection,
+  discord: DiscordSection,
   updates: UpdatesSection,
   about: AboutSection,
   support: SupportSection,

--- a/apps/web/src/hooks/queries/useDiscordRpc.ts
+++ b/apps/web/src/hooks/queries/useDiscordRpc.ts
@@ -1,0 +1,40 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { DiscordRpcSettings } from '@shiranami/shared';
+import { IS_ELECTRON } from '@/lib/platform';
+
+/**
+ * React Query access to the dedicated Discord RPC settings (electron-store key
+ * `discord-rpc-settings`, owned by the main-process service). This replaces the
+ * old `settings.discordRpc` boolean for the onboarding flow and summary; the
+ * full Settings section manages its own local draft state on top of the same
+ * IPC and invalidates this query on save.
+ */
+export const discordRpcKeys = {
+  all: ['discord-rpc-settings'] as const,
+};
+
+export function useDiscordRpcSettingsQuery() {
+  return useQuery({
+    queryKey: discordRpcKeys.all,
+    queryFn: async () => {
+      if (!IS_ELECTRON) return null;
+      return window.electronAPI.discord.getSettings();
+    },
+    enabled: IS_ELECTRON,
+    staleTime: Infinity,
+  });
+}
+
+export function useUpdateDiscordRpcSettingsMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (updates: Partial<DiscordRpcSettings>) => {
+      if (!IS_ELECTRON) return null;
+      return window.electronAPI.discord.updateSettings(updates);
+    },
+    onSuccess: next => {
+      if (next) queryClient.setQueryData(discordRpcKeys.all, next);
+    },
+  });
+}

--- a/apps/web/src/hooks/queries/useSettings.ts
+++ b/apps/web/src/hooks/queries/useSettings.ts
@@ -3,7 +3,6 @@ import { IS_ELECTRON } from '@/lib/platform';
 
 export interface ElectronSettings {
   rememberPlaybackPosition?: boolean;
-  discordRpc?: boolean;
   [key: string]: unknown;
 }
 
@@ -30,8 +29,7 @@ export function useUpdateSettingsMutation() {
   return useMutation({
     mutationFn: async (patch: Partial<ElectronSettings>) => {
       if (!IS_ELECTRON) return;
-      const current =
-        queryClient.getQueryData<ElectronSettings | null>(settingsKeys.all) ?? {};
+      const current = queryClient.getQueryData<ElectronSettings | null>(settingsKeys.all) ?? {};
       const merged: ElectronSettings = { ...current, ...patch };
       await window.electronAPI.store.set('settings', merged);
       return merged;

--- a/apps/web/src/lib/discord-utils.ts
+++ b/apps/web/src/lib/discord-utils.ts
@@ -1,0 +1,26 @@
+import type { DiscordMusicActivityType } from '@shiranami/shared';
+
+/** Sample track data for the live preview of Discord Rich Presence templates. */
+const PREVIEW_DATA: Record<
+  DiscordMusicActivityType,
+  { title: string; artist: string; album: string }
+> = {
+  playing: { title: 'Idol', artist: 'Yoasobi', album: 'THE BOOK 3' },
+  paused: { title: 'Idol', artist: 'Yoasobi', album: 'THE BOOK 3' },
+  idle: { title: '', artist: '', album: '' },
+};
+
+/** Substitute `{title}`/`{artist}`/`{album}` with preview data for the given activity. */
+export function substitutePreview(
+  template: string,
+  activityType: DiscordMusicActivityType
+): string {
+  if (!template) return '';
+  const data = PREVIEW_DATA[activityType];
+  return template
+    .replace(/\{title\}/g, data.title)
+    .replace(/\{artist\}/g, data.artist)
+    .replace(/\{album\}/g, data.album)
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -109,9 +109,7 @@
     "rememberDesc": "Resume tracks from where you left off",
     "crossfade": "Crossfade",
     "crossfadeDesc": "Smooth volume transition between tracks",
-    "duration": "Duration",
-    "discordRpc": "Discord Rich Presence",
-    "discordDesc": "Show currently playing track in Discord"
+    "duration": "Duration"
   },
   "vis": {
     "title": "Visualizer",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -15,6 +15,7 @@
     "lyrics": "Lyrics display options",
     "compact": "Mini-player window settings",
     "appearance": "Interface look and feel",
+    "discord": "Discord integration settings",
     "updates": "Application update channel",
     "about": "About this application",
     "support": "Support the project"
@@ -28,6 +29,7 @@
   "lyrics": "Lyrics",
   "compact": "Compact mode",
   "appearance": "Appearance",
+  "discord": "Discord",
   "updates": "Updates",
   "about": "About",
   "support": "Support",
@@ -110,6 +112,66 @@
     "crossfade": "Crossfade",
     "crossfadeDesc": "Smooth volume transition between tracks",
     "duration": "Duration"
+  },
+  "discord": {
+    "main": {
+      "title": "Discord Rich Presence",
+      "subtitle": "Connect to Discord and show what you are listening to.",
+      "enableAria": "Enable Discord Rich Presence",
+      "showDetailsTitle": "Show track details",
+      "showDetailsDescription": "Display the track title and artist on Discord.",
+      "showTimeTitle": "Show elapsed time",
+      "showTimeDescription": "Show how long you have been listening.",
+      "useTemplatesTitle": "Custom templates",
+      "useTemplatesDescription": "Customize the status text for each activity.",
+      "save": "Save",
+      "saved": "Saved"
+    },
+    "preview": {
+      "title": "Preview",
+      "subtitle": "How your status will look on Discord.",
+      "playingHeader": "Listening to music",
+      "elapsed": "03:42 left",
+      "landingButton": "Get Shiranami"
+    },
+    "editor": {
+      "title": "Status templates",
+      "subtitle": "Edit the text for each activity type.",
+      "activityType": "Activity type",
+      "line1": "Line 1 (description)",
+      "line2": "Line 2 (state)",
+      "line1Placeholder": "e.g. Listening to music",
+      "line2Placeholder": "e.g. {title} by {artist}",
+      "toggles": {
+        "duration": "Track timer",
+        "cover": "App logo",
+        "landingButton": "Shiranami button"
+      },
+      "variablesLabel": "Available variables:",
+      "resetDefaults": "Restore defaults"
+    },
+    "template": {
+      "playing": {
+        "details": "Listening to music"
+      },
+      "paused": {
+        "details": "Music paused"
+      },
+      "idle": {
+        "details": "Idle"
+      }
+    },
+    "activityLabel": {
+      "playing": "Playing",
+      "paused": "Paused",
+      "idle": "Idle"
+    },
+    "templateVariable": {
+      "title": "Track title",
+      "artist": "Artist",
+      "album": "Album"
+    },
+    "info": "Discord status only works while the Discord client is running on your computer. Friends will see what you are listening to in Shiranami on your Discord profile."
   },
   "vis": {
     "title": "Visualizer",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -109,9 +109,7 @@
     "rememberDesc": "Wznawiaj utwory od miejsca, w którym skończyłeś",
     "crossfade": "Crossfade",
     "crossfadeDesc": "Płynne przejście głośności między utworami",
-    "duration": "Czas trwania",
-    "discordRpc": "Discord Rich Presence",
-    "discordDesc": "Pokazuj aktualnie odtwarzany utwór w Discordzie"
+    "duration": "Czas trwania"
   },
   "vis": {
     "title": "Wizualizator",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -15,6 +15,7 @@
     "lyrics": "Opcje wyświetlania tekstu",
     "compact": "Ustawienia mini-odtwarzacza",
     "appearance": "Wygląd i styl interfejsu",
+    "discord": "Ustawienia integracji Discord",
     "updates": "Kanał aktualizacji aplikacji",
     "about": "Informacje o aplikacji",
     "support": "Wesprzyj projekt"
@@ -28,6 +29,7 @@
   "lyrics": "Tekst piosenki",
   "compact": "Tryb kompaktowy",
   "appearance": "Wygląd",
+  "discord": "Discord",
   "updates": "Aktualizacje",
   "about": "O aplikacji",
   "support": "Wsparcie",
@@ -110,6 +112,66 @@
     "crossfade": "Crossfade",
     "crossfadeDesc": "Płynne przejście głośności między utworami",
     "duration": "Czas trwania"
+  },
+  "discord": {
+    "main": {
+      "title": "Discord Rich Presence",
+      "subtitle": "Połącz z Discordem i pokazuj, czego słuchasz.",
+      "enableAria": "Włącz Discord Rich Presence",
+      "showDetailsTitle": "Pokazuj szczegóły utworu",
+      "showDetailsDescription": "Wyświetlaj tytuł i artystę na Discordzie.",
+      "showTimeTitle": "Pokazuj czas",
+      "showTimeDescription": "Pokazuj, jak długo już słuchasz.",
+      "useTemplatesTitle": "Własne szablony",
+      "useTemplatesDescription": "Dostosuj tekst statusu dla każdej aktywności.",
+      "save": "Zapisz",
+      "saved": "Zapisano"
+    },
+    "preview": {
+      "title": "Podgląd",
+      "subtitle": "Tak będzie wyglądał Twój status na Discordzie.",
+      "playingHeader": "Słucha muzyki",
+      "elapsed": "Pozostało 03:42",
+      "landingButton": "Pobierz Shiranami"
+    },
+    "editor": {
+      "title": "Szablony statusów",
+      "subtitle": "Edytuj tekst dla każdego typu aktywności.",
+      "activityType": "Typ aktywności",
+      "line1": "Linia 1 (opis)",
+      "line2": "Linia 2 (stan)",
+      "line1Placeholder": "np. Słucha muzyki",
+      "line2Placeholder": "np. {title} od {artist}",
+      "toggles": {
+        "duration": "Czas utworu",
+        "cover": "Logo aplikacji",
+        "landingButton": "Przycisk Shiranami"
+      },
+      "variablesLabel": "Dostępne zmienne:",
+      "resetDefaults": "Przywróć domyślne"
+    },
+    "template": {
+      "playing": {
+        "details": "Słucha muzyki"
+      },
+      "paused": {
+        "details": "Muzyka wstrzymana"
+      },
+      "idle": {
+        "details": "Bez aktywności"
+      }
+    },
+    "activityLabel": {
+      "playing": "Odtwarzanie",
+      "paused": "Wstrzymanie",
+      "idle": "Bez aktywności"
+    },
+    "templateVariable": {
+      "title": "Tytuł utworu",
+      "artist": "Artysta",
+      "album": "Album"
+    },
+    "info": "Status na Discordzie działa tylko, gdy klient Discord jest uruchomiony na komputerze. Na Twoim profilu Discord znajomi zobaczą, czego słuchasz w Shiranami."
   },
   "vis": {
     "title": "Wizualizator",

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { vi } from 'vitest';
+import { DEFAULT_DISCORD_TEMPLATES } from '@shiranami/shared';
 import type { ElectronAPI } from '@/types/electron';
 
 // Test-accessible ResizeObserver mock. Captures the callback and target so
@@ -132,6 +133,18 @@ function createElectronAPIMock(): ElectronAPI {
       onCommand: vi.fn(() => noopUnsub()),
       sendPlaybackState: vi.fn(),
       clearState: vi.fn(),
+    },
+    discord: {
+      getSettings: asyncFn({
+        enabled: false,
+        showTrackDetails: true,
+        showElapsedTime: true,
+        useCustomTemplates: false,
+        templates: DEFAULT_DISCORD_TEMPLATES,
+      }),
+      updateSettings: vi.fn(),
+      updatePresence: vi.fn(),
+      clearPresence: vi.fn(),
     },
     lyrics: {
       fetch: asyncFn({ synced: null, plain: null, source: null }),

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -5,6 +5,7 @@ import type {
   MetadataLookupResult,
   MainMetricsSnapshot,
 } from '@shiranami/contracts';
+import type { DiscordRpcSettings, DiscordMusicPresenceActivity } from '@shiranami/shared';
 
 export type { TrackMetadata, SearchResult } from '@shiranami/contracts';
 
@@ -128,6 +129,12 @@ export interface ElectronAPI {
       albumArt: string | null;
     }) => Promise<void>;
     clearState: () => Promise<void>;
+  };
+  discord: {
+    getSettings: () => Promise<DiscordRpcSettings>;
+    updateSettings: (updates: Partial<DiscordRpcSettings>) => Promise<DiscordRpcSettings>;
+    updatePresence: (activity: DiscordMusicPresenceActivity) => Promise<void>;
+    clearPresence: () => Promise<void>;
   };
   lyrics: {
     fetch: (

--- a/packages/contracts/src/ipc/channels.ts
+++ b/packages/contracts/src/ipc/channels.ts
@@ -47,6 +47,12 @@ export const IPC_CHANNELS = {
     clearState: 'media:clear-state',
     command: 'media:command',
   },
+  discord: {
+    getSettings: 'discord-rpc:get-settings',
+    updateSettings: 'discord-rpc:update-settings',
+    updatePresence: 'discord-rpc:update-presence',
+    clearPresence: 'discord-rpc:clear-presence',
+  },
   library: {
     parseMetadata: 'library:parse-metadata',
     scanFolder: 'library:scan-folder',

--- a/packages/shared/src/constants/discord.ts
+++ b/packages/shared/src/constants/discord.ts
@@ -1,0 +1,69 @@
+import type { DiscordMusicActivityType, DiscordPresenceTemplates } from '../types/discord';
+
+/**
+ * Shiranami's registered Discord application client ID. Presence only renders
+ * for a Discord application that exists at
+ * https://discord.com/developers/applications. The large-image asset key
+ * `DISCORD_LARGE_IMAGE_KEY` below must be uploaded as a Rich Presence art
+ * asset for THIS application or the logo slot renders blank.
+ */
+export const SHIRANAMI_DISCORD_CLIENT_ID = '1484544721060761610';
+
+/**
+ * Rich Presence art asset key. This is NOT a URL — it must match the name of
+ * an uploaded art asset in the Discord Developer Portal for application
+ * `SHIRANAMI_DISCORD_CLIENT_ID`. Shiranami's local album art uses the
+ * `shiranami-art://` protocol which is not externally reachable, so the static
+ * app logo is used for every presence state.
+ */
+export const DISCORD_LARGE_IMAGE_KEY = 'shiranami';
+
+/** Landing-page button shown on the presence card. */
+export const DISCORD_LANDING_URL = 'https://shiranami.app';
+
+/** Discord rich-presence string fields must be at most 128 characters. */
+export const DISCORD_MAX_FIELD_LENGTH = 128;
+
+export const DISCORD_ACTIVITY_TYPES: DiscordMusicActivityType[] = ['playing', 'paused', 'idle'];
+
+/**
+ * Template tokens available to users, with i18n key suffixes for their
+ * descriptions. The renderer resolves the descriptions via
+ * `settings:discord.templateVariable.<suffix>`.
+ */
+export const DISCORD_TEMPLATE_VARIABLES = [
+  { key: '{title}', descriptionKey: 'discord.templateVariable.title' },
+  { key: '{artist}', descriptionKey: 'discord.templateVariable.artist' },
+  { key: '{album}', descriptionKey: 'discord.templateVariable.album' },
+] as const;
+
+/**
+ * Default per-activity templates. Shiranami has no main-process i18n, so the
+ * `details` fields are literal English strings (not `@@i18n:` sentinels). The
+ * renderer presents these defaults verbatim and persists them as-is; resetting
+ * a template restores these literals. UI-language localization of the editor
+ * chrome (labels, placeholders) still happens via the `settings` namespace.
+ */
+export const DEFAULT_DISCORD_TEMPLATES: DiscordPresenceTemplates = {
+  playing: {
+    details: 'Listening to music',
+    state: '{title} by {artist}',
+    showTimestamp: true,
+    showLargeImage: true,
+    showButton: true,
+  },
+  paused: {
+    details: 'Music paused',
+    state: '{title} by {artist}',
+    showTimestamp: false,
+    showLargeImage: true,
+    showButton: false,
+  },
+  idle: {
+    details: 'Idle',
+    state: '',
+    showTimestamp: false,
+    showLargeImage: true,
+    showButton: false,
+  },
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 // Constants
 export * from './constants/app';
+export * from './constants/discord';
 
 // Types
 export * from './types/discord';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,9 @@
 // Constants
 export * from './constants/app';
 
+// Types
+export * from './types/discord';
+
 // Utilities
 export * from './utils';
 

--- a/packages/shared/src/types/discord.ts
+++ b/packages/shared/src/types/discord.ts
@@ -1,0 +1,54 @@
+// Discord Rich Presence types for Shiranami (music context).
+//
+// Adapted from ShiroAni's anime-oriented presence types. Shiranami exposes a
+// now-playing presence with three activity types and template-based status
+// text. There is no main-process i18n in Shiranami, so default template fields
+// ship as literal English strings (no `@@i18n:` sentinels) — see
+// `DEFAULT_DISCORD_TEMPLATES` in `../constants/discord`.
+
+/** Music player presence states. */
+export type DiscordMusicActivityType = 'playing' | 'paused' | 'idle';
+
+/**
+ * A single status template. `details` is line 1, `state` is line 2. The three
+ * toggles control whether the track timer, the app logo, and the landing
+ * button appear in the rendered presence.
+ */
+export interface DiscordPresenceTemplate {
+  details: string;
+  state: string;
+  showTimestamp: boolean;
+  showLargeImage: boolean;
+  showButton: boolean;
+}
+
+/** One template per activity type. */
+export type DiscordPresenceTemplates = Record<DiscordMusicActivityType, DiscordPresenceTemplate>;
+
+/** Persisted Discord RPC settings. Single source of truth lives in electron-store. */
+export interface DiscordRpcSettings {
+  enabled: boolean;
+  /** Show the track title/artist lines on Discord. */
+  showTrackDetails: boolean;
+  /** Show the elapsed/remaining track timer. */
+  showElapsedTime: boolean;
+  /** When true, the per-activity templates drive the presence text. */
+  useCustomTemplates: boolean;
+  templates: DiscordPresenceTemplates;
+}
+
+/**
+ * Now-playing snapshot the presence builder consumes. Mirrors the relevant
+ * fields of the main-process `PlaybackState`, kept independent so the builder
+ * stays pure and importable from the shared package.
+ */
+export interface DiscordMusicPresenceActivity {
+  isPlaying: boolean;
+  title: string;
+  artist: string;
+  album: string;
+  /** Total track length in seconds. */
+  duration: number;
+  /** Current playhead position in seconds. */
+  currentTime: number;
+}


### PR DESCRIPTION
## Summary

Replaces Shiranami's minimal Discord RPC module with a full, customizable Rich Presence feature ported from ShiroAni and adapted to music. Adds a dedicated **Discord** section in Settings (System group) with an enable toggle, track-detail / elapsed-time toggles, an optional custom-template editor, and a live preview. The now-playing track (title / artist / album, with playing / paused / idle states) drives the presence.

The old single boolean toggle in Playback settings is removed; existing users who had it on are migrated automatically (their `enabled` state is seeded once from the legacy flag).

## Architecture

ShiroAni's service / builder / IPC / preload split, adapted to Shiranami's conventions:

- **Main:** `discord-rpc.ts` (settings-aware lifecycle service: connect/disconnect, 15s throttle, exponential reconnect backoff) + a pure `discord-presence-builder.ts` (template substitution, large-image + timestamp + button assembly).
- **IPC:** 4 channels in `packages/contracts` (`discord-rpc:get-settings | update-settings | update-presence | clear-presence`), zod-validated; the preload allowlist auto-derives from the contracts manifest.
- **Preload:** `preload/api/discord.ts` exposed as `window.electronAPI.discord`.
- **Renderer:** `DiscordSection` + `DiscordTemplateEditor` + `DiscordPreview` + a `useDiscordRpc` query hook.
- **Shared:** `DiscordRpcSettings` / template types + `DEFAULT_DISCORD_TEMPLATES` in `packages/shared`.

The existing `media:playback-state` -> `updateDiscordPresence(state)` flow is unchanged; it remains the now-playing trigger. The dedicated `update-presence` channel only forces a refresh after the settings UI saves; `clear-presence` clears on stop.

## Customization

- **Activity types:** playing, paused, idle.
- **Tokens:** `{title}`, `{artist}`, `{album}`.
- **Defaults (literal strings):** playing -> "Listening to music" / "{title} by {artist}" (timestamp + logo + button on); paused -> "Music paused"; idle -> "Idle".
- Custom templates are opt-in (`useCustomTemplates`); the editor offers per-activity line 1 / line 2 plus timestamp / logo / button toggles, a variable reference, and reset-to-defaults.

## Decisions / scope

- **Localization:** default template text uses literal English strings (no `@@i18n:` sentinel system / main-process i18n) since Shiranami has no main-process i18n. The editor chrome itself is fully localized (EN + PL). Tradeoff: the default presence text is English regardless of UI language.
- **Cover art:** uses the static `'shiranami'` Discord art asset as the large image (matches the prior module); `largeImageText` = album or "Shiranami". Local `shiranami-art://` URLs are not externally reachable by Discord, so external album art is out of scope for v1.
- **Out of scope (v1):** idle-on-window-blur and view-change presence (less meaningful for a background music player).
- Client ID is the existing real `1484544721060761610`, lifted to a shared `SHIRANAMI_DISCORD_CLIENT_ID` constant.

## i18n

`discord.*` keys + nav label / subtitle in `en/settings.json` and `pl/settings.json` (proper Polish diacritics, no em/en dashes). The now-orphaned `play.discordRpc` / `play.discordDesc` keys are removed.

## Verification

- `pnpm typecheck` — clean (contracts, shared, database, web, desktop)
- `pnpm lint` — clean
- `pnpm --filter @shiranami/desktop test` — 697 pass (incl. 43 new discord / ipc / builder tests)
- `pnpm --filter @shiranami/web test` — 604 pass

## Manual step

The large-image slot relies on a Rich Presence art asset named **`shiranami`** in the Discord Developer Portal for app `1484544721060761610` (Rich Presence -> Art Assets). The prior module already assumed this; if missing, presence still works but the logo renders blank.

## Behavior for existing users

The Playback "Discord Rich Presence" toggle moves to its own Settings > Discord section. Anyone who had it enabled stays enabled (one-time migration from the legacy boolean); the dedicated settings key is the single source of truth thereafter.
