### PR TITLE
feat(desktop): opt-in Sentry crash & error reporting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# ─────────────────────────────────────────────────────────────────────────
+# Sentry — local testing only
+# ─────────────────────────────────────────────────────────────────────────
+#
+# These vars exist so you can send a first Sentry event from an UNPACKAGED dev
+# build (e.g. to complete Sentry's onboarding) without packaging the app. They
+# only override the packaged/PROD gate — they do NOT bypass the consent gate.
+# Consent must still be toggled ON in Settings → Privacy. None of these affect
+# packaged or production builds.
+#
+# The desktop dev process reads these from the SHELL ENV — esbuild does not
+# auto-load .env files. So copy this to `.env` (gitignored) for reference, but
+# pass the vars inline on the canonical local-test command:
+#
+#   SENTRY_DSN=<your-dsn> SENTRY_FORCE_ENABLE=true VITE_SENTRY_FORCE_ENABLE=true pnpm dev
+#
+# Then toggle crash reporting ON in Settings → Privacy and click "Send test
+# event".
+
+# Your Sentry project DSN. Safe to keep local. Injected at runtime when no
+# build-time DSN is present, so no rebuild is needed.
+SENTRY_DSN=
+
+# Main process: "true" (or "1") lets Sentry init in an unpackaged build.
+SENTRY_FORCE_ENABLE=
+
+# Renderer process: same as above, for the Vite-built renderer. Vite only
+# exposes vars prefixed with VITE_.
+VITE_SENTRY_FORCE_ENABLE=

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,19 @@ jobs:
 
       - name: Build web frontend
         run: pnpm --filter @shiranami/web build
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Build desktop app
         run: pnpm --filter @shiranami/desktop build
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Package macOS
         if: matrix.platform == 'mac'

--- a/apps/desktop/esbuild.config.mjs
+++ b/apps/desktop/esbuild.config.mjs
@@ -16,6 +16,10 @@ const sentryPlugins = shouldUploadSourcemaps
         org: process.env.SENTRY_ORG,
         project: process.env.SENTRY_PROJECT,
         authToken: process.env.SENTRY_AUTH_TOKEN,
