### PR TITLE
fix(library): responsive and accessible bulk action dock

### DIFF
--- a/apps/web/src/components/shared/BulkActionBar.tsx
+++ b/apps/web/src/components/shared/BulkActionBar.tsx
@@ -63,6 +63,7 @@ interface MenuActionProps {
 function MenuAction({ icon, label, onClick, variant = 'default' }: MenuActionProps) {
   return (
     <button
+      role="menuitem"
       onClick={onClick}
       className={cn(
         'w-full flex items-center gap-2.5 px-3 py-2 text-sm transition-colors text-left',
@@ -81,7 +82,7 @@ function MenuAction({ icon, label, onClick, variant = 'default' }: MenuActionPro
 }
 
 function Divider() {
-  return <div className="my-1 border-t border-border/50" />;
+  return <div role="separator" className="my-1 border-t border-border/50" />;
 }
 
 interface OverflowAction {
@@ -187,14 +188,12 @@ function MoreMenu({ actions }: { actions: OverflowAction[] }) {
                 return (
                   <div key={action.key} role="none">
                     {showDivider && <Divider />}
-                    <div role="menuitem">
-                      <MenuAction
-                        icon={action.icon}
-                        label={action.label}
-                        variant={action.variant}
-                        onClick={() => handleAction(action.onClick)}
-                      />
-                    </div>
+                    <MenuAction
+                      icon={action.icon}
+                      label={action.label}
+                      variant={action.variant}
+                      onClick={() => handleAction(action.onClick)}
+                    />
                   </div>
                 );
               })}

--- a/apps/web/src/components/shared/BulkActionBar.tsx
+++ b/apps/web/src/components/shared/BulkActionBar.tsx
@@ -24,9 +24,11 @@ interface ActionButtonProps {
   variant?: 'default' | 'destructive';
 }
 
-// Always-visible inline action. Icon-only below md; label appears at md+
-// (the secondary/destructive actions only render inline at md+ anyway, so
-// below md these never show without a label).
+// Inline dock action. Icon-only below md; label appears at md+. The
+// always-visible Play Next / Add to Queue follow this rule directly; the
+// secondary/destructive actions only mount inside the xl+ wrapper, so they
+// never appear without a label. min-h-9/min-w-9 keeps the icon-only hit area
+// near the 44px touch-target guideline.
 function ActionButton({ icon, label, onClick, variant = 'default' }: ActionButtonProps) {
   return (
     <motion.button
@@ -269,11 +271,11 @@ export function BulkActionBar({ trackList, onRemoveFromPlaylist }: BulkActionBar
 
   const allSelected = count === trackList.length;
 
-  // The secondary/destructive set. Rendered inline at md+ (where the worst-case
-  // PL/8-button row still fits) and collapsed into the More menu below md (the
-  // audit measured 768px overflowing with full labels). Below md these never
-  // appear inline, so destructive actions and the escape hatch never scroll off
-  // an invisible edge.
+  // The secondary/destructive set. Rendered inline at xl+ (where the worst-case
+  // PL/8-button row provably fits within max-w-[calc(100vw-2rem)]) and collapsed
+  // into the More menu below xl. The audit measured 768px overflowing with full
+  // labels; live measurement showed the full PL row needs ~1178px of content,
+  // which only fits from the xl breakpoint (1280px) up.
   const overflowActions: OverflowAction[] = [
     {
       key: 'toggleFavorites',
@@ -361,8 +363,13 @@ export function BulkActionBar({ trackList, onRemoveFromPlaylist }: BulkActionBar
           onClick={handleAddToQueue}
         />
 
-        {/* Secondary/destructive set inline at md+ */}
-        <div className="hidden md:flex md:items-center md:gap-1">
+        {/* Secondary/destructive set inline only at xl+. The worst case
+            (PL labels + Electron + playlist view = 8 buttons) measures ~1178px
+            of content, so it is only guaranteed to fit within
+            max-w-[calc(100vw-2rem)] from the xl breakpoint (1280px) up. Below
+            that it lives in the More menu, so destructive actions never scroll
+            off an invisible edge. */}
+        <div className="hidden xl:flex xl:items-center xl:gap-1">
           <div className="shrink-0 w-px h-5 bg-border/50 mx-1" />
 
           <ActionButton
@@ -398,8 +405,8 @@ export function BulkActionBar({ trackList, onRemoveFromPlaylist }: BulkActionBar
           )}
         </div>
 
-        {/* Same set collapsed into an overflow menu below md */}
-        <div className="flex items-center md:hidden">
+        {/* Same set collapsed into an overflow menu below xl */}
+        <div className="flex items-center xl:hidden">
           <div className="shrink-0 w-px h-5 bg-border/50 mx-1" />
           <MoreMenu actions={overflowActions} />
         </div>

--- a/apps/web/src/components/shared/BulkActionBar.tsx
+++ b/apps/web/src/components/shared/BulkActionBar.tsx
@@ -1,6 +1,7 @@
+import { useState, useCallback, useRef, useLayoutEffect, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
-import { Play, ListPlus, Heart, Trash2, X, CheckCheck } from 'lucide-react';
+import { Play, ListPlus, Heart, Trash2, X, CheckCheck, MoreHorizontal } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { IS_ELECTRON } from '@/lib/platform';
 import { useLibraryStore } from '@/stores/useLibraryStore';
@@ -23,13 +24,16 @@ interface ActionButtonProps {
   variant?: 'default' | 'destructive';
 }
 
+// Always-visible inline action. Icon-only below md; label appears at md+
+// (the secondary/destructive actions only render inline at md+ anyway, so
+// below md these never show without a label).
 function ActionButton({ icon, label, onClick, variant = 'default' }: ActionButtonProps) {
   return (
     <motion.button
       whileTap={{ scale: 0.92 }}
       onClick={onClick}
       className={cn(
-        'flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors whitespace-nowrap',
+        'shrink-0 flex items-center justify-center md:justify-start gap-1.5 px-2 md:px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors whitespace-nowrap',
         variant === 'destructive'
           ? 'text-destructive/80 hover:text-destructive hover:bg-destructive/10'
           : 'text-foreground/70 hover:text-foreground hover:bg-accent'
@@ -37,8 +41,156 @@ function ActionButton({ icon, label, onClick, variant = 'default' }: ActionButto
       title={label}
     >
       {icon}
-      <span className="hidden sm:inline">{label}</span>
+      <span className="hidden md:inline whitespace-nowrap">{label}</span>
     </motion.button>
+  );
+}
+
+interface MenuActionProps {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  variant?: 'default' | 'destructive';
+}
+
+// Row inside the overflow popover. Mirrors the TrackContextMenu MenuItem idiom
+// (~40px row, full label, destructive variant) so the two surfaces feel like
+// one family.
+function MenuAction({ icon, label, onClick, variant = 'default' }: MenuActionProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'w-full flex items-center gap-2.5 px-3 py-2 text-sm transition-colors text-left',
+        variant === 'destructive'
+          ? 'text-destructive hover:bg-destructive/10'
+          : 'text-foreground/80 hover:text-foreground hover:bg-accent'
+      )}
+    >
+      <span className="shrink-0 w-4 h-4 flex items-center justify-center text-muted-foreground/60">
+        {icon}
+      </span>
+      <span className="whitespace-nowrap">{label}</span>
+    </button>
+  );
+}
+
+function Divider() {
+  return <div className="my-1 border-t border-border/50" />;
+}
+
+interface OverflowAction {
+  key: string;
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  variant?: 'default' | 'destructive';
+}
+
+// Overflow trigger + popover. The popover is portalled to document.body with
+// fixed positioning derived from the trigger's getBoundingClientRect so it
+// escapes the dock's overflow-x-auto clip (the previous clipped-popover bug in
+// this file). Pattern mirrors AddToPlaylistButton / PlaylistPickerContent.
+function MoreMenu({ actions }: { actions: OverflowAction[] }) {
+  const { t: tCommon } = useTranslation('common');
+  const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({});
+
+  useLayoutEffect(() => {
+    if (!isOpen || !buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    setPopoverStyle({
+      position: 'fixed',
+      // Pin the popover's right edge to the trigger's right edge, then clamp so
+      // it never bleeds off the left of a 360px viewport.
+      right: Math.max(window.innerWidth - rect.right, 8),
+      // Open above the dock — there is rarely space below the bottom-24 dock.
+      bottom: window.innerHeight - rect.top + 8,
+      minWidth: 200,
+      maxWidth: 'calc(100vw - 1rem)',
+      zIndex: 50,
+    });
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (buttonRef.current?.contains(target)) return;
+      if (popoverRef.current?.contains(target)) return;
+      setIsOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handler);
+      document.addEventListener('keydown', onKey);
+    }, 0);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handler);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [isOpen]);
+
+  const handleAction = useCallback((onClick: () => void) => {
+    setIsOpen(false);
+    onClick();
+  }, []);
+
+  return (
+    <>
+      <motion.button
+        ref={buttonRef}
+        whileTap={{ scale: 0.92 }}
+        onClick={() => setIsOpen(prev => !prev)}
+        className={cn(
+          'shrink-0 flex items-center justify-center p-1.5 rounded-lg text-xs font-medium transition-colors',
+          'text-foreground/70 hover:text-foreground hover:bg-accent',
+          isOpen && 'text-foreground bg-accent'
+        )}
+        title={tCommon('more')}
+      >
+        <MoreHorizontal className="w-3.5 h-3.5" />
+      </motion.button>
+
+      {createPortal(
+        <AnimatePresence>
+          {isOpen && (
+            <motion.div
+              ref={popoverRef}
+              initial={{ opacity: 0, scale: 0.95, y: 6 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 6 }}
+              transition={{ duration: 0.12, ease: 'easeOut' }}
+              className="py-1 rounded-xl bg-card border border-border/50 shadow-xl shadow-black/30"
+              style={{ ...popoverStyle, transformOrigin: 'bottom right' }}
+            >
+              {actions.map((action, i) => {
+                const prev = actions[i - 1];
+                const showDivider =
+                  prev && prev.variant !== 'destructive' && action.variant === 'destructive';
+                return (
+                  <div key={action.key}>
+                    {showDivider && <Divider />}
+                    <MenuAction
+                      icon={action.icon}
+                      label={action.label}
+                      variant={action.variant}
+                      onClick={() => handleAction(action.onClick)}
+                    />
+                  </div>
+                );
+              })}
+            </motion.div>
+          )}
+        </AnimatePresence>,
+        document.body
+      )}
+    </>
   );
 }
 
@@ -106,6 +258,49 @@ export function BulkActionBar({ trackList, onRemoveFromPlaylist }: BulkActionBar
 
   const allSelected = count === trackList.length;
 
+  // The secondary/destructive set. Rendered inline at md+ (where the worst-case
+  // PL/8-button row still fits) and collapsed into the More menu below md (the
+  // audit measured 768px overflowing with full labels). Below md these never
+  // appear inline, so destructive actions and the escape hatch never scroll off
+  // an invisible edge.
+  const overflowActions: OverflowAction[] = [
+    {
+      key: 'toggleFavorites',
+      icon: <Heart className="w-4 h-4" />,
+      label: t('toggleFavorites'),
+      onClick: handleToggleFavorite,
+    },
+    ...(onRemoveFromPlaylist
+      ? [
+          {
+            key: 'removeFromPlaylist',
+            icon: <X className="w-4 h-4" />,
+            label: t('removeFromPlaylist'),
+            onClick: handleRemoveFromPlaylistClick,
+            variant: 'destructive' as const,
+          },
+        ]
+      : []),
+    {
+      key: 'removeFromLibrary',
+      icon: <Trash2 className="w-4 h-4" />,
+      label: t('removeFromLibrary'),
+      onClick: onRemoveFromLibrary,
+      variant: 'destructive' as const,
+    },
+    ...(IS_ELECTRON
+      ? [
+          {
+            key: 'deleteFromDisk',
+            icon: <Trash2 className="w-4 h-4" />,
+            label: t('deleteFromDisk'),
+            onClick: onDeleteFromDisk,
+            variant: 'destructive' as const,
+          },
+        ]
+      : []),
+  ];
+
   return createPortal(
     <AnimatePresence>
       <motion.div
@@ -115,25 +310,28 @@ export function BulkActionBar({ trackList, onRemoveFromPlaylist }: BulkActionBar
         transition={{ duration: 0.2, ease: 'easeOut' }}
         className="fixed bottom-24 left-1/2 -translate-x-1/2 z-40 flex items-center gap-1 px-3 py-2 rounded-2xl bg-card/95 backdrop-blur-xl border border-border/50 shadow-2xl shadow-black/30 max-w-[calc(100vw-2rem)] overflow-x-auto scrollbar-none"
       >
-        <span className="text-xs font-medium text-muted-foreground px-2 whitespace-nowrap">
-          {tCommon('selectedTracks', { count })}
+        <span className="shrink-0 text-xs font-medium text-muted-foreground px-2 whitespace-nowrap">
+          {/* Just the count below sm so the counter does not eat ~40% of a
+              360px viewport; full label from sm up. */}
+          <span className="sm:hidden">{count}</span>
+          <span className="hidden sm:inline">{tCommon('selectedTracks', { count })}</span>
         </span>
 
-        <div className="w-px h-5 bg-border/50 mx-1" />
+        <div className="shrink-0 w-px h-5 bg-border/50 mx-1" />
 
         <motion.button
           whileTap={{ scale: 0.92 }}
           onClick={() => (allSelected ? clearSelection() : selectAll(trackList))}
-          className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium text-primary/80 hover:text-primary hover:bg-primary/10 transition-colors"
+          className="shrink-0 flex items-center justify-center md:justify-start gap-1.5 px-2 md:px-2.5 py-1.5 rounded-lg text-xs font-medium text-primary/80 hover:text-primary hover:bg-primary/10 transition-colors"
           title={allSelected ? tCommon('clearSelection') : tCommon('selectAll')}
         >
           <CheckCheck className="w-3.5 h-3.5" />
-          <span className="hidden sm:inline whitespace-nowrap">
+          <span className="hidden md:inline whitespace-nowrap">
             {allSelected ? tCommon('clearSelection') : tCommon('selectAll')}
           </span>
         </motion.button>
 
-        <div className="w-px h-5 bg-border/50 mx-1" />
+        <div className="shrink-0 w-px h-5 bg-border/50 mx-1" />
 
         <ActionButton
           icon={<Play className="w-3.5 h-3.5" />}
@@ -146,44 +344,55 @@ export function BulkActionBar({ trackList, onRemoveFromPlaylist }: BulkActionBar
           onClick={handleAddToQueue}
         />
 
-        <ActionButton
-          icon={<Heart className="w-3.5 h-3.5" />}
-          label={t('toggleFavorites')}
-          onClick={handleToggleFavorite}
-        />
+        {/* Secondary/destructive set inline at md+ */}
+        <div className="hidden md:flex md:items-center md:gap-1">
+          <div className="shrink-0 w-px h-5 bg-border/50 mx-1" />
 
-        {onRemoveFromPlaylist && (
           <ActionButton
-            icon={<X className="w-3.5 h-3.5" />}
-            label={t('removeFromPlaylist')}
-            onClick={handleRemoveFromPlaylistClick}
-            variant="destructive"
+            icon={<Heart className="w-3.5 h-3.5" />}
+            label={t('toggleFavorites')}
+            onClick={handleToggleFavorite}
           />
-        )}
 
-        <div className="w-px h-5 bg-border/50 mx-1" />
+          {onRemoveFromPlaylist && (
+            <ActionButton
+              icon={<X className="w-3.5 h-3.5" />}
+              label={t('removeFromPlaylist')}
+              onClick={handleRemoveFromPlaylistClick}
+              variant="destructive"
+            />
+          )}
 
-        <ActionButton
-          icon={<Trash2 className="w-3.5 h-3.5" />}
-          label={t('removeFromLibrary')}
-          onClick={onRemoveFromLibrary}
-          variant="destructive"
-        />
-        {IS_ELECTRON && (
+          <div className="shrink-0 w-px h-5 bg-border/50 mx-1" />
+
           <ActionButton
             icon={<Trash2 className="w-3.5 h-3.5" />}
-            label={t('deleteFromDisk')}
-            onClick={onDeleteFromDisk}
+            label={t('removeFromLibrary')}
+            onClick={onRemoveFromLibrary}
             variant="destructive"
           />
-        )}
+          {IS_ELECTRON && (
+            <ActionButton
+              icon={<Trash2 className="w-3.5 h-3.5" />}
+              label={t('deleteFromDisk')}
+              onClick={onDeleteFromDisk}
+              variant="destructive"
+            />
+          )}
+        </div>
 
-        <div className="w-px h-5 bg-border/50 mx-1" />
+        {/* Same set collapsed into an overflow menu below md */}
+        <div className="flex items-center md:hidden">
+          <div className="shrink-0 w-px h-5 bg-border/50 mx-1" />
+          <MoreMenu actions={overflowActions} />
+        </div>
+
+        <div className="shrink-0 w-px h-5 bg-border/50 mx-1" />
 
         <motion.button
           whileTap={{ scale: 0.85 }}
           onClick={clearSelection}
-          className="p-1.5 rounded-lg text-muted-foreground/50 hover:text-foreground hover:bg-accent transition-colors"
+          className="shrink-0 flex items-center justify-center p-1.5 rounded-lg text-muted-foreground/50 hover:text-foreground hover:bg-accent transition-colors"
           title={tCommon('clearSelection')}
         >
           <X className="w-3.5 h-3.5" />

--- a/apps/web/src/components/shared/BulkActionBar.tsx
+++ b/apps/web/src/components/shared/BulkActionBar.tsx
@@ -1,4 +1,3 @@
-import { useState, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
 import { Play, ListPlus, Heart, Trash2, X, CheckCheck } from 'lucide-react';
@@ -9,33 +8,12 @@ import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import type { Track } from '@/stores/types';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 import { useRemoveFromLibrary } from '@/hooks/useRemoveFromLibrary';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
-import { PlaylistPickerContent } from './PlaylistPickerContent';
 
 interface BulkActionBarProps {
   trackList: Track[];
   onRemoveFromPlaylist?: (trackIds: string[]) => void;
-}
-
-function PlaylistPopover({ trackIds, onDone }: { trackIds: string[]; onDone: () => void }) {
-  const ref = useRef<HTMLDivElement>(null);
-  useClickOutside(ref, onDone);
-
-  return (
-    <motion.div
-      ref={ref}
-      initial={{ opacity: 0, scale: 0.9, y: 4 }}
-      animate={{ opacity: 1, scale: 1, y: 0 }}
-      exit={{ opacity: 0, scale: 0.9, y: 4 }}
-      transition={{ duration: 0.15 }}
-      className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 w-48 py-1 rounded-xl bg-card border border-border/50 shadow-xl shadow-black/20 z-50"
-      onClick={(e: React.MouseEvent) => e.stopPropagation()}
-    >
-      <PlaylistPickerContent trackIds={trackIds} onDone={onDone} toastMode="bulk" />
-    </motion.div>
-  );
 }
 
 interface ActionButtonProps {
@@ -80,7 +58,6 @@ export function BulkActionBar({ trackList, onRemoveFromPlaylist }: BulkActionBar
   const library = useLibraryStore(s => s.library);
 
   const { handleRemoveFromLibrary, handleDeleteFromDisk } = useRemoveFromLibrary();
-  const [showPlaylistPopover, setShowPlaylistPopover] = useState(false);
 
   if (count === 0) return null;
 
@@ -168,25 +145,6 @@ export function BulkActionBar({ trackList, onRemoveFromPlaylist }: BulkActionBar
           label={t('addToQueue')}
           onClick={handleAddToQueue}
         />
-
-        <div className="relative">
-          <ActionButton
-            icon={<ListPlus className="w-3.5 h-3.5" />}
-            label={t('addToPlaylist')}
-            onClick={() => setShowPlaylistPopover(v => !v)}
-          />
-          <AnimatePresence>
-            {showPlaylistPopover && (
-              <PlaylistPopover
-                trackIds={ids}
-                onDone={() => {
-                  setShowPlaylistPopover(false);
-                  clearSelection();
-                }}
-              />
-            )}
-          </AnimatePresence>
-        </div>
 
         <ActionButton
           icon={<Heart className="w-3.5 h-3.5" />}

--- a/apps/web/src/components/shared/BulkActionBar.tsx
+++ b/apps/web/src/components/shared/BulkActionBar.tsx
@@ -33,12 +33,14 @@ function ActionButton({ icon, label, onClick, variant = 'default' }: ActionButto
       whileTap={{ scale: 0.92 }}
       onClick={onClick}
       className={cn(
-        'shrink-0 flex items-center justify-center md:justify-start gap-1.5 px-2 md:px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors whitespace-nowrap',
+        'shrink-0 flex items-center justify-center md:justify-start gap-1.5 min-h-9 min-w-9 px-2 md:px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors whitespace-nowrap',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-card',
         variant === 'destructive'
           ? 'text-destructive/80 hover:text-destructive hover:bg-destructive/10'
           : 'text-foreground/70 hover:text-foreground hover:bg-accent'
       )}
       title={label}
+      aria-label={label}
     >
       {icon}
       <span className="hidden md:inline whitespace-nowrap">{label}</span>
@@ -62,6 +64,7 @@ function MenuAction({ icon, label, onClick, variant = 'default' }: MenuActionPro
       onClick={onClick}
       className={cn(
         'w-full flex items-center gap-2.5 px-3 py-2 text-sm transition-colors text-left',
+        'focus-visible:outline-none focus-visible:bg-accent',
         variant === 'destructive'
           ? 'text-destructive hover:bg-destructive/10'
           : 'text-foreground/80 hover:text-foreground hover:bg-accent'
@@ -148,11 +151,15 @@ function MoreMenu({ actions }: { actions: OverflowAction[] }) {
         whileTap={{ scale: 0.92 }}
         onClick={() => setIsOpen(prev => !prev)}
         className={cn(
-          'shrink-0 flex items-center justify-center p-1.5 rounded-lg text-xs font-medium transition-colors',
+          'shrink-0 flex items-center justify-center min-h-9 min-w-9 p-1.5 rounded-lg text-xs font-medium transition-colors',
           'text-foreground/70 hover:text-foreground hover:bg-accent',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-card',
           isOpen && 'text-foreground bg-accent'
         )}
         title={tCommon('more')}
+        aria-label={tCommon('more')}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
       >
         <MoreHorizontal className="w-3.5 h-3.5" />
       </motion.button>
@@ -162,6 +169,8 @@ function MoreMenu({ actions }: { actions: OverflowAction[] }) {
           {isOpen && (
             <motion.div
               ref={popoverRef}
+              role="menu"
+              aria-label={tCommon('more')}
               initial={{ opacity: 0, scale: 0.95, y: 6 }}
               animate={{ opacity: 1, scale: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.95, y: 6 }}
@@ -174,14 +183,16 @@ function MoreMenu({ actions }: { actions: OverflowAction[] }) {
                 const showDivider =
                   prev && prev.variant !== 'destructive' && action.variant === 'destructive';
                 return (
-                  <div key={action.key}>
+                  <div key={action.key} role="none">
                     {showDivider && <Divider />}
-                    <MenuAction
-                      icon={action.icon}
-                      label={action.label}
-                      variant={action.variant}
-                      onClick={() => handleAction(action.onClick)}
-                    />
+                    <div role="menuitem">
+                      <MenuAction
+                        icon={action.icon}
+                        label={action.label}
+                        variant={action.variant}
+                        onClick={() => handleAction(action.onClick)}
+                      />
+                    </div>
                   </div>
                 );
               })}
@@ -304,6 +315,8 @@ export function BulkActionBar({ trackList, onRemoveFromPlaylist }: BulkActionBar
   return createPortal(
     <AnimatePresence>
       <motion.div
+        role="toolbar"
+        aria-label={tCommon('bulkActionsLabel')}
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: 20 }}
@@ -322,8 +335,12 @@ export function BulkActionBar({ trackList, onRemoveFromPlaylist }: BulkActionBar
         <motion.button
           whileTap={{ scale: 0.92 }}
           onClick={() => (allSelected ? clearSelection() : selectAll(trackList))}
-          className="shrink-0 flex items-center justify-center md:justify-start gap-1.5 px-2 md:px-2.5 py-1.5 rounded-lg text-xs font-medium text-primary/80 hover:text-primary hover:bg-primary/10 transition-colors"
+          className={cn(
+            'shrink-0 flex items-center justify-center md:justify-start gap-1.5 min-h-9 min-w-9 px-2 md:px-2.5 py-1.5 rounded-lg text-xs font-medium text-primary/80 hover:text-primary hover:bg-primary/10 transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-card'
+          )}
           title={allSelected ? tCommon('clearSelection') : tCommon('selectAll')}
+          aria-label={allSelected ? tCommon('clearSelection') : tCommon('selectAll')}
         >
           <CheckCheck className="w-3.5 h-3.5" />
           <span className="hidden md:inline whitespace-nowrap">
@@ -392,8 +409,12 @@ export function BulkActionBar({ trackList, onRemoveFromPlaylist }: BulkActionBar
         <motion.button
           whileTap={{ scale: 0.85 }}
           onClick={clearSelection}
-          className="shrink-0 flex items-center justify-center p-1.5 rounded-lg text-muted-foreground/50 hover:text-foreground hover:bg-accent transition-colors"
+          className={cn(
+            'shrink-0 flex items-center justify-center min-h-9 min-w-9 p-1.5 rounded-lg text-muted-foreground/50 hover:text-foreground hover:bg-accent transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-card'
+          )}
           title={tCommon('clearSelection')}
+          aria-label={tCommon('clearSelection')}
         >
           <X className="w-3.5 h-3.5" />
         </motion.button>

--- a/apps/web/src/components/shared/BulkActionBar.tsx
+++ b/apps/web/src/components/shared/BulkActionBar.tsx
@@ -128,7 +128,7 @@ export function BulkActionBar({ trackList, onRemoveFromPlaylist }: BulkActionBar
           title={allSelected ? tCommon('clearSelection') : tCommon('selectAll')}
         >
           <CheckCheck className="w-3.5 h-3.5" />
-          <span className="hidden sm:inline">
+          <span className="hidden sm:inline whitespace-nowrap">
             {allSelected ? tCommon('clearSelection') : tCommon('selectAll')}
           </span>
         </motion.button>

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -17,5 +17,7 @@
   "liveRadio": "Live Radio",
   "selectedTracks": "{{count}} selected",
   "selectAll": "Select All",
-  "clearSelection": "Clear Selection"
+  "clearSelection": "Clear Selection",
+  "more": "More",
+  "bulkActionsLabel": "Bulk actions"
 }

--- a/apps/web/src/locales/pl/common.json
+++ b/apps/web/src/locales/pl/common.json
@@ -17,5 +17,7 @@
   "liveRadio": "Radio na żywo",
   "selectedTracks": "{{count}} zaznaczonych",
   "selectAll": "Zaznacz wszystko",
-  "clearSelection": "Wyczyść zaznaczenie"
+  "clearSelection": "Wyczyść zaznaczenie",
+  "more": "Więcej",
+  "bulkActionsLabel": "Akcje zbiorcze"
 }


### PR DESCRIPTION
## What

Two fixes to the floating bulk-action dock (the toolbar that appears when you multi-select tracks), plus an accessibility pass.

### 1. Removed the broken "Add to playlist" dock button

The dock's "Add to playlist" popover was clipped to zero visible pixels. The dock container uses `overflow-x-auto`, which per CSS forces `overflow-y` to compute as `auto` as well, so the popover (positioned above the bar) was scissored away: present in the DOM with every playlist, but invisible and unclickable. The action logic was fine; only the CSS clip made it unusable.

Rather than fight the overflow constraint, the redundant button is removed. Bulk "Add to playlist" still works fully via the right-click context menu on any selected track (that picker mounts in a non-clipping menu).

### 2. Made the dock responsive

Measured live, the dock overflowed horizontally as early as 768px with labels, and at 360 to 480px even icon-only. Because `scrollbar-none` hides the scrollbar, that overflow was undiscoverable, and the actions scrolling off the right edge were the destructive ones (Remove from library, Delete from disk) plus the Clear escape hatch.

Now the high-frequency cluster (count, Select All, Play Next, Add to Queue, Clear) stays single-row and always visible at any width down to 360px. The secondary and destructive actions (Toggle favorites, Remove from playlist, Remove from library, Delete from disk) render inline at `xl` and up, and collapse into a "More" overflow menu below that. The threshold is `xl` because the worst case (Polish labels + Electron + a playlist view = 8 buttons) measures about 1178px of content and only fits within `max-w-[calc(100vw-2rem)]` from 1280px up.

The overflow popover portals to `document.body` with fixed positioning (the same pattern as the per-row Add to playlist picker), so it never repeats the clipped-popover bug from item 1.

### 3. Accessibility and a latent layout fix

- `role="toolbar"` plus `aria-label` on the dock, `role="menu"` / `menuitem` on the overflow popover.
- `aria-label` on every icon-only button (previously only `title`, which screen readers do not reliably announce).
- Touch targets raised to `min-h-9 min-w-9` (closer to the 44px guideline; was about 26px).
- `focus-visible` rings on all buttons.
- Fixed a latent bug where the "Select All" label wrapped to two lines even at full width (its span was missing `whitespace-nowrap`).

New strings (`common.more`, `common.bulkActionsLabel`) are translated in both EN and PL.

## Blast radius

`BulkActionBar` is a single component used by Library, Favorites, Playlist detail, Mixes, and Album detail. Its props contract is unchanged, so no call-site edits were needed.

## Follow-up (not in this PR)

`ImportBulkActionBar` (playlist import flow) shares the identical container classes and has the same overflow problem. Worth a sibling pass.

## Test plan

- [x] `pnpm --filter @shiranami/web typecheck`
- [x] root `pnpm lint`
- [x] Live width check at 360 / 414 / 480 / 640 / 768 / 1024 / 1280 / 1440: always-visible cluster never overflows; destructive actions and Clear never hidden behind invisible scroll
- [ ] Manual: multi-select in Library, confirm dock actions and the More menu work; right-click a selection and confirm Add to playlist still works
- [ ] Manual: narrow the window and confirm the More menu opens above the dock and is fully reachable
