### PR TITLE
fix(overview): humanize session duration & fix top-albums count overflow

### DIFF
--- a/apps/web/src/components/overview/GreetingHero.tsx
+++ b/apps/web/src/components/overview/GreetingHero.tsx
@@ -6,6 +6,7 @@ import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useWeatherStore } from '@/stores/useWeatherStore';
 import { useWeatherQuery } from '@/hooks/queries/useWeather';
 import {
+  formatListeningDuration,
   getGreeting,
   getGreetingSubline,
   getTimeOfDay,
@@ -75,7 +76,7 @@ function GreetingHeroImpl() {
                 minute: '2-digit',
               })
             : '',
-        minutes: t('session.minutes', { count: session.elapsedMin }),
+        duration: formatListeningDuration(session.elapsedMin),
       })
     : t('session.summaryNoTracks');
 

--- a/apps/web/src/components/overview/TopAlbums.tsx
+++ b/apps/web/src/components/overview/TopAlbums.tsx
@@ -49,7 +49,7 @@ export function TopAlbums({ albums }: TopAlbumsProps) {
                     style={{ width: `${width}%` }}
                   />
                 </span>
-                <span className="w-12 shrink-0 text-right text-xs text-muted-foreground/70">
+                <span className="shrink-0 whitespace-nowrap text-right text-xs tabular-nums text-muted-foreground/70">
                   {t('albumPlays', { count: album.playCount })}
                 </span>
               </li>

--- a/apps/web/src/components/overview/overviewUtils.test.ts
+++ b/apps/web/src/components/overview/overviewUtils.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import i18n from '@/lib/i18n';
 import type { ListeningHourlyActivityPoint } from '@/types/electron';
 import {
   buildHeatmap,
+  formatListeningDuration,
   formatPeakWindow,
   formatTrendDelta,
   getISOWeek,
@@ -131,6 +133,38 @@ describe('buildHeatmap', () => {
     const model = buildHeatmap(points);
     expect(model.totalPlays).toBe(0);
     expect(model.hasData).toBe(false);
+  });
+});
+
+describe('formatListeningDuration', () => {
+  beforeAll(async () => {
+    await i18n.changeLanguage('en');
+  });
+  afterAll(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('shows minutes only under an hour', () => {
+    expect(formatListeningDuration(14)).toBe('14 minutes');
+    expect(formatListeningDuration(1)).toBe('1 minute');
+  });
+
+  it('rolls minutes into hours past 60', () => {
+    expect(formatListeningDuration(64)).toBe('1 hour and 4 minutes');
+    expect(formatListeningDuration(125)).toBe('2 hours and 5 minutes');
+  });
+
+  it('omits the minutes part on an exact hour', () => {
+    expect(formatListeningDuration(60)).toBe('1 hour');
+    expect(formatListeningDuration(120)).toBe('2 hours');
+  });
+
+  it('formats Polish with the "i" connector and correct plural forms', async () => {
+    await i18n.changeLanguage('pl');
+    expect(formatListeningDuration(64)).toBe('1 godzina i 4 minuty');
+    expect(formatListeningDuration(14)).toBe('14 minut');
+    expect(formatListeningDuration(120)).toBe('2 godziny');
+    await i18n.changeLanguage('en');
   });
 });
 

--- a/apps/web/src/components/overview/overviewUtils.ts
+++ b/apps/web/src/components/overview/overviewUtils.ts
@@ -102,6 +102,27 @@ export function formatHoursMinutes(totalMinutes: number): { hours: number; minut
 }
 
 /**
+ * Humanized listening duration for the session summary line. Rolls minutes into
+ * hours past 60 ("1 hour and 4 minutes" / "1 godzina i 4 minuty") rather than a
+ * flat "64 minutes", leaning on i18next plurals for both units so PL forms
+ * (godzina/godziny/godzin, minuta/minuty/minut) resolve correctly.
+ */
+export function formatListeningDuration(totalMinutes: number): string {
+  const { hours, minutes } = formatHoursMinutes(totalMinutes);
+  const minutesLabel = i18n.t('session.minutes', { ns: 'overview', count: minutes });
+  if (hours <= 0) return minutesLabel;
+
+  const hoursLabel = i18n.t('session.hours', { ns: 'overview', count: hours });
+  if (minutes === 0) return hoursLabel;
+
+  return i18n.t('session.hoursAndMinutes', {
+    ns: 'overview',
+    hours: hoursLabel,
+    minutes: minutesLabel,
+  });
+}
+
+/**
  * Signed delta label for the week-over-week trend ("+2h 18m", "-45m"). Returns
  * `null` when the delta rounds to zero so the trend line can be hidden.
  */

--- a/apps/web/src/locales/en/overview.json
+++ b/apps/web/src/locales/en/overview.json
@@ -13,10 +13,13 @@
     "night": "The world's asleep."
   },
   "session": {
-    "summary": "You started listening at {{time}} — that's {{minutes}} of music so far.",
+    "summary": "You started listening at {{time}}, that's {{duration}} of music so far.",
     "summaryNoTracks": "Nothing playing yet. Press play and the evening begins.",
     "minutes_one": "{{count}} minute",
-    "minutes_other": "{{count}} minutes"
+    "minutes_other": "{{count}} minutes",
+    "hours_one": "{{count}} hour",
+    "hours_other": "{{count}} hours",
+    "hoursAndMinutes": "{{hours}} and {{minutes}}"
   },
   "clock": {
     "week": "WK {{week}}",

--- a/apps/web/src/locales/pl/overview.json
+++ b/apps/web/src/locales/pl/overview.json
@@ -13,12 +13,17 @@
     "night": "Świat śpi."
   },
   "session": {
-    "summary": "Słuchasz od {{time}} — to już {{minutes}} muzyki.",
+    "summary": "Słuchasz od {{time}}, to już {{duration}} muzyki.",
     "summaryNoTracks": "Jeszcze nic nie gra. Naciśnij odtwarzanie i niech wieczór się zacznie.",
     "minutes_one": "{{count}} minuta",
     "minutes_few": "{{count}} minuty",
     "minutes_many": "{{count}} minut",
-    "minutes_other": "{{count}} minut"
+    "minutes_other": "{{count}} minut",
+    "hours_one": "{{count}} godzina",
+    "hours_few": "{{count}} godziny",
+    "hours_many": "{{count}} godzin",
+    "hours_other": "{{count}} godzin",
+    "hoursAndMinutes": "{{hours}} i {{minutes}}"
   },
   "clock": {
     "week": "TYDZ. {{week}}",


### PR DESCRIPTION
Two small Overview polish fixes spotted after #230 merged.

## Session duration (humanized)
The greeting card's session summary showed a flat minute count ("64 minuty"). It now rolls into hours once it passes 60 minutes:
- PL: "1 godzina i 4 minuty"
- EN: "1 hour and 4 minutes"

Uses i18next plurals for both units (godzina / godziny / godzin, minuta / minuty / minut), reusing the existing minutes keys. Also replaced the em-dash in the summary line with a comma.

## Top albums count overflow
The per-row play-count label was a fixed 48px box (`w-12`), sized for the English "6 plays" but too narrow for the Polish "6 odtworzeń", so the label overflowed its row. It now sizes to its content (`whitespace-nowrap`, `shrink-0`) while the title/artist column truncates to yield space.

## Verification
- `pnpm typecheck`: clean
- Overview tests: 31 pass (4 new for the duration humanizer, including PL "1 godzina i 4 minuty" and the exact-hour / under-an-hour cases)
- Overflow fix confirmed live over CDP: every Polish count label renders in full, right-aligned, no overflow past the card.