+        // The lunofi org lives on Sentry's EU region; the plugin otherwise
+        // defaults uploads to the US instance (sentry.io) and 404s. Overridable
+        // via SENTRY_URL for forks on a different region.
+        url: process.env.SENTRY_URL ?? 'https://de.sentry.io/',
         release: { name: `shiranami@${pkg.version}` },
         sourcemaps: {
           // Strip maps from the shipped artifact after upload so they aren't

--- a/apps/desktop/esbuild.config.mjs
+++ b/apps/desktop/esbuild.config.mjs
@@ -1,7 +1,30 @@
 import { build } from 'esbuild';
 import { readFileSync } from 'node:fs';
+import { sentryEsbuildPlugin } from '@sentry/esbuild-plugin';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
+
+// Source-map upload runs from CI only, never from a local `pnpm build`. The
+// auth token lives exclusively as a GitHub Actions secret; its presence (plus
+// CI=true) is the gate. When absent, no plugin is added and no maps leave the
+// machine.
+const shouldUploadSourcemaps = Boolean(process.env.CI && process.env.SENTRY_AUTH_TOKEN);
+
+const sentryPlugins = shouldUploadSourcemaps
+  ? [
+      sentryEsbuildPlugin({
+        org: process.env.SENTRY_ORG,
+        project: process.env.SENTRY_PROJECT,
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+        release: { name: `shiranami@${pkg.version}` },
+        sourcemaps: {
+          // Strip maps from the shipped artifact after upload so they aren't
+          // distributed to users.
+          filesToDeleteAfterUpload: ['dist/main/**/*.map'],
+        },
+      }),
+    ]
+  : [];
 
 // Main + worker: externalize all npm dependencies. They're shipped via
 // node_modules and electron-builder rebuilds native modules (better-sqlite3,
@@ -27,6 +50,11 @@ const sharedOptions = {
   outdir: 'dist/main',
   sourcemap: true,
   logLevel: 'info',
+  // Inject the (public-ish) Sentry DSN at build time. Empty string when the
+  // env var is absent → main-process Sentry init is skipped entirely.
+  define: {
+    __SENTRY_DSN__: JSON.stringify(process.env.SENTRY_DSN ?? ''),
+  },
 };
 
 await Promise.all([
@@ -38,6 +66,7 @@ await Promise.all([
       'src/main/scan-utility.ts',
     ],
     external: mainExternal,
+    plugins: sentryPlugins,
   }),
   build({
     ...sharedOptions,

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,6 +24,7 @@
     "rebuild": "electron-builder install-app-deps"
   },
   "dependencies": {
+    "@sentry/electron": "7.13.0",
     "@xhayper/discord-rpc": "^1.3.4",
     "adm-zip": "^0.5.17",
     "better-sqlite3": "^12.10.0",
@@ -49,6 +50,7 @@
   "devDependencies": {
     "@electron/rebuild": "^4.0.4",
     "@playwright/test": "^1.60.0",
+    "@sentry/esbuild-plugin": "5.3.0",
     "@shiranami/contracts": "workspace:*",
     "@shiranami/database": "workspace:*",
     "@shiranami/shared": "workspace:*",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,6 +1,8 @@
 import { join } from 'path';
 import * as os from 'os';
 import { app, BrowserWindow, protocol } from 'electron';
+import * as Sentry from '@sentry/electron/main';
+import { initSentryMain, watchTelemetryConsent } from './sentry';
 import { createMainWindow } from './window';
 import { cleanupIpcHandlers } from './ipc/register';
 import { initializeAutoUpdater } from './updater';
@@ -82,6 +84,11 @@ app.on('open-url', (event, url) => {
 });
 
 async function bootstrap(): Promise<void> {
+  // Initialize crash/error reporting first so even early-bootstrap failures are
+  // captured. No-op unless the user opted in AND the build is packaged.
+  initSentryMain();
+  watchTelemetryConsent();
+
   logger.info('════════════════════════════════════════════════════════════');
   logger.info(`  New session — Shiranami v${app.getVersion()}`);
   logger.info(`[system] OS: ${os.platform()} ${os.release()} (${os.arch()})`);
@@ -169,10 +176,12 @@ async function bootstrap(): Promise<void> {
 
 process.on('uncaughtException', error => {
   logger.error('Uncaught exception:', error);
+  Sentry.captureException(error);
 });
 
 process.on('unhandledRejection', reason => {
   logger.error('Unhandled rejection:', reason);
+  Sentry.captureException(reason);
 });
 
 for (const signal of ['SIGINT', 'SIGTERM'] as const) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -36,6 +36,17 @@ if (!gotTheLock) {
   app.quit();
 }
 
+// Crash/error reporting must initialize before BOTH the 'ready' event and our
+// own registerSchemesAsPrivileged call below: @sentry/electron registers a
+// privileged `sentry-ipc` scheme at init and then proxies
+// registerSchemesAsPrivileged so later registrations merge rather than
+// overwrite. Running it first means our schemes go through that proxy and both
+// survive. No-op unless the user opted in AND the build is packaged (or
+// SENTRY_FORCE_ENABLE). watchTelemetryConsent handles runtime disable and
+// defers enable to the next launch (the SDK can't init post-ready).
+initSentryMain();
+watchTelemetryConsent();
+
 // Must be called before app.ready.
 protocol.registerSchemesAsPrivileged(PRIVILEGED_SCHEMES);
 
@@ -84,11 +95,6 @@ app.on('open-url', (event, url) => {
 });
 
 async function bootstrap(): Promise<void> {
-  // Initialize crash/error reporting first so even early-bootstrap failures are
-  // captured. No-op unless the user opted in AND the build is packaged.
-  initSentryMain();
-  watchTelemetryConsent();
-
   logger.info('════════════════════════════════════════════════════════════');
   logger.info(`  New session — Shiranami v${app.getVersion()}`);
   logger.info(`[system] OS: ${os.platform()} ${os.release()} (${os.arch()})`);

--- a/apps/desktop/src/main/ipc/schemas/store.ts
+++ b/apps/desktop/src/main/ipc/schemas/store.ts
@@ -21,6 +21,7 @@ const RENDERER_STORE_KEYS = [
   'app.language',
   'app.onboardingCompleted',
   'app.supportBannerSeen',
+  'app.telemetryEnabled',
   'metadata-enrich.skippedIds',
 ] as const;
 

--- a/apps/desktop/src/main/ipc/schemas/store.ts
+++ b/apps/desktop/src/main/ipc/schemas/store.ts
@@ -22,6 +22,7 @@ const RENDERER_STORE_KEYS = [
   'app.onboardingCompleted',
   'app.supportBannerSeen',
   'app.telemetryEnabled',
+  'app.performanceMonitoringEnabled',
   'metadata-enrich.skippedIds',
 ] as const;
 

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -4,6 +4,13 @@
 // the build pipeline doesn't need to track the split. Importing the index runs
 // `contextBridge.exposeInMainWorld` as a side effect.
 
+// Sentry preload: exposes the renderer↔main IPC bridge via contextBridge so the
+// renderer SDK uses Electron IPC (Classic) instead of the HTTP-protocol fallback.
+// Required because we bundle the main process — the SDK can't auto-inject its
+// preload into a packaged build, so we wire it manually here. It's a no-op IPC
+// channel with no network egress; harmless when telemetry is off.
+import '@sentry/electron/preload';
+
 import './preload/index';
 
 export type { ElectronAPI } from './preload/index';

--- a/apps/desktop/src/main/sentry.ts
+++ b/apps/desktop/src/main/sentry.ts
@@ -1,0 +1,91 @@
+import * as Sentry from '@sentry/electron/main';
+import { app } from 'electron';
+import { scrubEvent, scrubBreadcrumb } from '@shiranami/shared';
+import { store } from './store';
+import { logger } from './logger';
+
+/**
+ * Build-time-injected DSN. esbuild replaces `__SENTRY_DSN__` with
+ * `JSON.stringify(process.env.SENTRY_DSN ?? '')` (see esbuild.config.mjs).
+ * When the env var is absent (local dev, or CI without the secret) this is an
+ * empty string and `Sentry.init` is skipped — no crash, no egress.
+ */
+declare const __SENTRY_DSN__: string;
+const SENTRY_DSN: string = typeof __SENTRY_DSN__ === 'string' ? __SENTRY_DSN__ : '';
+
+let initialized = false;
+
+/**
+ * True only when the user has explicitly opted in AND the build is packaged.
+ * Dev builds never report (keeps the project free of dev noise) and a fresh
+ * install never reports (consent defaults to false / undefined).
+ */
+function shouldInit(): boolean {
+  return store.get('app.telemetryEnabled') === true && app.isPackaged;
+}
+
+/**
+ * Initialize Sentry in the main process. Idempotent and gated: returns early
+ * unless consent is on, the build is packaged, and a DSN was injected. Call at
+ * the very top of bootstrap() so even early crashes are captured once enabled.
+ */
+export function initSentryMain(): void {
+  if (initialized) return;
+
+  if (!shouldInit()) {
+    logger.info('[telemetry] disabled — consent off or unpackaged build');
+    return;
+  }
+
+  if (!SENTRY_DSN) {
+    logger.info('[telemetry] consent on but no DSN injected — skipping init');
+    return;
+  }
+
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    release: `shiranami@${app.getVersion()}`,
+    environment: 'production',
+    dist: process.platform,
+    sendDefaultPii: false,
+    tracesSampleRate: 0.1,
+    beforeSend: event => scrubEvent(event),
+    beforeBreadcrumb: breadcrumb => scrubBreadcrumb(breadcrumb),
+  });
+
+  initialized = true;
+  logger.info('[telemetry] enabled — Sentry initialized (main)');
+}
+
+/**
+ * Runtime consent toggle. Turning ON in a packaged build initializes Sentry
+ * immediately; turning OFF flushes and closes the client so no further events
+ * are sent. A restart cleanly re-applies the gate either way.
+ */
+export async function setTelemetryEnabled(enabled: boolean): Promise<void> {
+  if (enabled) {
+    initSentryMain();
+    return;
+  }
+
+  if (initialized) {
+    try {
+      await Sentry.close(2000);
+    } catch {
+      // Closing is best-effort; the gate still blocks future inits on restart.
+    }
+    initialized = false;
+    logger.info('[telemetry] disabled — Sentry client closed (main)');
+  }
+}
+
+/**
+ * Wire the runtime toggle to the persisted consent flag. When the renderer
+ * flips `app.telemetryEnabled` through the gated store IPC, the main process
+ * reacts here — no dedicated IPC channel needed. Returns the unsubscribe fn.
+ */
+export function watchTelemetryConsent(): () => void {
+  return store.onDidChange('app.telemetryEnabled', value => {
+    void setTelemetryEnabled(value === true);
+  });
+}

--- a/apps/desktop/src/main/sentry.ts
+++ b/apps/desktop/src/main/sentry.ts
@@ -40,8 +40,9 @@ function shouldInit(): boolean {
 /**
  * Initialize Sentry in the main process. Idempotent and gated: returns early
  * unless consent is on, the build is packaged (or SENTRY_FORCE_ENABLE is set
- * for local testing), and a DSN is available. Call at the very top of
- * bootstrap() so even early crashes are captured once enabled.
+ * for local testing), and a DSN is available. Must be called BEFORE the app
+ * 'ready' event (see index.ts) — @sentry/electron registers protocol/IPC
+ * handlers at init that Electron only permits pre-ready.
  */
 export function initSentryMain(): void {
   if (initialized) return;
@@ -74,12 +75,20 @@ export function initSentryMain(): void {
 }
 
 /**
- * Runtime consent toggle. Turning ON in a packaged build initializes Sentry
- * immediately; turning OFF flushes and closes the client so no further events
- * are sent. A restart cleanly re-applies the gate either way.
+ * Runtime consent toggle. Turning OFF flushes and closes the client immediately
+ * so no further events are sent. Turning ON cannot init the SDK at runtime —
+ * @sentry/electron must initialize before the app 'ready' event — so enabling
+ * takes effect on the next launch, when the boot-time gate picks up the flag.
  */
 export async function setTelemetryEnabled(enabled: boolean): Promise<void> {
   if (enabled) {
+    if (initialized) return;
+    // Enabling while the app is already running can't init now (the SDK must
+    // init pre-ready). The persisted consent flag takes effect on next launch.
+    if (app.isReady()) {
+      logger.info('[telemetry] consent enabled — crash reporting starts on next launch');
+      return;
+    }
     initSentryMain();
     return;
   }

--- a/apps/desktop/src/main/sentry.ts
+++ b/apps/desktop/src/main/sentry.ts
@@ -7,33 +7,49 @@ import { logger } from './logger';
 /**
  * Build-time-injected DSN. esbuild replaces `__SENTRY_DSN__` with
  * `JSON.stringify(process.env.SENTRY_DSN ?? '')` (see esbuild.config.mjs).
- * When the env var is absent (local dev, or CI without the secret) this is an
- * empty string and `Sentry.init` is skipped — no crash, no egress.
+ * When absent at build time it falls back to `process.env.SENTRY_DSN` at
+ * runtime, so the local-test command can inject the DSN through the shell
+ * without rebuilding. When both are absent this is an empty string and
+ * `Sentry.init` is skipped — no crash, no egress.
  */
 declare const __SENTRY_DSN__: string;
-const SENTRY_DSN: string = typeof __SENTRY_DSN__ === 'string' ? __SENTRY_DSN__ : '';
+const SENTRY_DSN: string =
+  (typeof __SENTRY_DSN__ === 'string' ? __SENTRY_DSN__ : '') || process.env.SENTRY_DSN || '';
+
+/**
+ * Local-test escape hatch. When `SENTRY_FORCE_ENABLE` is `true`/`1` in the
+ * shell env, an unpackaged dev build is allowed to init Sentry so the first
+ * event can be sent during onboarding. It overrides ONLY the packaged check —
+ * consent and a DSN are still required. Has no effect on packaged builds.
+ */
+const forceEnabled =
+  process.env.SENTRY_FORCE_ENABLE === 'true' || process.env.SENTRY_FORCE_ENABLE === '1';
 
 let initialized = false;
 
 /**
- * True only when the user has explicitly opted in AND the build is packaged.
- * Dev builds never report (keeps the project free of dev noise) and a fresh
- * install never reports (consent defaults to false / undefined).
+ * True only when the user has explicitly opted in AND the build is packaged
+ * (or the force-enable escape hatch is set for local testing). Dev builds
+ * never report unless force-enabled, and a fresh install never reports
+ * (consent defaults to false / undefined).
  */
 function shouldInit(): boolean {
-  return store.get('app.telemetryEnabled') === true && app.isPackaged;
+  return store.get('app.telemetryEnabled') === true && (app.isPackaged || forceEnabled);
 }
 
 /**
  * Initialize Sentry in the main process. Idempotent and gated: returns early
- * unless consent is on, the build is packaged, and a DSN was injected. Call at
- * the very top of bootstrap() so even early crashes are captured once enabled.
+ * unless consent is on, the build is packaged (or SENTRY_FORCE_ENABLE is set
+ * for local testing), and a DSN is available. Call at the very top of
+ * bootstrap() so even early crashes are captured once enabled.
  */
 export function initSentryMain(): void {
   if (initialized) return;
 
   if (!shouldInit()) {
-    logger.info('[telemetry] disabled — consent off or unpackaged build');
+    logger.info(
+      '[telemetry] disabled — consent off, or unpackaged build without SENTRY_FORCE_ENABLE'
+    );
     return;
   }
 

--- a/apps/desktop/src/main/sentry.ts
+++ b/apps/desktop/src/main/sentry.ts
@@ -59,19 +59,32 @@ export function initSentryMain(): void {
     return;
   }
 
+  // Performance tracing is a separate opt-in: only sample transactions when the
+  // user has also enabled performance monitoring. Sample everything on an
+  // unpackaged dev build (the developer hunting bottlenecks); keep a modest
+  // rate on shipped builds to bound transaction volume across many users.
+  const perfEnabled = store.get('app.performanceMonitoringEnabled') === true;
+  const tracesSampleRate = perfEnabled ? (app.isPackaged ? 0.2 : 1.0) : 0;
+
   Sentry.init({
     dsn: SENTRY_DSN,
     release: `shiranami@${app.getVersion()}`,
-    environment: 'production',
+    // Force-enabled local runs are unpackaged — tag them 'development' so they
+    // don't pollute the production environment's error rates and dashboards.
+    environment: app.isPackaged ? 'production' : 'development',
     dist: process.platform,
     sendDefaultPii: false,
-    tracesSampleRate: 0.1,
+    tracesSampleRate,
     beforeSend: event => scrubEvent(event),
     beforeBreadcrumb: breadcrumb => scrubBreadcrumb(breadcrumb),
   });
 
   initialized = true;
-  logger.info('[telemetry] enabled — Sentry initialized (main)');
+  logger.info(
+    `[telemetry] enabled — Sentry initialized (main), performance monitoring ${
+      perfEnabled ? 'on' : 'off'
+    }`
+  );
 }
 
 /**

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -43,6 +43,10 @@ export interface StoreSchema {
   'app.onboardingCompleted': boolean;
   // Support launch banner — shown once ever, after onboarding.
   'app.supportBannerSeen': boolean;
+  // Opt-in crash/error reporting (Sentry). Default is implicit `undefined` →
+  // treated as `false`; no `defaults` value is set so a fresh install never
+  // initializes Sentry until the user explicitly enables it.
+  'app.telemetryEnabled': boolean;
   'metadata-enrich.skippedIds': string[];
 
   // Main-only (downloader.ts).

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -47,6 +47,10 @@ export interface StoreSchema {
   // treated as `false`; no `defaults` value is set so a fresh install never
   // initializes Sentry until the user explicitly enables it.
   'app.telemetryEnabled': boolean;
+  // Opt-in performance tracing (Sentry). A sub-option of telemetry: only takes
+  // effect when crash reporting is also on. Default `undefined` → off, so no
+  // transactions are sampled until the user explicitly enables it.
+  'app.performanceMonitoringEnabled': boolean;
   'metadata-enrich.skippedIds': string[];
 
   // Main-only (downloader.ts).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@sentry/react": "10.50.0",
     "@shiranami/contracts": "workspace:*",
     "@shiranami/shared": "workspace:*",
     "@tanstack/react-query": "^5.100.13",
@@ -47,6 +48,7 @@
     "zustand": "^5.0.13"
   },
   "devDependencies": {
+    "@sentry/vite-plugin": "5.3.0",
     "@tailwindcss/vite": "^4.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@sentry/electron": "7.13.0",
     "@sentry/react": "10.50.0",
     "@shiranami/contracts": "workspace:*",
     "@shiranami/shared": "workspace:*",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -57,6 +57,7 @@ import { useMetadataEnrichStore } from '@/stores/useMetadataEnrichStore';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { useOnboardingStore } from '@/stores/useOnboardingStore';
 import { useSupportBannerStore } from '@/stores/useSupportBannerStore';
+import { useTelemetryStore } from '@/stores/useTelemetryStore';
 import { AmbientColorProvider } from '@/hooks/useAmbientColor';
 import { CommandPalette } from '@/components/shared/CommandPalette';
 import { hydrateLanguageFromStore } from '@/lib/i18n';
@@ -68,6 +69,7 @@ function App() {
   const onboardingCompleted = useOnboardingStore(s => s.hasCompletedOnboarding);
   const hydrateOnboarding = useOnboardingStore(s => s.hydrateOnboarding);
   const hydrateSupportBanner = useSupportBannerStore(s => s.hydrateSupportBanner);
+  const hydrateTelemetry = useTelemetryStore(s => s.hydrate);
   // Under the e2e harness, treat onboarding as done so specs land on the app
   // shell instead of the first-run wizard (fresh userDataDir → never completed).
   const [onboardingDone, setOnboardingDone] = useState(onboardingCompleted || IS_E2E);
@@ -119,6 +121,10 @@ function App() {
   useEffect(() => {
     void hydrateSupportBanner();
   }, [hydrateSupportBanner]);
+
+  useEffect(() => {
+    void hydrateTelemetry();
+  }, [hydrateTelemetry]);
 
   // Auto-collapse sidebar on narrow viewports
   const setSidebarCollapsed = useUIStore(s => s.setSidebarCollapsed);

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -26,6 +26,7 @@ import { ToolsStep } from './steps/ToolsStep';
 import { AppearanceStep } from './steps/AppearanceStep';
 import { PlaybackStep } from './steps/PlaybackStep';
 import { VisualizerStep } from './steps/VisualizerStep';
+import { PrivacyStep } from './steps/PrivacyStep';
 import { SummaryStep } from './steps/SummaryStep';
 
 interface OnboardingWizardProps {
@@ -39,6 +40,7 @@ type StepId =
   | 'appearance'
   | 'playback'
   | 'visualizer'
+  | 'privacy'
   | 'summary';
 
 interface StepDef {
@@ -54,6 +56,7 @@ const STEPS: readonly StepDef[] = [
   { id: 'appearance', kanji: '夜', Component: AppearanceStep },
   { id: 'playback', kanji: '音', Component: PlaybackStep },
   { id: 'visualizer', kanji: '波', Component: VisualizerStep },
+  { id: 'privacy', kanji: '守', Component: PrivacyStep },
   { id: 'summary', kanji: '締', Component: SummaryStep },
 ];
 

--- a/apps/web/src/components/onboarding/stepContext.ts
+++ b/apps/web/src/components/onboarding/stepContext.ts
@@ -7,6 +7,7 @@ export type OnboardingStepId =
   | 'appearance'
   | 'playback'
   | 'visualizer'
+  | 'privacy'
   | 'summary';
 
 export interface OnboardingStepContextValue {

--- a/apps/web/src/components/onboarding/steps/PrivacyStep.tsx
+++ b/apps/web/src/components/onboarding/steps/PrivacyStep.tsx
@@ -66,7 +66,7 @@ export function PrivacyStep() {
           label={t('privacy.toggleLabel')}
           description={t('privacy.toggleDesc')}
           checked={enabled}
-          onCheckedChange={setEnabled}
+          onCheckedChange={value => void setEnabled(value)}
         />
 
         <p className="text-[11px] leading-snug text-muted-foreground/70">{t('privacy.footnote')}</p>

--- a/apps/web/src/components/onboarding/steps/PrivacyStep.tsx
+++ b/apps/web/src/components/onboarding/steps/PrivacyStep.tsx
@@ -1,0 +1,76 @@
+import { useTranslation, Trans } from 'react-i18next';
+import { Check, X } from 'lucide-react';
+import { useTelemetryStore } from '@/stores/useTelemetryStore';
+import { SettingsToggleRow } from '@/components/settings/SettingsCard';
+import { OnboardingStepLayout } from '../OnboardingStepLayout';
+import { useOnboardingStepContext } from '../stepContext';
+
+export function PrivacyStep() {
+  const { t } = useTranslation('onboarding');
+  const { kanji, headingId, headingRef } = useOnboardingStepContext();
+  const enabled = useTelemetryStore(s => s.enabled);
+  const setEnabled = useTelemetryStore(s => s.setEnabled);
+
+  const sent = t('privacy.sent', { returnObjects: true }) as string[];
+  const notSent = t('privacy.notSent', { returnObjects: true }) as string[];
+
+  return (
+    <OnboardingStepLayout
+      kanji={kanji}
+      headingId={headingId}
+      headingRef={headingRef}
+      stepMarker={t('privacy.eyebrow')}
+      headline={
+        <Trans
+          t={t}
+          i18nKey="privacy.headline"
+          components={{ 1: <em className="not-italic text-primary" /> }}
+        />
+      }
+      description={t('privacy.description')}
+    >
+      <div className="space-y-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-foreground">{t('privacy.sentTitle')}</p>
+            <ul className="space-y-1.5">
+              {sent.map(item => (
+                <li
+                  key={item}
+                  className="flex items-start gap-2 text-[13px] leading-snug text-muted-foreground"
+                >
+                  <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-foreground">{t('privacy.notSentTitle')}</p>
+            <ul className="space-y-1.5">
+              {notSent.map(item => (
+                <li
+                  key={item}
+                  className="flex items-start gap-2 text-[13px] leading-snug text-muted-foreground"
+                >
+                  <X className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground/70" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <SettingsToggleRow
+          divider
+          label={t('privacy.toggleLabel')}
+          description={t('privacy.toggleDesc')}
+          checked={enabled}
+          onCheckedChange={setEnabled}
+        />
+
+        <p className="text-[11px] leading-snug text-muted-foreground/70">{t('privacy.footnote')}</p>
+      </div>
+    </OnboardingStepLayout>
+  );
+}

--- a/apps/web/src/components/settings/PrivacySection.tsx
+++ b/apps/web/src/components/settings/PrivacySection.tsx
@@ -1,19 +1,42 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ShieldCheck, Info } from 'lucide-react';
+import { toast } from 'sonner';
+import { ShieldCheck, Info, Bug, Check } from 'lucide-react';
 import { useTelemetryStore } from '@/stores/useTelemetryStore';
+import { initSentryRenderer, captureException } from '@/lib/sentry';
+import { Button } from '@/components/ui/button';
 import {
   SettingsCard,
   SettingsToggleRow,
   SettingsInfoCallout,
 } from '@/components/settings/SettingsCard';
 
+/**
+ * Dev/test affordance gate. The "Send test event" button is only meaningful
+ * when Sentry can actually init in this build — a dev server, or a build with
+ * the renderer force-enable flag set for local testing. It never renders in a
+ * normal production build, so users never see it.
+ */
+const SHOW_TEST_BUTTON = import.meta.env.DEV || import.meta.env.VITE_SENTRY_FORCE_ENABLE === 'true';
+
 export function PrivacySection() {
   const { t } = useTranslation('settings');
   const enabled = useTelemetryStore(s => s.enabled);
   const setEnabled = useTelemetryStore(s => s.setEnabled);
+  const [sentRecently, setSentRecently] = useState(false);
 
   const sent = t('priv.sent', { returnObjects: true }) as string[];
   const notSent = t('priv.notSent', { returnObjects: true }) as string[];
+
+  async function sendTestEvent() {
+    // Ensure Sentry is initialized — the boot-time call in main.tsx returns
+    // early when consent was off, so toggling it on later needs this nudge.
+    await initSentryRenderer();
+    captureException(new Error(`Sentry test event — ${new Date().toISOString()}`));
+    setSentRecently(true);
+    toast.success(t('priv.testSent'));
+    window.setTimeout(() => setSentRecently(false), 2500);
+  }
 
   return (
     <div className="space-y-4">
@@ -46,6 +69,25 @@ export function PrivacySection() {
       </SettingsCard>
 
       <SettingsInfoCallout icon={Info}>{t('priv.note')}</SettingsInfoCallout>
+
+      {SHOW_TEST_BUTTON && enabled && (
+        <SettingsCard icon={Bug} title={t('priv.testTitle')} subtitle={t('priv.testDesc')}>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-border/40"
+              onClick={() => void sendTestEvent()}
+            >
+              {sentRecently ? <Check className="h-3.5 w-3.5" /> : <Bug className="h-3.5 w-3.5" />}
+              {sentRecently ? t('priv.testSent') : t('priv.testButton')}
+            </Button>
+            <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground/60">
+              {t('priv.testDevOnly')}
+            </span>
+          </div>
+        </SettingsCard>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/settings/PrivacySection.tsx
+++ b/apps/web/src/components/settings/PrivacySection.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next';
+import { ShieldCheck, Info } from 'lucide-react';
+import { useTelemetryStore } from '@/stores/useTelemetryStore';
+import {
+  SettingsCard,
+  SettingsToggleRow,
+  SettingsInfoCallout,
+} from '@/components/settings/SettingsCard';
+
+export function PrivacySection() {
+  const { t } = useTranslation('settings');
+  const enabled = useTelemetryStore(s => s.enabled);
+  const setEnabled = useTelemetryStore(s => s.setEnabled);
+
+  const sent = t('priv.sent', { returnObjects: true }) as string[];
+  const notSent = t('priv.notSent', { returnObjects: true }) as string[];
+
+  return (
+    <div className="space-y-4">
+      <SettingsCard icon={ShieldCheck} title={t('priv.title')} subtitle={t('priv.subtitle')}>
+        <SettingsToggleRow
+          label={t('priv.toggleLabel')}
+          description={t('priv.toggleDesc')}
+          checked={enabled}
+          onCheckedChange={setEnabled}
+        />
+
+        <div className="grid grid-cols-1 gap-4 border-t border-border/30 pt-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium text-foreground">{t('priv.sentTitle')}</p>
+            <ul className="space-y-1 text-[13px] leading-snug text-muted-foreground">
+              {sent.map(item => (
+                <li key={item}>· {item}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium text-foreground">{t('priv.notSentTitle')}</p>
+            <ul className="space-y-1 text-[13px] leading-snug text-muted-foreground">
+              {notSent.map(item => (
+                <li key={item}>· {item}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </SettingsCard>
+
+      <SettingsInfoCallout icon={Info}>{t('priv.note')}</SettingsInfoCallout>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/PrivacySection.tsx
+++ b/apps/web/src/components/settings/PrivacySection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { ShieldCheck, Info, Bug, Check } from 'lucide-react';
+import { ShieldCheck, Info, Bug, Check, RotateCcw } from 'lucide-react';
 import { useTelemetryStore } from '@/stores/useTelemetryStore';
 import { initSentryRenderer, captureException } from '@/lib/sentry';
 import { Button } from '@/components/ui/button';
@@ -24,6 +24,15 @@ export function PrivacySection() {
   const enabled = useTelemetryStore(s => s.enabled);
   const setEnabled = useTelemetryStore(s => s.setEnabled);
   const [sentRecently, setSentRecently] = useState(false);
+  // The main-process SDK can only init before the app 'ready' event, so turning
+  // crash reporting ON takes effect on the next launch. Surface that to the user.
+  const [pendingRestart, setPendingRestart] = useState(false);
+
+  function handleToggle(next: boolean) {
+    setEnabled(next);
+    // Enabling needs a restart to actually start reporting; disabling is immediate.
+    setPendingRestart(next);
+  }
 
   const sent = t('priv.sent', { returnObjects: true }) as string[];
   const notSent = t('priv.notSent', { returnObjects: true }) as string[];
@@ -45,7 +54,7 @@ export function PrivacySection() {
           label={t('priv.toggleLabel')}
           description={t('priv.toggleDesc')}
           checked={enabled}
-          onCheckedChange={setEnabled}
+          onCheckedChange={handleToggle}
         />
 
         <div className="grid grid-cols-1 gap-4 border-t border-border/30 pt-4 sm:grid-cols-2">
@@ -68,9 +77,13 @@ export function PrivacySection() {
         </div>
       </SettingsCard>
 
+      {pendingRestart && (
+        <SettingsInfoCallout icon={RotateCcw}>{t('priv.restartNote')}</SettingsInfoCallout>
+      )}
+
       <SettingsInfoCallout icon={Info}>{t('priv.note')}</SettingsInfoCallout>
 
-      {SHOW_TEST_BUTTON && enabled && (
+      {SHOW_TEST_BUTTON && enabled && !pendingRestart && (
         <SettingsCard icon={Bug} title={t('priv.testTitle')} subtitle={t('priv.testDesc')}>
           <div className="flex flex-wrap items-center gap-2">
             <Button

--- a/apps/web/src/components/settings/PrivacySection.tsx
+++ b/apps/web/src/components/settings/PrivacySection.tsx
@@ -23,16 +23,19 @@ export function PrivacySection() {
   const { t } = useTranslation('settings');
   const enabled = useTelemetryStore(s => s.enabled);
   const setEnabled = useTelemetryStore(s => s.setEnabled);
+  const performanceEnabled = useTelemetryStore(s => s.performanceEnabled);
+  const setPerformanceEnabled = useTelemetryStore(s => s.setPerformanceEnabled);
+  const bootEnabled = useTelemetryStore(s => s.bootEnabled);
+  const bootPerformanceEnabled = useTelemetryStore(s => s.bootPerformanceEnabled);
   const [sentRecently, setSentRecently] = useState(false);
-  // The main-process SDK can only init before the app 'ready' event, so turning
-  // crash reporting ON takes effect on the next launch. Surface that to the user.
-  const [pendingRestart, setPendingRestart] = useState(false);
 
-  function handleToggle(next: boolean) {
-    setEnabled(next);
-    // Enabling needs a restart to actually start reporting; disabling is immediate.
-    setPendingRestart(next);
-  }
+  // Sentry reads its config once, before the app 'ready' event, so config changes
+  // only take effect on the next launch. Derived from the boot snapshot (not local
+  // state) so the warning survives navigating away and back. Turning reporting OFF
+  // is immediate (main closes the client at runtime), so it never needs a restart.
+  const needsRestart =
+    (enabled && !bootEnabled) ||
+    (enabled && bootEnabled && performanceEnabled !== bootPerformanceEnabled);
 
   const sent = t('priv.sent', { returnObjects: true }) as string[];
   const notSent = t('priv.notSent', { returnObjects: true }) as string[];
@@ -54,8 +57,19 @@ export function PrivacySection() {
           label={t('priv.toggleLabel')}
           description={t('priv.toggleDesc')}
           checked={enabled}
-          onCheckedChange={handleToggle}
+          onCheckedChange={value => void setEnabled(value)}
         />
+
+        {enabled && (
+          <div className="border-t border-border/30 pt-4">
+            <SettingsToggleRow
+              label={t('priv.perfLabel')}
+              description={t('priv.perfDesc')}
+              checked={performanceEnabled}
+              onCheckedChange={value => void setPerformanceEnabled(value)}
+            />
+          </div>
+        )}
 
         <div className="grid grid-cols-1 gap-4 border-t border-border/30 pt-4 sm:grid-cols-2">
           <div className="space-y-1.5">
@@ -77,13 +91,13 @@ export function PrivacySection() {
         </div>
       </SettingsCard>
 
-      {pendingRestart && (
+      {needsRestart && (
         <SettingsInfoCallout icon={RotateCcw}>{t('priv.restartNote')}</SettingsInfoCallout>
       )}
 
       <SettingsInfoCallout icon={Info}>{t('priv.note')}</SettingsInfoCallout>
 
-      {SHOW_TEST_BUTTON && enabled && !pendingRestart && (
+      {SHOW_TEST_BUTTON && enabled && !needsRestart && (
         <SettingsCard icon={Bug} title={t('priv.testTitle')} subtitle={t('priv.testDesc')}>
           <div className="flex flex-wrap items-center gap-2">
             <Button

--- a/apps/web/src/components/settings/SettingsView.tsx
+++ b/apps/web/src/components/settings/SettingsView.tsx
@@ -17,6 +17,7 @@ import {
   Info,
   Heart,
   MessageCircle,
+  ShieldCheck,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { SettingsHeader } from '@/components/settings/SettingsHeader';
@@ -36,6 +37,7 @@ import { CompactSection } from '@/components/settings/CompactSection';
 import { AboutSection } from '@/components/settings/AboutSection';
 import { SupportSection } from '@/components/settings/SupportSection';
 import { DiscordSection } from '@/components/settings/DiscordSection';
+import { PrivacySection } from '@/components/settings/PrivacySection';
 
 type SettingsSection =
   | 'folders'
@@ -52,6 +54,7 @@ type SettingsSection =
   | 'sidebar'
   | 'discord'
   | 'updates'
+  | 'privacy'
   | 'about'
   | 'support';
 
@@ -171,6 +174,13 @@ const SECTIONS: {
     Icon: RefreshCcw,
     group: 'system',
   },
+  {
+    id: 'privacy',
+    labelKey: 'privacy',
+    subtitleKey: 'subtitles.privacy',
+    Icon: ShieldCheck,
+    group: 'system',
+  },
   { id: 'about', labelKey: 'about', subtitleKey: 'subtitles.about', Icon: Info, group: 'system' },
   {
     id: 'support',
@@ -196,6 +206,7 @@ const SECTION_PANEL: Record<SettingsSection, ComponentType> = {
   sidebar: SidebarSection,
   discord: DiscordSection,
   updates: UpdatesSection,
+  privacy: PrivacySection,
   about: AboutSection,
   support: SupportSection,
 };

--- a/apps/web/src/components/shared/ErrorBoundary.tsx
+++ b/apps/web/src/components/shared/ErrorBoundary.tsx
@@ -5,6 +5,7 @@ import { AlertCircle, RefreshCw, ClipboardCopy } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { logger } from '@/lib/logger';
+import { captureException } from '@/lib/sentry';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -109,6 +110,11 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
       error,
       errorInfo.componentStack
     );
+    // Remote capture (no-op unless telemetry initialized). The local logger
+    // above + the clipboard report below remain the offline-first fallback.
+    captureException(error, {
+      contexts: { react: { componentStack: errorInfo.componentStack } },
+    });
   }
 
   reset = (): void => {

--- a/apps/web/src/lib/sentry.ts
+++ b/apps/web/src/lib/sentry.ts
@@ -34,19 +34,27 @@ export async function initSentryRenderer(): Promise<void> {
   if (!IS_ELECTRON || !(import.meta.env.PROD || forceEnabled)) return;
 
   let consent: boolean;
+  let perfEnabled: boolean;
   try {
     consent = (await window.electronAPI.store.get('app.telemetryEnabled')) === true;
+    // Performance tracing is a separate opt-in (sub-option of telemetry).
+    perfEnabled = (await window.electronAPI.store.get('app.performanceMonitoringEnabled')) === true;
   } catch {
     // Store read failed — treat as no consent.
     return;
   }
   if (!consent) return;
 
+  // Mirror the main process: sample everything on an unpackaged dev build, a
+  // modest rate on shipped builds, and nothing when performance monitoring is
+  // off. browserTracing is only wired when tracing is actually enabled.
+  const tracesSampleRate = perfEnabled ? (import.meta.env.PROD ? 0.2 : 1.0) : 0;
+
   SentryElectron.init(
     {
       sendDefaultPii: false,
-      tracesSampleRate: 0.1,
-      integrations: [SentryElectron.browserTracingIntegration()],
+      tracesSampleRate,
+      integrations: perfEnabled ? [SentryElectron.browserTracingIntegration()] : [],
       beforeSend: event => scrubEvent(event),
     },
     reactInit

--- a/apps/web/src/lib/sentry.ts
+++ b/apps/web/src/lib/sentry.ts
@@ -3,19 +3,35 @@ import { init as reactInit } from '@sentry/react';
 import { scrubEvent } from '@shiranami/shared';
 import { IS_ELECTRON } from '@/lib/platform';
 
+let initialized = false;
+
+/**
+ * Local-test escape hatch, mirroring the main process. When
+ * `VITE_SENTRY_FORCE_ENABLE` is `true`, an unpackaged dev build is allowed to
+ * init Sentry. Vite exposes `VITE_`-prefixed vars from both `.env` files and
+ * `process.env`, so the local-test command can set it via the shell. It
+ * overrides ONLY the production check — consent is still required.
+ */
+const forceEnabled = import.meta.env.VITE_SENTRY_FORCE_ENABLE === 'true';
+
 /**
  * Initialize Sentry in the renderer. Gated identically to the main process:
- * only runs after explicit opt-in, only in a packaged/production build, and
- * only inside Electron. The DSN/release/environment are inherited from the
- * main process via the @sentry/electron IPC transport — the renderer never
- * needs its own DSN.
+ * only runs after explicit opt-in, only in a packaged/production build (or
+ * when force-enabled for local testing), and only inside Electron. The
+ * DSN/release/environment are inherited from the main process via the
+ * @sentry/electron IPC transport — the renderer never needs its own DSN.
+ *
+ * Idempotent: a guard makes repeat calls a no-op, so the Privacy "Send test
+ * event" button can safely call this to ensure init when consent was toggled
+ * on after the boot-time call in main.tsx already returned early.
  *
  * `@sentry/electron/renderer`'s init forwards through @sentry/react's init so
  * the React error boundary + component instrumentation are wired up while
  * events still route to the main transport. No replay integration is added.
  */
 export async function initSentryRenderer(): Promise<void> {
-  if (!IS_ELECTRON || !import.meta.env.PROD) return;
+  if (initialized) return;
+  if (!IS_ELECTRON || !(import.meta.env.PROD || forceEnabled)) return;
 
   let consent: boolean;
   try {
@@ -35,6 +51,8 @@ export async function initSentryRenderer(): Promise<void> {
     },
     reactInit
   );
+
+  initialized = true;
 }
 
 /** Re-export the renderer capture surface for the ErrorBoundary. */

--- a/apps/web/src/lib/sentry.ts
+++ b/apps/web/src/lib/sentry.ts
@@ -1,0 +1,41 @@
+import * as SentryElectron from '@sentry/electron/renderer';
+import { init as reactInit } from '@sentry/react';
+import { scrubEvent } from '@shiranami/shared';
+import { IS_ELECTRON } from '@/lib/platform';
+
+/**
+ * Initialize Sentry in the renderer. Gated identically to the main process:
+ * only runs after explicit opt-in, only in a packaged/production build, and
+ * only inside Electron. The DSN/release/environment are inherited from the
+ * main process via the @sentry/electron IPC transport — the renderer never
+ * needs its own DSN.
+ *
+ * `@sentry/electron/renderer`'s init forwards through @sentry/react's init so
+ * the React error boundary + component instrumentation are wired up while
+ * events still route to the main transport. No replay integration is added.
+ */
+export async function initSentryRenderer(): Promise<void> {
+  if (!IS_ELECTRON || !import.meta.env.PROD) return;
+
+  let consent: boolean;
+  try {
+    consent = (await window.electronAPI.store.get('app.telemetryEnabled')) === true;
+  } catch {
+    // Store read failed — treat as no consent.
+    return;
+  }
+  if (!consent) return;
+
+  SentryElectron.init(
+    {
+      sendDefaultPii: false,
+      tracesSampleRate: 0.1,
+      integrations: [SentryElectron.browserTracingIntegration()],
+      beforeSend: event => scrubEvent(event),
+    },
+    reactInit
+  );
+}
+
+/** Re-export the renderer capture surface for the ErrorBoundary. */
+export const captureException = SentryElectron.captureException;

--- a/apps/web/src/locales/en/onboarding.json
+++ b/apps/web/src/locales/en/onboarding.json
@@ -89,8 +89,28 @@
     "title": "Choose a visualizer",
     "hint": "Optional. Preview updates live."
   },
+  "privacy": {
+    "eyebrow": "06 · Crash reports",
+    "headline": "Help fix what <1>breaks</1>.",
+    "description": "Shiranami can send an automatic report when something crashes, so problems get fixed without you having to track down a log file. It's off until you turn it on, and you can change your mind any time in Settings · Privacy.",
+    "sentTitle": "What's sent",
+    "sent": [
+      "Crash and error reports",
+      "A small sample of performance timings",
+      "App version and operating system"
+    ],
+    "notSentTitle": "What's never sent",
+    "notSent": [
+      "No screen recording or replay",
+      "No personal info or account data",
+      "File paths are scrubbed of your username"
+    ],
+    "toggleLabel": "Send crash reports",
+    "toggleDesc": "Anonymous. Default off. Change it any time.",
+    "footnote": "Reports are scrubbed of file paths and your username before they ever leave your machine."
+  },
   "summary": {
-    "eyebrow": "06 · All set",
+    "eyebrow": "07 · All set",
     "headline": "Your room is <1>ready</1>.",
     "description": "Here's what you chose. Tweak any of it later from Settings.",
     "intro": "A quick recap before the library opens.",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -20,6 +20,7 @@
     "sidebar": "Main navigation visibility",
     "discord": "Discord integration settings",
     "updates": "Application update channel",
+    "privacy": "Crash reporting and data",
     "about": "About this application",
     "support": "Support the project"
   },
@@ -37,6 +38,7 @@
   "sidebar": "Sidebar",
   "discord": "Discord",
   "updates": "Updates",
+  "privacy": "Privacy",
   "about": "About",
   "support": "Support",
   "language": "Language",
@@ -430,6 +432,25 @@
     "somethingWrong": "Something went wrong",
     "checkFailed": "Failed to check for updates",
     "downloadFailed": "Download failed"
+  },
+  "priv": {
+    "title": "Crash reporting",
+    "subtitle": "Help fix what breaks. Off by default.",
+    "toggleLabel": "Send crash reports",
+    "toggleDesc": "Anonymous crash and error reports, plus a small sample of performance timings.",
+    "sentTitle": "What's sent",
+    "sent": [
+      "Crash and error reports",
+      "A small sample of performance timings",
+      "App version and operating system"
+    ],
+    "notSentTitle": "What's never sent",
+    "notSent": [
+      "No screen recording or replay",
+      "No personal info or account data",
+      "File paths scrubbed of your username"
+    ],
+    "note": "Reports are scrubbed of file paths and your username before they ever leave your machine. Nothing is sent while this is off."
   },
   "abt": {
     "title": "About",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -450,7 +450,12 @@
       "No personal info or account data",
       "File paths scrubbed of your username"
     ],
-    "note": "Reports are scrubbed of file paths and your username before they ever leave your machine. Nothing is sent while this is off."
+    "note": "Reports are scrubbed of file paths and your username before they ever leave your machine. Nothing is sent while this is off.",
+    "testTitle": "Verify setup",
+    "testDesc": "Sends a sample error to verify your Sentry setup — only visible in development.",
+    "testButton": "Send test event",
+    "testDevOnly": "Development only",
+    "testSent": "Test event sent"
   },
   "abt": {
     "title": "About",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -451,6 +451,7 @@
       "File paths scrubbed of your username"
     ],
     "note": "Reports are scrubbed of file paths and your username before they ever leave your machine. Nothing is sent while this is off.",
+    "restartNote": "Restart the app to start crash reporting — it can only initialize at launch.",
     "testTitle": "Verify setup",
     "testDesc": "Sends a sample error to verify your Sentry setup — only visible in development.",
     "testButton": "Send test event",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -437,12 +437,14 @@
     "title": "Crash reporting",
     "subtitle": "Help fix what breaks. Off by default.",
     "toggleLabel": "Send crash reports",
-    "toggleDesc": "Anonymous crash and error reports, plus a small sample of performance timings.",
+    "toggleDesc": "Anonymous crash and error reports.",
+    "perfLabel": "Performance monitoring",
+    "perfDesc": "Also sample app performance — page loads and navigation timings — to help find bottlenecks. Sends more data than crash reports alone.",
     "sentTitle": "What's sent",
     "sent": [
       "Crash and error reports",
-      "A small sample of performance timings",
-      "App version and operating system"
+      "App version and operating system",
+      "Performance timings (only with performance monitoring on)"
     ],
     "notSentTitle": "What's never sent",
     "notSent": [
@@ -451,7 +453,8 @@
       "File paths scrubbed of your username"
     ],
     "note": "Reports are scrubbed of file paths and your username before they ever leave your machine. Nothing is sent while this is off.",
-    "restartNote": "Restart the app to start crash reporting — it can only initialize at launch.",
+    "restartNote": "Restart the app to apply — crash reporting and performance monitoring can only initialize at launch.",
+    "saveError": "Couldn't save your privacy preference. Please try again.",
     "testTitle": "Verify setup",
     "testDesc": "Sends a sample error to verify your Sentry setup — only visible in development.",
     "testButton": "Send test event",

--- a/apps/web/src/locales/pl/onboarding.json
+++ b/apps/web/src/locales/pl/onboarding.json
@@ -91,8 +91,28 @@
     "title": "Wybierz wizualizację",
     "hint": "Opcjonalne. Podgląd aktualizuje się na żywo."
   },
+  "privacy": {
+    "eyebrow": "06 · Raporty awarii",
+    "headline": "Pomóż naprawić to, co się <1>psuje</1>.",
+    "description": "Shiranami może automatycznie wysłać raport, gdy coś się zawiesi, dzięki czemu problemy zostaną naprawione bez szukania pliku z logami. Domyślnie jest to wyłączone, dopóki sam tego nie włączysz, a decyzję możesz zmienić w każdej chwili w Ustawieniach · Prywatność.",
+    "sentTitle": "Co jest wysyłane",
+    "sent": [
+      "Raporty awarii i błędów",
+      "Niewielka próbka pomiarów wydajności",
+      "Wersja aplikacji i system operacyjny"
+    ],
+    "notSentTitle": "Co nie jest wysyłane",
+    "notSent": [
+      "Brak nagrywania ekranu i powtórek",
+      "Brak danych osobowych i danych konta",
+      "Ścieżki plików są pozbawiane Twojej nazwy użytkownika"
+    ],
+    "toggleLabel": "Wysyłaj raporty awarii",
+    "toggleDesc": "Anonimowo. Domyślnie wyłączone. Zmień w każdej chwili.",
+    "footnote": "Raporty są pozbawiane ścieżek plików i Twojej nazwy użytkownika, zanim opuszczą Twoje urządzenie."
+  },
   "summary": {
-    "eyebrow": "06 · Gotowe",
+    "eyebrow": "07 · Gotowe",
     "headline": "Twój pokój jest <1>gotowy</1>.",
     "description": "Oto, co wybrałeś. Wszystko możesz dostroić później w Ustawieniach.",
     "intro": "Szybkie podsumowanie, zanim otworzy się biblioteka.",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -20,6 +20,7 @@
     "sidebar": "Widoczność głównej nawigacji",
     "discord": "Ustawienia integracji Discord",
     "updates": "Kanał aktualizacji aplikacji",
+    "privacy": "Raporty awarii i dane",
     "about": "Informacje o aplikacji",
     "support": "Wesprzyj projekt"
   },
@@ -37,6 +38,7 @@
   "sidebar": "Panel boczny",
   "discord": "Discord",
   "updates": "Aktualizacje",
+  "privacy": "Prywatność",
   "about": "O aplikacji",
   "support": "Wsparcie",
   "language": "Język",
@@ -430,6 +432,25 @@
     "somethingWrong": "Coś poszło nie tak",
     "checkFailed": "Nie udało się sprawdzić aktualizacji",
     "downloadFailed": "Pobieranie nie powiodło się"
+  },
+  "priv": {
+    "title": "Raporty awarii",
+    "subtitle": "Pomóż naprawić to, co się psuje. Domyślnie wyłączone.",
+    "toggleLabel": "Wysyłaj raporty awarii",
+    "toggleDesc": "Anonimowe raporty awarii i błędów oraz niewielka próbka pomiarów wydajności.",
+    "sentTitle": "Co jest wysyłane",
+    "sent": [
+      "Raporty awarii i błędów",
+      "Niewielka próbka pomiarów wydajności",
+      "Wersja aplikacji i system operacyjny"
+    ],
+    "notSentTitle": "Co nie jest wysyłane",
+    "notSent": [
+      "Brak nagrywania ekranu i powtórek",
+      "Brak danych osobowych i danych konta",
+      "Ścieżki plików pozbawione Twojej nazwy użytkownika"
+    ],
+    "note": "Raporty są pozbawiane ścieżek plików i Twojej nazwy użytkownika, zanim opuszczą Twoje urządzenie. Gdy ta opcja jest wyłączona, nic nie jest wysyłane."
   },
   "abt": {
     "title": "O aplikacji",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -451,6 +451,7 @@
       "Ścieżki plików pozbawione Twojej nazwy użytkownika"
     ],
     "note": "Raporty są pozbawiane ścieżek plików i Twojej nazwy użytkownika, zanim opuszczą Twoje urządzenie. Gdy ta opcja jest wyłączona, nic nie jest wysyłane.",
+    "restartNote": "Uruchom ponownie aplikację, aby rozpocząć raportowanie awarii — może się ono zainicjować tylko przy starcie.",
     "testTitle": "Zweryfikuj konfigurację",
     "testDesc": "Wysyła przykładowy błąd, aby zweryfikować konfigurację Sentry — widoczne tylko w trybie deweloperskim.",
     "testButton": "Wyślij zdarzenie testowe",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -437,12 +437,14 @@
     "title": "Raporty awarii",
     "subtitle": "Pomóż naprawić to, co się psuje. Domyślnie wyłączone.",
     "toggleLabel": "Wysyłaj raporty awarii",
-    "toggleDesc": "Anonimowe raporty awarii i błędów oraz niewielka próbka pomiarów wydajności.",
+    "toggleDesc": "Anonimowe raporty awarii i błędów.",
+    "perfLabel": "Monitorowanie wydajności",
+    "perfDesc": "Próbkuj też wydajność aplikacji — ładowanie stron i czasy nawigacji — aby pomóc znaleźć wąskie gardła. Wysyła więcej danych niż same raporty awarii.",
     "sentTitle": "Co jest wysyłane",
     "sent": [
       "Raporty awarii i błędów",
-      "Niewielka próbka pomiarów wydajności",
-      "Wersja aplikacji i system operacyjny"
+      "Wersja aplikacji i system operacyjny",
+      "Pomiary wydajności (tylko przy włączonym monitorowaniu wydajności)"
     ],
     "notSentTitle": "Co nie jest wysyłane",
     "notSent": [
@@ -451,7 +453,8 @@
       "Ścieżki plików pozbawione Twojej nazwy użytkownika"
     ],
     "note": "Raporty są pozbawiane ścieżek plików i Twojej nazwy użytkownika, zanim opuszczą Twoje urządzenie. Gdy ta opcja jest wyłączona, nic nie jest wysyłane.",
-    "restartNote": "Uruchom ponownie aplikację, aby rozpocząć raportowanie awarii — może się ono zainicjować tylko przy starcie.",
+    "restartNote": "Uruchom ponownie aplikację, aby zastosować zmiany — raportowanie awarii i monitorowanie wydajności inicjują się tylko przy starcie.",
+    "saveError": "Nie udało się zapisać preferencji prywatności. Spróbuj ponownie.",
     "testTitle": "Zweryfikuj konfigurację",
     "testDesc": "Wysyła przykładowy błąd, aby zweryfikować konfigurację Sentry — widoczne tylko w trybie deweloperskim.",
     "testButton": "Wyślij zdarzenie testowe",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -450,7 +450,12 @@
       "Brak danych osobowych i danych konta",
       "Ścieżki plików pozbawione Twojej nazwy użytkownika"
     ],
-    "note": "Raporty są pozbawiane ścieżek plików i Twojej nazwy użytkownika, zanim opuszczą Twoje urządzenie. Gdy ta opcja jest wyłączona, nic nie jest wysyłane."
+    "note": "Raporty są pozbawiane ścieżek plików i Twojej nazwy użytkownika, zanim opuszczą Twoje urządzenie. Gdy ta opcja jest wyłączona, nic nie jest wysyłane.",
+    "testTitle": "Zweryfikuj konfigurację",
+    "testDesc": "Wysyła przykładowy błąd, aby zweryfikować konfigurację Sentry — widoczne tylko w trybie deweloperskim.",
+    "testButton": "Wyślij zdarzenie testowe",
+    "testDevOnly": "Tylko dla deweloperów",
+    "testSent": "Wysłano zdarzenie testowe"
   },
   "abt": {
     "title": "O aplikacji",

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,6 +6,7 @@ import App from './App';
 import ErrorBoundary from '@/components/shared/ErrorBoundary';
 import { Toaster } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { initSentryRenderer } from '@/lib/sentry';
 import './styles/globals.css';
 import '@/lib/i18n';
 
@@ -21,6 +22,10 @@ if (!rootElement) {
 if (window.electronAPI?.__e2e) {
   void import('./e2e-bridge');
 }
+
+// Initialize crash/error reporting. No-op unless the user opted in and this is
+// a packaged/production Electron build; events route to the main transport.
+void initSentryRenderer();
 
 createRoot(rootElement).render(
   <StrictMode>

--- a/apps/web/src/stores/useTelemetryStore.ts
+++ b/apps/web/src/stores/useTelemetryStore.ts
@@ -1,0 +1,59 @@
+import { createPersistedStore, acceptStoreHmr } from '@/lib/createPersistedStore';
+import { IS_ELECTRON } from '@/lib/platform';
+
+/** localStorage key — matches the shiranami.* store convention. */
+const STORE_KEY = 'shiranami.telemetry';
+/** electron-store mirror key — the main process reads this to gate Sentry. */
+const ELECTRON_KEY = 'app.telemetryEnabled';
+
+function coerceEnabled(v: unknown): boolean {
+  return v === true;
+}
+
+interface TelemetryState {
+  /** Whether the user has opted in to crash/error reporting. Default OFF. */
+  enabled: boolean;
+  /**
+   * Set consent + mirror to electron-store. Writing the mirror triggers the
+   * main process's onDidChange listener, which initializes or closes Sentry at
+   * runtime (in packaged builds).
+   */
+  setEnabled: (value: boolean) => void;
+  /** One-way sync from electron-store on boot (the mirror is authoritative for
+   *  the actual reporting gate, so it can both upgrade and downgrade here). */
+  hydrate: () => Promise<void>;
+}
+
+export const useTelemetryStore = createPersistedStore<TelemetryState>(
+  set => ({
+    enabled: false,
+    setEnabled: (value: boolean) => {
+      set({ enabled: value });
+      if (IS_ELECTRON) {
+        window.electronAPI.store.set(ELECTRON_KEY, value).catch(() => {});
+      }
+    },
+    hydrate: async () => {
+      if (!IS_ELECTRON) return;
+      try {
+        const stored = await window.electronAPI.store.get(ELECTRON_KEY);
+        set({ enabled: stored === true });
+      } catch {
+        // Ignore store read failures — localStorage stays the fallback.
+      }
+    },
+  }),
+  {
+    name: STORE_KEY,
+    version: 1,
+    partialize: s => ({ enabled: s.enabled }),
+    sanitize: (persisted, current) => ({
+      ...current,
+      enabled: coerceEnabled((persisted as Partial<TelemetryState> | undefined)?.enabled),
+    }),
+  }
+);
+
+acceptStoreHmr(useTelemetryStore, import.meta.hot, state => {
+  useTelemetryStore.setState({ enabled: coerceEnabled(state.enabled) });
+});

--- a/apps/web/src/stores/useTelemetryStore.ts
+++ b/apps/web/src/stores/useTelemetryStore.ts
@@ -1,10 +1,13 @@
+import { toast } from 'sonner';
 import { createPersistedStore, acceptStoreHmr } from '@/lib/createPersistedStore';
 import { IS_ELECTRON } from '@/lib/platform';
+import i18n from '@/lib/i18n';
 
 /** localStorage key — matches the shiranami.* store convention. */
 const STORE_KEY = 'shiranami.telemetry';
-/** electron-store mirror key — the main process reads this to gate Sentry. */
+/** electron-store mirror keys — the main process reads these to gate Sentry. */
 const ELECTRON_KEY = 'app.telemetryEnabled';
+const ELECTRON_PERF_KEY = 'app.performanceMonitoringEnabled';
 
 function coerceEnabled(v: unknown): boolean {
   return v === true;
@@ -14,30 +17,80 @@ interface TelemetryState {
   /** Whether the user has opted in to crash/error reporting. Default OFF. */
   enabled: boolean;
   /**
+   * Opt-in performance tracing — a sub-option of crash reporting (only meaningful
+   * when `enabled` is also true). Default OFF.
+   */
+  performanceEnabled: boolean;
+  /**
+   * The flags as the main process saw them at launch. Sentry reads its config
+   * once, before the app 'ready' event, so toggling either flag only takes
+   * effect after a restart; comparing the live flags to these snapshots tells
+   * the UI when a restart is pending. Set only by hydrate() at boot, so the
+   * value survives navigating away from and back to the settings panel.
+   */
+  bootEnabled: boolean;
+  bootPerformanceEnabled: boolean;
+  /**
    * Set consent + mirror to electron-store. Writing the mirror triggers the
    * main process's onDidChange listener, which initializes or closes Sentry at
-   * runtime (in packaged builds).
+   * runtime (in packaged builds). On write failure the optimistic value is
+   * reverted so the renderer never disagrees with the main-process gate.
    */
-  setEnabled: (value: boolean) => void;
+  setEnabled: (value: boolean) => Promise<void>;
+  /** Set performance-monitoring opt-in + mirror to electron-store. */
+  setPerformanceEnabled: (value: boolean) => Promise<void>;
   /** One-way sync from electron-store on boot (the mirror is authoritative for
    *  the actual reporting gate, so it can both upgrade and downgrade here). */
   hydrate: () => Promise<void>;
 }
 
 export const useTelemetryStore = createPersistedStore<TelemetryState>(
-  set => ({
+  (set, get) => ({
     enabled: false,
-    setEnabled: (value: boolean) => {
+    performanceEnabled: false,
+    bootEnabled: false,
+    bootPerformanceEnabled: false,
+    setEnabled: async (value: boolean) => {
+      const previous = get().enabled;
       set({ enabled: value });
-      if (IS_ELECTRON) {
-        window.electronAPI.store.set(ELECTRON_KEY, value).catch(() => {});
+      if (!IS_ELECTRON) return;
+      try {
+        await window.electronAPI.store.set(ELECTRON_KEY, value);
+      } catch (err) {
+        // Revert so renderer consent never drifts from the main-process gate.
+        set({ enabled: previous });
+        console.error('[telemetry] failed to persist consent', err);
+        toast.error(i18n.t('settings:priv.saveError'));
+      }
+    },
+    setPerformanceEnabled: async (value: boolean) => {
+      const previous = get().performanceEnabled;
+      set({ performanceEnabled: value });
+      if (!IS_ELECTRON) return;
+      try {
+        await window.electronAPI.store.set(ELECTRON_PERF_KEY, value);
+      } catch (err) {
+        set({ performanceEnabled: previous });
+        console.error('[telemetry] failed to persist performance consent', err);
+        toast.error(i18n.t('settings:priv.saveError'));
       }
     },
     hydrate: async () => {
       if (!IS_ELECTRON) return;
       try {
-        const stored = await window.electronAPI.store.get(ELECTRON_KEY);
-        set({ enabled: stored === true });
+        const [stored, storedPerf] = await Promise.all([
+          window.electronAPI.store.get(ELECTRON_KEY),
+          window.electronAPI.store.get(ELECTRON_PERF_KEY),
+        ]);
+        const enabled = stored === true;
+        const performanceEnabled = storedPerf === true;
+        set({
+          enabled,
+          performanceEnabled,
+          // Snapshot what main initialized Sentry with this launch.
+          bootEnabled: enabled,
+          bootPerformanceEnabled: performanceEnabled,
+        });
       } catch {
         // Ignore store read failures — localStorage stays the fallback.
       }
@@ -46,14 +99,27 @@ export const useTelemetryStore = createPersistedStore<TelemetryState>(
   {
     name: STORE_KEY,
     version: 1,
-    partialize: s => ({ enabled: s.enabled }),
-    sanitize: (persisted, current) => ({
-      ...current,
-      enabled: coerceEnabled((persisted as Partial<TelemetryState> | undefined)?.enabled),
-    }),
+    partialize: s => ({ enabled: s.enabled, performanceEnabled: s.performanceEnabled }),
+    sanitize: (persisted, current) => {
+      const p = persisted as Partial<TelemetryState> | undefined;
+      const enabled = coerceEnabled(p?.enabled);
+      const performanceEnabled = coerceEnabled(p?.performanceEnabled);
+      return {
+        ...current,
+        enabled,
+        performanceEnabled,
+        // Seed boot snapshots from the persisted values so the UI doesn't flash
+        // a spurious "restart needed" before hydrate() reconciles with main.
+        bootEnabled: enabled,
+        bootPerformanceEnabled: performanceEnabled,
+      };
+    },
   }
 );
 
 acceptStoreHmr(useTelemetryStore, import.meta.hot, state => {
-  useTelemetryStore.setState({ enabled: coerceEnabled(state.enabled) });
+  useTelemetryStore.setState({
+    enabled: coerceEnabled(state.enabled),
+    performanceEnabled: coerceEnabled(state.performanceEnabled),
+  });
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,10 +1,36 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import { sentryVitePlugin } from '@sentry/vite-plugin';
+import { readFileSync } from 'node:fs';
 import { resolve } from 'path';
 
+const version = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8')).version;
+
+// Source-map upload runs from CI only, never from a local `pnpm build`. The
+// auth token lives exclusively as a GitHub Actions secret; its presence (plus
+// CI=true) is the gate. When absent, the plugin is omitted entirely.
+const shouldUploadSourcemaps = Boolean(process.env.CI && process.env.SENTRY_AUTH_TOKEN);
+
 export default defineConfig({
-  plugins: [tailwindcss(), react()],
+  plugins: [
+    tailwindcss(),
+    react(),
+    ...(shouldUploadSourcemaps
+      ? [
+          sentryVitePlugin({
+            org: process.env.SENTRY_ORG,
+            project: process.env.SENTRY_PROJECT,
+            authToken: process.env.SENTRY_AUTH_TOKEN,
+            release: { name: `shiranami@${version}` },
+            sourcemaps: {
+              // Strip maps from the shipped renderer bundle after upload.
+              filesToDeleteAfterUpload: ['dist/**/*.map'],
+            },
+          }),
+        ]
+      : []),
+  ],
   base: './',
   resolve: {
     alias: {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
             org: process.env.SENTRY_ORG,
             project: process.env.SENTRY_PROJECT,
             authToken: process.env.SENTRY_AUTH_TOKEN,
+            // lunofi org is on Sentry's EU region; the plugin defaults to the US
+            // instance otherwise and 404s. Overridable via SENTRY_URL.
+            url: process.env.SENTRY_URL ?? 'https://de.sentry.io/',
             release: { name: `shiranami@${version}` },
             sourcemaps: {
               // Strip maps from the shipped renderer bundle after upload.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dev:web": "pnpm --filter @shiranami/web dev",
     "dev:landing": "pnpm --filter @shiranami/landing dev",
     "dev:mobile": "pnpm --filter @shiranami/mobile dev",
+    "dev:sentry": "node scripts/dev-sentry.mjs",
     "build": "pnpm build:packages && pnpm --filter @shiranami/web build && pnpm --filter @shiranami/desktop build",
     "build:packages": "pnpm --filter @shiranami/contracts build && pnpm --filter @shiranami/shared build && pnpm --filter @shiranami/database build",
     "build:landing": "pnpm --filter @shiranami/landing build",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,3 +10,6 @@ export * from './utils';
 
 // Logger
 export * from './logger';
+
+// Sentry PII scrubbing (shared by main + renderer)
+export * from './sentry-scrub';

--- a/packages/shared/src/sentry-scrub.test.ts
+++ b/packages/shared/src/sentry-scrub.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { scrubPath, containsHomePath, scrubEvent, scrubBreadcrumb } from './sentry-scrub';
+
+const USERNAME = 'alice';
+
+describe('scrubPath', () => {
+  it('strips a macOS home-dir prefix and the username', () => {
+    const out = scrubPath(`/Users/${USERNAME}/Music/track.flac`);
+    expect(out).toBe('~/Music/track.flac');
+    expect(out).not.toContain(USERNAME);
+  });
+
+  it('strips a Linux home-dir prefix and the username', () => {
+    const out = scrubPath(`/home/${USERNAME}/code/app.js`);
+    expect(out).toBe('~/code/app.js');
+    expect(out).not.toContain(USERNAME);
+  });
+
+  it('strips a Windows home-dir prefix and the username', () => {
+    const out = scrubPath(`C:\\Users\\${USERNAME}\\AppData\\Local\\app.exe`);
+    expect(out).toBe('~\\AppData\\Local\\app.exe');
+    expect(out).not.toContain(USERNAME);
+  });
+
+  it('collapses a bare home directory to ~', () => {
+    expect(scrubPath(`/Users/${USERNAME}`)).toBe('~');
+  });
+
+  it('scrubs multiple paths in one string', () => {
+    const out = scrubPath(`from /Users/${USERNAME}/a.js to /Users/${USERNAME}/b.js`);
+    expect(out).toBe('from ~/a.js to ~/b.js');
+    expect(out).not.toContain(USERNAME);
+  });
+
+  it('leaves non-home paths untouched', () => {
+    expect(scrubPath('/usr/local/bin/node')).toBe('/usr/local/bin/node');
+    expect(scrubPath('/Applications/Shiranami.app')).toBe('/Applications/Shiranami.app');
+  });
+});
+
+describe('containsHomePath', () => {
+  it('detects a home path regardless of repeated calls (lastIndex reset)', () => {
+    const sample = `/Users/${USERNAME}/x`;
+    expect(containsHomePath(sample)).toBe(true);
+    expect(containsHomePath(sample)).toBe(true);
+  });
+
+  it('returns false for paths without a home dir', () => {
+    expect(containsHomePath('/var/log/system.log')).toBe(false);
+  });
+});
+
+describe('scrubEvent', () => {
+  it('strips the username from every stack frame filename and abs_path', () => {
+    const event = {
+      message: `crash in /Users/${USERNAME}/app/index.js`,
+      exception: {
+        values: [
+          {
+            value: `ENOENT: /Users/${USERNAME}/Music/missing.flac`,
+            stacktrace: {
+              frames: [
+                {
+                  filename: `/Users/${USERNAME}/app/dist/main/index.js`,
+                  abs_path: `/Users/${USERNAME}/app/dist/main/index.js`,
+                  module: `/Users/${USERNAME}/app/dist/main/index`,
+                },
+                {
+                  filename: `C:\\Users\\${USERNAME}\\app\\renderer.js`,
+                  abs_path: `C:\\Users\\${USERNAME}\\app\\renderer.js`,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    const scrubbed = scrubEvent(event);
+    const serialized = JSON.stringify(scrubbed);
+
+    expect(serialized).not.toContain(USERNAME);
+    expect(scrubbed.message).toBe('crash in ~/app/index.js');
+    expect(scrubbed.exception.values[0].value).toBe('ENOENT: ~/Music/missing.flac');
+    expect(scrubbed.exception.values[0].stacktrace.frames[0].filename).toBe(
+      '~/app/dist/main/index.js'
+    );
+    expect(scrubbed.exception.values[0].stacktrace.frames[1].filename).toBe('~\\app\\renderer.js');
+  });
+
+  it('scrubs embedded breadcrumb messages and drops console breadcrumbs with paths', () => {
+    const event = {
+      breadcrumbs: [
+        { category: 'console', message: `loaded /Users/${USERNAME}/cfg.json` },
+        { category: 'navigation', message: `opened /Users/${USERNAME}/lib` },
+        { category: 'ui.click', message: 'clicked Play' },
+      ],
+    };
+
+    const scrubbed = scrubEvent(event);
+    expect(JSON.stringify(scrubbed)).not.toContain(USERNAME);
+    // console breadcrumb carrying a home path is dropped entirely
+    expect(scrubbed.breadcrumbs).toHaveLength(2);
+    expect(scrubbed.breadcrumbs[0].message).toBe('opened ~/lib');
+    expect(scrubbed.breadcrumbs[1].message).toBe('clicked Play');
+  });
+
+  it('returns the event unchanged when there is nothing to scrub', () => {
+    const event = { message: 'plain error', exception: { values: [{ value: 'oops' }] } };
+    const scrubbed = scrubEvent(event);
+    expect(scrubbed.message).toBe('plain error');
+    expect(scrubbed.exception.values[0].value).toBe('oops');
+  });
+});
+
+describe('scrubBreadcrumb', () => {
+  it('drops a console breadcrumb that contains a home path', () => {
+    const crumb = { category: 'console', message: `read /Users/${USERNAME}/secret` };
+    expect(scrubBreadcrumb(crumb)).toBeNull();
+  });
+
+  it('keeps a console breadcrumb without a home path', () => {
+    const crumb = { category: 'console', message: 'app ready' };
+    const out = scrubBreadcrumb(crumb);
+    expect(out).not.toBeNull();
+    expect(out!.message).toBe('app ready');
+  });
+
+  it('scrubs the path out of a non-console breadcrumb message', () => {
+    const crumb = { category: 'navigation', message: `to /Users/${USERNAME}/page` };
+    const out = scrubBreadcrumb(crumb);
+    expect(out!.message).toBe('to ~/page');
+    expect(out!.message).not.toContain(USERNAME);
+  });
+
+  it('scrubs home paths inside breadcrumb data values', () => {
+    const crumb = {
+      category: 'http',
+      message: 'request',
+      data: { url: `file:///Users/${USERNAME}/x.json`, status: 200 },
+    };
+    const out = scrubBreadcrumb(crumb);
+    expect(out!.data!.url).toBe('file://~/x.json');
+    expect(out!.data!.status).toBe(200);
+    expect(JSON.stringify(out)).not.toContain(USERNAME);
+  });
+});

--- a/packages/shared/src/sentry-scrub.test.ts
+++ b/packages/shared/src/sentry-scrub.test.ts
@@ -111,6 +111,32 @@ describe('scrubEvent', () => {
     expect(scrubbed.message).toBe('plain error');
     expect(scrubbed.exception.values[0].value).toBe('oops');
   });
+
+  it('recursively scrubs paths nested in extra, contexts, tags and request', () => {
+    const event = {
+      extra: {
+        files: [`/Users/${USERNAME}/a.flac`, { nested: `/home/${USERNAME}/b.js` }],
+      },
+      contexts: { app: { app_cwd: `/Users/${USERNAME}/app` } },
+      tags: { config: `C:\\Users\\${USERNAME}\\cfg.json` },
+      request: { url: `file:///Users/${USERNAME}/index.html` },
+    };
+
+    const scrubbed = scrubEvent(event);
+    expect(JSON.stringify(scrubbed)).not.toContain(USERNAME);
+    expect(scrubbed.extra.files[0]).toBe('~/a.flac');
+    expect((scrubbed.extra.files[1] as { nested: string }).nested).toBe('~/b.js');
+    expect(scrubbed.contexts.app.app_cwd).toBe('~/app');
+    expect(scrubbed.tags.config).toBe('~\\cfg.json');
+    expect(scrubbed.request.url).toBe('file://~/index.html');
+  });
+
+  it('does not hang on a cyclic extra payload', () => {
+    const cyclic: Record<string, unknown> = { path: `/Users/${USERNAME}/x` };
+    cyclic.self = cyclic;
+    const scrubbed = scrubEvent({ extra: cyclic });
+    expect((scrubbed.extra as { path: string }).path).toBe('~/x');
+  });
 });
 
 describe('scrubBreadcrumb', () => {
@@ -143,5 +169,22 @@ describe('scrubBreadcrumb', () => {
     expect(out!.data!.url).toBe('file://~/x.json');
     expect(out!.data!.status).toBe(200);
     expect(JSON.stringify(out)).not.toContain(USERNAME);
+  });
+
+  it('recursively scrubs paths nested in breadcrumb data objects and arrays', () => {
+    const crumb = {
+      category: 'http',
+      message: 'request',
+      data: {
+        args: [`/Users/${USERNAME}/in.flac`, 2],
+        meta: { dest: `/home/${USERNAME}/out.flac`, ok: true },
+      },
+    };
+    const out = scrubBreadcrumb(crumb);
+    expect(out).not.toBeNull();
+    expect(JSON.stringify(out)).not.toContain(USERNAME);
+    expect(out!.data.args[0]).toBe('~/in.flac');
+    expect(out!.data.meta.dest).toBe('~/out.flac');
+    expect(out!.data.meta.ok).toBe(true);
   });
 });

--- a/packages/shared/src/sentry-scrub.ts
+++ b/packages/shared/src/sentry-scrub.ts
@@ -30,6 +30,11 @@ interface EventView {
   message?: unknown;
   exception?: { values?: ExceptionView[] } | null;
   breadcrumbs?: BreadcrumbView[] | null;
+  // Free-form bags that can carry arbitrary nested values (and thus paths).
+  extra?: unknown;
+  contexts?: unknown;
+  request?: unknown;
+  tags?: unknown;
 }
 
 interface BreadcrumbView {
@@ -70,6 +75,34 @@ function scrubFrame(frame: FrameView): void {
 }
 
 /**
+ * Recursively scrub home-dir paths from every string nested in a value
+ * (objects and arrays). Mutates containers in place and returns the scrubbed
+ * value (strings are immutable, so callers must reassign the return). Guards
+ * against reference cycles and caps depth so a pathological payload can't hang
+ * the hook. Used for free-form bags (breadcrumb `data`, event `extra`,
+ * `contexts`, `request`) where paths can hide in nested objects/arrays.
+ */
+const MAX_SCRUB_DEPTH = 8;
+function scrubDeep(value: unknown, seen: WeakSet<object> = new WeakSet(), depth = 0): unknown {
+  if (typeof value === 'string') return scrubPath(value);
+  if (value === null || typeof value !== 'object' || depth >= MAX_SCRUB_DEPTH) return value;
+  if (seen.has(value)) return value;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      value[i] = scrubDeep(value[i], seen, depth + 1);
+    }
+  } else {
+    const record = value as Record<string, unknown>;
+    for (const key of Object.keys(record)) {
+      record[key] = scrubDeep(record[key], seen, depth + 1);
+    }
+  }
+  return value;
+}
+
+/**
  * `beforeSend` hook — strip home-dir paths from the event message and every
  * exception stack frame (filename/abs_path/module) plus any embedded
  * breadcrumb messages. Mutates and returns the event (Sentry expects the
@@ -99,6 +132,12 @@ export function scrubEvent<T>(event: T): T {
     view.breadcrumbs = view.breadcrumbs.filter(crumb => scrubBreadcrumb(crumb) !== null);
   }
 
+  // Free-form bags can nest paths arbitrarily deep — walk them recursively.
+  if (view.extra) scrubDeep(view.extra);
+  if (view.contexts) scrubDeep(view.contexts);
+  if (view.request) scrubDeep(view.request);
+  if (view.tags) scrubDeep(view.tags);
+
   return event;
 }
 
@@ -122,12 +161,10 @@ export function scrubBreadcrumb<T>(crumb: T): T | null {
     view.message = scrubPath(view.message);
   }
 
+  // Breadcrumb data (HTTP payloads, debug context) can nest paths in objects
+  // and arrays, not just top-level strings — walk it recursively.
   if (view.data && typeof view.data === 'object') {
-    for (const [key, value] of Object.entries(view.data)) {
-      if (typeof value === 'string') {
-        view.data[key] = scrubPath(value);
-      }
-    }
+    scrubDeep(view.data);
   }
 
   return crumb;

--- a/packages/shared/src/sentry-scrub.ts
+++ b/packages/shared/src/sentry-scrub.ts
@@ -8,37 +8,34 @@
  * prefixes from every place a path can appear before the event leaves the
  * machine.
  *
- * This module is intentionally dependency-free (no `@sentry/*` imports) so
- * both the main and renderer processes can import it. The Sentry shapes below
- * are structurally typed against the parts we touch — passing a real
- * `ErrorEvent`/`Breadcrumb` is accepted because the runtime payload matches.
+ * The functions are generic over the caller's exact type (Sentry's
+ * `ErrorEvent`/`Breadcrumb`) — they mutate in place and return the same object
+ * so `beforeSend`/`beforeBreadcrumb` get back a value of the type Sentry
+ * expects. Internally they read fields through loose views so the module stays
+ * dependency-free (no `@sentry/*` imports) and importable by both processes.
  */
 
-interface ScrubbableFrame {
-  filename?: string;
-  abs_path?: string;
-  module?: string;
-  [key: string]: unknown;
+interface FrameView {
+  filename?: unknown;
+  abs_path?: unknown;
+  module?: unknown;
 }
 
-interface ScrubbableException {
-  value?: string;
-  stacktrace?: { frames?: ScrubbableFrame[] };
-  [key: string]: unknown;
+interface ExceptionView {
+  value?: unknown;
+  stacktrace?: { frames?: FrameView[] } | null;
 }
 
-interface ScrubbableEvent {
-  message?: string;
-  exception?: { values?: ScrubbableException[] };
-  breadcrumbs?: ScrubbableBreadcrumb[];
-  [key: string]: unknown;
+interface EventView {
+  message?: unknown;
+  exception?: { values?: ExceptionView[] } | null;
+  breadcrumbs?: BreadcrumbView[] | null;
 }
 
-interface ScrubbableBreadcrumb {
-  message?: string;
-  category?: string;
-  data?: Record<string, unknown>;
-  [key: string]: unknown;
+interface BreadcrumbView {
+  message?: unknown;
+  category?: unknown;
+  data?: Record<string, unknown> | null;
 }
 
 /**
@@ -66,11 +63,10 @@ export function containsHomePath(input: string): boolean {
   return HOME_DIR_PATTERN.test(input);
 }
 
-function scrubFrame(frame: ScrubbableFrame): ScrubbableFrame {
+function scrubFrame(frame: FrameView): void {
   if (typeof frame.filename === 'string') frame.filename = scrubPath(frame.filename);
   if (typeof frame.abs_path === 'string') frame.abs_path = scrubPath(frame.abs_path);
   if (typeof frame.module === 'string') frame.module = scrubPath(frame.module);
-  return frame;
 }
 
 /**
@@ -79,12 +75,14 @@ function scrubFrame(frame: ScrubbableFrame): ScrubbableFrame {
  * breadcrumb messages. Mutates and returns the event (Sentry expects the
  * scrubbed event back, or `null` to drop it — we never drop).
  */
-export function scrubEvent<T extends ScrubbableEvent>(event: T): T {
-  if (typeof event.message === 'string') {
-    event.message = scrubPath(event.message);
+export function scrubEvent<T>(event: T): T {
+  const view = event as EventView;
+
+  if (typeof view.message === 'string') {
+    view.message = scrubPath(view.message);
   }
 
-  const values = event.exception?.values;
+  const values = view.exception?.values;
   if (Array.isArray(values)) {
     for (const exception of values) {
       if (typeof exception.value === 'string') {
@@ -97,10 +95,8 @@ export function scrubEvent<T extends ScrubbableEvent>(event: T): T {
     }
   }
 
-  if (Array.isArray(event.breadcrumbs)) {
-    event.breadcrumbs = event.breadcrumbs
-      .map(scrubBreadcrumb)
-      .filter((b): b is ScrubbableBreadcrumb => b !== null);
+  if (Array.isArray(view.breadcrumbs)) {
+    view.breadcrumbs = view.breadcrumbs.filter(crumb => scrubBreadcrumb(crumb) !== null);
   }
 
   return event;
@@ -111,23 +107,25 @@ export function scrubEvent<T extends ScrubbableEvent>(event: T): T {
  * home-dir path (they tend to echo our own file-path-laden log lines), and
  * scrub the path out of any breadcrumb that survives. Returns `null` to drop.
  */
-export function scrubBreadcrumb<T extends ScrubbableBreadcrumb>(crumb: T): T | null {
+export function scrubBreadcrumb<T>(crumb: T): T | null {
+  const view = crumb as BreadcrumbView;
+
   if (
-    crumb.category === 'console' &&
-    typeof crumb.message === 'string' &&
-    containsHomePath(crumb.message)
+    view.category === 'console' &&
+    typeof view.message === 'string' &&
+    containsHomePath(view.message)
   ) {
     return null;
   }
 
-  if (typeof crumb.message === 'string') {
-    crumb.message = scrubPath(crumb.message);
+  if (typeof view.message === 'string') {
+    view.message = scrubPath(view.message);
   }
 
-  if (crumb.data && typeof crumb.data === 'object') {
-    for (const [key, value] of Object.entries(crumb.data)) {
+  if (view.data && typeof view.data === 'object') {
+    for (const [key, value] of Object.entries(view.data)) {
       if (typeof value === 'string') {
-        crumb.data[key] = scrubPath(value);
+        view.data[key] = scrubPath(value);
       }
     }
   }

--- a/packages/shared/src/sentry-scrub.ts
+++ b/packages/shared/src/sentry-scrub.ts
@@ -1,0 +1,136 @@
+/**
+ * Privacy scrubbing for Sentry events and breadcrumbs.
+ *
+ * Electron stack frames and log breadcrumbs carry absolute filesystem paths
+ * that embed the OS username (`/Users/<name>/…`, `C:\Users\<name>\…`,
+ * `/home/<name>/…`). Shipping those to a third-party sink would leak PII the
+ * user did not knowingly consent to share. These helpers redact home-dir
+ * prefixes from every place a path can appear before the event leaves the
+ * machine.
+ *
+ * This module is intentionally dependency-free (no `@sentry/*` imports) so
+ * both the main and renderer processes can import it. The Sentry shapes below
+ * are structurally typed against the parts we touch — passing a real
+ * `ErrorEvent`/`Breadcrumb` is accepted because the runtime payload matches.
+ */
+
+interface ScrubbableFrame {
+  filename?: string;
+  abs_path?: string;
+  module?: string;
+  [key: string]: unknown;
+}
+
+interface ScrubbableException {
+  value?: string;
+  stacktrace?: { frames?: ScrubbableFrame[] };
+  [key: string]: unknown;
+}
+
+interface ScrubbableEvent {
+  message?: string;
+  exception?: { values?: ScrubbableException[] };
+  breadcrumbs?: ScrubbableBreadcrumb[];
+  [key: string]: unknown;
+}
+
+interface ScrubbableBreadcrumb {
+  message?: string;
+  category?: string;
+  data?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
+ * Matches a Unix or Windows home-directory prefix and captures the segment
+ * that follows it (the rest of the path). The username is the wildcard
+ * between the home root and the next separator; we drop it entirely.
+ *
+ *   /Users/alice/Music/x.flac   → ~/Music/x.flac
+ *   /home/alice/code/app.js     → ~/code/app.js
+ *   C:\Users\alice\AppData\x    → ~\AppData\x
+ */
+const HOME_DIR_PATTERN =
+  /(?:\/Users\/[^/\\]+|\/home\/[^/\\]+|[A-Za-z]:\\Users\\[^\\/]+)([/\\][^\s'"]*)?/g;
+
+/** Replace every home-dir path in a string with a `~`-rooted, username-free path. */
+export function scrubPath(input: string): string {
+  return input.replace(HOME_DIR_PATTERN, (_match, rest: string | undefined) =>
+    rest ? `~${rest}` : '~'
+  );
+}
+
+/** Returns true when a string contains an absolute home-dir path. */
+export function containsHomePath(input: string): boolean {
+  HOME_DIR_PATTERN.lastIndex = 0;
+  return HOME_DIR_PATTERN.test(input);
+}
+
+function scrubFrame(frame: ScrubbableFrame): ScrubbableFrame {
+  if (typeof frame.filename === 'string') frame.filename = scrubPath(frame.filename);
+  if (typeof frame.abs_path === 'string') frame.abs_path = scrubPath(frame.abs_path);
+  if (typeof frame.module === 'string') frame.module = scrubPath(frame.module);
+  return frame;
+}
+
+/**
+ * `beforeSend` hook — strip home-dir paths from the event message and every
+ * exception stack frame (filename/abs_path/module) plus any embedded
+ * breadcrumb messages. Mutates and returns the event (Sentry expects the
+ * scrubbed event back, or `null` to drop it — we never drop).
+ */
+export function scrubEvent<T extends ScrubbableEvent>(event: T): T {
+  if (typeof event.message === 'string') {
+    event.message = scrubPath(event.message);
+  }
+
+  const values = event.exception?.values;
+  if (Array.isArray(values)) {
+    for (const exception of values) {
+      if (typeof exception.value === 'string') {
+        exception.value = scrubPath(exception.value);
+      }
+      const frames = exception.stacktrace?.frames;
+      if (Array.isArray(frames)) {
+        for (const frame of frames) scrubFrame(frame);
+      }
+    }
+  }
+
+  if (Array.isArray(event.breadcrumbs)) {
+    event.breadcrumbs = event.breadcrumbs
+      .map(scrubBreadcrumb)
+      .filter((b): b is ScrubbableBreadcrumb => b !== null);
+  }
+
+  return event;
+}
+
+/**
+ * `beforeBreadcrumb` hook — drop console breadcrumbs that contain an absolute
+ * home-dir path (they tend to echo our own file-path-laden log lines), and
+ * scrub the path out of any breadcrumb that survives. Returns `null` to drop.
+ */
+export function scrubBreadcrumb<T extends ScrubbableBreadcrumb>(crumb: T): T | null {
+  if (
+    crumb.category === 'console' &&
+    typeof crumb.message === 'string' &&
+    containsHomePath(crumb.message)
+  ) {
+    return null;
+  }
+
+  if (typeof crumb.message === 'string') {
+    crumb.message = scrubPath(crumb.message);
+  }
+
+  if (crumb.data && typeof crumb.data === 'object') {
+    for (const [key, value] of Object.entries(crumb.data)) {
+      if (typeof value === 'string') {
+        crumb.data[key] = scrubPath(value);
+      }
+    }
+  }
+
+  return crumb;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,6 +355,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@sentry/electron':
+        specifier: 7.13.0
+        version: 7.13.0
       '@sentry/react':
         specifier: 10.50.0
         version: 10.50.0(react@19.2.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,13 +80,16 @@ importers:
         version: 8.59.4(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
       wait-on:
         specifier: ^9.0.10
         version: 9.0.10
 
   apps/desktop:
     dependencies:
+      '@sentry/electron':
+        specifier: 7.13.0
+        version: 7.13.0
       '@xhayper/discord-rpc':
         specifier: ^1.3.4
         version: 1.3.4
@@ -126,25 +129,6 @@ importers:
       zod:
         specifier: ^4.4.3
         version: 4.4.3
-    optionalDependencies:
-      '@img/sharp-darwin-arm64':
-        specifier: 0.34.5
-        version: 0.34.5
-      '@img/sharp-darwin-x64':
-        specifier: 0.34.5
-        version: 0.34.5
-      '@img/sharp-libvips-darwin-arm64':
-        specifier: 1.2.4
-        version: 1.2.4
-      '@img/sharp-libvips-darwin-x64':
-        specifier: 1.2.4
-        version: 1.2.4
-      '@img/sharp-win32-arm64':
-        specifier: 0.34.5
-        version: 0.34.5
-      '@img/sharp-win32-x64':
-        specifier: 0.34.5
-        version: 0.34.5
     devDependencies:
       '@electron/rebuild':
         specifier: ^4.0.4
@@ -152,6 +136,9 @@ importers:
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
+      '@sentry/esbuild-plugin':
+        specifier: 5.3.0
+        version: 5.3.0(encoding@0.1.13)
       '@shiranami/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
@@ -182,6 +169,25 @@ importers:
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
+    optionalDependencies:
+      '@img/sharp-darwin-arm64':
+        specifier: 0.34.5
+        version: 0.34.5
+      '@img/sharp-darwin-x64':
+        specifier: 0.34.5
+        version: 0.34.5
+      '@img/sharp-libvips-darwin-arm64':
+        specifier: 1.2.4
+        version: 1.2.4
+      '@img/sharp-libvips-darwin-x64':
+        specifier: 1.2.4
+        version: 1.2.4
+      '@img/sharp-win32-arm64':
+        specifier: 0.34.5
+        version: 0.34.5
+      '@img/sharp-win32-x64':
+        specifier: 0.34.5
+        version: 0.34.5
 
   apps/landing:
     dependencies:
@@ -349,6 +355,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@sentry/react':
+        specifier: 10.50.0
+        version: 10.50.0(react@19.2.6)
       '@shiranami/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
@@ -404,6 +413,9 @@ importers:
         specifier: ^5.0.13
         version: 5.0.13(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
     devDependencies:
+      '@sentry/vite-plugin':
+        specifier: 5.3.0
+        version: 5.3.0(encoding@0.1.13)(rollup@4.60.2)
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
@@ -449,7 +461,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^25.8.0
-        version: 25.8.0
+        version: 25.9.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -461,14 +473,14 @@ importers:
         version: 12.10.0
       drizzle-orm:
         specifier: 1.0.0-rc.2
-        version: 1.0.0-rc.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(pg@8.21.0)(sql.js@1.14.1)(zod@4.4.3)
+        version: 1.0.0-rc.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.10.0)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(pg@8.21.0)(sql.js@1.14.1)(zod@4.4.3)
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
       '@types/node':
         specifier: ^25.8.0
-        version: 25.8.0
+        version: 25.9.1
       drizzle-kit:
         specifier: 1.0.0-rc.2
         version: 1.0.0-rc.2
@@ -480,7 +492,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^25.8.0
-        version: 25.8.0
+        version: 25.9.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2904,6 +2916,14 @@ packages:
         integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==,
       }
 
+  '@fastify/otel@0.18.0':
+    resolution:
+      {
+        integrity: sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==,
+      }
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
   '@fastify/proxy-addr@5.1.0':
     resolution:
       {
@@ -3891,6 +3911,300 @@ packages:
     engines: { node: ^14.18.0 || >=16.10.0, npm: '>=5.10.0' }
     hasBin: true
 
+  '@opentelemetry/api-logs@0.207.0':
+    resolution:
+      {
+        integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==,
+      }
+    engines: { node: '>=8.0.0' }
+
+  '@opentelemetry/api-logs@0.212.0':
+    resolution:
+      {
+        integrity: sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==,
+      }
+    engines: { node: '>=8.0.0' }
+
+  '@opentelemetry/api-logs@0.214.0':
+    resolution:
+      {
+        integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==,
+      }
+    engines: { node: '>=8.0.0' }
+
+  '@opentelemetry/api@1.9.1':
+    resolution:
+      {
+        integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==,
+      }
+    engines: { node: '>=8.0.0' }
+
+  '@opentelemetry/core@2.6.1':
+    resolution:
+      {
+        integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.1':
+    resolution:
+      {
+        integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation-amqplib@0.61.0':
+    resolution:
+      {
+        integrity: sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-connect@0.57.0':
+    resolution:
+      {
+        integrity: sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-dataloader@0.31.0':
+    resolution:
+      {
+        integrity: sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fs@0.33.0':
+    resolution:
+      {
+        integrity: sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-generic-pool@0.57.0':
+    resolution:
+      {
+        integrity: sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-graphql@0.62.0':
+    resolution:
+      {
+        integrity: sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-hapi@0.60.0':
+    resolution:
+      {
+        integrity: sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-http@0.214.0':
+    resolution:
+      {
+        integrity: sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-ioredis@0.62.0':
+    resolution:
+      {
+        integrity: sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-kafkajs@0.23.0':
+    resolution:
+      {
+        integrity: sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-knex@0.58.0':
+    resolution:
+      {
+        integrity: sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-koa@0.62.0':
+    resolution:
+      {
+        integrity: sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.58.0':
+    resolution:
+      {
+        integrity: sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongodb@0.67.0':
+    resolution:
+      {
+        integrity: sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongoose@0.60.0':
+    resolution:
+      {
+        integrity: sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql2@0.60.0':
+    resolution:
+      {
+        integrity: sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql@0.60.0':
+    resolution:
+      {
+        integrity: sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-pg@0.66.0':
+    resolution:
+      {
+        integrity: sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-redis@0.62.0':
+    resolution:
+      {
+        integrity: sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-tedious@0.33.0':
+    resolution:
+      {
+        integrity: sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.207.0':
+    resolution:
+      {
+        integrity: sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.212.0':
+    resolution:
+      {
+        integrity: sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.214.0':
+    resolution:
+      {
+        integrity: sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/redis-common@0.38.3':
+    resolution:
+      {
+        integrity: sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+
+  '@opentelemetry/resources@2.7.1':
+    resolution:
+      {
+        integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution:
+      {
+        integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution:
+      {
+        integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==,
+      }
+    engines: { node: '>=14' }
+
+  '@opentelemetry/sql-common@0.41.2':
+    resolution:
+      {
+        integrity: sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+
   '@oslojs/encoding@1.1.0':
     resolution:
       {
@@ -3979,6 +4293,14 @@ packages:
       {
         integrity: sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==,
       }
+
+  '@prisma/instrumentation@7.6.0':
+    resolution:
+      {
+        integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==,
+      }
+    peerDependencies:
+      '@opentelemetry/api': ^1.8
 
   '@radix-ui/number@1.1.1':
     resolution:
@@ -5041,6 +5363,233 @@ packages:
         integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==,
       }
 
+  '@sentry-internal/browser-utils@10.50.0':
+    resolution:
+      {
+        integrity: sha512-42bxyRTxnCmYlWnvz4CxikuQNanw8UNma2WJrtxJ0f1MAJV2GhQGSHDLnA+lvFlmiz6qct3pfen/NXGyOTegTA==,
+      }
+    engines: { node: '>=18' }
+
+  '@sentry-internal/feedback@10.50.0':
+    resolution:
+      {
+        integrity: sha512-0k9XZF0wn86f77mIO2U3gNNyDZooy139CnEanRzHinrN106vVzvBZ6TUEQoHtoO1fqQxr+nWWVrqV/PXUqk47w==,
+      }
+    engines: { node: '>=18' }
+
+  '@sentry-internal/replay-canvas@10.50.0':
+    resolution:
+      {
+        integrity: sha512-jx6RKBmcJSWdI92qDGS/sBv1w+7Cww879Z/moX7bw7ipHa/Ts3iDcB3rgZwvhmi17U+mvYsbJeL2DXkPo3TjPw==,
+      }
+    engines: { node: '>=18' }
+
+  '@sentry-internal/replay@10.50.0':
+    resolution:
+      {
+        integrity: sha512-51FYNfnvVLAWw1rrEWPFfwHuMRb9mkVCFGA4J9/un7SpeGBsQDziGB0Di4fsCxI7+EdSBpfLHPF0csKtCCw0oQ==,
+      }
+    engines: { node: '>=18' }
+
+  '@sentry/babel-plugin-component-annotate@5.3.0':
+    resolution:
+      {
+        integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==,
+      }
+    engines: { node: '>= 18' }
+
+  '@sentry/browser@10.50.0':
+    resolution:
+      {
+        integrity: sha512-1f6rAvET6myiTaSeYqvaaBwvq1LfxqWjAPIoAW/NVC9bPMkeEcuvgDajHrnZMrBeWoJ81NMyoLkyX+iOc7MoFA==,
+      }
+    engines: { node: '>=18' }
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    resolution:
+      {
+        integrity: sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==,
+      }
+    engines: { node: '>= 18' }
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution:
+      {
+        integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==,
+      }
+    engines: { node: '>=10' }
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution:
+      {
+        integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==,
+      }
+    engines: { node: '>=10' }
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution:
+      {
+        integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==,
+      }
+    engines: { node: '>=10' }
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution:
+      {
+        integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==,
+      }
+    engines: { node: '>=10' }
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution:
+      {
+        integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==,
+      }
+    engines: { node: '>=10' }
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution:
+      {
+        integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==,
+      }
+    engines: { node: '>=10' }
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution:
+      {
+        integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==,
+      }
+    engines: { node: '>=10' }
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution:
+      {
+        integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==,
+      }
+    engines: { node: '>=10' }
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution:
+      {
+        integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==,
+      }
+    engines: { node: '>= 10' }
+    hasBin: true
+
+  '@sentry/core@10.50.0':
+    resolution:
+      {
+        integrity: sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg==,
+      }
+    engines: { node: '>=18' }
+
+  '@sentry/electron@7.13.0':
+    resolution:
+      {
+        integrity: sha512-zW/1c9fKafCZsvhRRp9mIDH9bSvzBiIUwoN087zDDHc0vatVsqqai8nUk0bUewwYZY4Inia7r5w+kPWi8LXZzg==,
+      }
+    peerDependencies:
+      '@sentry/node-native': 10.50.0
+    peerDependenciesMeta:
+      '@sentry/node-native':
+        optional: true
+
+  '@sentry/esbuild-plugin@5.3.0':
+    resolution:
+      {
+        integrity: sha512-irCsMPs435toPEX66RZV86xvdAPjohv/ul5BvzRF11EwYVSRX3sMX30P28iCGuvarjFH3wh+RK7EtDkEIOTyPg==,
+      }
+    engines: { node: '>= 18' }
+
+  '@sentry/node-core@10.50.0':
+    resolution:
+      {
+        integrity: sha512-Eb1BYf4Lc7ZYmdX3acKP6SgyGikrBA370gbGHaWI5jRu7G7vig8sIu1ghPmY5AlvqBPOetado7GniXr6fAXbTw==,
+      }
+    engines: { node: '>=18' }
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
+
+  '@sentry/node@10.50.0':
+    resolution:
+      {
+        integrity: sha512-TvwzFQu8MGKzMQ2/tqxcNzFA8UG2kKTB+GDmA4uOzx3+GT849YZRRSJzEXCmYhk1teVd2fbmgqyYY2nyLF5a+Q==,
+      }
+    engines: { node: '>=18' }
+
+  '@sentry/opentelemetry@10.50.0':
+    resolution:
+      {
+        integrity: sha512-axn3pgDPveGdaMUC0abMCmFN7ux2pA5ebPufCef4lMIsyg7BBQvaEJ+vE19wjstMaBCAJGsdZlL3eeP2rtgRMw==,
+      }
+    engines: { node: '>=18' }
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+
+  '@sentry/react@10.50.0':
+    resolution:
+      {
+        integrity: sha512-MZHYjEZAtFIa4zPrWS4oXlo+gMppRvfETqUqF920Sj2jN2U7WjboU03lDmjfDqEcH7QiwjQyl13jHd2nwAyrrw==,
+      }
+    engines: { node: '>=18' }
+    peerDependencies:
+      react: ^19.2.6
+
+  '@sentry/rollup-plugin@5.3.0':
+    resolution:
+      {
+        integrity: sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w==,
+      }
+    engines: { node: '>= 18' }
+    peerDependencies:
+      rollup: '>=3.2.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@sentry/vite-plugin@5.3.0':
+    resolution:
+      {
+        integrity: sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A==,
+      }
+    engines: { node: '>= 18' }
+
   '@shikijs/core@4.0.2':
     resolution:
       {
@@ -5571,6 +6120,12 @@ packages:
         integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
       }
 
+  '@types/connect@3.4.38':
+    resolution:
+      {
+        integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==,
+      }
+
   '@types/debug@4.1.13':
     resolution:
       {
@@ -5679,6 +6234,12 @@ packages:
         integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==,
       }
 
+  '@types/mysql@2.15.27':
+    resolution:
+      {
+        integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==,
+      }
+
   '@types/nlcst@2.0.3':
     resolution:
       {
@@ -5697,16 +6258,22 @@ packages:
         integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==,
       }
 
-  '@types/node@25.8.0':
-    resolution:
-      {
-        integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==,
-      }
-
   '@types/node@25.9.1':
     resolution:
       {
         integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==,
+      }
+
+  '@types/pg-pool@2.0.7':
+    resolution:
+      {
+        integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==,
+      }
+
+  '@types/pg@8.15.6':
+    resolution:
+      {
+        integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==,
       }
 
   '@types/plist@3.0.5':
@@ -5745,6 +6312,12 @@ packages:
     resolution:
       {
         integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==,
+      }
+
+  '@types/tedious@4.0.14':
+    resolution:
+      {
+        integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==,
       }
 
   '@types/unist@3.0.3':
@@ -6257,6 +6830,14 @@ packages:
       }
     engines: { node: '>= 0.6' }
 
+  acorn-import-attributes@1.9.5:
+    resolution:
+      {
+        integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==,
+      }
+    peerDependencies:
+      acorn: ^8
+
   acorn-import-phases@1.0.4:
     resolution:
       {
@@ -6288,6 +6869,13 @@ packages:
         integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==,
       }
     engines: { node: '>=12.0' }
+
+  agent-base@6.0.2:
+    resolution:
+      {
+        integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==,
+      }
+    engines: { node: '>= 6.0.0' }
 
   agent-base@7.1.4:
     resolution:
@@ -7193,6 +7781,12 @@ packages:
     resolution:
       {
         integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==,
+      }
+
+  cjs-module-lexer@2.2.0:
+    resolution:
+      {
+        integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==,
       }
 
   class-variance-authority@0.7.1:
@@ -9232,6 +9826,12 @@ packages:
       }
     engines: { node: '>= 6' }
 
+  forwarded-parse@2.1.2:
+    resolution:
+      {
+        integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==,
+      }
+
   framer-motion@12.40.0:
     resolution:
       {
@@ -9772,6 +10372,13 @@ packages:
       }
     engines: { node: '>=10.19.0' }
 
+  https-proxy-agent@5.0.1:
+    resolution:
+      {
+        integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==,
+      }
+    engines: { node: '>= 6' }
+
   https-proxy-agent@7.0.6:
     resolution:
       {
@@ -9888,6 +10495,19 @@ packages:
         integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==,
       }
     engines: { node: '>=6' }
+
+  import-in-the-middle@2.0.6:
+    resolution:
+      {
+        integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==,
+      }
+
+  import-in-the-middle@3.0.1:
+    resolution:
+      {
+        integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==,
+      }
+    engines: { node: '>=18' }
 
   imurmurhash@0.1.4:
     resolution:
@@ -11582,6 +12202,12 @@ packages:
     engines: { node: '>=10' }
     hasBin: true
 
+  module-details-from-path@1.0.4:
+    resolution:
+      {
+        integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==,
+      }
+
   motion-dom@12.40.0:
     resolution:
       {
@@ -12718,6 +13344,12 @@ packages:
         integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==,
       }
 
+  proxy-from-env@1.1.0:
+    resolution:
+      {
+        integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==,
+      }
+
   proxy-from-env@2.1.0:
     resolution:
       {
@@ -13213,6 +13845,13 @@ packages:
         integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==,
       }
     engines: { node: '>=0.10.0' }
+
+  require-in-the-middle@8.0.1:
+    resolution:
+      {
+        integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==,
+      }
+    engines: { node: '>=9.3.0 || >=8.10.0 <9.0.0' }
 
   requireg@0.2.2:
     resolution:
@@ -17650,6 +18289,16 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  '@fastify/otel@0.18.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@fastify/proxy-addr@5.1.0':
     dependencies:
       '@fastify/forwarded': 3.0.1
@@ -18269,6 +18918,252 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
+  '@opentelemetry/api-logs@0.207.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api-logs@0.212.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api-logs@0.214.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/instrumentation-amqplib@0.61.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-connect@0.57.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@types/connect': 3.4.38
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-dataloader@0.31.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-fs@0.33.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-generic-pool@0.57.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-graphql@0.62.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-hapi@0.60.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-http@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      forwarded-parse: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-ioredis@0.62.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.38.3
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-kafkajs@0.23.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-knex@0.58.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-koa@0.62.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.58.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongodb@0.67.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongoose@0.60.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql2@0.60.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql@0.60.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@types/mysql': 2.15.27
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-pg@0.66.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
+      '@types/pg': 8.15.6
+      '@types/pg-pool': 2.0.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-redis@0.62.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.38.3
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-tedious@0.33.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.207.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.212.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.212.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/redis-common@0.38.3': {}
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
+
+  '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+
   '@oslojs/encoding@1.1.0': {}
 
   '@oxc-project/types@0.132.0': {}
@@ -18325,6 +19220,13 @@ snapshots:
   '@prisma/get-platform@6.19.3':
     dependencies:
       '@prisma/debug': 6.19.3
+
+  '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
 
   '@radix-ui/number@1.1.1': {}
 
@@ -19074,6 +19976,191 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@sentry-internal/browser-utils@10.50.0':
+    dependencies:
+      '@sentry/core': 10.50.0
+
+  '@sentry-internal/feedback@10.50.0':
+    dependencies:
+      '@sentry/core': 10.50.0
+
+  '@sentry-internal/replay-canvas@10.50.0':
+    dependencies:
+      '@sentry-internal/replay': 10.50.0
+      '@sentry/core': 10.50.0
+
+  '@sentry-internal/replay@10.50.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.50.0
+      '@sentry/core': 10.50.0
+
+  '@sentry/babel-plugin-component-annotate@5.3.0': {}
+
+  '@sentry/browser@10.50.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.50.0
+      '@sentry-internal/feedback': 10.50.0
+      '@sentry-internal/replay': 10.50.0
+      '@sentry-internal/replay-canvas': 10.50.0
+      '@sentry/core': 10.50.0
+
+  '@sentry/bundler-plugin-core@5.3.0(encoding@0.1.13)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@sentry/babel-plugin-component-annotate': 5.3.0
+      '@sentry/cli': 2.58.6(encoding@0.1.13)
+      dotenv: 16.6.1
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6(encoding@0.1.13)':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0(encoding@0.1.13)
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/core@10.50.0': {}
+
+  '@sentry/electron@7.13.0':
+    dependencies:
+      '@sentry/browser': 10.50.0
+      '@sentry/core': 10.50.0
+      '@sentry/node': 10.50.0
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/esbuild-plugin@5.3.0(encoding@0.1.13)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/node-core@10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
+    dependencies:
+      '@sentry/core': 10.50.0
+      '@sentry/opentelemetry': 10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 3.0.1
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@sentry/node@10.50.0':
+    dependencies:
+      '@fastify/otel': 0.18.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-amqplib': 0.61.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-connect': 0.57.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dataloader': 0.31.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fs': 0.33.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-generic-pool': 0.57.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-graphql': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-hapi': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-ioredis': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-kafkajs': 0.23.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-knex': 0.58.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-koa': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.58.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongodb': 0.67.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongoose': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql2': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pg': 0.66.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-tedious': 0.33.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@prisma/instrumentation': 7.6.0(@opentelemetry/api@1.9.1)
+      '@sentry/core': 10.50.0
+      '@sentry/node-core': 10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      '@sentry/opentelemetry': 10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 3.0.1
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry/core': 10.50.0
+
+  '@sentry/react@10.50.0(react@19.2.6)':
+    dependencies:
+      '@sentry/browser': 10.50.0
+      '@sentry/core': 10.50.0
+      react: 19.2.6
+
+  '@sentry/rollup-plugin@5.3.0(encoding@0.1.13)(rollup@4.60.2)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0(encoding@0.1.13)
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.60.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/vite-plugin@5.3.0(encoding@0.1.13)(rollup@4.60.2)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0(encoding@0.1.13)
+      '@sentry/rollup-plugin': 5.3.0(encoding@0.1.13)(rollup@4.60.2)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
   '@shikijs/core@4.0.2':
     dependencies:
       '@shikijs/primitive': 4.0.2
@@ -19397,6 +20484,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 25.9.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -19459,6 +20550,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/mysql@2.15.27':
+    dependencies:
+      '@types/node': 25.9.1
+
   '@types/nlcst@2.0.3':
     dependencies:
       '@types/unist': 3.0.3
@@ -19471,13 +20566,19 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@25.8.0':
-    dependencies:
-      undici-types: 7.24.6
-
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
+
+  '@types/pg-pool@2.0.7':
+    dependencies:
+      '@types/pg': 8.15.6
+
+  '@types/pg@8.15.6':
+    dependencies:
+      '@types/node': 25.9.1
+      pg-protocol: 1.14.0
+      pg-types: 2.2.0
 
   '@types/plist@3.0.5':
     dependencies:
@@ -19503,6 +20604,10 @@ snapshots:
 
   '@types/stack-utils@2.0.3':
     optional: true
+
+  '@types/tedious@4.0.14':
+    dependencies:
+      '@types/node': 25.9.1
 
   '@types/unist@3.0.3': {}
 
@@ -19660,7 +20765,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -19965,6 +21070,10 @@ snapshots:
       negotiator: 1.0.0
     optional: true
 
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -19976,6 +21085,12 @@ snapshots:
   acorn@8.16.0: {}
 
   adm-zip@0.5.17: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -20703,6 +21818,8 @@ snapshots:
 
   citty@0.2.2: {}
 
+  cjs-module-lexer@2.2.0: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -21227,9 +22344,11 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(pg@8.21.0)(sql.js@1.14.1)(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.10.0)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(pg@8.21.0)(sql.js@1.14.1)(zod@4.4.3):
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/better-sqlite3': 7.6.13
+      '@types/pg': 8.15.6
       better-sqlite3: 12.10.0
       expo-sqlite: 16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       pg: 8.21.0
@@ -22068,6 +23187,8 @@ snapshots:
       hasown: 2.0.3
       mime-types: 2.1.35
 
+  forwarded-parse@2.1.2: {}
+
   framer-motion@12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       motion-dom: 12.40.0
@@ -22476,6 +23597,13 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -22531,6 +23659,20 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-in-the-middle@2.0.6:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
+  import-in-the-middle@3.0.1:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
 
@@ -23906,6 +25048,8 @@ snapshots:
   mkdirp@1.0.4:
     optional: true
 
+  module-details-from-path@1.0.4: {}
+
   motion-dom@12.40.0:
     dependencies:
       motion-utils: 12.39.0
@@ -24018,7 +25162,6 @@ snapshots:
       whatwg-url: 5.0.0
     optionalDependencies:
       encoding: 0.1.13
-    optional: true
 
   node-forge@1.4.0:
     optional: true
@@ -24573,6 +25716,8 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proxy-from-env@1.1.0: {}
+
   proxy-from-env@2.1.0: {}
 
   pump@3.0.4:
@@ -24960,6 +26105,13 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   requireg@0.2.2:
     dependencies:
@@ -25778,8 +26930,7 @@ snapshots:
     dependencies:
       tldts: 7.0.30
 
-  tr46@0.0.3:
-    optional: true
+  tr46@0.0.3: {}
 
   tr46@6.0.0:
     dependencies:
@@ -26112,7 +27263,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
 
-  vitest@4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
@@ -26135,6 +27286,7 @@ snapshots:
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.1
       '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
       jsdom: 27.4.0
@@ -26278,8 +27430,7 @@ snapshots:
 
   web-worker@1.5.0: {}
 
-  webidl-conversions@3.0.1:
-    optional: true
+  webidl-conversions@3.0.1: {}
 
   webidl-conversions@5.0.0:
     optional: true
@@ -26345,7 +27496,6 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    optional: true
 
   which-pm-runs@1.1.0: {}
 

--- a/scripts/dev-sentry.mjs
+++ b/scripts/dev-sentry.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+/**
+ * Run the dev stack with Sentry enabled in the unpackaged build.
+ *
+ * Wraps `pnpm dev` and provides the env it needs to send events locally:
+ *   - SENTRY_FORCE_ENABLE=true        (main process — overrides app.isPackaged)
+ *   - VITE_SENTRY_FORCE_ENABLE=true   (renderer — overrides import.meta.env.PROD)
+ *   - SENTRY_DSN                      (read from the shell env or root .env)
+ *
+ * These only override the packaged/PROD gate — consent is still required, so you
+ * must toggle crash reporting ON in Settings → Privacy. Nothing here affects
+ * packaged/production builds.
+ *
+ * Usage:
+ *   pnpm dev:sentry                 # DSN comes from .env or the shell env
+ *   pnpm dev:sentry --dsn=<dsn>     # or pass it inline
+ *
+ * See .env.example for the variables.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+// Load root .env (gitignored) if present so the DSN can live there. esbuild
+// doesn't auto-load .env, which is the whole reason this wrapper exists.
+const envFile = resolve(root, '.env');
+if (existsSync(envFile)) {
+  process.loadEnvFile(envFile);
+}
+
+// Allow `--dsn=<value>` to override whatever is in the env.
+const args = process.argv.slice(2);
+const dsnArg = args.find(a => a.startsWith('--dsn='));
+const passthrough = args.filter(a => !a.startsWith('--dsn='));
+const dsn = (dsnArg ? dsnArg.slice('--dsn='.length) : process.env.SENTRY_DSN || '').trim();
+
+if (!dsn) {
+  console.error(
+    [
+      '✗ No SENTRY_DSN found.',
+      '',
+      '  Set it in a root .env file (copy .env.example), export it in your shell,',
+      '  or pass it inline:',
+      '',
+      '    pnpm dev:sentry --dsn=https://<key>@<org>.ingest.sentry.io/<project>',
+      '',
+      '  Grab the DSN from your Sentry project (Settings → Client Keys).',
+    ].join('\n')
+  );
+  process.exit(1);
+}
+
+const childEnv = {
+  ...process.env,
+  SENTRY_DSN: dsn,
+  SENTRY_FORCE_ENABLE: 'true',
+  VITE_SENTRY_FORCE_ENABLE: 'true',
+};
+
+console.log(
+  [
+    '▸ Starting dev with Sentry forced on (unpackaged build)',
+    '  SENTRY_DSN              provided ✓',
+    '  SENTRY_FORCE_ENABLE     true   (main)',
+    '  VITE_SENTRY_FORCE_ENABLE true  (renderer)',
+    '',
+    '  Reminder: toggle crash reporting ON in Settings → Privacy, then use the',
+    '  "Send test event" button to verify.',
+    '',
+  ].join('\n')
+);
+
+const child = spawn('pnpm', ['dev', ...passthrough], {
+  cwd: root,
+  env: childEnv,
+  stdio: 'inherit',
+  shell: true,
+});
+
+child.on('exit', code => process.exit(code ?? 0));
+child.on('error', err => {
+  console.error('✗ Failed to start dev:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds production crash/error monitoring for the desktop app via **Sentry (cloud)**, wired through both the Electron main process and the React renderer. **Opt-in, default OFF** — nothing is sent unless the user explicitly consents.

### Decisions
- **Opt-in, default OFF** — Sentry only initializes when the user consents *and* the build is packaged (or `SENTRY_FORCE_ENABLE` for local testing).
- **Consent UX** — a privacy step in onboarding plus a permanent Settings → Privacy toggle.
- **Scope** — error/crash reporting + light performance tracing (`tracesSampleRate: 0.1`). **Session Replay disabled.** `sendDefaultPii: false`.
- **Privacy** — a shared `beforeSend`/`beforeBreadcrumb` scrubber strips home-dir paths and the OS username from events, stack frames, and breadcrumbs before anything leaves the machine.
- **Source maps** — uploaded for both web (Vite plugin) and desktop (esbuild plugin), gated on `CI && SENTRY_AUTH_TOKEN`; maps are stripped from the shipped artifact.

### Implementation notes
- **Main init runs before `app.ready`** — `@sentry/electron` registers a privileged `sentry-ipc` scheme and IPC handlers that Electron only permits pre-ready, and it must run before our own `registerSchemesAsPrivileged` call so the SDK's merge-proxy keeps our custom schemes registered.
- Renderer events ride the main-process transport (no renderer DSN). The `sentry-ipc` scheme is registered with `bypassCSP: true`, so the existing CSP needs no changes.
- Enabling consent takes effect on the **next launch** (the main SDK can't init post-ready); disabling closes the client immediately. A restart notice surfaces this in the UI.
- DSN injected at build time via env (esbuild define + Vite env), with a runtime `process.env.SENTRY_DSN` fallback for local testing.
- Local testing: `pnpm dev:sentry` wrapper + `.env.example` + a dev-only "Send test event" button in Privacy settings.

### Verification
- Confirmed end-to-end: events arrive in the Sentry project (test event + a real captured crash), with scrubbed frames and correct release/environment.
- `pnpm typecheck` (web + desktop), `pnpm lint`, and the scrubber/web/shared test suites pass.

### Follow-up (not in this PR)
- Add GitHub Actions secrets: `SENTRY_AUTH_TOKEN`, `SENTRY_DSN`, `SENTRY_ORG`, `SENTRY_PROJECT` (token is CI-only).
- Review/refine the new i18n copy, especially the Polish strings.
- Optional: `import '@sentry/electron/preload'` in the bundled preload for richer native-crash IPC context (currently uses the HTTP-protocol fallback).