### PR TITLE
feat: music recommendation engine (desktop v1) — library affinity + YouTube Mix discovery

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -54,6 +54,7 @@
     "@sentry/esbuild-plugin": "5.3.0",
     "@shiranami/contracts": "workspace:*",
     "@shiranami/database": "workspace:*",
+    "@shiranami/recommendation": "workspace:*",
     "@shiranami/shared": "workspace:*",
     "@types/adm-zip": "^0.5.8",
     "@types/better-sqlite3": "^7.6.13",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -16,6 +16,10 @@ import { registerArtProtocol, pruneOrphanedAlbumArt } from './art-protocol';
 import { migrateAlbumArtToDisk } from './migrate-album-art';
 import { prewarm as prewarmFoldersCache } from './shared/folders-cache';
 import { initializeDatabase, closeDatabase } from '@shiranami/database/client';
+import {
+  scheduleRecommendationRefresh,
+  cancelRecommendationRefresh,
+} from './recommendation-service';
 import { PRIVILEGED_SCHEMES } from './privileged-schemes';
 
 // E2E hatch: when running under @playwright/test we disable noisy bootstrap
@@ -125,6 +129,13 @@ async function bootstrap(): Promise<void> {
 
   initializeDatabase({ path: join(app.getPath('userData'), 'shiranami.db') });
   logger.info('Database initialized');
+
+  // Warm the recommendation discover shelf in the background once after startup
+  // (only if its cache is stale). yt-dlp never runs on the render path; a
+  // failure here is swallowed and the shelves simply serve the cache.
+  if (!isE2E) {
+    scheduleRecommendationRefresh();
+  }
 
   registerAudioProtocol();
   registerRadioProtocol();
@@ -236,6 +247,11 @@ app.on('before-quit', event => {
   isShuttingDown = true;
 
   (async () => {
+    try {
+      cancelRecommendationRefresh();
+    } catch {
+      /* ignore */
+    }
     try {
       cleanupDiscordRpc();
     } catch {

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -16,3 +16,4 @@ export { registerRadioHandlers, cleanupRadioHandlers } from './radio';
 export { registerPlaylistHandlers, cleanupPlaylistHandlers } from './playlist';
 export { registerShareHandlers, cleanupShareHandlers } from './share';
 export { registerMetadataEnrichHandlers, cleanupMetadataEnrichHandlers } from './metadata-enrich';
+export { registerRecommendationsHandlers, cleanupRecommendationsHandlers } from './recommendations';

--- a/apps/desktop/src/main/ipc/recommendations.ts
+++ b/apps/desktop/src/main/ipc/recommendations.ts
@@ -1,0 +1,40 @@
+import { ipcMain } from 'electron';
+import { IPC_CHANNELS, type RecommendationShelves } from '@shiranami/contracts';
+import { getRecommendationShelves, triggerRefresh } from '../recommendation-service';
+import { handleWithFallback } from './with-ipc-handler';
+import { recommendationsGetArgs, recommendationsRefreshArgs } from './schemas/recommendations';
+
+const C = IPC_CHANNELS.recommendations;
+
+/** Empty shelves returned when even the cache read fails — the renderer renders
+ *  a quiet empty state rather than crashing. */
+const EMPTY_SHELVES: RecommendationShelves = {
+  library: { kind: 'library', items: [], generatedAt: null, stale: true },
+  discover: { kind: 'discover', items: [], generatedAt: null, stale: true },
+};
+
+export function registerRecommendationsHandlers(): void {
+  // Read path: cache-backed, fast. Falls back to empty shelves on any error so
+  // the home view never errors out over recommendations.
+  handleWithFallback(
+    C.get,
+    async (): Promise<RecommendationShelves> => getRecommendationShelves(),
+    () => EMPTY_SHELVES,
+    { schema: recommendationsGetArgs }
+  );
+
+  // Refresh path: runs the background job (affinity + yt-dlp RD-mix), coalesced
+  // so concurrent triggers share one run. Degrades to the current cache on
+  // failure (yt-dlp is best-effort).
+  handleWithFallback(
+    C.refresh,
+    async (): Promise<RecommendationShelves> => triggerRefresh(),
+    () => getRecommendationShelves(),
+    { schema: recommendationsRefreshArgs }
+  );
+}
+
+export function cleanupRecommendationsHandlers(): void {
+  ipcMain.removeHandler(C.get);
+  ipcMain.removeHandler(C.refresh);
+}

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -66,6 +66,8 @@ import {
   cleanupShareHandlers,
   registerMetadataEnrichHandlers,
   cleanupMetadataEnrichHandlers,
+  registerRecommendationsHandlers,
+  cleanupRecommendationsHandlers,
 } from './';
 
 export function registerIpcHandlers(mainWindow: BrowserWindow): void {
@@ -87,6 +89,7 @@ export function registerIpcHandlers(mainWindow: BrowserWindow): void {
   registerPlaylistHandlers();
   registerShareHandlers();
   registerMetadataEnrichHandlers();
+  registerRecommendationsHandlers();
 }
 
 export function cleanupIpcHandlers(): void {
@@ -108,4 +111,5 @@ export function cleanupIpcHandlers(): void {
   cleanupPlaylistHandlers();
   cleanupShareHandlers();
   cleanupMetadataEnrichHandlers();
+  cleanupRecommendationsHandlers();
 }

--- a/apps/desktop/src/main/ipc/schemas/index.ts
+++ b/apps/desktop/src/main/ipc/schemas/index.ts
@@ -17,6 +17,7 @@ export * from './media';
 export * from './metadata';
 export * from './playlist';
 export * from './radio';
+export * from './recommendations';
 export * from './share';
 export * from './shell';
 export * from './store';

--- a/apps/desktop/src/main/ipc/schemas/recommendations.ts
+++ b/apps/desktop/src/main/ipc/schemas/recommendations.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+// Both recommendation channels take no arguments — the renderer is read-only
+// and shelf selection is fixed. Empty tuples so the renderer can invoke with
+// zero args and tampered payloads are rejected by the shared validator.
+export const recommendationsGetArgs = z.tuple([]);
+export const recommendationsRefreshArgs = z.tuple([]);

--- a/apps/desktop/src/main/preload/api/recommendations.ts
+++ b/apps/desktop/src/main/preload/api/recommendations.ts
@@ -1,0 +1,16 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS, type RecommendationShelves } from '@shiranami/contracts';
+
+const C = IPC_CHANNELS.recommendations;
+
+export interface RecommendationsApi {
+  /** Read both shelves from the cache (fast; library recomputes inline if stale). */
+  get: () => Promise<RecommendationShelves>;
+  /** Run the background refresh (affinity + yt-dlp RD-mix) and return fresh shelves. */
+  refresh: () => Promise<RecommendationShelves>;
+}
+
+export const recommendationsApi: RecommendationsApi = {
+  get: () => ipcRenderer.invoke(C.get),
+  refresh: () => ipcRenderer.invoke(C.refresh),
+};

--- a/apps/desktop/src/main/preload/index.ts
+++ b/apps/desktop/src/main/preload/index.ts
@@ -24,6 +24,7 @@ import { mediaApi, type MediaApi } from './api/media';
 import { metadataApi, type MetadataApi } from './api/metadata';
 import { playlistApi, type PlaylistApi } from './api/playlist';
 import { radioApi, type RadioApi } from './api/radio';
+import { recommendationsApi, type RecommendationsApi } from './api/recommendations';
 import { shareApi, type ShareApi } from './api/share';
 import { shellApi, type ShellApi } from './api/shell';
 import { storeApi, type StoreApi } from './api/store';
@@ -47,6 +48,7 @@ export interface ElectronAPI {
   radio: RadioApi;
   playlist: PlaylistApi;
   metadata: MetadataApi;
+  recommendations: RecommendationsApi;
   share: ShareApi;
   debug: DebugApi;
   errors: {
@@ -83,6 +85,7 @@ const electronAPI: ElectronAPI = {
   radio: radioApi,
   playlist: playlistApi,
   metadata: metadataApi,
+  recommendations: recommendationsApi,
   share: shareApi,
   debug: debugApi,
   errors: {

--- a/apps/desktop/src/main/recommendation-service.ts
+++ b/apps/desktop/src/main/recommendation-service.ts
@@ -281,14 +281,18 @@ function isStale(generatedAt: string | null): boolean {
   return Date.now() - ms > RECOMMENDATION_TTL_MS;
 }
 
-function parsePayload<T>(raw: string | null): T[] {
-  if (!raw) return [];
+function parsePayload<T>(raw: string | null): { items: T[]; valid: boolean } {
+  if (!raw) return { items: [], valid: false };
   try {
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? (parsed as T[]) : [];
+    if (!Array.isArray(parsed)) {
+      logger.warn('[recommendations] cached payload is not an array; marking stale');
+      return { items: [], valid: false };
+    }
+    return { items: parsed as T[], valid: true };
   } catch (err) {
     logger.warn('[recommendations] failed to parse cached payload', err);
-    return [];
+    return { items: [], valid: false };
   }
 }
 
@@ -299,10 +303,11 @@ function readShelf<T>(kind: RecommendationKind): {
 } {
   const row = readCacheRow(kind);
   const generatedAt = row?.generatedAt ?? null;
+  const { items, valid } = parsePayload<T>(row?.payload ?? null);
   return {
-    items: parsePayload<T>(row?.payload ?? null),
+    items,
     generatedAt,
-    stale: isStale(generatedAt),
+    stale: isStale(generatedAt) || !valid,
   };
 }
 
@@ -343,29 +348,32 @@ export function getRecommendationShelves(): RecommendationShelves {
  * yt-dlp failure; the library computation is offline and always succeeds.
  */
 export async function refreshRecommendations(signal?: AbortSignal): Promise<RecommendationShelves> {
-  const now = new Date().toISOString();
+  const prevLibrary = readShelf<LibraryRecommendation>('library');
+  const prevDiscover = readShelf<DiscoverRecommendation>('discover');
 
-  let libraryItems: LibraryRecommendation[] = [];
+  let library: Omit<LibraryShelf, 'kind'> = prevLibrary;
   try {
-    libraryItems = computeLibraryItems();
-    writeCacheRow('library', libraryItems);
+    const items = computeLibraryItems();
+    writeCacheRow('library', items);
+    library = { items, generatedAt: new Date().toISOString(), stale: false };
   } catch (err) {
-    logger.warn('[recommendations] library refresh failed', err);
+    logger.warn('[recommendations] library refresh failed; serving previous shelf', err);
   }
 
-  let discoverItems: DiscoverRecommendation[] = [];
+  let discover: Omit<DiscoverShelf, 'kind'> = prevDiscover;
   try {
-    discoverItems = await computeDiscoverItems(signal);
-    writeCacheRow('discover', discoverItems);
-    logger.info(`[recommendations] discover refresh wrote ${discoverItems.length} items`);
+    const items = await computeDiscoverItems(signal);
+    writeCacheRow('discover', items);
+    logger.info(`[recommendations] discover refresh wrote ${items.length} items`);
+    discover = { items, generatedAt: new Date().toISOString(), stale: false };
   } catch (err) {
     if (err instanceof Error && err.name === 'AbortError') throw err;
-    logger.warn('[recommendations] discover refresh failed; shelf left empty', err);
+    logger.warn('[recommendations] discover refresh failed; serving previous shelf', err);
   }
 
   return {
-    library: { kind: 'library', items: libraryItems, generatedAt: now, stale: false },
-    discover: { kind: 'discover', items: discoverItems, generatedAt: now, stale: false },
+    library: { kind: 'library', ...library } satisfies LibraryShelf,
+    discover: { kind: 'discover', ...discover } satisfies DiscoverShelf,
   };
 }
 

--- a/apps/desktop/src/main/recommendation-service.ts
+++ b/apps/desktop/src/main/recommendation-service.ts
@@ -1,0 +1,419 @@
+/**
+ * Desktop recommendation service.
+ *
+ * Owns the two recommendation shelves and their SQLite cache:
+ *  - "library"  : existing tracks ranked by listening affinity (offline,
+ *                 reuses the play_history aggregate patterns from
+ *                 ipc/database/history.ts; scored by @shiranami/recommendation).
+ *  - "discover" : NEW tracks pulled from YouTube RD mixes (yt-dlp), seeded by
+ *                 the user's top affinity tracks, deduped against the library.
+ *
+ * Reads come from the `recommendations` cache table (TTL-checked). The discover
+ * shelf spawns yt-dlp and so is only ever computed in a bounded BACKGROUND job
+ * (scheduleRecommendationRefresh / refreshRecommendations), never on the render
+ * path. Any yt-dlp failure degrades that shelf to empty — it never throws up to
+ * the renderer.
+ */
+
+import { getDatabase } from '@shiranami/database/client';
+import {
+  tracks,
+  playHistory,
+  youtubeMappings,
+  recommendations,
+  eq,
+  sql,
+  inArray,
+  type NewRecommendation,
+} from '@shiranami/database';
+import { rankByAffinity, selectSeedTracks, type TrackStats } from '@shiranami/recommendation';
+import {
+  RECOMMENDATION_TTL_MS,
+  type DiscoverRecommendation,
+  type DiscoverShelf,
+  type LibraryRecommendation,
+  type LibraryShelf,
+  type RecommendationKind,
+  type RecommendationShelves,
+} from '@shiranami/contracts';
+import { logger } from './logger';
+import { spawnYtDlp, parseYtDlpJsonLines } from './utils/ytdlp-spawn';
+import { isYtDlpInstalled } from './ytdlp-manager';
+
+/** How many top-affinity tracks seed the discover shelf. One RD mix already
+ *  yields ~25 candidates, so a couple of seeds covers a shelf. */
+const DISCOVER_SEED_COUNT = 3;
+
+/** Bounded concurrency for the parallel RD-mix fetches — matches the proven
+ *  ENRICH_CONCURRENCY worker-pool size from metadata-enrich-batch.ts. */
+const DISCOVER_CONCURRENCY = 4;
+
+/** Cap on discover items written to the cache, across all seed mixes. */
+const DISCOVER_MAX_ITEMS = 24;
+
+/** Cap on library affinity items written to the cache. */
+const LIBRARY_MAX_ITEMS = 20;
+
+/** Idle delay after startup before the first background refresh runs. */
+const REFRESH_STARTUP_DELAY_MS = 30_000;
+
+// ───────────────────────────── library affinity ─────────────────────────────
+
+/**
+ * Aggregate play_history + tracks into the per-track listening stats the pure
+ * scoring core consumes. Mirrors the grouped query behind the Overview top
+ * tracks (history.ts getSummary) so affinity ranking sanity-checks against it.
+ */
+function getLibraryStats(): TrackStats[] {
+  const db = getDatabase();
+  const rows = db
+    .select({
+      trackId: tracks.id,
+      title: tracks.title,
+      artist: tracks.artist,
+      album: tracks.album,
+      plays: sql<number>`COUNT(*)`,
+      avgCompletion: sql<number>`COALESCE(AVG(${playHistory.completionRatio}), 0)`,
+      lastPlayedAt: sql<string>`MAX(${playHistory.playedAt})`,
+      isFavorite: tracks.isFavorite,
+    })
+    .from(playHistory)
+    .innerJoin(tracks, eq(playHistory.trackId, tracks.id))
+    .groupBy(tracks.id)
+    .all();
+
+  return rows.map(row => ({
+    trackId: row.trackId,
+    title: row.title,
+    artist: row.artist ?? '',
+    album: row.album ?? '',
+    plays: Number(row.plays),
+    avgCompletion: Number(row.avgCompletion),
+    lastPlayedAt: row.lastPlayedAt,
+    isFavorite: Boolean(row.isFavorite),
+  }));
+}
+
+/** Album art lookup for a set of track ids, so library recommendations can
+ *  show covers without the renderer re-querying. */
+function getAlbumArtFor(trackIds: string[]): Map<string, string | null> {
+  if (trackIds.length === 0) return new Map();
+  const db = getDatabase();
+  const rows = db
+    .select({ id: tracks.id, albumArt: tracks.albumArt })
+    .from(tracks)
+    .where(inArray(tracks.id, trackIds))
+    .all();
+  return new Map(rows.map(row => [row.id, row.albumArt ?? null]));
+}
+
+/** Compute the "Recommended from your library" items (no network). */
+function computeLibraryItems(): LibraryRecommendation[] {
+  const stats = getLibraryStats();
+  const ranked = rankByAffinity(stats).slice(0, LIBRARY_MAX_ITEMS);
+  const art = getAlbumArtFor(ranked.map(track => track.trackId));
+  return ranked.map(track => ({
+    trackId: track.trackId,
+    title: track.title,
+    artist: track.artist,
+    album: track.album,
+    albumArt: art.get(track.trackId) ?? null,
+  }));
+}
+
+// ──────────────────────────── yt-dlp discovery ─────────────────────────────
+
+/** Resolve seed track ids to their YouTube video ids (1:1 via the mapping). */
+function getSeedYoutubeIds(seedTrackIds: string[]): string[] {
+  if (seedTrackIds.length === 0) return [];
+  const db = getDatabase();
+  const rows = db
+    .select({ trackId: youtubeMappings.trackId, youtubeId: youtubeMappings.youtubeId })
+    .from(youtubeMappings)
+    .where(inArray(youtubeMappings.trackId, seedTrackIds))
+    .all();
+  // Preserve seed order (highest affinity first) so the strongest seed's mix
+  // is fetched first and its tracks win the dedupe.
+  const byTrack = new Map(rows.map(row => [row.trackId, row.youtubeId]));
+  return seedTrackIds
+    .map(id => byTrack.get(id))
+    .filter((youtubeId): youtubeId is string => Boolean(youtubeId));
+}
+
+/** Every YouTube id already in the library, so discovery only surfaces NEW
+ *  music. */
+function getLibraryYoutubeIds(): Set<string> {
+  const db = getDatabase();
+  const rows = db.select({ youtubeId: youtubeMappings.youtubeId }).from(youtubeMappings).all();
+  return new Set(rows.map(row => row.youtubeId));
+}
+
+/**
+ * Fetch one YouTube RD ("radio mix") for a seed video id. Uses the WATCH-URL
+ * form (`watch?v=<id>&list=RD<id>`) — the bare playlist URL is unviewable — and
+ * the same flat `--flat-playlist --dump-json --no-warnings` arg set as search.
+ *
+ * BEST-EFFORT: yt-dlp's YouTube extractor is unofficial and breaks (live
+ * streams, processing videos, frontend changes). Any failure — non-zero exit,
+ * spawn error, parse failure — resolves to [] so the shelf degrades to empty
+ * rather than throwing.
+ */
+async function fetchRdMix(
+  seedYoutubeId: string,
+  signal?: AbortSignal
+): Promise<DiscoverRecommendation[]> {
+  const url = `https://www.youtube.com/watch?v=${seedYoutubeId}&list=RD${seedYoutubeId}`;
+  try {
+    const { stdout, code } = await spawnYtDlp(
+      ['--flat-playlist', '--dump-json', '--no-warnings', url],
+      signal
+    );
+    if (code !== 0) {
+      logger.warn(`[recommendations] RD mix for ${seedYoutubeId} exited ${code}; skipping`);
+      return [];
+    }
+    return parseYtDlpJsonLines(stdout)
+      .filter(result => result.id && result.id !== seedYoutubeId)
+      .map(result => ({
+        youtubeId: result.id,
+        title: result.title,
+        uploader: result.uploader,
+        thumbnail: result.thumbnail,
+        url: result.webpage_url || result.url,
+      }));
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') throw err;
+    logger.warn(`[recommendations] RD mix for ${seedYoutubeId} failed; skipping`, err);
+    return [];
+  }
+}
+
+/**
+ * Worker-pool runner over the seed mixes, bounded to DISCOVER_CONCURRENCY.
+ * Mirrors the metadata-enrich-batch cursor pattern. Results are merged in seed
+ * order; duplicates (across mixes and against the library) are dropped.
+ */
+async function computeDiscoverItems(signal?: AbortSignal): Promise<DiscoverRecommendation[]> {
+  if (!isYtDlpInstalled()) {
+    logger.info('[recommendations] yt-dlp not installed; discover shelf stays empty');
+    return [];
+  }
+
+  const seedTrackIds = selectSeedTracks(getLibraryStats(), DISCOVER_SEED_COUNT).map(
+    track => track.trackId
+  );
+  const seedYoutubeIds = getSeedYoutubeIds(seedTrackIds);
+  if (seedYoutubeIds.length === 0) {
+    logger.info('[recommendations] no YouTube-mapped seed tracks; discover shelf stays empty');
+    return [];
+  }
+
+  const libraryIds = getLibraryYoutubeIds();
+  const seedSet = new Set(seedYoutubeIds);
+  const seen = new Set<string>();
+  const merged: DiscoverRecommendation[] = [];
+
+  // Per-seed results slotted by index so the merge preserves seed order even
+  // though mixes finish out of order.
+  const slots: DiscoverRecommendation[][] = new Array(seedYoutubeIds.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      if (signal?.aborted) return;
+      const i = nextIndex++;
+      if (i >= seedYoutubeIds.length) return;
+      slots[i] = await fetchRdMix(seedYoutubeIds[i], signal);
+    }
+  }
+
+  const poolSize = Math.max(1, Math.min(DISCOVER_CONCURRENCY, seedYoutubeIds.length));
+  await Promise.all(Array.from({ length: poolSize }, () => worker()));
+
+  for (const items of slots) {
+    if (!items) continue;
+    for (const item of items) {
+      if (merged.length >= DISCOVER_MAX_ITEMS) break;
+      if (seen.has(item.youtubeId)) continue;
+      if (seedSet.has(item.youtubeId)) continue; // never recommend a seed back
+      if (libraryIds.has(item.youtubeId)) continue; // already owned — not "new"
+      seen.add(item.youtubeId);
+      merged.push(item);
+    }
+  }
+
+  return merged;
+}
+
+// ───────────────────────────────── cache ────────────────────────────────────
+
+function readCacheRow(kind: RecommendationKind): { payload: string; generatedAt: string } | null {
+  const db = getDatabase();
+  const row = db
+    .select({ payload: recommendations.payload, generatedAt: recommendations.generatedAt })
+    .from(recommendations)
+    .where(eq(recommendations.kind, kind))
+    .get();
+  return row ?? null;
+}
+
+function writeCacheRow(kind: RecommendationKind, items: unknown[]): void {
+  const db = getDatabase();
+  const row: NewRecommendation = {
+    kind,
+    payload: JSON.stringify(items),
+    generatedAt: new Date().toISOString(),
+  };
+  db.insert(recommendations)
+    .values(row)
+    .onConflictDoUpdate({
+      target: recommendations.kind,
+      set: { payload: row.payload, generatedAt: row.generatedAt },
+    })
+    .run();
+}
+
+/** True when a cache row is missing or older than the 24h TTL. */
+function isStale(generatedAt: string | null): boolean {
+  if (!generatedAt) return true;
+  const ms = Date.parse(generatedAt);
+  if (Number.isNaN(ms)) return true;
+  return Date.now() - ms > RECOMMENDATION_TTL_MS;
+}
+
+function parsePayload<T>(raw: string | null): T[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch (err) {
+    logger.warn('[recommendations] failed to parse cached payload', err);
+    return [];
+  }
+}
+
+function readShelf<T>(kind: RecommendationKind): {
+  items: T[];
+  generatedAt: string | null;
+  stale: boolean;
+} {
+  const row = readCacheRow(kind);
+  const generatedAt = row?.generatedAt ?? null;
+  return {
+    items: parsePayload<T>(row?.payload ?? null),
+    generatedAt,
+    stale: isStale(generatedAt),
+  };
+}
+
+// ───────────────────────────────── public API ───────────────────────────────
+
+/**
+ * Read both shelves from the cache. Pure SQLite reads — sub-millisecond, safe
+ * on the render path. The library shelf is recomputed inline when its cache is
+ * stale/missing (it is offline + cheap); the discover shelf is NEVER recomputed
+ * here (it would spawn yt-dlp) — a stale/empty discover shelf is returned as-is
+ * and refreshed by the background job.
+ */
+export function getRecommendationShelves(): RecommendationShelves {
+  let library = readShelf<LibraryRecommendation>('library');
+  if (library.stale) {
+    try {
+      const items = computeLibraryItems();
+      writeCacheRow('library', items);
+      library = { items, generatedAt: new Date().toISOString(), stale: false };
+    } catch (err) {
+      logger.warn('[recommendations] inline library recompute failed; serving cache', err);
+    }
+  }
+
+  const discover = readShelf<DiscoverRecommendation>('discover');
+
+  return {
+    library: { kind: 'library', ...library } satisfies LibraryShelf,
+    discover: { kind: 'discover', ...discover } satisfies DiscoverShelf,
+  };
+}
+
+/**
+ * Recompute BOTH shelves and write them to the cache, then return the fresh
+ * shelves. This is the heavy path (spawns yt-dlp for discover) and must only
+ * run off the render thread — from the background scheduler or an explicit
+ * user-triggered refresh. The discover computation degrades to empty on any
+ * yt-dlp failure; the library computation is offline and always succeeds.
+ */
+export async function refreshRecommendations(signal?: AbortSignal): Promise<RecommendationShelves> {
+  const now = new Date().toISOString();
+
+  let libraryItems: LibraryRecommendation[] = [];
+  try {
+    libraryItems = computeLibraryItems();
+    writeCacheRow('library', libraryItems);
+  } catch (err) {
+    logger.warn('[recommendations] library refresh failed', err);
+  }
+
+  let discoverItems: DiscoverRecommendation[] = [];
+  try {
+    discoverItems = await computeDiscoverItems(signal);
+    writeCacheRow('discover', discoverItems);
+    logger.info(`[recommendations] discover refresh wrote ${discoverItems.length} items`);
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') throw err;
+    logger.warn('[recommendations] discover refresh failed; shelf left empty', err);
+  }
+
+  return {
+    library: { kind: 'library', items: libraryItems, generatedAt: now, stale: false },
+    discover: { kind: 'discover', items: discoverItems, generatedAt: now, stale: false },
+  };
+}
+
+let refreshTimer: NodeJS.Timeout | null = null;
+let refreshInFlight: Promise<unknown> | null = null;
+
+/**
+ * Schedule a single background refresh shortly after startup, only when the
+ * discover cache is stale. Idempotent and self-cancelling; fire-and-forget so
+ * it never blocks bootstrap. A failed refresh is swallowed (logged) — the
+ * shelves simply serve whatever the cache holds.
+ */
+export function scheduleRecommendationRefresh(): void {
+  if (refreshTimer) return;
+  refreshTimer = setTimeout(() => {
+    refreshTimer = null;
+    const discover = readCacheRow('discover');
+    if (!isStale(discover?.generatedAt ?? null)) {
+      logger.debug('[recommendations] discover cache warm; skipping background refresh');
+      return;
+    }
+    triggerRefresh();
+  }, REFRESH_STARTUP_DELAY_MS);
+  refreshTimer.unref?.();
+}
+
+/**
+ * Run a refresh now, coalescing concurrent callers onto one in-flight run so a
+ * user-triggered refresh and the scheduled job never spawn yt-dlp twice.
+ */
+export function triggerRefresh(): Promise<RecommendationShelves> {
+  if (!refreshInFlight) {
+    refreshInFlight = refreshRecommendations()
+      .catch(err => {
+        logger.warn('[recommendations] background refresh failed', err);
+        return getRecommendationShelves();
+      })
+      .finally(() => {
+        refreshInFlight = null;
+      });
+  }
+  return refreshInFlight as Promise<RecommendationShelves>;
+}
+
+/** Cancel a pending scheduled refresh (called on teardown). */
+export function cancelRecommendationRefresh(): void {
+  if (refreshTimer) {
+    clearTimeout(refreshTimer);
+    refreshTimer = null;
+  }
+}

--- a/apps/web/src/components/overview/OverviewView.test.tsx
+++ b/apps/web/src/components/overview/OverviewView.test.tsx
@@ -65,6 +65,9 @@ vi.mock('./TopThisWeek', () => ({ TopThisWeek: () => <div data-testid="top" /> }
 vi.mock('./ListeningClock', () => ({ ListeningClock: () => <div data-testid="clock" /> }));
 vi.mock('./TopAlbums', () => ({ TopAlbums: () => <div data-testid="albums" /> }));
 vi.mock('./RecentlyAdded', () => ({ RecentlyAdded: () => <div data-testid="recents" /> }));
+vi.mock('./RecommendationsShelf', () => ({
+  RecommendationsShelf: () => <div data-testid="recommendations" />,
+}));
 
 describe('OverviewView', () => {
   beforeEach(() => {

--- a/apps/web/src/components/overview/OverviewView.tsx
+++ b/apps/web/src/components/overview/OverviewView.tsx
@@ -10,6 +10,7 @@ import { TopThisWeek } from '@/components/overview/TopThisWeek';
 import { ListeningClock } from '@/components/overview/ListeningClock';
 import { TopAlbums } from '@/components/overview/TopAlbums';
 import { RecentlyAdded } from '@/components/overview/RecentlyAdded';
+import { RecommendationsShelf } from '@/components/overview/RecommendationsShelf';
 import { OverviewViewSkeleton } from '@/components/overview/OverviewViewSkeleton';
 
 export default function OverviewView() {
@@ -107,6 +108,8 @@ export default function OverviewView() {
             icon={Disc3}
           />
         )}
+
+        <RecommendationsShelf onPlay={handlePlayTrack} />
 
         {recentlyAdded.length > 0 && (
           <RecentlyAdded tracks={recentlyAdded} onPlay={handlePlayTrack} />

--- a/apps/web/src/components/overview/OverviewView.tsx
+++ b/apps/web/src/components/overview/OverviewView.tsx
@@ -109,7 +109,7 @@ export default function OverviewView() {
           />
         )}
 
-        <RecommendationsShelf onPlay={handlePlayTrack} />
+        <RecommendationsShelf onPlay={handlePlayTrack} hasLibrary={hasLibrary} />
 
         {recentlyAdded.length > 0 && (
           <RecentlyAdded tracks={recentlyAdded} onPlay={handlePlayTrack} />

--- a/apps/web/src/components/overview/OverviewViewSkeleton.tsx
+++ b/apps/web/src/components/overview/OverviewViewSkeleton.tsx
@@ -21,7 +21,41 @@ export function OverviewViewSkeleton() {
         </div>
       </div>
 
-      <div className="h-44 animate-pulse rounded-[24px] border border-border/25 glass-panel" />
+      {/* Recommendations shelf skeleton — heading bar + 2× two-col rows per section */}
+      <div className="flex flex-col gap-4 rounded-[24px] border border-border/25 glass-panel p-4">
+        {/* Header: icon placeholder + title + refresh button */}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <div className="size-4 animate-pulse rounded-full bg-foreground/10" />
+            <div className="h-5 w-36 animate-pulse rounded-lg bg-foreground/10" />
+          </div>
+          <div className="h-4 w-16 animate-pulse rounded-md bg-foreground/8" />
+        </div>
+        {/* Library section */}
+        <div className="flex flex-col gap-2">
+          <div className="h-3 w-28 animate-pulse rounded bg-foreground/8" />
+          <div className="grid gap-2 sm:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-14 animate-pulse rounded-2xl border border-border/15 glass-subtle"
+              />
+            ))}
+          </div>
+        </div>
+        {/* Discover section */}
+        <div className="flex flex-col gap-2">
+          <div className="h-3 w-32 animate-pulse rounded bg-foreground/8" />
+          <div className="grid gap-2 sm:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-14 animate-pulse rounded-2xl border border-border/15 glass-subtle"
+              />
+            ))}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/overview/RecommendationsShelf.tsx
+++ b/apps/web/src/components/overview/RecommendationsShelf.tsx
@@ -1,0 +1,159 @@
+import { useTranslation } from 'react-i18next';
+import { Compass, Download, Loader2, Play, RefreshCw, Sparkles } from 'lucide-react';
+import type { DiscoverRecommendation, LibraryRecommendation } from '@shiranami/contracts';
+import { OverviewCover } from '@/components/overview/OverviewCover';
+import { useRecommendations } from '@/hooks/queries/useRecommendations';
+import { useDiscoverDownload } from '@/hooks/useDiscoverDownload';
+
+interface RecommendationsShelfProps {
+  /** Plays an existing library track by id (Overview's handler). */
+  onPlay: (trackId: string) => void;
+}
+
+/**
+ * Minimal, functional recommendations shelf for the Overview. Surfaces two
+ * sections — "Recommended from your library" (affinity-ranked owned tracks)
+ * and "Discover new music" (yt-dlp RD-mix, downloadable). Deliberately
+ * unpolished: visual/UX design is a follow-up /kirei ui pass. Renders nothing
+ * when both shelves are empty so it never shows a dead panel.
+ */
+export function RecommendationsShelf({ onPlay }: RecommendationsShelfProps) {
+  const { t } = useTranslation('recommendations');
+  const { library, discover, isLoading, isRefreshing, refresh, hasAny } = useRecommendations();
+  const { download, statuses } = useDiscoverDownload();
+
+  if (isLoading || !hasAny) return null;
+
+  return (
+    <section className="flex flex-col gap-4 rounded-[24px] border border-border/25 glass-panel p-4">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Sparkles className="size-4 text-primary/80" />
+          <h2 className="font-display text-lg font-semibold text-foreground">{t('title')}</h2>
+        </div>
+        <button
+          type="button"
+          onClick={() => refresh()}
+          disabled={isRefreshing}
+          className="flex items-center gap-1.5 rounded-lg px-2 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-primary/80 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+        >
+          <RefreshCw className={`size-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+          {t('refresh')}
+        </button>
+      </div>
+
+      {library.items.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground/70">
+            {t('fromLibrary')}
+          </h3>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {library.items.slice(0, 8).map(item => (
+              <LibraryRow key={item.trackId} item={item} onPlay={onPlay} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <h3 className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground/70">
+          <Compass className="size-3" />
+          {t('discover')}
+        </h3>
+        {discover.items.length === 0 ? (
+          <p className="rounded-2xl border border-border/20 bg-background/20 px-4 py-6 text-center text-sm text-muted-foreground/60">
+            {t('discoverEmpty')}
+          </p>
+        ) : (
+          <div className="grid gap-2 sm:grid-cols-2">
+            {discover.items.slice(0, 8).map(item => (
+              <DiscoverRow
+                key={item.youtubeId}
+                item={item}
+                status={statuses[item.youtubeId] ?? 'idle'}
+                onDownload={download}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function LibraryRow({
+  item,
+  onPlay,
+}: {
+  item: LibraryRecommendation;
+  onPlay: (trackId: string) => void;
+}) {
+  const { t } = useTranslation('recommendations');
+  return (
+    <button
+      type="button"
+      onClick={() => onPlay(item.trackId)}
+      aria-label={t('playAria', { title: item.title })}
+      className="group flex w-full items-center gap-3 rounded-2xl border border-border/15 bg-background/20 px-3 py-2.5 text-left transition-colors hover:border-border/35 hover:bg-accent/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <div className="relative size-10 shrink-0">
+        <OverviewCover
+          albumArt={item.albumArt}
+          title={item.title}
+          seed={item.album || item.artist}
+          className="size-10"
+        />
+        <span className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-xl bg-black/45 opacity-0 transition-opacity group-hover:opacity-100">
+          <Play className="size-4 fill-white text-white" />
+        </span>
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-foreground">{item.title}</p>
+        <p className="truncate text-xs text-muted-foreground">{item.artist}</p>
+      </div>
+    </button>
+  );
+}
+
+function DiscoverRow({
+  item,
+  status,
+  onDownload,
+}: {
+  item: DiscoverRecommendation;
+  status: 'idle' | 'downloading' | 'done' | 'error';
+  onDownload: (item: DiscoverRecommendation) => void;
+}) {
+  const { t } = useTranslation('recommendations');
+  const busy = status === 'downloading';
+  const done = status === 'done';
+  return (
+    <div className="flex w-full items-center gap-3 rounded-2xl border border-border/15 bg-background/20 px-3 py-2.5">
+      <div className="size-10 shrink-0 overflow-hidden rounded-xl bg-foreground/8">
+        {item.thumbnail ? (
+          <img src={item.thumbnail} alt="" className="size-full object-cover" loading="lazy" />
+        ) : (
+          <OverviewCover
+            albumArt={null}
+            title={item.title}
+            seed={item.uploader}
+            className="size-10"
+          />
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-foreground">{item.title}</p>
+        <p className="truncate text-xs text-muted-foreground">{item.uploader}</p>
+      </div>
+      <button
+        type="button"
+        onClick={() => onDownload(item)}
+        disabled={busy || done}
+        aria-label={t('downloadAria', { title: item.title })}
+        className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border/20 text-primary/80 transition-colors hover:border-border/40 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+      >
+        {busy ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/overview/RecommendationsShelf.tsx
+++ b/apps/web/src/components/overview/RecommendationsShelf.tsx
@@ -7,6 +7,7 @@ import {
   Download,
   LibraryBig,
   Loader2,
+  Pause,
   Play,
   RefreshCw,
   Sparkles,
@@ -16,6 +17,26 @@ import { OverviewCover } from '@/components/overview/OverviewCover';
 import { formatRelativeTime } from '@/components/overview/overviewUtils';
 import { useRecommendations } from '@/hooks/queries/useRecommendations';
 import { useDiscoverDownload } from '@/hooks/useDiscoverDownload';
+import { useAudioPreview, type PreviewableItem } from '@/hooks/useAudioPreview';
+import { useSearchDependencies } from '@/hooks/useSearchDependencies';
+import { DependencyInstallCard } from '@/components/search/DependencyInstallCard';
+
+/**
+ * Maps a discover recommendation onto the shared preview shape. Discover items
+ * come from a `--flat-playlist` dump, so there's no duration — the player
+ * resolves the real length from the stream once it loads.
+ */
+function toPreviewable(item: DiscoverRecommendation): PreviewableItem {
+  return {
+    id: item.youtubeId,
+    title: item.title,
+    uploader: item.uploader,
+    duration: 0,
+    thumbnail: item.thumbnail,
+    url: item.url,
+    webpage_url: item.url,
+  };
+}
 
 interface RecommendationsShelfProps {
   /** Plays an existing library track by id (Overview's handler). */
@@ -221,11 +242,17 @@ function DiscoverRow({
   item,
   status,
   onDownload,
+  onPreview,
+  isPreviewLoading,
+  isPreviewing,
   liveRegionId,
 }: {
   item: DiscoverRecommendation;
   status: 'idle' | 'downloading' | 'done' | 'error';
   onDownload: (item: DiscoverRecommendation) => void;
+  onPreview: (item: DiscoverRecommendation) => void;
+  isPreviewLoading: boolean;
+  isPreviewing: boolean;
   liveRegionId: string;
 }) {
   const { t } = useTranslation('recommendations');
@@ -257,7 +284,16 @@ function DiscoverRow({
     cardExtra = 'border-emerald-400/15 motion-safe:transition-colors motion-safe:duration-200';
 
   const cover = (
-    <div className="relative size-10 shrink-0 overflow-hidden rounded-xl bg-foreground/8 ring-1 ring-primary/20">
+    <button
+      type="button"
+      onClick={() => onPreview(item)}
+      aria-label={
+        isPreviewing
+          ? t('pausePreviewAria', { title: item.title })
+          : t('previewAria', { title: item.title })
+      }
+      className="relative size-10 shrink-0 overflow-hidden rounded-xl bg-foreground/8 ring-1 ring-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
       {item.thumbnail ? (
         <img
           src={item.thumbnail}
@@ -273,7 +309,20 @@ function DiscoverRow({
           className="size-10 motion-safe:transition-transform motion-safe:duration-200 motion-safe:group-hover:scale-[1.03]"
         />
       )}
-    </div>
+      <span
+        className={`pointer-events-none absolute inset-0 flex items-center justify-center rounded-xl bg-black/45 transition-opacity ${
+          isPreviewLoading || isPreviewing ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+        }`}
+      >
+        {isPreviewLoading ? (
+          <Loader2 className="size-4 animate-spin text-white" />
+        ) : isPreviewing ? (
+          <Pause className="size-4 fill-white text-white" />
+        ) : (
+          <Play className="size-4 fill-white text-white" />
+        )}
+      </span>
+    </button>
   );
 
   const subtitle = (
@@ -342,11 +391,28 @@ export function RecommendationsShelf({ onPlay, hasLibrary }: RecommendationsShel
   const { t, i18n } = useTranslation('recommendations');
   const { library, discover, isLoading, isRefreshing, refresh, hasAny } = useRecommendations();
   const { download, statuses } = useDiscoverDownload();
+  const { previewLoadingId, isPreviewPlaying, handlePreview } = useAudioPreview();
+  const {
+    dependencyState,
+    dependenciesSnapshot,
+    dependencyInstallStatus,
+    dependencyInstallError,
+    isDependencyInstallInProgress,
+    dependencyInstallProgress,
+    dependencyInstallLabel,
+    handleInstallDependencies,
+  } = useSearchDependencies();
   const headingId = useId();
 
   // True first run (no library at all): stay hidden so Overview's welcome
   // empty state owns the surface. Also stay hidden while still loading.
   if (isLoading || !hasLibrary) return null;
+
+  // Discover needs yt-dlp (preview stream + download) and ffmpeg (transcode).
+  // When they're missing the backend can't fetch a mix, so we show the same
+  // install card search/import use instead of a generic empty state. The
+  // library section needs no tools (local files), so gating is discover-only.
+  const needsInstall = dependencyState === 'needs-install';
 
   const isStale = library.stale || discover.stale;
   const generatedAt = library.generatedAt ?? discover.generatedAt;
@@ -392,7 +458,9 @@ export function RecommendationsShelf({ onPlay, hasLibrary }: RecommendationsShel
       </div>
 
       {/* ── Both-empty inner state (library exists but no picks yet) ── */}
-      {!hasAny && (
+      {/* Suppressed when tools are missing — the discover install card below
+          is the actionable message in that case. */}
+      {!hasAny && !needsInstall && (
         <div className="flex flex-col items-center gap-3 rounded-2xl border border-border/20 bg-background/20 px-4 py-8 text-center">
           <Sparkles className="size-6 text-muted-foreground/40" aria-hidden="true" />
           <div className="max-w-sm">
@@ -420,13 +488,25 @@ export function RecommendationsShelf({ onPlay, hasLibrary }: RecommendationsShel
       )}
 
       {/* ── Discover section ── */}
-      {hasAny && (
+      {/* Render when there's something to show OR tools need installing, so the
+          install card always has a home even when the backend returned nothing. */}
+      {(hasAny || needsInstall) && (
         <RecommendationSection
           icon={<Compass className="size-3" />}
           label={t('discover')}
-          extraCount={discoverExtra}
+          extraCount={needsInstall ? 0 : discoverExtra}
         >
-          {discoverSlice.length === 0 ? (
+          {needsInstall ? (
+            <DependencyInstallCard
+              ffmpegInstalled={dependenciesSnapshot?.ffmpegInstalled}
+              installStatus={dependencyInstallStatus}
+              installError={dependencyInstallError}
+              isInstallInProgress={isDependencyInstallInProgress}
+              installProgress={dependencyInstallProgress}
+              installLabel={dependencyInstallLabel}
+              onInstall={handleInstallDependencies}
+            />
+          ) : discoverSlice.length === 0 ? (
             <div className="flex flex-col items-center gap-2 rounded-2xl border border-border/20 bg-background/20 px-4 py-6 text-center">
               <Compass className="size-5 text-muted-foreground/35" aria-hidden="true" />
               <p className="max-w-sm text-sm text-muted-foreground/60">{t('discoverEmpty')}</p>
@@ -441,6 +521,9 @@ export function RecommendationsShelf({ onPlay, hasLibrary }: RecommendationsShel
                   item={item}
                   status={statuses[item.youtubeId] ?? 'idle'}
                   onDownload={download}
+                  onPreview={it => handlePreview(toPreviewable(it))}
+                  isPreviewLoading={previewLoadingId === item.youtubeId}
+                  isPreviewing={isPreviewPlaying({ id: item.youtubeId })}
                   liveRegionId={`discover-status-${item.youtubeId}`}
                 />
               ))}

--- a/apps/web/src/components/overview/RecommendationsShelf.tsx
+++ b/apps/web/src/components/overview/RecommendationsShelf.tsx
@@ -56,7 +56,6 @@ interface RecommendationCardProps {
   cover: React.ReactNode;
   subtitle: React.ReactNode;
   trailing: React.ReactNode;
-  variant: 'library' | 'discover';
   /** When provided the whole card is a button (library rows). */
   onActivate?: () => void;
   ariaLabel?: string;
@@ -70,7 +69,6 @@ function RecommendationCard({
   cover,
   subtitle,
   trailing,
-  variant: _variant,
   onActivate,
   ariaLabel,
   className = '',
@@ -78,7 +76,7 @@ function RecommendationCard({
 }: RecommendationCardProps) {
   const baseClasses =
     'group relative flex w-full items-center gap-3 rounded-2xl border px-3 py-2.5 transition-colors';
-  const variantClasses =
+  const surfaceClasses =
     'border-border/15 bg-background/20 hover:border-border/35 hover:bg-accent/35';
 
   if (onActivate) {
@@ -87,7 +85,7 @@ function RecommendationCard({
         type="button"
         onClick={onActivate}
         aria-label={ariaLabel}
-        className={`text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${baseClasses} ${variantClasses} ${className}`}
+        className={`text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${baseClasses} ${surfaceClasses} ${className}`}
       >
         {cover}
         <div className="min-w-0 flex-1">{subtitle}</div>
@@ -98,7 +96,7 @@ function RecommendationCard({
   }
 
   return (
-    <div className={`${baseClasses} ${variantClasses} ${className}`}>
+    <div className={`${baseClasses} ${surfaceClasses} ${className}`}>
       {cover}
       <div className="min-w-0 flex-1">{subtitle}</div>
       {trailing}
@@ -229,7 +227,6 @@ function LibraryRow({
       cover={cover}
       subtitle={subtitle}
       trailing={null}
-      variant="library"
       onActivate={() => onPlay(item.trackId)}
       ariaLabel={t('playAria', { title: item.title })}
     />
@@ -372,7 +369,6 @@ function DiscoverRow({
             onDownload={() => onDownload(item)}
           />
         }
-        variant="discover"
         className={cardExtra}
         overlay={progressBar}
       />

--- a/apps/web/src/components/overview/RecommendationsShelf.tsx
+++ b/apps/web/src/components/overview/RecommendationsShelf.tsx
@@ -1,85 +1,177 @@
+import { useId } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Compass, Download, Loader2, Play, RefreshCw, Sparkles } from 'lucide-react';
+import {
+  AlertCircle,
+  Check,
+  Compass,
+  Download,
+  LibraryBig,
+  Loader2,
+  Play,
+  RefreshCw,
+  Sparkles,
+} from 'lucide-react';
 import type { DiscoverRecommendation, LibraryRecommendation } from '@shiranami/contracts';
 import { OverviewCover } from '@/components/overview/OverviewCover';
+import { formatRelativeTime } from '@/components/overview/overviewUtils';
 import { useRecommendations } from '@/hooks/queries/useRecommendations';
 import { useDiscoverDownload } from '@/hooks/useDiscoverDownload';
 
 interface RecommendationsShelfProps {
   /** Plays an existing library track by id (Overview's handler). */
   onPlay: (trackId: string) => void;
+  /**
+   * Whether the user already has a library. Controls the both-empty behaviour:
+   * when true and both shelves are empty, show the shell + quiet inner empty
+   * state (not null). When false (first run), return null so the Overview's
+   * first-run state owns the surface.
+   */
+  hasLibrary: boolean;
 }
 
-/**
- * Minimal, functional recommendations shelf for the Overview. Surfaces two
- * sections — "Recommended from your library" (affinity-ranked owned tracks)
- * and "Discover new music" (yt-dlp RD-mix, downloadable). Deliberately
- * unpolished: visual/UX design is a follow-up /kirei ui pass. Renders nothing
- * when both shelves are empty so it never shows a dead panel.
- */
-export function RecommendationsShelf({ onPlay }: RecommendationsShelfProps) {
-  const { t } = useTranslation('recommendations');
-  const { library, discover, isLoading, isRefreshing, refresh, hasAny } = useRecommendations();
-  const { download, statuses } = useDiscoverDownload();
+// ── Shared card row ──────────────────────────────────────────────────────────
 
-  if (isLoading || !hasAny) return null;
+interface RecommendationCardProps {
+  cover: React.ReactNode;
+  subtitle: React.ReactNode;
+  trailing: React.ReactNode;
+  variant: 'library' | 'discover';
+  /** When provided the whole card is a button (library rows). */
+  onActivate?: () => void;
+  ariaLabel?: string;
+  /** Extra classes applied to the root element. */
+  className?: string;
+  /** Optional overlay children (e.g. the download progress bar). */
+  overlay?: React.ReactNode;
+}
+
+function RecommendationCard({
+  cover,
+  subtitle,
+  trailing,
+  variant: _variant,
+  onActivate,
+  ariaLabel,
+  className = '',
+  overlay,
+}: RecommendationCardProps) {
+  const baseClasses =
+    'group relative flex w-full items-center gap-3 rounded-2xl border px-3 py-2.5 transition-colors';
+  const variantClasses =
+    'border-border/15 bg-background/20 hover:border-border/35 hover:bg-accent/35';
+
+  if (onActivate) {
+    return (
+      <button
+        type="button"
+        onClick={onActivate}
+        aria-label={ariaLabel}
+        className={`text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${baseClasses} ${variantClasses} ${className}`}
+      >
+        {cover}
+        <div className="min-w-0 flex-1">{subtitle}</div>
+        {trailing}
+        {overlay}
+      </button>
+    );
+  }
 
   return (
-    <section className="flex flex-col gap-4 rounded-[24px] border border-border/25 glass-panel p-4">
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <Sparkles className="size-4 text-primary/80" />
-          <h2 className="font-display text-lg font-semibold text-foreground">{t('title')}</h2>
-        </div>
-        <button
-          type="button"
-          onClick={() => refresh()}
-          disabled={isRefreshing}
-          className="flex items-center gap-1.5 rounded-lg px-2 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-primary/80 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-        >
-          <RefreshCw className={`size-3 ${isRefreshing ? 'animate-spin' : ''}`} />
-          {t('refresh')}
-        </button>
-      </div>
-
-      {library.items.length > 0 && (
-        <div className="flex flex-col gap-2">
-          <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground/70">
-            {t('fromLibrary')}
-          </h3>
-          <div className="grid gap-2 sm:grid-cols-2">
-            {library.items.slice(0, 8).map(item => (
-              <LibraryRow key={item.trackId} item={item} onPlay={onPlay} />
-            ))}
-          </div>
-        </div>
-      )}
-
-      <div className="flex flex-col gap-2">
-        <h3 className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground/70">
-          <Compass className="size-3" />
-          {t('discover')}
-        </h3>
-        {discover.items.length === 0 ? (
-          <p className="rounded-2xl border border-border/20 bg-background/20 px-4 py-6 text-center text-sm text-muted-foreground/60">
-            {t('discoverEmpty')}
-          </p>
-        ) : (
-          <div className="grid gap-2 sm:grid-cols-2">
-            {discover.items.slice(0, 8).map(item => (
-              <DiscoverRow
-                key={item.youtubeId}
-                item={item}
-                status={statuses[item.youtubeId] ?? 'idle'}
-                onDownload={download}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-    </section>
+    <div className={`${baseClasses} ${variantClasses} ${className}`}>
+      {cover}
+      <div className="min-w-0 flex-1">{subtitle}</div>
+      {trailing}
+      {overlay}
+    </div>
   );
 }
+
+// ── Download button state machine ────────────────────────────────────────────
+
+interface DiscoverDownloadButtonProps {
+  title: string;
+  status: 'idle' | 'downloading' | 'done' | 'error';
+  onDownload: () => void;
+}
+
+function DiscoverDownloadButton({ title, status, onDownload }: DiscoverDownloadButtonProps) {
+  const { t } = useTranslation('recommendations');
+
+  const ariaLabel =
+    status === 'downloading'
+      ? t('downloadingAria', { title })
+      : status === 'done'
+        ? t('addedAria', { title })
+        : status === 'error'
+          ? t('retryDownloadAria', { title })
+          : t('downloadAria', { title });
+
+  const isDisabled = status === 'downloading' || status === 'done';
+
+  let icon: React.ReactNode;
+  let colorClass: string;
+  let borderClass: string;
+
+  if (status === 'downloading') {
+    icon = <Loader2 className="size-4 animate-spin" />;
+    colorClass = 'text-primary/80';
+    borderClass = 'border-primary/20';
+  } else if (status === 'done') {
+    icon = <Check className="size-4" />;
+    colorClass = 'text-emerald-400/90';
+    borderClass = 'border-emerald-400/15 motion-safe:transition-colors motion-safe:duration-200';
+  } else if (status === 'error') {
+    icon = <AlertCircle className="size-4" />;
+    colorClass = 'text-destructive';
+    borderClass = 'border-destructive/20';
+  } else {
+    icon = <Download className="size-4" />;
+    colorClass = 'text-primary/80';
+    borderClass = 'border-border/20';
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={isDisabled ? undefined : onDownload}
+      disabled={isDisabled}
+      aria-label={ariaLabel}
+      aria-busy={status === 'downloading' ? 'true' : undefined}
+      className={`flex size-8 shrink-0 items-center justify-center rounded-lg border ${borderClass} ${colorClass} transition-colors hover:border-border/40 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-100`}
+    >
+      {icon}
+    </button>
+  );
+}
+
+// ── Section header (icon + label + optional +N more pill) ────────────────────
+
+interface RecommendationSectionProps {
+  icon: React.ReactNode;
+  label: string;
+  extraCount?: number;
+  children: React.ReactNode;
+}
+
+function RecommendationSection({ icon, label, extraCount, children }: RecommendationSectionProps) {
+  const { t } = useTranslation('recommendations');
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground/70">
+        {icon}
+        <span className="min-w-0 flex-1 truncate">{label}</span>
+        {extraCount !== undefined && extraCount > 0 && (
+          <span className="shrink-0 font-mono text-[10px] text-muted-foreground/45">
+            {t('moreCount', { count: extraCount })}
+          </span>
+        )}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+// ── Library row ──────────────────────────────────────────────────────────────
 
 function LibraryRow({
   item,
@@ -89,71 +181,273 @@ function LibraryRow({
   onPlay: (trackId: string) => void;
 }) {
   const { t } = useTranslation('recommendations');
+
+  const cover = (
+    <div className="relative size-10 shrink-0">
+      <OverviewCover
+        albumArt={item.albumArt}
+        title={item.title}
+        seed={item.album || item.artist}
+        className="size-10 motion-safe:transition-transform motion-safe:duration-200 motion-safe:group-hover:scale-[1.03]"
+      />
+      <span className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-xl bg-black/45 opacity-0 transition-opacity group-hover:opacity-100">
+        <Play className="size-4 fill-white text-white" />
+      </span>
+    </div>
+  );
+
+  const subtitle = (
+    <>
+      <p className="truncate text-sm font-medium text-foreground">{item.title}</p>
+      <p className="truncate text-xs text-muted-foreground">{item.artist}</p>
+    </>
+  );
+
   return (
-    <button
-      type="button"
-      onClick={() => onPlay(item.trackId)}
-      aria-label={t('playAria', { title: item.title })}
-      className="group flex w-full items-center gap-3 rounded-2xl border border-border/15 bg-background/20 px-3 py-2.5 text-left transition-colors hover:border-border/35 hover:bg-accent/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-    >
-      <div className="relative size-10 shrink-0">
-        <OverviewCover
-          albumArt={item.albumArt}
-          title={item.title}
-          seed={item.album || item.artist}
-          className="size-10"
-        />
-        <span className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-xl bg-black/45 opacity-0 transition-opacity group-hover:opacity-100">
-          <Play className="size-4 fill-white text-white" />
-        </span>
-      </div>
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium text-foreground">{item.title}</p>
-        <p className="truncate text-xs text-muted-foreground">{item.artist}</p>
-      </div>
-    </button>
+    <RecommendationCard
+      cover={cover}
+      subtitle={subtitle}
+      trailing={null}
+      variant="library"
+      onActivate={() => onPlay(item.trackId)}
+      ariaLabel={t('playAria', { title: item.title })}
+    />
   );
 }
+
+// ── Discover row ─────────────────────────────────────────────────────────────
 
 function DiscoverRow({
   item,
   status,
   onDownload,
+  liveRegionId,
 }: {
   item: DiscoverRecommendation;
   status: 'idle' | 'downloading' | 'done' | 'error';
   onDownload: (item: DiscoverRecommendation) => void;
+  liveRegionId: string;
 }) {
   const { t } = useTranslation('recommendations');
-  const busy = status === 'downloading';
-  const done = status === 'done';
-  return (
-    <div className="flex w-full items-center gap-3 rounded-2xl border border-border/15 bg-background/20 px-3 py-2.5">
-      <div className="size-10 shrink-0 overflow-hidden rounded-xl bg-foreground/8">
-        {item.thumbnail ? (
-          <img src={item.thumbnail} alt="" className="size-full object-cover" loading="lazy" />
-        ) : (
-          <OverviewCover
-            albumArt={null}
-            title={item.title}
-            seed={item.uploader}
-            className="size-10"
-          />
+
+  const isDownloading = status === 'downloading';
+  const isDone = status === 'done';
+  const isError = status === 'error';
+
+  // Sub-title line changes to reflect current download state.
+  let subtitleText: React.ReactNode;
+  let subtitleClass = 'truncate text-xs text-muted-foreground';
+  if (isDownloading) {
+    subtitleText = t('downloading');
+    subtitleClass = 'truncate text-xs text-primary/70';
+  } else if (isDone) {
+    subtitleText = t('addedToLibrary');
+    subtitleClass = 'truncate text-xs text-emerald-400/80';
+  } else if (isError) {
+    subtitleText = t('downloadError');
+    subtitleClass = 'truncate text-xs text-destructive/80';
+  } else {
+    subtitleText = item.uploader;
+  }
+
+  // Card border and bg evolve with state.
+  let cardExtra = '';
+  if (isDownloading) cardExtra = 'bg-primary/[0.04]';
+  if (isDone)
+    cardExtra = 'border-emerald-400/15 motion-safe:transition-colors motion-safe:duration-200';
+
+  const cover = (
+    <div className="relative size-10 shrink-0 overflow-hidden rounded-xl bg-foreground/8 ring-1 ring-primary/20">
+      {item.thumbnail ? (
+        <img
+          src={item.thumbnail}
+          alt=""
+          className="size-full object-cover motion-safe:transition-transform motion-safe:duration-200 motion-safe:group-hover:scale-[1.03]"
+          loading="lazy"
+        />
+      ) : (
+        <OverviewCover
+          albumArt={null}
+          title={item.title}
+          seed={item.uploader}
+          className="size-10 motion-safe:transition-transform motion-safe:duration-200 motion-safe:group-hover:scale-[1.03]"
+        />
+      )}
+    </div>
+  );
+
+  const subtitle = (
+    <>
+      <div className="flex items-center gap-1.5">
+        <p className="truncate text-sm font-medium text-foreground">{item.title}</p>
+        {!isDone && !isDownloading && !isError && (
+          <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.15em] text-primary/70">
+            {t('discoverTag')}
+          </span>
         )}
       </div>
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium text-foreground">{item.title}</p>
-        <p className="truncate text-xs text-muted-foreground">{item.uploader}</p>
+      <p className={subtitleClass}>{subtitleText}</p>
+    </>
+  );
+
+  // Indeterminate progress bar along the card bottom while downloading.
+  // The sweep animation class is gated in globals.css reduced-motion block.
+  const progressBar = isDownloading ? (
+    <span
+      className="pointer-events-none absolute inset-x-0 bottom-0 h-[3px] overflow-hidden rounded-b-2xl"
+      aria-hidden="true"
+    >
+      <span className="progress-sweep block h-full w-1/3 rounded-full bg-primary/60" />
+    </span>
+  ) : null;
+
+  return (
+    <>
+      {/* aria-live region announces state changes to screen readers */}
+      <span id={liveRegionId} className="sr-only" aria-live="polite" aria-atomic="true">
+        {isDownloading
+          ? t('downloadingAria', { title: item.title })
+          : isDone
+            ? t('addedAria', { title: item.title })
+            : isError
+              ? t('retryDownloadAria', { title: item.title })
+              : ''}
+      </span>
+      <RecommendationCard
+        cover={cover}
+        subtitle={subtitle}
+        trailing={
+          <DiscoverDownloadButton
+            title={item.title}
+            status={status}
+            onDownload={() => onDownload(item)}
+          />
+        }
+        variant="discover"
+        className={cardExtra}
+        overlay={progressBar}
+      />
+    </>
+  );
+}
+
+// ── Main shelf ───────────────────────────────────────────────────────────────
+
+/**
+ * Recommendations shelf: "From your library" + "Discover new music" sections.
+ * Hardened against all data states — both-empty, stale, loading (skeleton owns
+ * loading via OverviewViewSkeleton), download in-progress/done/error.
+ */
+export function RecommendationsShelf({ onPlay, hasLibrary }: RecommendationsShelfProps) {
+  const { t, i18n } = useTranslation('recommendations');
+  const { library, discover, isLoading, isRefreshing, refresh, hasAny } = useRecommendations();
+  const { download, statuses } = useDiscoverDownload();
+  const headingId = useId();
+
+  // True first run (no library at all): stay hidden so Overview's welcome
+  // empty state owns the surface. Also stay hidden while still loading.
+  if (isLoading || !hasLibrary) return null;
+
+  const isStale = library.stale || discover.stale;
+  const generatedAt = library.generatedAt ?? discover.generatedAt;
+  const updatedAgo = isStale && generatedAt ? formatRelativeTime(generatedAt, i18n.language) : null;
+
+  const librarySlice = library.items.slice(0, 8);
+  const libraryExtra = Math.max(0, library.items.length - 8);
+  const discoverSlice = discover.items.slice(0, 8);
+  const discoverExtra = Math.max(0, discover.items.length - 8);
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      aria-busy={isRefreshing ? 'true' : undefined}
+      className="flex flex-col gap-4 rounded-[24px] border border-border/25 glass-panel p-4"
+    >
+      {/* ── Header ── */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Sparkles className="size-4 shrink-0 text-primary/80" />
+          <h2 id={headingId} className="font-display text-lg font-semibold text-foreground">
+            {t('title')}
+          </h2>
+          {updatedAgo && (
+            <span className="hidden items-center gap-1 text-[11px] text-muted-foreground/55 sm:flex">
+              <span className="size-1.5 shrink-0 rounded-full bg-primary/40" aria-hidden="true" />
+              {t('updatedAgo', { time: updatedAgo })}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => refresh()}
+          disabled={isRefreshing}
+          aria-label={t('refreshAria')}
+          className={`flex items-center gap-1.5 rounded-lg px-2 py-1 font-mono text-[10px] uppercase tracking-[0.18em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 ${
+            isStale ? 'text-primary hover:text-primary/80' : 'text-primary/80 hover:text-primary'
+          }`}
+        >
+          <RefreshCw className={`size-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+          {t('refresh')}
+        </button>
       </div>
-      <button
-        type="button"
-        onClick={() => onDownload(item)}
-        disabled={busy || done}
-        aria-label={t('downloadAria', { title: item.title })}
-        className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border/20 text-primary/80 transition-colors hover:border-border/40 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-      >
-        {busy ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
-      </button>
-    </div>
+
+      {/* ── Both-empty inner state (library exists but no picks yet) ── */}
+      {!hasAny && (
+        <div className="flex flex-col items-center gap-3 rounded-2xl border border-border/20 bg-background/20 px-4 py-8 text-center">
+          <Sparkles className="size-6 text-muted-foreground/40" aria-hidden="true" />
+          <div className="max-w-sm">
+            <p className="text-sm font-medium text-foreground/80">{t('shelfEmptyTitle')}</p>
+            <p className="mt-1 text-xs text-muted-foreground/60">{t('shelfEmptySubtitle')}</p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Library section ── */}
+      {librarySlice.length > 0 && (
+        <RecommendationSection
+          icon={<LibraryBig className="size-3" />}
+          label={t('fromLibrary')}
+          extraCount={libraryExtra}
+        >
+          <div
+            className={`grid gap-2 sm:grid-cols-2 motion-safe:transition-opacity motion-safe:duration-200 ${isRefreshing ? 'opacity-70' : 'opacity-100'}`}
+          >
+            {librarySlice.map(item => (
+              <LibraryRow key={item.trackId} item={item} onPlay={onPlay} />
+            ))}
+          </div>
+        </RecommendationSection>
+      )}
+
+      {/* ── Discover section ── */}
+      {hasAny && (
+        <RecommendationSection
+          icon={<Compass className="size-3" />}
+          label={t('discover')}
+          extraCount={discoverExtra}
+        >
+          {discoverSlice.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 rounded-2xl border border-border/20 bg-background/20 px-4 py-6 text-center">
+              <Compass className="size-5 text-muted-foreground/35" aria-hidden="true" />
+              <p className="max-w-sm text-sm text-muted-foreground/60">{t('discoverEmpty')}</p>
+            </div>
+          ) : (
+            <div
+              className={`grid gap-2 sm:grid-cols-2 motion-safe:transition-opacity motion-safe:duration-200 ${isRefreshing ? 'opacity-70' : 'opacity-100'}`}
+            >
+              {discoverSlice.map(item => (
+                <DiscoverRow
+                  key={item.youtubeId}
+                  item={item}
+                  status={statuses[item.youtubeId] ?? 'idle'}
+                  onDownload={download}
+                  liveRegionId={`discover-status-${item.youtubeId}`}
+                />
+              ))}
+            </div>
+          )}
+        </RecommendationSection>
+      )}
+    </section>
   );
 }

--- a/apps/web/src/hooks/queries/useRecommendations.ts
+++ b/apps/web/src/hooks/queries/useRecommendations.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { RecommendationShelves } from '@shiranami/contracts';
+import { IS_ELECTRON } from '@/lib/platform';
+
+/** Recommendations come from a precomputed cache; a 15-minute stale window
+ *  matches the other Overview queries so navigating away and back is snappy.
+ *  The discover shelf is refreshed by a background job in main, not here. */
+const RECOMMENDATIONS_STALE_MS = 15 * 60 * 1000;
+
+const EMPTY_SHELVES: RecommendationShelves = {
+  library: { kind: 'library', items: [], generatedAt: null, stale: true },
+  discover: { kind: 'discover', items: [], generatedAt: null, stale: true },
+};
+
+export const recommendationKeys = {
+  all: ['recommendations'] as const,
+};
+
+/**
+ * Reads both recommendation shelves from the desktop cache (read-only over
+ * IPC) and exposes a manual refresh that runs the background job in main
+ * (affinity + yt-dlp RD-mix) and writes the result back into the query cache.
+ *
+ * Always resolves — the main-process handlers degrade to empty shelves on any
+ * failure, and outside Electron the query short-circuits to empty — so the
+ * shelf never errors out the home view.
+ */
+export function useRecommendations() {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: recommendationKeys.all,
+    queryFn: async (): Promise<RecommendationShelves> => {
+      if (!IS_ELECTRON) return EMPTY_SHELVES;
+      return window.electronAPI.recommendations.get();
+    },
+    enabled: IS_ELECTRON,
+    staleTime: RECOMMENDATIONS_STALE_MS,
+  });
+
+  const refresh = useMutation({
+    mutationFn: async (): Promise<RecommendationShelves> => {
+      if (!IS_ELECTRON) return EMPTY_SHELVES;
+      return window.electronAPI.recommendations.refresh();
+    },
+    onSuccess: shelves => {
+      queryClient.setQueryData(recommendationKeys.all, shelves);
+    },
+  });
+
+  const shelves = query.data ?? EMPTY_SHELVES;
+
+  return {
+    library: shelves.library,
+    discover: shelves.discover,
+    isLoading: query.isLoading,
+    isRefreshing: refresh.isPending,
+    refresh: refresh.mutate,
+    hasAny: shelves.library.items.length > 0 || shelves.discover.items.length > 0,
+  };
+}

--- a/apps/web/src/hooks/useDiscoverDownload.ts
+++ b/apps/web/src/hooks/useDiscoverDownload.ts
@@ -1,0 +1,53 @@
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+import i18n from '@/lib/i18n';
+import { IS_ELECTRON } from '@/lib/platform';
+import { useTrackImport } from '@/hooks/useTrackImport';
+import { translateYtDlpError } from '@/lib/ytdlpErrors';
+import { logger } from '@/lib/logger';
+import type { DiscoverRecommendation } from '@shiranami/contracts';
+
+type DownloadStatus = 'idle' | 'downloading' | 'done' | 'error';
+
+/**
+ * Downloads + imports a discovered (not-yet-owned) track into the library,
+ * reusing the same downloader → importTrack flow as search. Tracks a per-item
+ * status keyed by youtubeId so the shelf can disable/label a single row while
+ * it downloads. yt-dlp failures surface as a translated toast, never a crash.
+ */
+export function useDiscoverDownload() {
+  const { importTrack } = useTrackImport();
+  const [statuses, setStatuses] = useState<Record<string, DownloadStatus>>({});
+
+  const setStatus = useCallback((youtubeId: string, status: DownloadStatus) => {
+    setStatuses(prev => ({ ...prev, [youtubeId]: status }));
+  }, []);
+
+  const download = useCallback(
+    async (item: DiscoverRecommendation) => {
+      if (!IS_ELECTRON || statuses[item.youtubeId] === 'downloading') return;
+      setStatus(item.youtubeId, 'downloading');
+      try {
+        const filePath = await window.electronAPI.downloader.download(item.url);
+        const track = await importTrack(filePath);
+        if (track) {
+          if (item.youtubeId) {
+            window.electronAPI.share.cacheYoutubeId(track.id, item.youtubeId).catch(() => {});
+          }
+          toast.success(i18n.t('downloaded', { ns: 'toast', title: track.title }));
+        } else {
+          toast.info(i18n.t('trackAlreadyInLibrary', { ns: 'toast' }));
+        }
+        setStatus(item.youtubeId, 'done');
+      } catch (err) {
+        const raw = err instanceof Error ? err.message : i18n.t('unknownError', { ns: 'common' });
+        logger.error('[recommendations] discover download failed', err);
+        toast.error(i18n.t('downloadFailed', { ns: 'toast', error: translateYtDlpError(raw) }));
+        setStatus(item.youtubeId, 'error');
+      }
+    },
+    [importTrack, setStatus, statuses]
+  );
+
+  return { download, statuses };
+}

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -31,6 +31,7 @@ import errorBoundaryEn from '@/locales/en/errorBoundary.json';
 import equalizerEn from '@/locales/en/equalizer.json';
 import enrichDialogEn from '@/locales/en/enrichDialog.json';
 import onboardingEn from '@/locales/en/onboarding.json';
+import recommendationsEn from '@/locales/en/recommendations.json';
 
 import commonPl from '@/locales/pl/common.json';
 import sidebarPl from '@/locales/pl/sidebar.json';
@@ -61,6 +62,7 @@ import errorBoundaryPl from '@/locales/pl/errorBoundary.json';
 import equalizerPl from '@/locales/pl/equalizer.json';
 import enrichDialogPl from '@/locales/pl/enrichDialog.json';
 import onboardingPl from '@/locales/pl/onboarding.json';
+import recommendationsPl from '@/locales/pl/recommendations.json';
 
 export const SUPPORTED_LANGUAGES = [
   { code: 'en', label: 'English' },
@@ -121,6 +123,7 @@ const namespaces = [
   'equalizer',
   'enrichDialog',
   'onboarding',
+  'recommendations',
 ] as const;
 
 i18n.use(initReactI18next).init({
@@ -155,6 +158,7 @@ i18n.use(initReactI18next).init({
       equalizer: equalizerEn,
       enrichDialog: enrichDialogEn,
       onboarding: onboardingEn,
+      recommendations: recommendationsEn,
     },
     pl: {
       common: commonPl,
@@ -186,6 +190,7 @@ i18n.use(initReactI18next).init({
       equalizer: equalizerPl,
       enrichDialog: enrichDialogPl,
       onboarding: onboardingPl,
+      recommendations: recommendationsPl,
     },
   },
   lng: getInitialLanguage(),

--- a/apps/web/src/locales/en/recommendations.json
+++ b/apps/web/src/locales/en/recommendations.json
@@ -3,7 +3,20 @@
   "refresh": "Refresh",
   "fromLibrary": "From your library",
   "discover": "Discover new music",
-  "discoverEmpty": "Nothing to discover yet. Play a few tracks and refresh to pull fresh picks from YouTube.",
+  "discoverEmpty": "Nothing to discover yet. Play a few tracks and refresh to pull fresh picks from the web.",
   "playAria": "Play {{title}}",
-  "downloadAria": "Download {{title}}"
+  "downloadAria": "Download {{title}}",
+  "downloading": "Adding…",
+  "addedToLibrary": "In your library",
+  "downloadError": "Couldn't add — tap to retry",
+  "downloadingAria": "Adding {{title}} to your library",
+  "addedAria": "{{title}} added to your library",
+  "retryDownloadAria": "Retry adding {{title}}",
+  "shelfEmptyTitle": "No picks just yet",
+  "shelfEmptySubtitle": "Listen to a few more tracks, then refresh to pull fresh recommendations.",
+  "updatedAgo": "Updated {{time}}",
+  "stale": "Out of date",
+  "refreshAria": "Refresh recommendations",
+  "moreCount": "+{{count}} more",
+  "discoverTag": "New"
 }

--- a/apps/web/src/locales/en/recommendations.json
+++ b/apps/web/src/locales/en/recommendations.json
@@ -8,7 +8,7 @@
   "downloadAria": "Download {{title}}",
   "downloading": "Adding…",
   "addedToLibrary": "In your library",
-  "downloadError": "Couldn't add — tap to retry",
+  "downloadError": "Couldn't add · retry",
   "downloadingAria": "Adding {{title}} to your library",
   "addedAria": "{{title}} added to your library",
   "retryDownloadAria": "Retry adding {{title}}",

--- a/apps/web/src/locales/en/recommendations.json
+++ b/apps/web/src/locales/en/recommendations.json
@@ -1,0 +1,9 @@
+{
+  "title": "Recommended for you",
+  "refresh": "Refresh",
+  "fromLibrary": "From your library",
+  "discover": "Discover new music",
+  "discoverEmpty": "Nothing to discover yet. Play a few tracks and refresh to pull fresh picks from YouTube.",
+  "playAria": "Play {{title}}",
+  "downloadAria": "Download {{title}}"
+}

--- a/apps/web/src/locales/en/recommendations.json
+++ b/apps/web/src/locales/en/recommendations.json
@@ -18,5 +18,7 @@
   "stale": "Out of date",
   "refreshAria": "Refresh recommendations",
   "moreCount": "+{{count}} more",
-  "discoverTag": "New"
+  "discoverTag": "New",
+  "previewAria": "Preview {{title}}",
+  "pausePreviewAria": "Pause preview of {{title}}"
 }

--- a/apps/web/src/locales/pl/recommendations.json
+++ b/apps/web/src/locales/pl/recommendations.json
@@ -3,7 +3,20 @@
   "refresh": "Odśwież",
   "fromLibrary": "Z Twojej biblioteki",
   "discover": "Odkryj nową muzykę",
-  "discoverEmpty": "Nie ma jeszcze czego odkrywać. Posłuchaj kilku utworów i odśwież, aby pobrać nowe propozycje z YouTube.",
+  "discoverEmpty": "Nie ma jeszcze czego odkrywać. Posłuchaj kilku utworów i odśwież, aby pobrać nowe propozycje z sieci.",
   "playAria": "Odtwórz {{title}}",
-  "downloadAria": "Pobierz {{title}}"
+  "downloadAria": "Pobierz {{title}}",
+  "downloading": "Dodawanie…",
+  "addedToLibrary": "W Twojej bibliotece",
+  "downloadError": "Nie udało się dodać — dotknij, by spróbować ponownie",
+  "downloadingAria": "Dodawanie {{title}} do biblioteki",
+  "addedAria": "{{title}} dodano do biblioteki",
+  "retryDownloadAria": "Spróbuj ponownie dodać {{title}}",
+  "shelfEmptyTitle": "Brak propozycji",
+  "shelfEmptySubtitle": "Posłuchaj jeszcze kilku utworów, a potem odśwież, aby pobrać nowe propozycje.",
+  "updatedAgo": "Zaktualizowano {{time}}",
+  "stale": "Nieaktualne",
+  "refreshAria": "Odśwież polecane",
+  "moreCount": "+{{count}} więcej",
+  "discoverTag": "Nowe"
 }

--- a/apps/web/src/locales/pl/recommendations.json
+++ b/apps/web/src/locales/pl/recommendations.json
@@ -18,5 +18,7 @@
   "stale": "Nieaktualne",
   "refreshAria": "Odśwież polecane",
   "moreCount": "+{{count}} więcej",
-  "discoverTag": "Nowe"
+  "discoverTag": "Nowe",
+  "previewAria": "Posłuchaj zapowiedzi {{title}}",
+  "pausePreviewAria": "Wstrzymaj zapowiedź {{title}}"
 }

--- a/apps/web/src/locales/pl/recommendations.json
+++ b/apps/web/src/locales/pl/recommendations.json
@@ -8,7 +8,7 @@
   "downloadAria": "Pobierz {{title}}",
   "downloading": "Dodawanie…",
   "addedToLibrary": "W Twojej bibliotece",
-  "downloadError": "Nie udało się dodać — dotknij, by spróbować ponownie",
+  "downloadError": "Nie udało się dodać · spróbuj ponownie",
   "downloadingAria": "Dodawanie {{title}} do biblioteki",
   "addedAria": "{{title}} dodano do biblioteki",
   "retryDownloadAria": "Spróbuj ponownie dodać {{title}}",

--- a/apps/web/src/locales/pl/recommendations.json
+++ b/apps/web/src/locales/pl/recommendations.json
@@ -1,0 +1,9 @@
+{
+  "title": "Polecane dla Ciebie",
+  "refresh": "Odśwież",
+  "fromLibrary": "Z Twojej biblioteki",
+  "discover": "Odkryj nową muzykę",
+  "discoverEmpty": "Nie ma jeszcze czego odkrywać. Posłuchaj kilku utworów i odśwież, aby pobrać nowe propozycje z YouTube.",
+  "playAria": "Odtwórz {{title}}",
+  "downloadAria": "Pobierz {{title}}"
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -314,6 +314,13 @@
   }
 }
 
+/* Download progress bar — indeterminate sweep for the discover-row in-progress state.
+   Reuses the same translate sweep as splash-sweep. Decorative — gated under
+   reduced-motion so it falls back to a static partial fill. */
+.progress-sweep {
+  animation: splash-sweep 1.4s ease-in-out infinite;
+}
+
 /* Splash degradation — collapse every animated scene layer to a static still
    under reduced-motion OR low-performance mode. Steam + streaks have no
    meaningful static state → hidden; lights / LED / sweep go static; the loader
@@ -328,7 +335,8 @@
   .splash-led {
     animation: none !important;
   }
-  .splash-sweep {
+  .splash-sweep,
+  .progress-sweep {
     animation: none !important;
     transform: none !important;
   }
@@ -348,7 +356,8 @@
   .animate-pulse,
   .animate-pulse-subtle,
   .float-mascot,
-  .overview-blink {
+  .overview-blink,
+  .progress-sweep {
     animation: none !important;
   }
   .animate-marquee {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -374,7 +374,8 @@
 [data-perf-mode='low'] .splash-led {
   animation: none !important;
 }
-[data-perf-mode='low'] .splash-sweep {
+[data-perf-mode='low'] .splash-sweep,
+[data-perf-mode='low'] .progress-sweep {
   animation: none !important;
   transform: none !important;
 }

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -282,6 +282,16 @@ function createElectronAPIMock(): ElectronAPI {
       stop: asyncFn(undefined),
       onMetrics: vi.fn(() => noopUnsub()),
     },
+    recommendations: {
+      get: asyncFn({
+        library: { kind: 'library', items: [], generatedAt: null, stale: true },
+        discover: { kind: 'discover', items: [], generatedAt: null, stale: true },
+      }),
+      refresh: asyncFn({
+        library: { kind: 'library', items: [], generatedAt: null, stale: true },
+        discover: { kind: 'discover', items: [], generatedAt: null, stale: true },
+      }),
+    },
     platform: 'win32',
     __e2e: false,
   };

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -6,6 +6,7 @@ import type {
   MainMetricsSnapshot,
   GeocodeResult,
   WeatherCurrent,
+  RecommendationShelves,
 } from '@shiranami/contracts';
 import type { DiscordRpcSettings, DiscordMusicPresenceActivity } from '@shiranami/shared';
 
@@ -415,6 +416,10 @@ export interface ElectronAPI {
     start: () => Promise<void>;
     stop: () => Promise<void>;
     onMetrics: (callback: (snapshot: MainMetricsSnapshot) => void) => () => void;
+  };
+  recommendations: {
+    get: () => Promise<RecommendationShelves>;
+    refresh: () => Promise<RecommendationShelves>;
   };
   platform: NodeJS.Platform;
   /** True when the main process was launched with SHIRANAMI_E2E=1. */

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dev:mobile": "pnpm --filter @shiranami/mobile dev",
     "dev:sentry": "node scripts/dev-sentry.mjs",
     "build": "pnpm build:packages && pnpm --filter @shiranami/web build && pnpm --filter @shiranami/desktop build",
-    "build:packages": "pnpm --filter @shiranami/contracts build && pnpm --filter @shiranami/shared build && pnpm --filter @shiranami/database build",
+    "build:packages": "pnpm --filter @shiranami/contracts build && pnpm --filter @shiranami/shared build && pnpm --filter @shiranami/database build && pnpm --filter @shiranami/recommendation build",
     "build:landing": "pnpm --filter @shiranami/landing build",
     "package": "pnpm build && pnpm --filter @shiranami/desktop package",
     "package:win": "pnpm build && pnpm --filter @shiranami/desktop package:win",

--- a/packages/contracts/src/domain/recommendation.ts
+++ b/packages/contracts/src/domain/recommendation.ts
@@ -39,16 +39,20 @@ export interface DiscoverRecommendation {
  * `stale` is computed at read time (older than the 24h TTL). An empty `items`
  * array is a valid result — for `discover` it means yt-dlp returned nothing or
  * degraded, which the shelf renders as a quiet empty state, never an error.
+ *
+ * The two-parameter generic ties `kind` to the item type so the TypeScript
+ * discriminant is enforced: a `LibraryShelf` cannot carry `kind: 'discover'`
+ * and vice-versa.
  */
-export interface RecommendationShelf<TItem> {
-  kind: RecommendationKind;
+export interface RecommendationShelf<TKind extends RecommendationKind, TItem> {
+  kind: TKind;
   items: TItem[];
   generatedAt: string | null;
   stale: boolean;
 }
 
-export type LibraryShelf = RecommendationShelf<LibraryRecommendation>;
-export type DiscoverShelf = RecommendationShelf<DiscoverRecommendation>;
+export type LibraryShelf = RecommendationShelf<'library', LibraryRecommendation>;
+export type DiscoverShelf = RecommendationShelf<'discover', DiscoverRecommendation>;
 
 /** Both shelves, as returned by the single read channel. */
 export interface RecommendationShelves {

--- a/packages/contracts/src/domain/recommendation.ts
+++ b/packages/contracts/src/domain/recommendation.ts
@@ -1,0 +1,60 @@
+// Recommendation contracts shared between the desktop main process (affinity
+// query + yt-dlp RD-mix discovery) and the renderer. The renderer is read-only
+// over these — it consumes precomputed shelves from the cache and never
+// triggers scoring or yt-dlp itself.
+
+/** Shelf identifiers. One cache row + one renderer section per kind. */
+export type RecommendationKind = 'library' | 'discover';
+
+/**
+ * A track on the "Recommended from your library" shelf — an existing local
+ * track surfaced by affinity ranking. `trackId` is the local `tracks.id`, so
+ * the renderer plays it through the normal library queue.
+ */
+export interface LibraryRecommendation {
+  trackId: string;
+  title: string;
+  artist: string;
+  album: string;
+  albumArt: string | null;
+}
+
+/**
+ * A track on the "Discover new music" shelf — pulled from a YouTube RD mix and
+ * NOT in the local library. `youtubeId` is the video id; the renderer routes a
+ * click through the existing search/download flow (yt-dlp), so no new playback
+ * path is needed.
+ */
+export interface DiscoverRecommendation {
+  youtubeId: string;
+  title: string;
+  uploader: string;
+  thumbnail: string;
+  /** Watch URL, for the download/import path. */
+  url: string;
+}
+
+/**
+ * One shelf's cached result. `generatedAt` is the ISO instant it was produced;
+ * `stale` is computed at read time (older than the 24h TTL). An empty `items`
+ * array is a valid result — for `discover` it means yt-dlp returned nothing or
+ * degraded, which the shelf renders as a quiet empty state, never an error.
+ */
+export interface RecommendationShelf<TItem> {
+  kind: RecommendationKind;
+  items: TItem[];
+  generatedAt: string | null;
+  stale: boolean;
+}
+
+export type LibraryShelf = RecommendationShelf<LibraryRecommendation>;
+export type DiscoverShelf = RecommendationShelf<DiscoverRecommendation>;
+
+/** Both shelves, as returned by the single read channel. */
+export interface RecommendationShelves {
+  library: LibraryShelf;
+  discover: DiscoverShelf;
+}
+
+/** Time-to-live for a cached shelf before it is considered stale (24 hours). */
+export const RECOMMENDATION_TTL_MS = 24 * 60 * 60 * 1000;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3,6 +3,7 @@
 export * from './domain/track';
 export * from './domain/media';
 export * from './domain/weather';
+export * from './domain/recommendation';
 export * from './ipc/channels';
 export * from './ipc/debug';
 export * from './ipc/metadata';

--- a/packages/contracts/src/ipc/channels.ts
+++ b/packages/contracts/src/ipc/channels.ts
@@ -153,6 +153,13 @@ export const IPC_CHANNELS = {
     enrichCancel: 'metadata:enrich:cancel',
     enrichProgress: 'metadata:enrich:progress',
   },
+  recommendations: {
+    // Renderer-facing reads. `get` returns both shelves from the cache;
+    // `refresh` runs the background job (affinity + yt-dlp RD-mix) and returns
+    // the freshly-cached shelves. The renderer never spawns yt-dlp itself.
+    get: 'recommendations:get',
+    refresh: 'recommendations:refresh',
+  },
   share: {
     track: 'share:track',
     playlist: 'share:playlist',

--- a/packages/database/src/client.test.ts
+++ b/packages/database/src/client.test.ts
@@ -36,6 +36,9 @@ describe('database client', () => {
     const names = tables.map(t => t.name);
     expect(names).toContain('tracks');
     expect(names).toContain('play_history');
+    // The recommendation cache table is created by the runtime DDL, not only
+    // declared in the drizzle schema — assert it actually exists at runtime.
+    expect(names).toContain('recommendations');
 
     closeDatabase();
 

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -161,6 +161,17 @@ function createTables(database: Database.Database): void {
     )
   `);
 
+  // Recommendation cache table — one row per shelf kind, holding a JSON
+  // payload + the instant it was generated. The 24h TTL is enforced at read
+  // time against generated_at, not in SQL. See schema/recommendations.ts.
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS recommendations (
+      kind TEXT PRIMARY KEY,
+      payload TEXT NOT NULL,
+      generated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+
   // Create indexes for common queries
   database.exec(`
     CREATE INDEX IF NOT EXISTS idx_tracks_file_path ON tracks(file_path);

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -6,28 +6,18 @@ export { tracks, type Track, type NewTrack } from './tracks.js';
 
 export { playlists, type Playlist, type NewPlaylist } from './playlists.js';
 
-export {
-  playlistTracks,
-  type PlaylistTrack,
-  type NewPlaylistTrack,
-} from './playlist-tracks.js';
+export { playlistTracks, type PlaylistTrack, type NewPlaylistTrack } from './playlist-tracks.js';
 
 export { folders, type Folder, type NewFolder } from './folders.js';
 
-export {
-  radioFavorites,
-  type RadioFavorite,
-  type NewRadioFavorite,
-} from './radio-favorites.js';
+export { radioFavorites, type RadioFavorite, type NewRadioFavorite } from './radio-favorites.js';
 
-export {
-  playHistory,
-  type PlayHistory,
-  type NewPlayHistory,
-} from './play-history.js';
+export { playHistory, type PlayHistory, type NewPlayHistory } from './play-history.js';
 
 export {
   youtubeMappings,
   type YoutubeMapping,
   type NewYoutubeMapping,
 } from './youtube-mappings.js';
+
+export { recommendations, type Recommendation, type NewRecommendation } from './recommendations.js';

--- a/packages/database/src/schema/recommendations.ts
+++ b/packages/database/src/schema/recommendations.ts
@@ -1,0 +1,30 @@
+/**
+ * Recommendation cache table schema.
+ *
+ * A single row per shelf `kind` (e.g. 'library' | 'discover') holds that
+ * shelf's fully-resolved payload as a JSON string, plus the instant it was
+ * generated. Reads come from this cache; a background job refreshes it. The
+ * 24h TTL is enforced at read time against `generatedAt` (see the desktop
+ * recommendation service), not by a DB trigger — keeping the table dumb.
+ *
+ * The yt-dlp discover shelf is best-effort and can be empty; an empty payload
+ * is a valid, cacheable result (it just means "nothing discovered / yt-dlp
+ * degraded"), so emptiness is never treated as a cache miss.
+ */
+
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { sql } from 'drizzle-orm';
+
+export const recommendations = sqliteTable('recommendations', {
+  /** Shelf identifier — one cache row per kind. */
+  kind: text('kind').primaryKey(),
+  /** Resolved shelf payload, JSON-serialized (array of recommended items). */
+  payload: text('payload').notNull(),
+  /** ISO-8601 instant the payload was generated; drives the read-time TTL. */
+  generatedAt: text('generated_at')
+    .notNull()
+    .default(sql`(datetime('now'))`),
+});
+
+export type Recommendation = typeof recommendations.$inferSelect;
+export type NewRecommendation = typeof recommendations.$inferInsert;

--- a/packages/recommendation/package.json
+++ b/packages/recommendation/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@shiranami/recommendation",
+  "version": "0.19.0",
+  "private": true,
+  "description": "Shiranami recommendation scoring core: pure, dependency-free affinity + content-similarity functions",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --build --clean && tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --project recommendation"
+  },
+  "devDependencies": {
+    "@types/node": "^25.8.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/recommendation/src/affinity.test.ts
+++ b/packages/recommendation/src/affinity.test.ts
@@ -99,22 +99,22 @@ describe('rankByAffinity', () => {
   });
 
   it('breaks ties by most-recent play', () => {
-    // Same plays + completion, decayed to the same score by equal age would tie;
-    // give them identical age via same timestamp and differ only by recency.
+    // Freeze decay (infinite half-life) so both tracks score identically despite
+    // different ages — the recency tie-break on lastPlayedMs then decides order.
     const ranked = rankByAffinity(
       [
-        stats({ trackId: 'older', lastPlayedAt: daysAgo(5) }),
+        stats({ trackId: 'older', lastPlayedAt: daysAgo(6) }),
         stats({ trackId: 'newer', lastPlayedAt: daysAgo(5) }),
       ],
-      { now: NOW }
+      { now: NOW, halfLifeDays: Number.POSITIVE_INFINITY }
     );
-    // Equal scores: stable order preserved (older first as input order).
-    expect(ranked).toHaveLength(2);
+    expect(ranked.map(t => t.trackId)).toEqual(['newer', 'older']);
   });
 
   it('does not leak the internal lastPlayedAt field', () => {
     const ranked = rankByAffinity([stats()], { now: NOW });
     expect(ranked[0]).not.toHaveProperty('lastPlayedAt');
+    expect(ranked[0]).not.toHaveProperty('lastPlayedMs');
     expect(Object.keys(ranked[0]).sort()).toEqual(
       ['album', 'artist', 'score', 'title', 'trackId'].sort()
     );

--- a/packages/recommendation/src/affinity.test.ts
+++ b/packages/recommendation/src/affinity.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { affinityScore, rankByAffinity, selectSeedTracks } from './affinity.js';
+import type { TrackStats } from './types.js';
+
+const NOW = Date.parse('2026-05-23T12:00:00.000Z');
+
+function daysAgo(days: number): string {
+  return new Date(NOW - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function stats(overrides: Partial<TrackStats> = {}): TrackStats {
+  return {
+    trackId: 't1',
+    title: 'Track One',
+    artist: 'Artist',
+    album: 'Album',
+    plays: 10,
+    avgCompletion: 1,
+    lastPlayedAt: daysAgo(0),
+    isFavorite: false,
+    ...overrides,
+  };
+}
+
+describe('affinityScore', () => {
+  it('returns 0 for a track with no plays', () => {
+    expect(affinityScore(stats({ plays: 0 }), { now: NOW })).toBe(0);
+  });
+
+  it('returns 0 for an unparseable lastPlayedAt', () => {
+    expect(affinityScore(stats({ lastPlayedAt: 'not-a-date' }), { now: NOW })).toBe(0);
+  });
+
+  it('equals plays × completion when played just now (recency ≈ 1)', () => {
+    const score = affinityScore(stats({ plays: 8, avgCompletion: 0.5 }), { now: NOW });
+    expect(score).toBeCloseTo(8 * 0.5 * 1, 5);
+  });
+
+  it('halves the score after one half-life', () => {
+    const fresh = affinityScore(stats({ lastPlayedAt: daysAgo(0) }), {
+      now: NOW,
+      halfLifeDays: 14,
+    });
+    const aged = affinityScore(stats({ lastPlayedAt: daysAgo(14) }), {
+      now: NOW,
+      halfLifeDays: 14,
+    });
+    expect(aged).toBeCloseTo(fresh / 2, 5);
+  });
+
+  it('applies the favorite boost multiplicatively', () => {
+    const plain = affinityScore(stats({ isFavorite: false }), { now: NOW, favoriteBoost: 0.5 });
+    const fav = affinityScore(stats({ isFavorite: true }), { now: NOW, favoriteBoost: 0.5 });
+    expect(fav).toBeCloseTo(plain * 1.5, 5);
+  });
+
+  it('clamps completion above 1 and below 0', () => {
+    const over = affinityScore(stats({ avgCompletion: 5 }), { now: NOW });
+    const exact = affinityScore(stats({ avgCompletion: 1 }), { now: NOW });
+    expect(over).toBeCloseTo(exact, 5);
+    expect(affinityScore(stats({ avgCompletion: -3 }), { now: NOW })).toBe(0);
+  });
+
+  it('treats a future timestamp as age 0 (no amplification)', () => {
+    const future = affinityScore(stats({ lastPlayedAt: daysAgo(-10) }), { now: NOW });
+    const present = affinityScore(stats({ lastPlayedAt: daysAgo(0) }), { now: NOW });
+    expect(future).toBeCloseTo(present, 5);
+  });
+
+  it('uses the default half-life when given an invalid one', () => {
+    const withZero = affinityScore(stats({ lastPlayedAt: daysAgo(14) }), {
+      now: NOW,
+      halfLifeDays: 0,
+    });
+    const withDefault = affinityScore(stats({ lastPlayedAt: daysAgo(14) }), { now: NOW });
+    expect(withZero).toBeCloseTo(withDefault, 5);
+  });
+});
+
+describe('rankByAffinity', () => {
+  it('ranks higher-affinity tracks first', () => {
+    const ranked = rankByAffinity(
+      [
+        stats({ trackId: 'low', plays: 1, lastPlayedAt: daysAgo(30) }),
+        stats({ trackId: 'high', plays: 50, lastPlayedAt: daysAgo(0) }),
+        stats({ trackId: 'mid', plays: 10, lastPlayedAt: daysAgo(7) }),
+      ],
+      { now: NOW }
+    );
+    expect(ranked.map(t => t.trackId)).toEqual(['high', 'mid', 'low']);
+  });
+
+  it('drops tracks that score 0', () => {
+    const ranked = rankByAffinity(
+      [stats({ trackId: 'keep' }), stats({ trackId: 'drop', plays: 0 })],
+      { now: NOW }
+    );
+    expect(ranked.map(t => t.trackId)).toEqual(['keep']);
+  });
+
+  it('breaks ties by most-recent play', () => {
+    // Same plays + completion, decayed to the same score by equal age would tie;
+    // give them identical age via same timestamp and differ only by recency.
+    const ranked = rankByAffinity(
+      [
+        stats({ trackId: 'older', lastPlayedAt: daysAgo(5) }),
+        stats({ trackId: 'newer', lastPlayedAt: daysAgo(5) }),
+      ],
+      { now: NOW }
+    );
+    // Equal scores: stable order preserved (older first as input order).
+    expect(ranked).toHaveLength(2);
+  });
+
+  it('does not leak the internal lastPlayedAt field', () => {
+    const ranked = rankByAffinity([stats()], { now: NOW });
+    expect(ranked[0]).not.toHaveProperty('lastPlayedAt');
+    expect(Object.keys(ranked[0]).sort()).toEqual(
+      ['album', 'artist', 'score', 'title', 'trackId'].sort()
+    );
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(rankByAffinity([], { now: NOW })).toEqual([]);
+  });
+});
+
+describe('selectSeedTracks', () => {
+  const pool = [
+    stats({ trackId: 'a', plays: 100, lastPlayedAt: daysAgo(0) }),
+    stats({ trackId: 'b', plays: 50, lastPlayedAt: daysAgo(1) }),
+    stats({ trackId: 'c', plays: 10, lastPlayedAt: daysAgo(2) }),
+  ];
+
+  it('returns the top-N seeds', () => {
+    expect(selectSeedTracks(pool, 2, { now: NOW }).map(t => t.trackId)).toEqual(['a', 'b']);
+  });
+
+  it('returns [] when count <= 0', () => {
+    expect(selectSeedTracks(pool, 0, { now: NOW })).toEqual([]);
+    expect(selectSeedTracks(pool, -1, { now: NOW })).toEqual([]);
+  });
+
+  it('returns all available seeds when count exceeds the pool', () => {
+    expect(selectSeedTracks(pool, 99, { now: NOW })).toHaveLength(3);
+  });
+});

--- a/packages/recommendation/src/affinity.ts
+++ b/packages/recommendation/src/affinity.ts
@@ -68,11 +68,11 @@ export function rankByAffinity(
       artist: track.artist,
       album: track.album,
       score: affinityScore(track, options),
-      lastPlayedAt: track.lastPlayedAt,
+      lastPlayedMs: Date.parse(track.lastPlayedAt),
     }))
     .filter(scored => scored.score > 0)
-    .sort((a, b) => b.score - a.score || Date.parse(b.lastPlayedAt) - Date.parse(a.lastPlayedAt))
-    .map(({ lastPlayedAt: _lastPlayedAt, ...scored }) => scored);
+    .sort((a, b) => b.score - a.score || b.lastPlayedMs - a.lastPlayedMs)
+    .map(({ lastPlayedMs: _lastPlayedMs, ...scored }) => scored);
 }
 
 /**

--- a/packages/recommendation/src/affinity.ts
+++ b/packages/recommendation/src/affinity.ts
@@ -1,0 +1,96 @@
+/**
+ * Listening-affinity scoring. Ranks tracks the user already plays by how much
+ * they seem to love them, so the desktop adapter can pick the strongest seeds
+ * for a "more of what you play" shelf and for yt-dlp RD-mix discovery.
+ *
+ * The formula mirrors the data-lens query 5a but lives here in pure TS so it is
+ * unit-testable and shareable: a recency-decayed, completion-weighted play
+ * count, lifted by a favorite boost. There is no negative/skip signal in the
+ * schema today, so this only ranks positives — see the data-lens G1 note.
+ */
+
+import type { AffinityOptions, ScoredTrack, TrackStats } from './types.js';
+
+const DEFAULT_HALF_LIFE_DAYS = 14;
+const DEFAULT_FAVORITE_BOOST = 0.5;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Compute the affinity score for a single track's stats.
+ *
+ * `frequency × avgCompletion` is the base engagement, decayed by how long ago
+ * the track was last played (exponential half-life), then lifted by the
+ * favorite boost. Completion acts as a quality gate — a track played many times
+ * but always abandoned early scores below one played fewer times to completion.
+ *
+ * Returns 0 for tracks with no plays, an unparseable `lastPlayedAt`, or a
+ * future timestamp clamped to "now" (no negative ages).
+ */
+export function affinityScore(stats: TrackStats, options: AffinityOptions = {}): number {
+  const halfLifeDays =
+    options.halfLifeDays && options.halfLifeDays > 0
+      ? options.halfLifeDays
+      : DEFAULT_HALF_LIFE_DAYS;
+  const favoriteBoost = options.favoriteBoost ?? DEFAULT_FAVORITE_BOOST;
+  const now = options.now ?? Date.now();
+
+  if (stats.plays <= 0) return 0;
+
+  const lastPlayedMs = Date.parse(stats.lastPlayedAt);
+  if (Number.isNaN(lastPlayedMs)) return 0;
+
+  // Clamp completion into [0, 1] so a malformed row can't inflate the score,
+  // and clamp age at 0 so a clock-skewed future timestamp doesn't amplify it.
+  const completion = clamp01(stats.avgCompletion);
+  const ageDays = Math.max(0, (now - lastPlayedMs) / MS_PER_DAY);
+  const recency = Math.pow(0.5, ageDays / halfLifeDays);
+
+  const base = stats.plays * completion * recency;
+  const boost = stats.isFavorite ? 1 + favoriteBoost : 1;
+
+  return base * boost;
+}
+
+/**
+ * Score every track and return them ranked by affinity, highest first. Ties
+ * break on more recent `lastPlayedAt` (matches the Overview top-tracks
+ * tie-break: `ORDER BY COUNT(*) DESC, MAX(played_at) DESC`). Tracks scoring 0
+ * are dropped so seed selection never picks a never-engaged track.
+ */
+export function rankByAffinity(
+  stats: readonly TrackStats[],
+  options: AffinityOptions = {}
+): ScoredTrack[] {
+  return stats
+    .map(track => ({
+      trackId: track.trackId,
+      title: track.title,
+      artist: track.artist,
+      album: track.album,
+      score: affinityScore(track, options),
+      lastPlayedAt: track.lastPlayedAt,
+    }))
+    .filter(scored => scored.score > 0)
+    .sort((a, b) => b.score - a.score || Date.parse(b.lastPlayedAt) - Date.parse(a.lastPlayedAt))
+    .map(({ lastPlayedAt: _lastPlayedAt, ...scored }) => scored);
+}
+
+/**
+ * Convenience wrapper: the top-N seed tracks by affinity. The desktop adapter
+ * resolves these to `youtube_mappings.youtubeId` for RD-mix discovery.
+ */
+export function selectSeedTracks(
+  stats: readonly TrackStats[],
+  count: number,
+  options: AffinityOptions = {}
+): ScoredTrack[] {
+  if (count <= 0) return [];
+  return rankByAffinity(stats, options).slice(0, count);
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}

--- a/packages/recommendation/src/index.ts
+++ b/packages/recommendation/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @shiranami/recommendation
+ *
+ * Pure scoring core for the recommendation engine. No DB, no yt-dlp, no IPC,
+ * no Electron — just typed functions that turn listening signals into ranked
+ * tracks. Platform adapters (desktop main, later mobile) project their storage
+ * into these shapes and consume the ranked output.
+ */
+
+export * from './types.js';
+export { affinityScore, rankByAffinity, selectSeedTracks } from './affinity.js';
+export { similarityScore, rankBySimilarity } from './similarity.js';

--- a/packages/recommendation/src/similarity.test.ts
+++ b/packages/recommendation/src/similarity.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { similarityScore, rankBySimilarity } from './similarity.js';
+import type { SimilarityTrack } from './types.js';
+
+const seed: SimilarityTrack = { trackId: 'seed', artist: 'Nujabes', album: 'Modal Soul' };
+
+function candidate(overrides: Partial<SimilarityTrack> = {}): SimilarityTrack {
+  return { trackId: 'c', artist: 'Other', album: 'Other Album', ...overrides };
+}
+
+describe('similarityScore', () => {
+  it('returns 0 for the seed itself', () => {
+    expect(similarityScore(seed, { ...seed }, 0)).toBe(0);
+  });
+
+  it('scores a shared artist', () => {
+    expect(similarityScore(seed, candidate({ artist: 'Nujabes' }), 0)).toBe(3);
+  });
+
+  it('scores a shared album', () => {
+    expect(similarityScore(seed, candidate({ album: 'Modal Soul' }), 0)).toBe(2);
+  });
+
+  it('sums shared artist + album', () => {
+    expect(similarityScore(seed, candidate({ artist: 'Nujabes', album: 'Modal Soul' }), 0)).toBe(5);
+  });
+
+  it('adds per-shared-playlist points', () => {
+    expect(similarityScore(seed, candidate(), 3)).toBe(3);
+  });
+
+  it('does NOT match on the Unknown Artist sentinel', () => {
+    const unknownSeed: SimilarityTrack = {
+      trackId: 'u',
+      artist: 'Unknown Artist',
+      album: 'Modal Soul',
+    };
+    const cand = candidate({ artist: 'Unknown Artist', album: 'Other Album' });
+    // artist match suppressed; only real signals count → 0 here
+    expect(similarityScore(unknownSeed, cand, 0)).toBe(0);
+  });
+
+  it('does NOT match on the Unknown Album sentinel', () => {
+    const unknownSeed: SimilarityTrack = {
+      trackId: 'u',
+      artist: 'Nujabes',
+      album: 'Unknown Album',
+    };
+    const cand = candidate({ artist: 'Other', album: 'Unknown Album' });
+    expect(similarityScore(unknownSeed, cand, 0)).toBe(0);
+  });
+
+  it('does NOT match on empty artist/album', () => {
+    const emptySeed: SimilarityTrack = { trackId: 'e', artist: '', album: '' };
+    expect(similarityScore(emptySeed, candidate({ artist: '', album: '' }), 0)).toBe(0);
+  });
+
+  it('respects custom weights', () => {
+    const score = similarityScore(seed, candidate({ artist: 'Nujabes' }), 2, {
+      sameArtist: 10,
+      perSharedPlaylist: 5,
+    });
+    expect(score).toBe(10 + 2 * 5);
+  });
+});
+
+describe('rankBySimilarity', () => {
+  const pool: SimilarityTrack[] = [
+    { trackId: 'same-artist', artist: 'Nujabes', album: 'Spiritual State' },
+    { trackId: 'same-album', artist: 'Cise Starr', album: 'Modal Soul' },
+    { trackId: 'unrelated', artist: 'Random', album: 'Random Album' },
+    { trackId: 'seed', artist: 'Nujabes', album: 'Modal Soul' },
+  ];
+
+  it('ranks by similarity and drops zero-overlap + the seed', () => {
+    const ranked = rankBySimilarity(seed, pool);
+    expect(ranked.map(t => t.trackId)).toEqual(['same-artist', 'same-album']);
+  });
+
+  it('folds in shared-playlist counts', () => {
+    const ranked = rankBySimilarity(seed, pool, { unrelated: 4 });
+    // unrelated now scores 4 (4 shared playlists), above same-artist (3)
+    expect(ranked[0].trackId).toBe('unrelated');
+  });
+
+  it('returns [] when nothing overlaps', () => {
+    expect(rankBySimilarity(seed, [{ trackId: 'x', artist: 'A', album: 'B' }])).toEqual([]);
+  });
+});

--- a/packages/recommendation/src/similarity.ts
+++ b/packages/recommendation/src/similarity.ts
@@ -1,0 +1,90 @@
+/**
+ * Content-based similarity. Given a seed track and a candidate pool, scores
+ * each candidate by content overlap with the seed: shared artist, shared album,
+ * and shared playlist membership.
+ *
+ * Genre is intentionally NOT a signal — it is a single sentinel-defaulted
+ * string in this schema and too sparse to drive recommendations (data-lens
+ * §1, research §10.2). Artist/album co-membership and playlist co-membership
+ * are the reliable axes. Sentinel values (`Unknown Artist` / `Unknown Album`)
+ * are guarded so untagged tracks never falsely match each other.
+ */
+
+import {
+  UNKNOWN_ALBUM,
+  UNKNOWN_ARTIST,
+  type SharedPlaylistCounts,
+  type SimilarityTrack,
+  type SimilarityWeights,
+  type SimilarTrack,
+} from './types.js';
+
+const DEFAULT_WEIGHTS: Required<SimilarityWeights> = {
+  sameArtist: 3,
+  sameAlbum: 2,
+  perSharedPlaylist: 1,
+};
+
+/**
+ * Score one candidate against the seed. `sharedPlaylists` is the number of
+ * playlists the candidate shares with the seed (0 when none / unknown).
+ * Returns 0 for the seed itself and for candidates with no overlap.
+ */
+export function similarityScore(
+  seed: SimilarityTrack,
+  candidate: SimilarityTrack,
+  sharedPlaylists: number,
+  weights: SimilarityWeights = {}
+): number {
+  if (candidate.trackId === seed.trackId) return 0;
+
+  const w = { ...DEFAULT_WEIGHTS, ...weights };
+  let score = 0;
+
+  if (isRealArtist(seed.artist) && candidate.artist === seed.artist) {
+    score += w.sameArtist;
+  }
+  if (isRealAlbum(seed.album) && candidate.album === seed.album) {
+    score += w.sameAlbum;
+  }
+  if (sharedPlaylists > 0) {
+    score += sharedPlaylists * w.perSharedPlaylist;
+  }
+
+  return score;
+}
+
+/**
+ * Rank a candidate pool by content similarity to the seed, highest first.
+ * Candidates scoring 0 (no overlap, or the seed itself) are dropped. Ties keep
+ * input order, which is stable in V8's sort.
+ */
+export function rankBySimilarity(
+  seed: SimilarityTrack,
+  candidates: readonly SimilarityTrack[],
+  sharedPlaylists: SharedPlaylistCounts = {},
+  weights: SimilarityWeights = {}
+): SimilarTrack[] {
+  return candidates
+    .map(candidate => ({
+      trackId: candidate.trackId,
+      artist: candidate.artist,
+      album: candidate.album,
+      similarity: similarityScore(
+        seed,
+        candidate,
+        sharedPlaylists[candidate.trackId] ?? 0,
+        weights
+      ),
+    }))
+    .filter(scored => scored.similarity > 0)
+    .sort((a, b) => b.similarity - a.similarity);
+}
+
+function isRealArtist(artist: string): boolean {
+  return artist.length > 0 && artist !== UNKNOWN_ARTIST;
+}
+
+function isRealAlbum(album: string): boolean {
+  return album.length > 0 && album !== UNKNOWN_ALBUM;
+}

--- a/packages/recommendation/src/types.ts
+++ b/packages/recommendation/src/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Input/output shapes for the pure recommendation scoring core.
+ *
+ * Everything here is plain data — no DB rows, no IPC, no yt-dlp. The desktop
+ * (and, later, mobile) adapters are responsible for projecting their own
+ * storage into these shapes and consuming the ranked output. Keeping the core
+ * data-only is what lets a single algorithm be shared across platforms that do
+ * not share a data layer.
+ */
+
+/**
+ * Per-track listening signal aggregated from `play_history` + `tracks`. One
+ * entry per track the user has actually played. `plays` / `avgCompletion` /
+ * `lastPlayedAt` come straight from the grouped affinity query; the content
+ * axes (`artist`/`album`) and `isFavorite` come from the joined `tracks` row.
+ */
+export interface TrackStats {
+  trackId: string;
+  /** Display title — passed through for the caller, not used in scoring. */
+  title: string;
+  artist: string;
+  album: string;
+  /** Total play_history rows for this track (frequency signal). */
+  plays: number;
+  /** Mean completion_ratio across those plays, 0..1 (engagement depth). */
+  avgCompletion: number;
+  /** ISO-8601 timestamp of the most recent play (recency signal). */
+  lastPlayedAt: string;
+  /** Explicit positive signal — boosts affinity when set. */
+  isFavorite: boolean;
+}
+
+/** A track scored and ranked by listening affinity. */
+export interface ScoredTrack {
+  trackId: string;
+  title: string;
+  artist: string;
+  album: string;
+  /** Composite affinity score; higher means a stronger seed candidate. */
+  score: number;
+}
+
+/** Knobs for the affinity score. Defaults match the data-lens query 5a. */
+export interface AffinityOptions {
+  /**
+   * Recency half-life in days. A play contributes `0.5^(ageDays/halfLife)` of
+   * its weight, so a 14-day half-life means a two-week-old play counts half as
+   * much as a fresh one. Must be > 0.
+   */
+  halfLifeDays?: number;
+  /** Multiplicative boost applied to favorited tracks (e.g. 0.5 → +50%). */
+  favoriteBoost?: number;
+  /**
+   * Reference instant for the recency decay. Defaults to `Date.now()`.
+   * Injectable so tests are deterministic and the caller can score against a
+   * fixed "as of" time.
+   */
+  now?: number;
+}
+
+/**
+ * Minimal track shape for content-based similarity. Includes the candidate's
+ * id plus the two reliable content axes (artist/album). Genre is deliberately
+ * excluded — it is sparse / single-valued in this schema (research §10.2).
+ */
+export interface SimilarityTrack {
+  trackId: string;
+  artist: string;
+  album: string;
+}
+
+/**
+ * Playlist co-membership counts for a seed: for each candidate track id, how
+ * many playlists it shares with the seed. The desktop adapter computes this
+ * with the join in data-lens query 5b; the core just folds it into the score.
+ */
+export type SharedPlaylistCounts = Readonly<Record<string, number>>;
+
+/** A candidate scored by content similarity to a seed track. */
+export interface SimilarTrack {
+  trackId: string;
+  artist: string;
+  album: string;
+  /** Similarity score; higher means more content overlap with the seed. */
+  similarity: number;
+}
+
+/** Weights for content-similarity signals. Defaults match data-lens query 5b. */
+export interface SimilarityWeights {
+  /** Points for a shared, non-sentinel artist. */
+  sameArtist?: number;
+  /** Points for a shared, non-sentinel album. */
+  sameAlbum?: number;
+  /** Points per shared playlist membership. */
+  perSharedPlaylist?: number;
+}
+
+/** Sentinel values the scanner writes for missing tags — never a real match. */
+export const UNKNOWN_ARTIST = 'Unknown Artist';
+export const UNKNOWN_ALBUM = 'Unknown Album';

--- a/packages/recommendation/tsconfig.json
+++ b/packages/recommendation/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/recommendation/vitest.config.ts
+++ b/packages/recommendation/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    name: 'recommendation',
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.d.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@shiranami/recommendation': resolve(root, './src/index.ts'),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,6 +491,15 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/recommendation:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.8.0
+        version: 25.9.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/shared:
     devDependencies:
       '@types/node':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '@shiranami/database':
         specifier: workspace:*
         version: link:../../packages/database
+      '@shiranami/recommendation':
+        specifier: workspace:*
+        version: link:../../packages/recommendation
       '@shiranami/shared':
         specifier: workspace:*
         version: link:../../packages/shared

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       'packages/shared/vitest.config.ts',
       'packages/database/vitest.config.ts',
       'packages/contracts/vitest.config.ts',
+      'packages/recommendation/vitest.config.ts',
       'apps/server/vitest.config.ts',
     ],
     coverage: {
@@ -18,6 +19,7 @@ export default defineConfig({
         'packages/shared/src/**/*.ts',
         'packages/database/src/**/*.ts',
         'packages/contracts/src/**/*.ts',
+        'packages/recommendation/src/**/*.ts',
         'apps/server/src/**/*.ts',
       ],
       exclude: [


### PR DESCRIPTION
## What this adds

A first version of a **music recommendation engine** for the desktop app, surfaced as a shelf on the Overview with two sections:

- **Recommended from your library** — re-ranks tracks you already own by a play-history affinity score (recency-decay × completion × frequency, with a favourite boost). Instant play. **Fully offline, zero new network calls.**
- **Discover new music** — pulls fresh tracks from YouTube **Mix/radio** (`RD<videoId>`) seeded from the tracks you listen to most, via yt-dlp.

## Why this design

Feasibility was researched across architecture, data, performance, and algorithm/external-API angles before any code. Headline decisions:

- **No YouTube Data API.** Its `relatedToVideoId` mechanism was removed in 2023, and a shared API key gives ~100 searches/day across *all* installs (BYOK is an onboarding non-starter for a local-first app). yt-dlp's `RD` Mix reaches the recommendation graph the official API can't even read — at zero quota and no API key (~1.6s/fetch).
- **Single-user / local-first** rules out classic collaborative filtering — the engine is a pure content + behavioural scorer.
- The scoring core is a **pure, dependency-free `packages/recommendation`** package (28 unit tests); platform glue lives in the desktop main process.

## What's included

**Engine & data**
- `packages/recommendation` — pure affinity + similarity scoring core (+ tests)
- `recommendations` cache table (per-shelf JSON payload, 24h TTL) — added to the drizzle schema **and** the runtime DDL in `client.ts`
- Desktop service: library affinity query + yt-dlp `RD`-mix discovery (bounded concurrency 4, dedupes against the library, **degrades to an empty shelf on any yt-dlp failure**), with a background refresh ~30s after startup
- `recommendations:get` / `:refresh` IPC namespace + preload bridge (renderer is read-only)

**UI**
- `useRecommendations` hook + `RecommendationsShelf` on the Overview, with a designed treatment for every state: populated, loading skeleton, quiet empty (when you have a library but no picks yet), stale + refresh, and a discover download state machine (idle → downloading → in-library → retry)
- Quiet library-vs-discover differentiation (structure, not colour), `motion-safe` micro-interactions honouring reduced-motion, keyboard + ARIA throughout
- 13 new i18n keys in **en + pl**

## Non-obvious choices

- **Discover playback is download-then-play** (search → download → import), because the player only plays local tracks. A future pass could add stream-preview-before-download.
- Cards intentionally omit **duration** — there's no duration field on the recommendation contracts; adding it is main-process work, out of scope here.

## Verification

- `pnpm typecheck` + `pnpm lint` clean across all packages
- Full suite green: **1458 passed / 1 skipped** (115 files, incl. 28 new core tests)
- yt-dlp `RD`-mix verified manually (`watch?v=<id>&list=RD<id>` returns a curated mix; bare `playlist?list=RD...` is "unviewable", which is why the watch-URL form + degrade guard are used)
- en/pl locale key parity confirmed (20/20)

## Out of scope / follow-ups

- **Skip / sub-threshold capture** in `play_history` — today only positive plays are recorded, so the affinity core has no negative signal. This is the biggest future quality lever.
- **Mobile** adapter + a server `/api/youtube/related` endpoint (v2).
- Live CDP visual verification of the timing-dependent stale + download-progress states.

## Test plan

1. Play a few tracks so `play_history` has data → open Overview → "Recommended from your library" populates.
2. With at least one `youtube_mappings` entry, let the background refresh run (or hit Refresh) → "Discover new music" populates from a Mix.
3. Download a discover card → button transitions to in-library; track is importable/playable.
4. Toggle OS reduced-motion → animations are suppressed.