### PR TITLE
feat: now playing panels + compact-mode lyrics (#223)

### DIFF
--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -1,21 +1,24 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
-import { useUIStore } from '@/stores/useUIStore';
+import { useUIStore, type NowPlayingPanel } from '@/stores/useUIStore';
 import { useLyricsAppearanceStore, type LyricsFontSize } from '@/stores/useLyricsAppearanceStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { useLyricsView } from '@/hooks/useLyricsView';
 import { LyricsBody } from '@/components/lyrics/LyricsBody';
+import { QueuePanel } from '@/components/player/QueuePanel';
+import { EqualizerPanel } from '@/components/player/EqualizerPanel';
 import { cn } from '@/lib/utils';
 import { formatDuration } from '@shiranami/shared';
 import { PlayerControls } from '@/components/player/PlayerControls';
 import { SeekBar } from '@/components/player/SeekBar';
 import { VolumeControl } from '@/components/player/VolumeControl';
 import { TimeDisplay } from '@/components/player/TimeDisplay';
-import { Music, ArrowLeft, Mic2, MicOff } from 'lucide-react';
+import { Music, ArrowLeft, Mic2, ListMusic, SlidersVertical } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { IconButton } from '@/components/ui/icon-button';
+import type { LucideIcon } from 'lucide-react';
 
 const NP_PLAIN_SIZE_CLASS: Record<LyricsFontSize, string> = {
   sm: 'text-xs @5xl:text-sm @7xl:text-base',
@@ -44,13 +47,27 @@ const NP_BASE_SHARED =
 const NP_IDLE = 'text-foreground opacity-[var(--lyrics-idle-opacity)] hover:opacity-100';
 const NP_PAST = 'text-foreground opacity-[var(--lyrics-past-opacity)]';
 
+type ActivePanel = Exclude<NowPlayingPanel, null>;
+
+const PANEL_ORDER: ActivePanel[] = ['lyrics', 'queue', 'eq'];
+
+const PANEL_META: Record<
+  ActivePanel,
+  { icon: LucideIcon; labelKey: string; showKey: string; hideKey: string }
+> = {
+  lyrics: { icon: Mic2, labelKey: 'lyrics', showKey: 'showLyrics', hideKey: 'hideLyrics' },
+  queue: { icon: ListMusic, labelKey: 'queue', showKey: 'showQueue', hideKey: 'hideQueue' },
+  eq: { icon: SlidersVertical, labelKey: 'eq', showKey: 'showEq', hideKey: 'hideEq' },
+};
+
 export function NowPlayingView() {
   const { t } = useTranslation('nowPlaying');
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const duration = usePlaybackStore(s => s.duration);
   const exitNowPlaying = useViewStore(s => s.exitNowPlaying);
-  const lyricsVisible = useUIStore(s => s.nowPlayingLyricsVisible);
-  const toggleLyrics = useUIStore(s => s.toggleNowPlayingLyrics);
+  const panel = useUIStore(s => s.nowPlayingPanel);
+  const togglePanel = useUIStore(s => s.toggleNowPlayingPanel);
+  const lowPerformanceMode = useUIStore(s => s.lowPerformanceMode);
   const lyricsPlainOpacity = useLyricsAppearanceStore(s => s.lyricsPlainOpacity);
   const lyricsPlainFontSize = useLyricsAppearanceStore(s => s.lyricsPlainFontSize);
   const lyricsSyncedDimOpacity = useLyricsAppearanceStore(s => s.lyricsSyncedDimOpacity);
@@ -63,6 +80,8 @@ export function NowPlayingView() {
   );
 
   const { synced, plain, activeLine, isLoading: lyricsLoading, handleLineClick } = useLyricsView();
+
+  const panelVisible = panel !== null;
 
   // Exit if no track is playing
   useEffect(() => {
@@ -77,7 +96,7 @@ export function NowPlayingView() {
     <div className="@container flex-1 flex flex-col overflow-hidden relative">
       {/* Ambient gradient is painted globally by <AmbientBackground /> — no local duplicate here. */}
 
-      {/* Header: back button + lyrics toggle */}
+      {/* Header: back button + lyrics / queue / EQ segmented toggle group */}
       <div className="relative px-6 @3xl:px-10 pt-4 pb-2 shrink-0 flex items-center justify-between">
         <motion.button
           whileTap={{ scale: 0.9 }}
@@ -88,26 +107,37 @@ export function NowPlayingView() {
           <ArrowLeft className="w-4 h-4" />
         </motion.button>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <IconButton
-              size="lg"
-              onClick={toggleLyrics}
-              className={cn(
-                lyricsVisible
-                  ? 'text-primary bg-primary/10 hover:bg-primary/15 hover:text-primary'
-                  : 'text-muted-foreground/60 hover:bg-accent/40'
-              )}
-              aria-label={lyricsVisible ? t('hideLyrics') : t('showLyrics')}
-              aria-pressed={lyricsVisible}
-            >
-              {lyricsVisible ? <Mic2 /> : <MicOff />}
-            </IconButton>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            {lyricsVisible ? t('hideLyrics') : t('showLyrics')}
-          </TooltipContent>
-        </Tooltip>
+        <div
+          role="group"
+          aria-label={t('panelGroup')}
+          className="glass-subtle flex items-center gap-0.5 rounded-xl border border-border/20 p-1"
+        >
+          {PANEL_ORDER.map(id => {
+            const meta = PANEL_META[id];
+            const Icon = meta.icon;
+            const isActive = panel === id;
+            const label = isActive ? t(meta.hideKey) : t(meta.showKey);
+            return (
+              <Tooltip key={id}>
+                <TooltipTrigger asChild>
+                  <IconButton
+                    onClick={() => togglePanel(id)}
+                    className={cn(
+                      isActive
+                        ? 'text-primary bg-primary/10 hover:bg-primary/15 hover:text-primary'
+                        : 'text-muted-foreground/60 hover:bg-accent/40'
+                    )}
+                    aria-label={label}
+                    aria-pressed={isActive}
+                  >
+                    <Icon />
+                  </IconButton>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{label}</TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </div>
       </div>
 
       {/* Main content: stacked on narrow, side-by-side on wide */}
@@ -115,7 +145,7 @@ export function NowPlayingView() {
         className={cn(
           'flex-1 min-h-0 relative flex',
           'flex-col @3xl:flex-row',
-          lyricsVisible
+          panelVisible
             ? 'gap-4 @3xl:gap-8 @5xl:gap-12 @7xl:gap-16 px-6 @3xl:px-10 @5xl:px-14 @7xl:px-20'
             : 'justify-center px-8'
         )}
@@ -129,7 +159,7 @@ export function NowPlayingView() {
             'justify-start @3xl:justify-center',
             'py-4 @3xl:py-8 @5xl:py-10 @7xl:py-14',
             // Narrow: full-width auto-centered; wide: fixed percentage that scales up
-            lyricsVisible
+            panelVisible
               ? 'w-full max-w-[460px] mx-auto @3xl:mx-0 @3xl:w-[42%] @3xl:max-w-[420px] @5xl:max-w-[500px] @6xl:max-w-[580px] @7xl:max-w-[640px]'
               : 'w-full max-w-[520px] @5xl:max-w-[580px] @7xl:max-w-[640px] py-6 @5xl:py-10'
           )}
@@ -145,7 +175,7 @@ export function NowPlayingView() {
               className={cn(
                 'shrink-0 aspect-square rounded-2xl @5xl:rounded-3xl overflow-hidden',
                 'shadow-2xl shadow-black/40 bg-muted flex items-center justify-center',
-                lyricsVisible
+                panelVisible
                   ? 'w-[55%] min-w-[180px] max-w-[240px] @3xl:w-full @3xl:max-w-[min(48vh,clamp(280px,22vw,480px))]'
                   : 'w-full max-w-[min(52vh,clamp(300px,24vw,440px))]'
               )}
@@ -203,40 +233,66 @@ export function NowPlayingView() {
           </div>
         </div>
 
-        {/* Right column / bottom section: Lyrics — always mounted when lyricsVisible to prevent layout shift on track change */}
-        {lyricsVisible && (
+        {/* Right column / bottom section: active panel (lyrics / queue / EQ). */}
+        {panelVisible && (
           <div className="flex-1 min-w-0 flex flex-col min-h-0 pb-4 @3xl:py-8 @5xl:py-10 @7xl:py-14">
-            <div className="mb-2 @3xl:mb-4">
-              <h2 className="text-[10px] @5xl:text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground/40">
-                {t('lyrics')}
-              </h2>
-            </div>
+            <AnimatePresence mode="wait" initial={false}>
+              <motion.div
+                key={panel}
+                initial={lowPerformanceMode ? false : { opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={lowPerformanceMode ? { opacity: 0 } : { opacity: 0, y: -8 }}
+                transition={{ duration: lowPerformanceMode ? 0.1 : 0.2 }}
+                className="flex-1 min-h-0 flex flex-col"
+              >
+                {panel === 'lyrics' && (
+                  <>
+                    <div className="mb-2 @3xl:mb-4">
+                      <h2 className="text-[10px] @5xl:text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground/40">
+                        {t('lyrics')}
+                      </h2>
+                    </div>
+                    <LyricsBody
+                      synced={synced}
+                      plain={plain}
+                      activeLine={activeLine}
+                      isLoading={lyricsLoading}
+                      onLineClick={handleLineClick}
+                      loadingLabel={t('findingLyrics')}
+                      emptyLabel={t('noLyrics')}
+                      syncedDimOpacity={lyricsSyncedDimOpacity}
+                      plainOpacity={lyricsPlainOpacity}
+                      syncedWrapperClassName="contents"
+                      syncedContainerClassName="pr-2 @3xl:pr-4"
+                      syncedSpacingClassName="space-y-4 @5xl:space-y-5 @7xl:space-y-6"
+                      syncedBottomSpacerClassName="h-[40vh]"
+                      syncedBaseClassName={npBase}
+                      syncedActiveClassName={npActive}
+                      syncedPastClassName={NP_PAST}
+                      syncedIdleClassName={NP_IDLE}
+                      plainContainerClassName="pr-2 @3xl:pr-4"
+                      plainTextClassName={cn(
+                        'text-foreground whitespace-pre-wrap font-sans font-medium tracking-[0.005em] leading-relaxed',
+                        NP_PLAIN_SIZE_CLASS[lyricsPlainFontSize]
+                      )}
+                      emptyClassName="text-muted-foreground/25"
+                    />
+                  </>
+                )}
 
-            <LyricsBody
-              synced={synced}
-              plain={plain}
-              activeLine={activeLine}
-              isLoading={lyricsLoading}
-              onLineClick={handleLineClick}
-              loadingLabel={t('findingLyrics')}
-              emptyLabel={t('noLyrics')}
-              syncedDimOpacity={lyricsSyncedDimOpacity}
-              plainOpacity={lyricsPlainOpacity}
-              syncedWrapperClassName="contents"
-              syncedContainerClassName="pr-2 @3xl:pr-4"
-              syncedSpacingClassName="space-y-4 @5xl:space-y-5 @7xl:space-y-6"
-              syncedBottomSpacerClassName="h-[40vh]"
-              syncedBaseClassName={npBase}
-              syncedActiveClassName={npActive}
-              syncedPastClassName={NP_PAST}
-              syncedIdleClassName={NP_IDLE}
-              plainContainerClassName="pr-2 @3xl:pr-4"
-              plainTextClassName={cn(
-                'text-foreground whitespace-pre-wrap font-sans font-medium tracking-[0.005em] leading-relaxed',
-                NP_PLAIN_SIZE_CLASS[lyricsPlainFontSize]
-              )}
-              emptyClassName="text-muted-foreground/25"
-            />
+                {panel === 'queue' && (
+                  <div className="glass-subtle flex-1 min-h-0 rounded-2xl border border-border/20 overflow-hidden">
+                    <QueuePanel />
+                  </div>
+                )}
+
+                {panel === 'eq' && (
+                  <div className="glass-subtle flex-1 min-h-0 overflow-y-auto overflow-x-auto scrollbar-thin rounded-2xl border border-border/20 p-4 @5xl:p-5">
+                    <EqualizerPanel inline />
+                  </div>
+                )}
+              </motion.div>
+            </AnimatePresence>
           </div>
         )}
       </div>

--- a/apps/web/src/components/player/CompactPlayer.tsx
+++ b/apps/web/src/components/player/CompactPlayer.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useLibraryStore } from '@/stores/useLibraryStore';
@@ -22,8 +22,9 @@ import { useMarqueeOnOverflow } from '@/hooks/useMarqueeOnOverflow';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { IconButton } from '@/components/ui/icon-button';
 import { TrackThumbnail } from '@/components/shared/TrackThumbnail';
+import { LyricsPanel } from '@/components/lyrics/LyricsPanel';
 import { TimeDisplay } from './TimeDisplay';
-import { Heart, Maximize2, Minimize2, Music, Pin } from 'lucide-react';
+import { Heart, Maximize2, Mic2, Minimize2, Music, Pin } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 
 export function CompactPlayer() {
@@ -42,6 +43,15 @@ export function CompactPlayer() {
   const compactShowSeek = useCompactStore(s => s.compactShowSeek);
   const compactShowVolume = useCompactStore(s => s.compactShowVolume);
   const compactShowFavorite = useCompactStore(s => s.compactShowFavorite);
+  const compactShowLyrics = useCompactStore(s => s.compactShowLyrics);
+
+  // Lyrics open-state lives in the store because opening it resizes the OS
+  // window (the store owns compact window dimensions). Toggling it grows the
+  // window and reveals the panel below the player; closing shrinks it back.
+  const lyricsOpen = useCompactStore(s => s.compactLyricsExpanded);
+  const setLyricsOpen = useCompactStore(s => s.setCompactLyricsExpanded);
+  const lyricsButtonRef = useRef<HTMLButtonElement>(null);
+  const lyricsPanelRef = useRef<HTMLDivElement>(null);
 
   const ambientColor = useAmbientColor();
   const { minimize: handleMinimize } = useWindowControls();
@@ -66,6 +76,34 @@ export function CompactPlayer() {
       enterNowPlaying();
     }
   }, [setCompactMode, nowPlayingViewEnabled, enterNowPlaying, currentTrack]);
+
+  // Close the lyrics overlay when there is nothing to show it for, or when
+  // the user disables the button setting while it happens to be open.
+  useEffect(() => {
+    if (lyricsOpen && (!currentTrack || !compactShowLyrics)) {
+      setLyricsOpen(false);
+    }
+  }, [lyricsOpen, currentTrack, compactShowLyrics]);
+
+  // Move focus into the lyrics panel on open and back to the trigger on close
+  // so keyboard users stay anchored to the region they invoked. The ref guard
+  // skips the close branch on the initial render (nothing was opened yet).
+  const lyricsWasOpen = useRef(false);
+  useEffect(() => {
+    if (lyricsOpen) {
+      lyricsWasOpen.current = true;
+      lyricsPanelRef.current?.focus();
+    } else if (lyricsWasOpen.current) {
+      lyricsButtonRef.current?.focus();
+    }
+  }, [lyricsOpen]);
+
+  const handleLyricsKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      setLyricsOpen(false);
+    }
+  }, []);
 
   const showSeekBar = compactShowSeek && !!currentTrack && !isRadioTrack(currentTrack.filePath);
 
@@ -102,6 +140,28 @@ export function CompactPlayer() {
           {compactShowFavorite && <FavoriteButton />}
 
           <div className="flex items-center rounded-xl border border-border/20 bg-background/35 p-0.5 shadow-sm shadow-black/10">
+            {compactShowLyrics && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <IconButton
+                    ref={lyricsButtonRef}
+                    onClick={() => setLyricsOpen(!lyricsOpen)}
+                    className={cn(
+                      lyricsOpen &&
+                        'bg-primary/15 text-primary hover:bg-primary/20 hover:text-primary'
+                    )}
+                    aria-label={lyricsOpen ? t('hideLyrics') : t('showLyrics')}
+                    aria-pressed={lyricsOpen}
+                  >
+                    <Mic2 />
+                  </IconButton>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {lyricsOpen ? t('hideLyrics') : t('showLyrics')}
+                </TooltipContent>
+              </Tooltip>
+            )}
+
             <Tooltip>
               <TooltipTrigger asChild>
                 <IconButton
@@ -141,8 +201,22 @@ export function CompactPlayer() {
         </div>
       </div>
 
-      <div className="relative flex min-h-0 flex-1 items-center p-2.5">
-        <div className="glass-subtle relative flex h-full w-full items-stretch gap-2.5 overflow-hidden rounded-[20px] border border-border/25 p-2.5">
+      <div
+        className={cn(
+          'relative flex items-center p-2.5',
+          // When lyrics are open the window has grown: keep the player at its
+          // natural height up top so the lyrics panel takes the new space
+          // below. Otherwise the player fills (and vertically centers in) the
+          // short window as before.
+          lyricsOpen ? 'shrink-0' : 'min-h-0 flex-1'
+        )}
+      >
+        <div
+          className={cn(
+            'glass-subtle relative flex w-full items-stretch gap-2.5 overflow-hidden rounded-[20px] border border-border/25 p-2.5',
+            lyricsOpen ? 'h-auto' : 'h-full'
+          )}
+        >
           {compactShowAlbumArt && (
             <button
               type="button"
@@ -211,6 +285,28 @@ export function CompactPlayer() {
           </div>
         </div>
       </div>
+
+      <AnimatePresence>
+        {lyricsOpen && currentTrack && (
+          <motion.div
+            ref={lyricsPanelRef}
+            key="compact-lyrics"
+            role="region"
+            aria-label={t('lyricsTitle')}
+            tabIndex={-1}
+            onKeyDown={handleLyricsKeyDown}
+            initial={lowPerformanceMode ? { opacity: 0 } : { opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: lowPerformanceMode ? 0.1 : 0.2 }}
+            className="relative z-10 flex min-h-0 flex-1 flex-col px-2.5 pb-2.5 focus:outline-none"
+          >
+            <div className="glass-panel h-full overflow-hidden rounded-2xl border border-border/25 shadow-lg shadow-black/20">
+              <LyricsPanel />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/apps/web/src/components/settings/CompactModePreview.tsx
+++ b/apps/web/src/components/settings/CompactModePreview.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Music2, Heart, Play, SkipBack, SkipForward } from 'lucide-react';
+import { Music2, Heart, Mic2, Play, SkipBack, SkipForward } from 'lucide-react';
 import {
   useCompactStore,
   CMP_TITLE_CLASS,
@@ -26,6 +26,7 @@ export function CompactModePreview() {
   const compactShowSeek = useCompactStore(s => s.compactShowSeek);
   const compactShowVolume = useCompactStore(s => s.compactShowVolume);
   const compactShowFavorite = useCompactStore(s => s.compactShowFavorite);
+  const compactShowLyrics = useCompactStore(s => s.compactShowLyrics);
 
   const cardWidth = SIZE_WIDTH[compactSize];
   const titleClass = CMP_TITLE_CLASS[compactFontSize];
@@ -76,8 +77,15 @@ export function CompactModePreview() {
               )}
             </div>
 
-            {compactShowFavorite && (
-              <Heart size={controlSize} className="shrink-0 text-muted-foreground/50" />
+            {(compactShowFavorite || compactShowLyrics) && (
+              <div className="flex shrink-0 items-center gap-1">
+                {compactShowFavorite && (
+                  <Heart size={controlSize} className="text-muted-foreground/50" />
+                )}
+                {compactShowLyrics && (
+                  <Mic2 size={controlSize} className="text-muted-foreground/50" />
+                )}
+              </div>
             )}
           </div>
 

--- a/apps/web/src/components/settings/CompactSection.tsx
+++ b/apps/web/src/components/settings/CompactSection.tsx
@@ -31,6 +31,7 @@ export function CompactSection() {
   const compactShowSeek = useCompactStore(s => s.compactShowSeek);
   const compactShowVolume = useCompactStore(s => s.compactShowVolume);
   const compactShowFavorite = useCompactStore(s => s.compactShowFavorite);
+  const compactShowLyrics = useCompactStore(s => s.compactShowLyrics);
   const compactDefaultAlwaysOnTop = useCompactStore(s => s.compactDefaultAlwaysOnTop);
 
   const setCompactSize = useCompactStore(s => s.setCompactSize);
@@ -41,6 +42,7 @@ export function CompactSection() {
   const setCompactShowSeek = useCompactStore(s => s.setCompactShowSeek);
   const setCompactShowVolume = useCompactStore(s => s.setCompactShowVolume);
   const setCompactShowFavorite = useCompactStore(s => s.setCompactShowFavorite);
+  const setCompactShowLyrics = useCompactStore(s => s.setCompactShowLyrics);
   const setCompactDefaultAlwaysOnTop = useCompactStore(s => s.setCompactDefaultAlwaysOnTop);
   const resetCompactAppearance = useCompactStore(s => s.resetCompactAppearance);
 
@@ -53,6 +55,7 @@ export function CompactSection() {
     !compactShowSeek ||
     !compactShowVolume ||
     compactShowFavorite ||
+    compactShowLyrics ||
     compactDefaultAlwaysOnTop;
 
   return (
@@ -124,6 +127,13 @@ export function CompactSection() {
             description={t('cmp.elements.favoriteDesc')}
             checked={compactShowFavorite}
             onCheckedChange={setCompactShowFavorite}
+          />
+          <SettingsToggleRow
+            divider
+            label={t('cmp.elements.lyrics')}
+            description={t('cmp.elements.lyricsDesc')}
+            checked={compactShowLyrics}
+            onCheckedChange={setCompactShowLyrics}
           />
         </Subsection>
 

--- a/apps/web/src/locales/en/compact.json
+++ b/apps/web/src/locales/en/compact.json
@@ -8,5 +8,8 @@
   "disableOnTop": "Disable always on top",
   "exitCompactMode": "Exit compact mode",
   "minimize": "Minimize",
-  "expandFromCompact": "Expand to full player"
+  "expandFromCompact": "Expand to full player",
+  "showLyrics": "Show lyrics",
+  "hideLyrics": "Hide lyrics",
+  "lyricsTitle": "Lyrics"
 }

--- a/apps/web/src/locales/en/nowPlaying.json
+++ b/apps/web/src/locales/en/nowPlaying.json
@@ -1,8 +1,15 @@
 {
   "back": "Back",
   "lyrics": "Lyrics",
+  "queue": "Queue",
+  "eq": "Equalizer",
   "findingLyrics": "Finding lyrics...",
   "noLyrics": "No lyrics available",
   "showLyrics": "Show lyrics",
-  "hideLyrics": "Hide lyrics"
+  "hideLyrics": "Hide lyrics",
+  "showQueue": "Show queue",
+  "hideQueue": "Hide queue",
+  "showEq": "Show equalizer",
+  "hideEq": "Hide equalizer",
+  "panelGroup": "Now playing panels"
 }

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -301,7 +301,9 @@
       "volume": "Volume slider",
       "volumeDesc": "Inline slider next to the playback controls",
       "favorite": "Favorite button",
-      "favoriteDesc": "Heart button in the title bar to favorite the current track"
+      "favoriteDesc": "Heart button in the title bar to favorite the current track",
+      "lyrics": "Lyrics button",
+      "lyricsDesc": "Button in the title bar that opens lyrics over the mini-player"
     },
     "behavior": {
       "title": "Behavior",

--- a/apps/web/src/locales/pl/compact.json
+++ b/apps/web/src/locales/pl/compact.json
@@ -8,5 +8,8 @@
   "disableOnTop": "Wyłącz zawsze na wierzchu",
   "exitCompactMode": "Wyjdź z trybu kompaktowego",
   "minimize": "Minimalizuj",
-  "expandFromCompact": "Rozwiń do pełnego odtwarzacza"
+  "expandFromCompact": "Rozwiń do pełnego odtwarzacza",
+  "showLyrics": "Pokaż tekst",
+  "hideLyrics": "Ukryj tekst",
+  "lyricsTitle": "Tekst"
 }

--- a/apps/web/src/locales/pl/nowPlaying.json
+++ b/apps/web/src/locales/pl/nowPlaying.json
@@ -1,8 +1,15 @@
 {
   "back": "Wróć",
   "lyrics": "Tekst",
+  "queue": "Kolejka",
+  "eq": "Korektor",
   "findingLyrics": "Szukanie tekstu...",
   "noLyrics": "Tekst niedostępny",
   "showLyrics": "Pokaż tekst",
-  "hideLyrics": "Ukryj tekst"
+  "hideLyrics": "Ukryj tekst",
+  "showQueue": "Pokaż kolejkę",
+  "hideQueue": "Ukryj kolejkę",
+  "showEq": "Pokaż korektor",
+  "hideEq": "Ukryj korektor",
+  "panelGroup": "Panele odtwarzania"
 }

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -301,7 +301,9 @@
       "volume": "Suwak głośności",
       "volumeDesc": "Suwak obok kontrolek odtwarzania",
       "favorite": "Przycisk ulubionych",
-      "favoriteDesc": "Przycisk serca w pasku tytułu do dodawania bieżącego utworu do ulubionych"
+      "favoriteDesc": "Przycisk serca w pasku tytułu do dodawania bieżącego utworu do ulubionych",
+      "lyrics": "Przycisk tekstu",
+      "lyricsDesc": "Przycisk w pasku tytułu otwierający tekst nad mini-odtwarzaczem"
     },
     "behavior": {
       "title": "Zachowanie",

--- a/apps/web/src/stores/useCompactStore.ts
+++ b/apps/web/src/stores/useCompactStore.ts
@@ -16,6 +16,25 @@ export const COMPACT_DIMENSIONS: Record<CompactSize, { width: number; height: nu
   lg: { width: 600, height: 260 },
 };
 
+// Extra window height (px) added below the player when the in-window lyrics
+// panel is expanded. The player controls keep their normal height at the top
+// and the lyrics fill this new space, so toggling lyrics never hides the
+// transport like a full-body overlay would. Forwarded over IPC as part of the
+// compact dimensions, so it lives under the same min/max/size lock.
+export const COMPACT_LYRICS_EXTRA_HEIGHT = 200;
+
+/** Compact window dimensions for a preset, grown when lyrics are expanded. */
+function compactDimensions(
+  size: CompactSize,
+  lyricsExpanded: boolean
+): { width: number; height: number } {
+  const base = COMPACT_DIMENSIONS[size];
+  return {
+    width: base.width,
+    height: base.height + (lyricsExpanded ? COMPACT_LYRICS_EXTRA_HEIGHT : 0),
+  };
+}
+
 // --- Compact mode appearance prefs ---
 export const COMPACT_AMBIENT_INTENSITY_MIN = 0;
 export const COMPACT_AMBIENT_INTENSITY_MAX = 0.2;
@@ -149,6 +168,12 @@ interface CompactState {
   compactShowVolume: boolean;
   compactShowFavorite: boolean;
   compactShowLyrics: boolean;
+  /**
+   * Runtime-only: whether the in-window lyrics panel is currently open in
+   * compact mode. Not persisted — lyrics always start collapsed on entry so
+   * the mini-player keeps its small footprint until the user opts in.
+   */
+  compactLyricsExpanded: boolean;
   compactDefaultAlwaysOnTop: boolean;
 }
 
@@ -166,6 +191,7 @@ interface CompactActions {
   setCompactShowVolume: (visible: boolean) => void;
   setCompactShowFavorite: (visible: boolean) => void;
   setCompactShowLyrics: (visible: boolean) => void;
+  setCompactLyricsExpanded: (expanded: boolean) => void;
   setCompactDefaultAlwaysOnTop: (enabled: boolean) => void;
   resetCompactAppearance: () => void;
 }
@@ -183,6 +209,7 @@ export const useCompactStore = createPersistedStore<CompactState & CompactAction
     compactShowVolume: true,
     compactShowFavorite: false,
     compactShowLyrics: false,
+    compactLyricsExpanded: false,
     compactDefaultAlwaysOnTop: false,
 
     setCompactMode: async compactMode => {
@@ -198,7 +225,9 @@ export const useCompactStore = createPersistedStore<CompactState & CompactAction
         set({ compactAlwaysOnTop: true });
       }
 
-      set({ compactMode });
+      // Always enter/exit with lyrics collapsed so the window opens at its
+      // base footprint and the grown height never leaks across transitions.
+      set({ compactMode, compactLyricsExpanded: false });
 
       if (!IS_ELECTRON) return;
 
@@ -249,7 +278,7 @@ export const useCompactStore = createPersistedStore<CompactState & CompactAction
       // If the window is currently in compact mode, push the new dimensions
       // immediately so the preset switch is reflected without a re-toggle.
       if (IS_ELECTRON && get().compactMode) {
-        const dims = COMPACT_DIMENSIONS[next];
+        const dims = compactDimensions(next, get().compactLyricsExpanded);
         window.electronAPI.window.setCompactMode(true, dims).catch(() => {
           // Failure to resize is non-fatal; the next enter-compact will retry.
         });
@@ -267,6 +296,20 @@ export const useCompactStore = createPersistedStore<CompactState & CompactAction
     setCompactShowVolume: visible => set({ compactShowVolume: visible }),
     setCompactShowFavorite: visible => set({ compactShowFavorite: visible }),
     setCompactShowLyrics: visible => set({ compactShowLyrics: visible }),
+    setCompactLyricsExpanded: expanded => {
+      if (get().compactLyricsExpanded === expanded) return;
+      set({ compactLyricsExpanded: expanded });
+      // Grow the OS window when opening lyrics (and shrink it back on close)
+      // so the panel gets dedicated space below the player. No-op outside
+      // Electron or when not in compact mode — the renderer flag still drives
+      // the in-window panel either way.
+      if (IS_ELECTRON && get().compactMode) {
+        const dims = compactDimensions(get().compactSize, expanded);
+        window.electronAPI.window.setCompactMode(true, dims).catch(() => {
+          // Resize failure is non-fatal; the panel still renders in-window.
+        });
+      }
+    },
     setCompactDefaultAlwaysOnTop: enabled => set({ compactDefaultAlwaysOnTop: enabled }),
     resetCompactAppearance: () => {
       set({

--- a/apps/web/src/stores/useCompactStore.ts
+++ b/apps/web/src/stores/useCompactStore.ts
@@ -75,6 +75,7 @@ interface PersistedCompactState {
   compactShowSeek: boolean;
   compactShowVolume: boolean;
   compactShowFavorite: boolean;
+  compactShowLyrics: boolean;
   compactDefaultAlwaysOnTop: boolean;
 }
 
@@ -102,6 +103,8 @@ function sanitize(
     out.compactShowVolume = persisted.compactShowVolume;
   if (typeof persisted.compactShowFavorite === 'boolean')
     out.compactShowFavorite = persisted.compactShowFavorite;
+  if (typeof persisted.compactShowLyrics === 'boolean')
+    out.compactShowLyrics = persisted.compactShowLyrics;
   if (typeof persisted.compactDefaultAlwaysOnTop === 'boolean')
     out.compactDefaultAlwaysOnTop = persisted.compactDefaultAlwaysOnTop;
   return out;
@@ -145,6 +148,7 @@ interface CompactState {
   compactShowSeek: boolean;
   compactShowVolume: boolean;
   compactShowFavorite: boolean;
+  compactShowLyrics: boolean;
   compactDefaultAlwaysOnTop: boolean;
 }
 
@@ -161,6 +165,7 @@ interface CompactActions {
   setCompactShowSeek: (visible: boolean) => void;
   setCompactShowVolume: (visible: boolean) => void;
   setCompactShowFavorite: (visible: boolean) => void;
+  setCompactShowLyrics: (visible: boolean) => void;
   setCompactDefaultAlwaysOnTop: (enabled: boolean) => void;
   resetCompactAppearance: () => void;
 }
@@ -177,6 +182,7 @@ export const useCompactStore = createPersistedStore<CompactState & CompactAction
     compactShowSeek: true,
     compactShowVolume: true,
     compactShowFavorite: false,
+    compactShowLyrics: false,
     compactDefaultAlwaysOnTop: false,
 
     setCompactMode: async compactMode => {
@@ -260,6 +266,7 @@ export const useCompactStore = createPersistedStore<CompactState & CompactAction
     setCompactShowSeek: visible => set({ compactShowSeek: visible }),
     setCompactShowVolume: visible => set({ compactShowVolume: visible }),
     setCompactShowFavorite: visible => set({ compactShowFavorite: visible }),
+    setCompactShowLyrics: visible => set({ compactShowLyrics: visible }),
     setCompactDefaultAlwaysOnTop: enabled => set({ compactDefaultAlwaysOnTop: enabled }),
     resetCompactAppearance: () => {
       set({
@@ -271,6 +278,7 @@ export const useCompactStore = createPersistedStore<CompactState & CompactAction
         compactShowSeek: true,
         compactShowVolume: true,
         compactShowFavorite: false,
+        compactShowLyrics: false,
         compactDefaultAlwaysOnTop: false,
       });
     },
@@ -289,6 +297,7 @@ export const useCompactStore = createPersistedStore<CompactState & CompactAction
       compactShowSeek: s.compactShowSeek,
       compactShowVolume: s.compactShowVolume,
       compactShowFavorite: s.compactShowFavorite,
+      compactShowLyrics: s.compactShowLyrics,
       compactDefaultAlwaysOnTop: s.compactDefaultAlwaysOnTop,
     }),
     sanitize: (persisted, current) => ({

--- a/apps/web/src/stores/useCompactStore.ts
+++ b/apps/web/src/stores/useCompactStore.ts
@@ -221,6 +221,7 @@ export const useCompactStore = createPersistedStore<CompactState & CompactAction
       // setCompactAlwaysOnTop short-circuits when not yet in compact mode,
       // so we just write the value directly here.
       const previousAlwaysOnTop = get().compactAlwaysOnTop;
+      const previousLyricsExpanded = get().compactLyricsExpanded;
       if (compactMode && get().compactDefaultAlwaysOnTop && !previousAlwaysOnTop) {
         set({ compactAlwaysOnTop: true });
       }
@@ -238,7 +239,11 @@ export const useCompactStore = createPersistedStore<CompactState & CompactAction
         // Compact-mode IPC failed: undo the store flips and bail before
         // touching always-on-top so we don't pin a window the user thinks
         // is still in normal mode.
-        set({ compactMode: previous, compactAlwaysOnTop: previousAlwaysOnTop });
+        set({
+          compactMode: previous,
+          compactAlwaysOnTop: previousAlwaysOnTop,
+          compactLyricsExpanded: previousLyricsExpanded,
+        });
         return;
       }
 
@@ -298,6 +303,7 @@ export const useCompactStore = createPersistedStore<CompactState & CompactAction
     setCompactShowLyrics: visible => set({ compactShowLyrics: visible }),
     setCompactLyricsExpanded: expanded => {
       if (get().compactLyricsExpanded === expanded) return;
+      const previous = get().compactLyricsExpanded;
       set({ compactLyricsExpanded: expanded });
       // Grow the OS window when opening lyrics (and shrink it back on close)
       // so the panel gets dedicated space below the player. No-op outside
@@ -306,7 +312,8 @@ export const useCompactStore = createPersistedStore<CompactState & CompactAction
       if (IS_ELECTRON && get().compactMode) {
         const dims = compactDimensions(get().compactSize, expanded);
         window.electronAPI.window.setCompactMode(true, dims).catch(() => {
-          // Resize failure is non-fatal; the panel still renders in-window.
+          // Roll back so the renderer never paints a panel into clipped space.
+          set({ compactLyricsExpanded: previous });
         });
       }
     },

--- a/apps/web/src/stores/useUIStore.ts
+++ b/apps/web/src/stores/useUIStore.ts
@@ -39,6 +39,8 @@ export type LibraryViewMode = 'tracks' | 'albums';
 export type AlbumGridSize = 'small' | 'medium' | 'large';
 export type AlbumSortMode = 'name' | 'artist' | 'year' | 'recentlyAdded';
 export type AlbumSortOrder = 'asc' | 'desc';
+/** Which panel the full-screen Now Playing view shows in its right column. */
+export type NowPlayingPanel = 'lyrics' | 'queue' | 'eq' | null;
 
 export const UI_SCALE_MIN = 80;
 export const UI_SCALE_MAX = 120;
@@ -103,6 +105,9 @@ function coerceAlbumSortMode(v: unknown): AlbumSortMode {
 function coerceAlbumSortOrder(v: unknown): AlbumSortOrder {
   return v === 'asc' || v === 'desc' ? v : 'asc';
 }
+function coerceNowPlayingPanel(v: unknown): NowPlayingPanel {
+  return v === 'lyrics' || v === 'queue' || v === 'eq' || v === null ? v : 'lyrics';
+}
 function coerceUiScale(v: unknown): number {
   const parsed = typeof v === 'number' ? v : Number(v);
   if (Number.isNaN(parsed)) return UI_SCALE_DEFAULT;
@@ -124,13 +129,20 @@ interface PersistedUIState {
   albumSortMode: AlbumSortMode;
   albumSortOrder: AlbumSortOrder;
   nowPlayingViewEnabled: boolean;
-  nowPlayingLyricsVisible: boolean;
+  nowPlayingPanel: NowPlayingPanel;
   libraryHeroCardEnabled: boolean;
   lowPerformanceMode: boolean;
   noiseOverlayEnabled: boolean;
 }
 
-function sanitize(persisted: Partial<PersistedUIState> | undefined): Partial<PersistedUIState> {
+// Legacy fields that may still live in the persisted bucket from older
+// versions but are no longer part of the current persisted shape. Read-only
+// during sanitize so we can migrate them forward, then drop them.
+type LegacyPersistedUIState = Partial<PersistedUIState> & {
+  nowPlayingLyricsVisible?: boolean;
+};
+
+function sanitize(persisted: LegacyPersistedUIState | undefined): Partial<PersistedUIState> {
   if (!persisted || typeof persisted !== 'object') return {};
   const out: Partial<PersistedUIState> = {};
   if (typeof persisted.sidebarCollapsed === 'boolean')
@@ -155,8 +167,12 @@ function sanitize(persisted: Partial<PersistedUIState> | undefined): Partial<Per
     out.albumSortOrder = coerceAlbumSortOrder(persisted.albumSortOrder);
   if (typeof persisted.nowPlayingViewEnabled === 'boolean')
     out.nowPlayingViewEnabled = persisted.nowPlayingViewEnabled;
-  if (typeof persisted.nowPlayingLyricsVisible === 'boolean')
-    out.nowPlayingLyricsVisible = persisted.nowPlayingLyricsVisible;
+  if (persisted.nowPlayingPanel !== undefined) {
+    out.nowPlayingPanel = coerceNowPlayingPanel(persisted.nowPlayingPanel);
+  } else if (typeof persisted.nowPlayingLyricsVisible === 'boolean') {
+    // Migrate the legacy boolean toggle: lyrics-on => 'lyrics', off => null.
+    out.nowPlayingPanel = persisted.nowPlayingLyricsVisible ? 'lyrics' : null;
+  }
   if (typeof persisted.libraryHeroCardEnabled === 'boolean')
     out.libraryHeroCardEnabled = persisted.libraryHeroCardEnabled;
   if (typeof persisted.lowPerformanceMode === 'boolean')
@@ -168,7 +184,10 @@ function sanitize(persisted: Partial<PersistedUIState> | undefined): Partial<Per
 
 // --- Passthrough: fields in the shared bucket that belong to sibling stores ---
 
-const UI_KEYS: ReadonlySet<keyof PersistedUIState> = new Set([
+// Includes the legacy `nowPlayingLyricsVisible` so that, once migrated to
+// `nowPlayingPanel`, the stale boolean is treated as ours and dropped from
+// future writes rather than being re-injected by the passthrough below.
+const UI_KEYS: ReadonlySet<string> = new Set([
   'sidebarCollapsed',
   'sidebarHiddenItems',
   'sidebarPlaylistsVisible',
@@ -181,6 +200,7 @@ const UI_KEYS: ReadonlySet<keyof PersistedUIState> = new Set([
   'albumSortMode',
   'albumSortOrder',
   'nowPlayingViewEnabled',
+  'nowPlayingPanel',
   'nowPlayingLyricsVisible',
   'libraryHeroCardEnabled',
   'lowPerformanceMode',
@@ -196,7 +216,7 @@ function readPassthroughLegacyFields(): Record<string, unknown> {
     if (!parsed.state || typeof parsed.state !== 'object') return {};
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(parsed.state)) {
-      if (!UI_KEYS.has(k as keyof PersistedUIState)) out[k] = v;
+      if (!UI_KEYS.has(k)) out[k] = v;
     }
     return out;
   } catch {
@@ -274,7 +294,7 @@ function importLegacyUIStore() {
 
   const nowPlayingLyricsVisible = ls.getItem(LEGACY_KEYS.nowPlayingLyricsVisible);
   if (nowPlayingLyricsVisible !== null)
-    state.nowPlayingLyricsVisible = nowPlayingLyricsVisible !== 'false';
+    state.nowPlayingPanel = nowPlayingLyricsVisible !== 'false' ? 'lyrics' : null;
 
   const libraryHeroCardEnabled = ls.getItem(LEGACY_KEYS.libraryHeroCardEnabled);
   if (libraryHeroCardEnabled !== null)
@@ -305,7 +325,7 @@ interface UIState {
   albumSortMode: AlbumSortMode;
   albumSortOrder: AlbumSortOrder;
   nowPlayingViewEnabled: boolean;
-  nowPlayingLyricsVisible: boolean;
+  nowPlayingPanel: NowPlayingPanel;
   libraryHeroCardEnabled: boolean;
   lowPerformanceMode: boolean;
   noiseOverlayEnabled: boolean;
@@ -313,7 +333,9 @@ interface UIState {
 
 interface UIActions {
   setNowPlayingViewEnabled: (enabled: boolean) => void;
-  toggleNowPlayingLyrics: () => void;
+  setNowPlayingPanel: (panel: NowPlayingPanel) => void;
+  /** Show the panel, or hide it (back to `null`) when it is already active. */
+  toggleNowPlayingPanel: (panel: Exclude<NowPlayingPanel, null>) => void;
   setLibraryHeroCardEnabled: (enabled: boolean) => void;
   setLowPerformanceMode: (enabled: boolean) => void;
   setNoiseOverlayEnabled: (enabled: boolean) => void;
@@ -346,7 +368,7 @@ export const useUIStore = createPersistedStore<UIState & UIActions>(
     albumSortMode: 'name',
     albumSortOrder: 'asc',
     nowPlayingViewEnabled: false,
-    nowPlayingLyricsVisible: true,
+    nowPlayingPanel: 'lyrics',
     libraryHeroCardEnabled: true,
     lowPerformanceMode: false,
     noiseOverlayEnabled: false,
@@ -358,8 +380,11 @@ export const useUIStore = createPersistedStore<UIState & UIActions>(
         view.exitNowPlaying();
       }
     },
-    toggleNowPlayingLyrics: () => {
-      set({ nowPlayingLyricsVisible: !get().nowPlayingLyricsVisible });
+    setNowPlayingPanel: panel => {
+      set({ nowPlayingPanel: panel });
+    },
+    toggleNowPlayingPanel: panel => {
+      set({ nowPlayingPanel: get().nowPlayingPanel === panel ? null : panel });
     },
     setLibraryHeroCardEnabled: enabled => {
       set({ libraryHeroCardEnabled: enabled });
@@ -439,7 +464,7 @@ export const useUIStore = createPersistedStore<UIState & UIActions>(
         albumSortMode: s.albumSortMode,
         albumSortOrder: s.albumSortOrder,
         nowPlayingViewEnabled: s.nowPlayingViewEnabled,
-        nowPlayingLyricsVisible: s.nowPlayingLyricsVisible,
+        nowPlayingPanel: s.nowPlayingPanel,
         libraryHeroCardEnabled: s.libraryHeroCardEnabled,
         lowPerformanceMode: s.lowPerformanceMode,
         noiseOverlayEnabled: s.noiseOverlayEnabled,


### PR DESCRIPTION
Closes #223

Implements both feature requests from the issue, in one PR.

## 1. Now Playing — Lyrics / Queue / EQ panels

The full-screen Now Playing view had a single Lyrics toggle. It now has a 3-button segmented group (Lyrics / Queue / EQ) in the header; clicking each swaps the right-side panel, and clicking the active one hides it (full-bleed album art returns).

- `useUIStore`'s `nowPlayingLyricsVisible` boolean was replaced with a `nowPlayingPanel: 'lyrics' | 'queue' | 'eq' | null` selector. The legacy boolean is migrated forward in both `sanitize()` and the localStorage importer (`true → 'lyrics'`, `false → null`), so existing users keep their preference.
- Reuses the existing `QueuePanel` and `EqualizerPanel` (`inline`); EQ sits in a scroll-safe container so its tall slider grid never overflows the column.
- Panel swaps animate with `AnimatePresence`, gated behind `lowPerformanceMode`. Segmented group is a `role="group"` with `aria-pressed` per button + tooltips.

## 2. Compact player — lyrics button + gated setting

A new **"Lyrics button"** toggle lives in **Settings → Compact Mode → Visible elements** (default off). When enabled, a mic button appears in the compact title bar.

- Clicking it **grows the compact window and reveals the lyrics panel below the player**, so the track info and transport controls stay visible (no full-body overlay). Closing shrinks the window back.
- The open-state is a runtime (non-persisted) `compactLyricsExpanded` flag in `useCompactStore`, since it drives the window resize via the existing `setCompactMode` IPC. Lyrics always start collapsed on compact entry.
- Esc closes, focus moves into the panel on open and back to the button on close, and it auto-closes when the track ends. Motion is gated behind `lowPerformanceMode`.

All new user-facing strings are translated in both `en` and `pl`.

## Test plan

- [x] `pnpm typecheck` (web + desktop + packages)
- [x] `pnpm lint`
- [x] `pnpm --filter @shiranami/web test` — 614/614 pass
- [x] Manual: Now Playing → toggle Lyrics/Queue/EQ; existing lyrics-shown/hidden preference migrates
- [x] Manual: enable the Compact Mode lyrics setting → enter compact → lyrics button grows the window and shows lyrics below the player; Esc/re-click shrinks back; auto-closes on track end
