### PR TITLE
chore(audit): harden security, contracts, concurrency, a11y and observability

### DIFF
--- a/apps/desktop/src/main/discord-rpc.ts
+++ b/apps/desktop/src/main/discord-rpc.ts
@@ -198,8 +198,12 @@ async function doConnect(): Promise<void> {
 
   try {
     await client.login();
-  } catch {
-    logger.debug('[discord-rpc] Discord not available, scheduling reconnect');
+  } catch (err) {
+    // Keep the error: "Discord not running" and a real auth/handshake failure
+    // (bad client id, protocol error) are otherwise indistinguishable, and at
+    // the default info level the failure was completely invisible. Exponential
+    // backoff in scheduleReconnect caps the frequency, so warn is not spammy.
+    logger.warn('[discord-rpc] login failed, scheduling reconnect:', err);
     isConnected = false;
     scheduleReconnect();
   }

--- a/apps/desktop/src/main/ipc/database.integration.test.ts
+++ b/apps/desktop/src/main/ipc/database.integration.test.ts
@@ -128,6 +128,49 @@ describe('database ipc (integration)', () => {
     expect(summary.topArtists.some(a => a.artist === 'Unknown Artist')).toBe(true);
   });
 
+  it('db:tracks:add is idempotent on file_path (concurrent-import safety)', async () => {
+    const addTrack = ipcHandlers.get('db:tracks:add')!;
+    const filePath = '/music/dupe-guard.mp3';
+    const first = (await addTrack(null as never, {
+      filePath,
+      title: 'First',
+      artist: 'A',
+      album: 'B',
+      duration: 100,
+    })) as { id: string };
+
+    // A racing import calls add() for the same file (exists()->add() is not
+    // atomic across two IPC calls). The UNIQUE(file_path) constraint must make
+    // this a no-op that returns the existing row, not a thrown constraint error.
+    const second = (await addTrack(null as never, {
+      filePath,
+      title: 'Second',
+      artist: 'C',
+      album: 'D',
+      duration: 200,
+    })) as { id: string };
+    expect(second.id).toBe(first.id);
+
+    const getAll = ipcHandlers.get('db:tracks:get-all')!;
+    const all = (await getAll(null as never)) as Array<{ filePath: string }>;
+    expect(all.filter(t => t.filePath === filePath)).toHaveLength(1);
+  });
+
+  it('db:playlists:add-track is idempotent on (playlist, track)', async () => {
+    const track = await insertTrack();
+    const createPlaylist = ipcHandlers.get('db:playlists:create')!;
+    const playlist = (await createPlaylist(null as never, { name: 'Dedupe' })) as { id: string };
+
+    const addTrack = ipcHandlers.get('db:playlists:add-track')!;
+    await addTrack(null as never, { playlistId: playlist.id, trackId: track.id });
+    // Second add of the same track must not duplicate the row or throw.
+    await addTrack(null as never, { playlistId: playlist.id, trackId: track.id });
+
+    const getTracks = ipcHandlers.get('db:playlists:get-tracks')!;
+    const inPlaylist = (await getTracks(null as never, playlist.id)) as unknown[];
+    expect(inPlaylist).toHaveLength(1);
+  });
+
   /* ------------------------------------------------------------------ */
   /*  History aggregations: hourly activity + weekly insights            */
   /* ------------------------------------------------------------------ */

--- a/apps/desktop/src/main/ipc/database.integration.test.ts
+++ b/apps/desktop/src/main/ipc/database.integration.test.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path';
 import * as crypto from 'node:crypto';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { closeDatabase, initializeDatabase, getDatabase } from '@shiranami/database/client';
-import { playHistory } from '@shiranami/database';
+import { playHistory, tracks } from '@shiranami/database';
 import { ipcHandlers, makeTempDir, cleanupTempDir } from '../../../test/setup';
 import { cleanupDatabaseHandlers, registerDatabaseHandlers } from './database';
 
@@ -80,6 +80,52 @@ describe('database ipc (integration)', () => {
     const activity = (await getActivity(null as never, {})) as Array<{ playCount: number }>;
     expect(activity.length).toBeGreaterThanOrEqual(1);
     expect(activity.some(a => a.playCount >= 1)).toBe(true);
+  });
+
+  it('coalesces NULL artist/album to Unknown sentinels in get-recent and get-summary', async () => {
+    // Insert a track with NULL artist/album directly (simulating an untagged
+    // scan or a row predating backfill). The wire types declare these non-null,
+    // so the handler must collapse them or the UI renders the literal "null".
+    const db = getDatabase();
+    const trackId = crypto.randomUUID();
+    db.insert(tracks)
+      .values({
+        id: trackId,
+        filePath: `/music/${trackId}.mp3`,
+        title: 'Null Meta Track',
+        artist: null,
+        album: null,
+        duration: 120,
+      })
+      .run();
+
+    const recordPlay = ipcHandlers.get('db:history:record-play')!;
+    await recordPlay(null as never, {
+      trackId,
+      playedSeconds: 90,
+      duration: 120,
+      source: 'library',
+    });
+
+    const getRecent = ipcHandlers.get('db:history:get-recent')!;
+    const recent = (await getRecent(null as never, { limit: 10 })) as Array<{
+      trackId: string;
+      artist: string;
+      album: string;
+    }>;
+    const entry = recent.find(r => r.trackId === trackId)!;
+    expect(entry.artist).toBe('Unknown Artist');
+    expect(entry.album).toBe('Unknown Album');
+
+    const getSummary = ipcHandlers.get('db:history:get-summary')!;
+    const summary = (await getSummary(null as never, {})) as {
+      topTracks: Array<{ trackId: string; artist: string; album: string }>;
+      topArtists: Array<{ artist: string }>;
+    };
+    const topTrack = summary.topTracks.find(r => r.trackId === trackId)!;
+    expect(topTrack.artist).toBe('Unknown Artist');
+    expect(topTrack.album).toBe('Unknown Album');
+    expect(summary.topArtists.some(a => a.artist === 'Unknown Artist')).toBe(true);
   });
 
   /* ------------------------------------------------------------------ */

--- a/apps/desktop/src/main/ipc/database/history.ts
+++ b/apps/desktop/src/main/ipc/database/history.ts
@@ -16,6 +16,14 @@ import {
 /** A new session starts after this much idle time between consecutive plays. */
 const SESSION_GAP_MS = 30 * 60 * 1000;
 
+// The `tracks` table stores nullable artist/album, but the history wire types
+// (ListeningHistoryEntry / ListeningStatsTrack / ListeningStatsArtist) declare
+// them non-null and the renderer renders them directly. Collapse nulls to these
+// sentinels at the IPC boundary so the type is honest and the UI never shows a
+// literal "null". (The simplify pass folds these into a shared constant.)
+const UNKNOWN_ARTIST = 'Unknown Artist';
+const UNKNOWN_ALBUM = 'Unknown Album';
+
 const H = IPC_CHANNELS.db.history;
 
 function buildHistorySinceFilter(since?: string | null) {
@@ -101,7 +109,14 @@ export function registerHistoryHandlers(): void {
         .innerJoin(tracks, eq(playHistory.trackId, tracks.id))
         .orderBy(desc(playHistory.playedAt));
 
-      return (sinceFilter ? recentQuery.where(sinceFilter) : recentQuery).limit(safeLimit).all();
+      const rows = (sinceFilter ? recentQuery.where(sinceFilter) : recentQuery)
+        .limit(safeLimit)
+        .all();
+      return rows.map(row => ({
+        ...row,
+        artist: row.artist ?? UNKNOWN_ARTIST,
+        album: row.album ?? UNKNOWN_ALBUM,
+      }));
     },
     { schema: historyGetRecentArgs }
   );
@@ -141,7 +156,12 @@ export function registerHistoryHandlers(): void {
       const topTracks = (sinceFilter ? topTracksQuery.where(sinceFilter) : topTracksQuery)
         .orderBy(desc(sql`COUNT(*)`), desc(sql`MAX(${playHistory.playedAt})`))
         .limit(5)
-        .all();
+        .all()
+        .map(row => ({
+          ...row,
+          artist: row.artist ?? UNKNOWN_ARTIST,
+          album: row.album ?? UNKNOWN_ALBUM,
+        }));
 
       const topArtistsQuery = db
         .select({
@@ -155,7 +175,8 @@ export function registerHistoryHandlers(): void {
       const topArtists = (sinceFilter ? topArtistsQuery.where(sinceFilter) : topArtistsQuery)
         .orderBy(desc(sql`COUNT(*)`), desc(sql`COALESCE(SUM(${playHistory.playedSeconds}), 0)`))
         .limit(5)
-        .all();
+        .all()
+        .map(row => ({ ...row, artist: row.artist ?? UNKNOWN_ARTIST }));
 
       return {
         totalPlays: totals?.totalPlays ?? 0,

--- a/apps/desktop/src/main/ipc/database/playlists.ts
+++ b/apps/desktop/src/main/ipc/database/playlists.ts
@@ -111,37 +111,44 @@ export function registerPlaylistHandlers(): void {
     async (_event, data: { playlistId: string; trackId: string }) => {
       const db = getDatabase();
 
-      const existing = db
-        .select({ id: playlistTracks.id })
-        .from(playlistTracks)
-        .where(
-          and(
-            eq(playlistTracks.playlistId, data.playlistId),
-            eq(playlistTracks.trackId, data.trackId)
+      // Wrap the existence check + MAX(position) read + insert in a single
+      // transaction so the read-modify-write is atomic. The body is synchronous
+      // today (no interleave), but this guarantees two adds can't compute the
+      // same next position if an await is ever introduced, and pairs with the
+      // UNIQUE(playlist_id, track_id) constraint to keep membership idempotent.
+      return db.transaction(tx => {
+        const existing = tx
+          .select({ id: playlistTracks.id })
+          .from(playlistTracks)
+          .where(
+            and(
+              eq(playlistTracks.playlistId, data.playlistId),
+              eq(playlistTracks.trackId, data.trackId)
+            )
           )
-        )
-        .get();
+          .get();
 
-      if (existing) return existing;
+        if (existing) return existing;
 
-      const maxRow = db
-        .select({ maxPos: sql<number>`COALESCE(MAX(${playlistTracks.position}), -1)` })
-        .from(playlistTracks)
-        .where(eq(playlistTracks.playlistId, data.playlistId))
-        .get();
+        const maxRow = tx
+          .select({ maxPos: sql<number>`COALESCE(MAX(${playlistTracks.position}), -1)` })
+          .from(playlistTracks)
+          .where(eq(playlistTracks.playlistId, data.playlistId))
+          .get();
 
-      const nextPosition = (maxRow?.maxPos ?? -1) + 1;
+        const nextPosition = (maxRow?.maxPos ?? -1) + 1;
 
-      return db
-        .insert(playlistTracks)
-        .values({
-          id: crypto.randomUUID(),
-          playlistId: data.playlistId,
-          trackId: data.trackId,
-          position: nextPosition,
-        })
-        .returning()
-        .get();
+        return tx
+          .insert(playlistTracks)
+          .values({
+            id: crypto.randomUUID(),
+            playlistId: data.playlistId,
+            trackId: data.trackId,
+            position: nextPosition,
+          })
+          .returning()
+          .get();
+      });
     },
     { schema: playlistsAddTrackArgs }
   );

--- a/apps/desktop/src/main/ipc/database/tracks.ts
+++ b/apps/desktop/src/main/ipc/database/tracks.ts
@@ -39,7 +39,17 @@ export function registerTrackHandlers(): void {
       const db = getDatabase();
       const id = crypto.randomUUID();
       const row: NewTrack = { ...track, id };
-      return db.insert(tracks).values(row).returning().get();
+      // file_path is UNIQUE. A concurrent import of the same file (the renderer
+      // does a non-atomic exists()->add() across two IPC calls) would otherwise
+      // throw a constraint error on the loser. Make add idempotent: no-op the
+      // insert on conflict and return the existing row instead of throwing.
+      const inserted = db
+        .insert(tracks)
+        .values(row)
+        .onConflictDoNothing({ target: tracks.filePath })
+        .returning()
+        .get();
+      return inserted ?? db.select().from(tracks).where(eq(tracks.filePath, row.filePath)).get();
     },
     { schema: tracksAddArgs }
   );

--- a/apps/desktop/src/main/ipc/downloader.ts
+++ b/apps/desktop/src/main/ipc/downloader.ts
@@ -23,8 +23,10 @@ import { handle, handleWithFallback } from './with-ipc-handler';
 import { IpcError } from './errors';
 import { invalidate as invalidateFoldersCache } from '../shared/folders-cache';
 import { runYtDlpDownload, type DownloadProgress } from '../yt-dlp-download';
+import { isHttpUrl } from '../shared/url-safety';
 import {
   spawnYtDlp,
+  appendUrlArg,
   ytSearch,
   classifyYtDlpFailure,
   tailOutput,
@@ -323,6 +325,11 @@ export function registerDownloaderHandlers(): void {
     C.download,
     async (_event, opts: { url: string; outputDir?: string }) => {
       const { url, outputDir } = opts;
+      // Reject non-http(s) URLs up front: stops argument injection into yt-dlp
+      // (e.g. a `--exec=<cmd>` value from a tampered playlist/share payload).
+      if (!isHttpUrl(url)) {
+        throw new IpcError('downloader.invalid_url', 'Refusing to download a non-http(s) URL');
+      }
       const downloadDir = outputDir ?? getDownloadDir();
       fs.mkdirSync(downloadDir, { recursive: true });
 
@@ -338,14 +345,13 @@ export function registerDownloaderHandlers(): void {
   handle(
     C.getStreamUrl,
     async (_event, url: string) => {
+      if (!isHttpUrl(url)) {
+        throw new IpcError('downloader.invalid_url', 'Refusing to resolve a non-http(s) URL');
+      }
       logger.info(`[downloader] Getting stream URL for: ${url}`);
-      const { stdout, stderr, code } = await spawnYtDlp([
-        '-f',
-        'bestaudio',
-        '--get-url',
-        '--no-warnings',
-        url,
-      ]);
+      const { stdout, stderr, code } = await spawnYtDlp(
+        appendUrlArg(['-f', 'bestaudio', '--get-url', '--no-warnings'], url)
+      );
 
       if (code !== 0) {
         const reason = classifyYtDlpFailure(`${stderr}\n${stdout}`);

--- a/apps/desktop/src/main/ipc/errors.ts
+++ b/apps/desktop/src/main/ipc/errors.ts
@@ -14,9 +14,7 @@ export class IpcError extends Error {
  * Structural check for IpcError on the renderer side.
  * Electron strips the prototype across IPC; instanceof won't work renderer-side.
  */
-export function isIpcError(
-  e: unknown,
-): e is { code: string; message: string; details?: unknown } {
+export function isIpcError(e: unknown): e is { code: string; message: string; details?: unknown } {
   return (
     typeof e === 'object' &&
     e !== null &&
@@ -31,6 +29,7 @@ export const SHARE_ERROR_CODES = {
   PLAYLIST_NOT_FOUND: 'share.playlist_not_found',
   PLAYLIST_EMPTY: 'share.playlist_empty',
   NO_MATCHES_FOR_ANY_TRACK: 'share.no_matches_for_any_track',
+  INVALID_RESPONSE: 'share.invalid_response',
 } as const;
 
 export const PLAYLIST_ERROR_CODES = {

--- a/apps/desktop/src/main/ipc/playlist.ts
+++ b/apps/desktop/src/main/ipc/playlist.ts
@@ -4,7 +4,13 @@ import { logger } from '../logger';
 import { handle } from './with-ipc-handler';
 import { IpcError, PLAYLIST_ERROR_CODES } from './errors';
 import { playlistExtractArgs, playlistCancelArgs } from './schemas/playlist';
-import { spawnYtDlp, parseYtDlpJsonLines, ytSearch, type SearchResult } from '../utils/ytdlp-spawn';
+import {
+  spawnYtDlp,
+  appendUrlArg,
+  parseYtDlpJsonLines,
+  ytSearch,
+  type SearchResult,
+} from '../utils/ytdlp-spawn';
 import { sendToRenderer } from '../utils/window';
 import { BROWSER_USER_AGENT } from '../shared/user-agent';
 import { pickBestMatch, type SpotifyTrack } from '../utils/spotify-match';
@@ -70,12 +76,9 @@ export function extractSpotifyPlaylistId(url: string): string | null {
 async function extractYouTubePlaylist(url: string): Promise<SearchResult[]> {
   logger.info(`[playlist] Extracting YouTube playlist: ${url}`);
 
-  const { stdout, code } = await spawnYtDlp([
-    '--flat-playlist',
-    '--dump-json',
-    '--no-warnings',
-    url,
-  ]);
+  const { stdout, code } = await spawnYtDlp(
+    appendUrlArg(['--flat-playlist', '--dump-json', '--no-warnings'], url)
+  );
 
   if (code !== 0) {
     throw new IpcError(PLAYLIST_ERROR_CODES.NO_TRACKS, 'yt-dlp failed to extract playlist');

--- a/apps/desktop/src/main/ipc/share.test.ts
+++ b/apps/desktop/src/main/ipc/share.test.ts
@@ -1,13 +1,7 @@
 import { join } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { closeDatabase, initializeDatabase, getDatabase } from '@shiranami/database/client';
-import {
-  tracks,
-  playlists,
-  playlistTracks,
-  youtubeMappings,
-  eq,
-} from '@shiranami/database';
+import { tracks, playlists, playlistTracks, youtubeMappings, eq } from '@shiranami/database';
 import { ipcHandlers, makeTempDir, cleanupTempDir } from '../../../test/setup';
 
 vi.mock('../logger', () => ({
@@ -57,8 +51,12 @@ vi.mock('electron', async () => {
       },
     },
     BrowserWindow: class {
-      static getFocusedWindow() { return null; }
-      static getAllWindows() { return []; }
+      static getFocusedWindow() {
+        return null;
+      }
+      static getAllWindows() {
+        return [];
+      }
     },
     app: {
       isPackaged: false,
@@ -127,9 +125,7 @@ function insertTrack(overrides: Record<string, unknown> = {}): string {
 
 function insertYoutubeMapping(trackId: string, youtubeId: string): void {
   const db = getDatabase();
-  db.insert(youtubeMappings)
-    .values({ id: crypto.randomUUID(), trackId, youtubeId })
-    .run();
+  db.insert(youtubeMappings).values({ id: crypto.randomUUID(), trackId, youtubeId }).run();
 }
 
 function insertPlaylist(name: string): string {
@@ -227,7 +223,7 @@ describe('share ipc handlers', () => {
       // Valid-shape UUID that simply isn't in the DB — otherwise we'd trip
       // the zod validator and get BAD_REQUEST instead of TRACK_NOT_FOUND.
       await expect(
-        handler(null as never, '00000000-0000-4000-8000-000000000000'),
+        handler(null as never, '00000000-0000-4000-8000-000000000000')
       ).rejects.toMatchObject({
         code: 'share.track_not_found',
       });
@@ -263,7 +259,7 @@ describe('share ipc handlers', () => {
     it('throws PLAYLIST_NOT_FOUND for missing playlist', async () => {
       const handler = ipcHandlers.get('share:playlist')!;
       await expect(
-        handler(null as never, '00000000-0000-4000-8000-000000000000'),
+        handler(null as never, '00000000-0000-4000-8000-000000000000')
       ).rejects.toMatchObject({
         code: 'share.playlist_not_found',
       });
@@ -291,15 +287,32 @@ describe('share ipc handlers', () => {
   });
 
   describe('share:import', () => {
-    it('fetches shared payload by code and returns parsed JSON', async () => {
-      apiResponse = { statusCode: 200, body: { type: 'TRACK', payload: { title: 'Shared' } } };
+    it('fetches shared payload by code and returns the validated response', async () => {
+      const shared = {
+        type: 'TRACK',
+        payload: { title: 'Shared', artist: 'Artist', ytId: 'abc123' },
+        code: 'abc123',
+        expiresAt: '2026-06-01T00:00:00.000Z',
+      };
+      apiResponse = { statusCode: 200, body: shared };
 
       const handler = ipcHandlers.get('share:import')!;
       const result = await handler(null as never, 'abc123');
 
-      expect(result).toEqual({ type: 'TRACK', payload: { title: 'Shared' } });
+      expect(result).toEqual(shared);
       expect(apiCalls[0].url).toMatch(/\/api\/share\/abc123$/);
       expect(apiCalls[0].method).toBe('GET');
+    });
+
+    it('rejects a malformed share response with share.invalid_response', async () => {
+      // Missing artist/ytId/code/expiresAt — the handler must validate the
+      // untrusted remote response and not pass a lying shape to the renderer.
+      apiResponse = { statusCode: 200, body: { type: 'TRACK', payload: { title: 'Shared' } } };
+
+      const handler = ipcHandlers.get('share:import')!;
+      await expect(handler(null as never, 'abc123')).rejects.toMatchObject({
+        code: 'share.invalid_response',
+      });
     });
 
     it('rejects when API returns an error status', async () => {

--- a/apps/desktop/src/main/ipc/share.ts
+++ b/apps/desktop/src/main/ipc/share.ts
@@ -2,7 +2,12 @@ import { ipcMain } from 'electron';
 import { randomUUID } from 'crypto';
 import { eq, youtubeMappings, tracks } from '@shiranami/database';
 import { getDatabase } from '@shiranami/database/client';
-import { createShareSchema, IPC_CHANNELS, type CreateShareDto } from '@shiranami/contracts';
+import {
+  createShareSchema,
+  shareImportResponseSchema,
+  IPC_CHANNELS,
+  type CreateShareDto,
+} from '@shiranami/contracts';
 import { logger } from '../logger';
 import { HttpError, requestJson } from '../http';
 import { IpcError, SHARE_ERROR_CODES, VALIDATION_ERROR_CODES } from './errors';
@@ -236,7 +241,17 @@ export function registerShareHandlers(): void {
     async (_event, code: string) => {
       logger.info(`[share] Importing share code: ${code}`);
       const result = await fetchApi(`/api/share/${code}`, { method: 'GET' });
-      return result;
+      // Validate the remote response before handing it to the renderer: this is
+      // untrusted network input, and the renderer reads payload fields directly.
+      const parsed = shareImportResponseSchema.safeParse(result);
+      if (!parsed.success) {
+        logger.warn('[share] Import response failed schema validation', parsed.error.format());
+        throw new IpcError(
+          SHARE_ERROR_CODES.INVALID_RESPONSE,
+          'Received invalid share data from the server'
+        );
+      }
+      return parsed.data;
     },
     { schema: shareImportArgs }
   );

--- a/apps/desktop/src/main/metadata-lookup.ts
+++ b/apps/desktop/src/main/metadata-lookup.ts
@@ -2,6 +2,7 @@ import type { MetadataLookupResult } from '@shiranami/contracts';
 import { requestBuffer, requestJson } from './http';
 import { isYtDlpInstalled } from './ytdlp-manager';
 import { spawnYtDlp } from './utils/ytdlp-spawn';
+import { isStreamUrlAllowed } from './shared/url-safety';
 import { logger } from './logger';
 
 export type { MetadataLookupResult } from '@shiranami/contracts';
@@ -210,7 +211,16 @@ const IMAGE_MAX_SIZE = 10 * 1024 * 1024; // 10 MB
  * Routed through `requestBuffer` so cover-art hosts (e.g. i.ytimg.com,
  * iTunes thumbnails) share the per-host spacing + 429 handling.
  */
-export function downloadImage(url: string, signal?: AbortSignal): Promise<Buffer> {
+export async function downloadImage(url: string, signal?: AbortSignal): Promise<Buffer> {
+  // SSRF guard: cover-art URLs come from external APIs (iTunes) and yt-dlp
+  // extraction output, so a tampered upstream response could point us at a
+  // private/internal address (127.0.0.1, 169.254.169.254 cloud metadata, ...).
+  // Resolve + reject denied ranges before the outbound request, mirroring the
+  // radio protocol. See shared/url-safety.ts.
+  const guard = await isStreamUrlAllowed(url);
+  if (!guard.ok) {
+    throw new Error(`Refusing to fetch image from a disallowed URL (${guard.reason})`);
+  }
   return requestBuffer(url, {
     timeoutMs: IMAGE_TIMEOUT_MS,
     maxBytes: IMAGE_MAX_SIZE,

--- a/apps/desktop/src/main/preload/api/share.ts
+++ b/apps/desktop/src/main/preload/api/share.ts
@@ -1,5 +1,5 @@
 import { ipcRenderer } from 'electron';
-import { IPC_CHANNELS } from '@shiranami/contracts';
+import { IPC_CHANNELS, type ShareImportResponse } from '@shiranami/contracts';
 import { createIpcListener } from '../ipc-listener';
 
 const C = IPC_CHANNELS.share;
@@ -10,17 +10,12 @@ interface ShareCode {
   expiresAt: string;
 }
 
-interface ImportResult {
-  type: 'TRACK' | 'PLAYLIST';
-  payload: unknown;
-  code: string;
-  expiresAt: string;
-}
-
 export interface ShareApi {
   track: (trackId: string) => Promise<ShareCode>;
   playlist: (playlistId: string) => Promise<ShareCode>;
-  import: (code: string) => Promise<ImportResult>;
+  // The main-process handler validates this against shareImportResponseSchema,
+  // so the renderer receives a fully-typed discriminated union, not raw unknown.
+  import: (code: string) => Promise<ShareImportResponse>;
   cacheYoutubeId: (trackId: string, youtubeId: string) => Promise<void>;
   onDeepLink: (callback: (code: string) => void) => () => void;
 }

--- a/apps/desktop/src/main/recommendation-service.ts
+++ b/apps/desktop/src/main/recommendation-service.ts
@@ -37,7 +37,7 @@ import {
   type RecommendationShelves,
 } from '@shiranami/contracts';
 import { logger } from './logger';
-import { spawnYtDlp, parseYtDlpJsonLines } from './utils/ytdlp-spawn';
+import { spawnYtDlp, appendUrlArg, parseYtDlpJsonLines } from './utils/ytdlp-spawn';
 import { isYtDlpInstalled } from './ytdlp-manager';
 
 /** How many top-affinity tracks seed the discover shelf. One RD mix already
@@ -165,7 +165,7 @@ async function fetchRdMix(
   const url = `https://www.youtube.com/watch?v=${seedYoutubeId}&list=RD${seedYoutubeId}`;
   try {
     const { stdout, code } = await spawnYtDlp(
-      ['--flat-playlist', '--dump-json', '--no-warnings', url],
+      appendUrlArg(['--flat-playlist', '--dump-json', '--no-warnings'], url),
       signal
     );
     if (code !== 0) {

--- a/apps/desktop/src/main/shared/url-safety.test.ts
+++ b/apps/desktop/src/main/shared/url-safety.test.ts
@@ -5,7 +5,7 @@ vi.mock('node:dns', () => ({
   promises: { lookup: vi.fn() },
 }));
 
-import { isStreamUrlAllowed, parseStreamUrl } from './url-safety';
+import { isStreamUrlAllowed, parseStreamUrl, isHttpUrl } from './url-safety';
 
 const mockedLookup = vi.mocked(dns.promises.lookup);
 
@@ -30,6 +30,39 @@ describe('parseStreamUrl', () => {
     const u = parseStreamUrl('http://stream.example.com/live');
     expect(u).toBeInstanceOf(URL);
     expect(u?.hostname).toBe('stream.example.com');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  isHttpUrl — synchronous scheme gate for spawn-arg injection        */
+/* ------------------------------------------------------------------ */
+
+describe('isHttpUrl', () => {
+  it('accepts http and https URLs', () => {
+    expect(isHttpUrl('http://example.com/')).toBe(true);
+    expect(isHttpUrl('https://www.youtube.com/watch?v=abc123')).toBe(true);
+    expect(isHttpUrl('https://youtube.com/playlist?list=PL123')).toBe(true);
+  });
+
+  it('rejects non-http(s) schemes', () => {
+    expect(isHttpUrl('file:///etc/passwd')).toBe(false);
+    expect(isHttpUrl('ftp://example.com/')).toBe(false);
+    expect(isHttpUrl('javascript:alert(1)')).toBe(false);
+    expect(isHttpUrl('data:text/plain,hi')).toBe(false);
+  });
+
+  it('rejects yt-dlp argument-injection vectors that are not URLs', () => {
+    // These would be parsed by yt-dlp as options if passed positionally.
+    expect(isHttpUrl('--exec=calc.exe')).toBe(false);
+    expect(isHttpUrl('--exec-before-download=rm -rf ~')).toBe(false);
+    expect(isHttpUrl('--downloader=/bin/sh')).toBe(false);
+    expect(isHttpUrl('-x')).toBe(false);
+    expect(isHttpUrl('--paths=/tmp')).toBe(false);
+  });
+
+  it('rejects empty / non-URL input', () => {
+    expect(isHttpUrl('')).toBe(false);
+    expect(isHttpUrl('not a url')).toBe(false);
   });
 });
 

--- a/apps/desktop/src/main/shared/url-safety.ts
+++ b/apps/desktop/src/main/shared/url-safety.ts
@@ -34,18 +34,16 @@ import ipaddr from 'ipaddr.js';
  * the alternative (pre-resolving and rewriting the URL) breaks TLS/SNI and is
  * ignored by Chromium's network stack anyway.
  *
- * // TODO(security): Extend this guard to other `net.fetch` / `net.request`
- * // call sites that handle renderer-derived URLs (e.g. `metadata-lookup.ts`,
- * // `playlist.ts` if its scope grows). Today the radio protocol is the only
- * // hot path; widen as new entry points appear.
+ * Coverage: applied to the `shiranami-radio://` protocol (`radio-protocol.ts`)
+ * and to cover-art fetches (`metadata-lookup.ts` `downloadImage`). Extend to any
+ * future `net.fetch` / `net.request` call site that handles renderer- or
+ * upstream-derived URLs.
  */
 
 /** Why a URL was rejected. Renderer never sees this — main-side log only. */
 export type UrlGuardReason = 'parse' | 'scheme' | 'private-ip' | 'dns';
 
-export type UrlGuardResult =
-  | { ok: true; url: URL }
-  | { ok: false; reason: UrlGuardReason };
+export type UrlGuardResult = { ok: true; url: URL } | { ok: false; reason: UrlGuardReason };
 
 const ALLOWED_SCHEMES = new Set(['http:', 'https:']);
 
@@ -80,6 +78,26 @@ export function parseStreamUrl(input: string): URL | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Synchronous http(s) scheme check for a URL that will be passed as a
+ * POSITIONAL ARGUMENT to a child process (yt-dlp).
+ *
+ * This guards a DIFFERENT threat from `isStreamUrlAllowed`: argument injection.
+ * yt-dlp (like most CLIs) treats any argument beginning with `-` as an option,
+ * so a renderer/extraction-derived value such as `--exec=<cmd>` would execute
+ * an arbitrary OS command. Callers MUST also insert a literal `--`
+ * end-of-options separator before the URL (see `appendUrlArg` in
+ * `utils/ytdlp-spawn.ts`).
+ *
+ * Unlike `isStreamUrlAllowed`, this performs NO DNS / private-IP resolution —
+ * it is purely a cheap scheme gate for the spawn-argument path. SSRF on
+ * outbound `net.request` is a separate concern handled by `isStreamUrlAllowed`.
+ */
+export function isHttpUrl(input: string): boolean {
+  const url = parseStreamUrl(input);
+  return url !== null && ALLOWED_SCHEMES.has(url.protocol);
 }
 
 /**

--- a/apps/desktop/src/main/utils/ytdlp-spawn.test.ts
+++ b/apps/desktop/src/main/utils/ytdlp-spawn.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { appendUrlArg } from './ytdlp-spawn';
+
+/*
+ * Regression coverage for the yt-dlp argument-injection (RCE) fix.
+ *
+ * yt-dlp treats any argument beginning with `-` as an option, so a
+ * renderer/extraction-derived value like `--exec=<cmd>` passed as a positional
+ * argument would run an arbitrary OS command. appendUrlArg must (1) reject any
+ * non-http(s) value and (2) insert a literal `--` end-of-options separator so
+ * the URL is always parsed positionally.
+ */
+
+describe('appendUrlArg', () => {
+  it('appends the `--` end-of-options separator before a valid URL', () => {
+    const args = appendUrlArg(
+      ['-f', 'bestaudio', '--get-url'],
+      'https://www.youtube.com/watch?v=abc'
+    );
+    expect(args).toEqual([
+      '-f',
+      'bestaudio',
+      '--get-url',
+      '--',
+      'https://www.youtube.com/watch?v=abc',
+    ]);
+    // The `--` must come immediately before the URL, and the URL must be last.
+    expect(args[args.length - 2]).toBe('--');
+    expect(args[args.length - 1]).toBe('https://www.youtube.com/watch?v=abc');
+  });
+
+  it('does not mutate the original args array', () => {
+    const original = ['--flat-playlist', '--dump-json'];
+    appendUrlArg(original, 'https://youtube.com/playlist?list=PL1');
+    expect(original).toEqual(['--flat-playlist', '--dump-json']);
+  });
+
+  it('throws on an argument-injection payload instead of passing it to yt-dlp', () => {
+    expect(() => appendUrlArg(['--get-url'], '--exec=calc.exe')).toThrow(/non-http/);
+    expect(() => appendUrlArg(['--get-url'], '--downloader=/bin/sh')).toThrow(/non-http/);
+    expect(() => appendUrlArg([], '-x')).toThrow(/non-http/);
+  });
+
+  it('throws on non-http(s) schemes', () => {
+    expect(() => appendUrlArg([], 'file:///etc/passwd')).toThrow(/non-http/);
+    expect(() => appendUrlArg([], 'ftp://example.com/x')).toThrow(/non-http/);
+  });
+
+  it('throws on empty / non-URL input', () => {
+    expect(() => appendUrlArg([], '')).toThrow(/non-http/);
+    expect(() => appendUrlArg([], 'not a url')).toThrow(/non-http/);
+  });
+});

--- a/apps/desktop/src/main/utils/ytdlp-spawn.ts
+++ b/apps/desktop/src/main/utils/ytdlp-spawn.ts
@@ -2,8 +2,26 @@ import { spawn } from 'child_process';
 import type { SearchResult } from '@shiranami/contracts';
 import { logger } from '../logger';
 import { getYtDlpPath } from '../ytdlp-manager';
+import { isHttpUrl } from '../shared/url-safety';
 
 export type { SearchResult };
+
+/**
+ * Append a user/extraction-derived URL to a yt-dlp argument array safely.
+ *
+ * Guards against ARGUMENT INJECTION: yt-dlp treats any argument starting with
+ * `-` as an option, so a value like `--exec=<cmd>` would run an arbitrary OS
+ * command. We (1) reject anything that is not an http(s) URL and (2) append the
+ * literal `--` end-of-options separator so yt-dlp always parses the value as a
+ * positional URL. Throws when `url` is not an http(s) URL — callers at IPC
+ * boundaries should validate with `isHttpUrl` first to return a typed error.
+ */
+export function appendUrlArg(args: string[], url: string): string[] {
+  if (!isHttpUrl(url)) {
+    throw new Error(`yt-dlp: refusing to pass a non-http(s) URL argument: ${url}`);
+  }
+  return [...args, '--', url];
+}
 
 /**
  * Spawn the bundled yt-dlp binary with the given args and buffer its full
@@ -24,7 +42,12 @@ export function spawnYtDlp(
       return;
     }
 
-    const proc = spawn(getYtDlpPath(), args, { env: { ...process.env } });
+    // `--ignore-config` stops yt-dlp from reading any ambient yt-dlp.conf on
+    // the config search path, which could otherwise inject dangerous options
+    // (e.g. `--exec`) outside this app's control.
+    const proc = spawn(getYtDlpPath(), ['--ignore-config', ...args], {
+      env: { ...process.env },
+    });
     let stdout = '';
     let stderr = '';
 

--- a/apps/desktop/src/main/yt-dlp-download.ts
+++ b/apps/desktop/src/main/yt-dlp-download.ts
@@ -6,7 +6,7 @@ import { randomUUID } from 'crypto';
 import { logger } from './logger';
 import { getYtDlpPath } from './ytdlp-manager';
 import { getFFmpegDir, isFFmpegInstalled } from './ffmpeg-manager';
-import { classifyYtDlpFailure, tailOutput } from './utils/ytdlp-spawn';
+import { classifyYtDlpFailure, tailOutput, appendUrlArg } from './utils/ytdlp-spawn';
 
 export interface DownloadProgress {
   url: string;
@@ -51,7 +51,9 @@ export function runYtDlpDownload(
       }
     }
 
-    const args: string[] = [];
+    // `--ignore-config` prevents yt-dlp from reading an ambient yt-dlp.conf that
+    // could inject dangerous options (e.g. --exec). Keep it first.
+    const args: string[] = ['--ignore-config'];
     if (ffmpegLocation) {
       args.push('--ffmpeg-location', ffmpegLocation);
     }
@@ -77,11 +79,14 @@ export function runYtDlpDownload(
       'after_move:filepath',
       tmpFile,
       '-o',
-      outputTemplate,
-      url
+      outputTemplate
     );
 
-    const proc = spawn(getYtDlpPath(), args, { env: { ...process.env } });
+    // appendUrlArg validates the http(s) scheme and inserts the `--`
+    // end-of-options separator so `url` can never be parsed as a yt-dlp flag.
+    const proc = spawn(getYtDlpPath(), appendUrlArg(args, url), {
+      env: { ...process.env },
+    });
 
     let allOutput = '';
     let downloadedFilePath = '';

--- a/apps/web/src/components/library/LibraryView.tsx
+++ b/apps/web/src/components/library/LibraryView.tsx
@@ -110,6 +110,11 @@ export function LibraryView() {
                     ? t('filterAlbumsPlaceholder')
                     : t('filterPlaceholder')
                 }
+                aria-label={
+                  libraryViewMode === 'albums'
+                    ? t('filterAlbumsPlaceholder')
+                    : t('filterPlaceholder')
+                }
                 className="h-auto w-full pl-10 pr-9 py-2.5 rounded-xl text-sm glass-subtle border-border/40 text-foreground placeholder:text-muted-foreground/50 focus-visible:ring-primary/40 focus-visible:border-primary/40 shadow-none"
               />
               <AnimatePresence>

--- a/apps/web/src/components/overview/RecommendationsShelf.tsx
+++ b/apps/web/src/components/overview/RecommendationsShelf.tsx
@@ -21,6 +21,9 @@ import { useAudioPreview, type PreviewableItem } from '@/hooks/useAudioPreview';
 import { useSearchDependencies } from '@/hooks/useSearchDependencies';
 import { DependencyInstallCard } from '@/components/search/DependencyInstallCard';
 
+/** Max items shown per shelf row before the "+N more" affordance. */
+const MAX_SHELF_ITEMS = 8;
+
 /**
  * Maps a discover recommendation onto the shared preview shape. Discover items
  * come from a `--flat-playlist` dump, so there's no duration — the player
@@ -414,10 +417,10 @@ export function RecommendationsShelf({ onPlay, hasLibrary }: RecommendationsShel
   const generatedAt = library.generatedAt ?? discover.generatedAt;
   const updatedAgo = isStale && generatedAt ? formatRelativeTime(generatedAt, i18n.language) : null;
 
-  const librarySlice = library.items.slice(0, 8);
-  const libraryExtra = Math.max(0, library.items.length - 8);
-  const discoverSlice = discover.items.slice(0, 8);
-  const discoverExtra = Math.max(0, discover.items.length - 8);
+  const librarySlice = library.items.slice(0, MAX_SHELF_ITEMS);
+  const libraryExtra = Math.max(0, library.items.length - MAX_SHELF_ITEMS);
+  const discoverSlice = discover.items.slice(0, MAX_SHELF_ITEMS);
+  const discoverExtra = Math.max(0, discover.items.length - MAX_SHELF_ITEMS);
 
   return (
     <section

--- a/apps/web/src/components/player/EqualizerPanel.tsx
+++ b/apps/web/src/components/player/EqualizerPanel.tsx
@@ -175,9 +175,11 @@ export function EqualizerPanel({ layout = 'popover', inline = false }: Equalizer
 
       {/* Preset select */}
       <div className="flex items-center justify-between gap-3">
-        <label className="text-xs text-muted-foreground">{t('preset')}</label>
+        <label htmlFor="eq-preset" className="text-xs text-muted-foreground">
+          {t('preset')}
+        </label>
         <Select value={preset} onValueChange={handlePresetChange}>
-          <SelectTrigger className="min-w-[140px]">
+          <SelectTrigger id="eq-preset" className="min-w-[140px]">
             <SelectValue placeholder={t('presetPlaceholder')}>
               {preset === 'custom' ? t('customPreset') : t(`preset.${preset}`)}
             </SelectValue>

--- a/apps/web/src/components/player/SeekBar.test.tsx
+++ b/apps/web/src/components/player/SeekBar.test.tsx
@@ -15,14 +15,18 @@ const uiState = vi.hoisted(() => ({
   setScrubTime: vi.fn(),
 }));
 
-vi.mock('@/stores/usePlaybackStore', () => ({
-  usePlaybackStore: <T,>(selector: (s: typeof playbackState) => T) => selector(playbackState),
-  currentTimeRef: { current: 0 },
-}));
+vi.mock('@/stores/usePlaybackStore', () => {
+  const hook = <T,>(selector: (s: typeof playbackState) => T) => selector(playbackState);
+  return {
+    usePlaybackStore: Object.assign(hook, { getState: () => playbackState }),
+    currentTimeRef: { current: 0 },
+  };
+});
 
-vi.mock('@/stores/usePlayerUIStore', () => ({
-  usePlayerUIStore: <T,>(selector: (s: typeof uiState) => T) => selector(uiState),
-}));
+vi.mock('@/stores/usePlayerUIStore', () => {
+  const hook = <T,>(selector: (s: typeof uiState) => T) => selector(uiState);
+  return { usePlayerUIStore: Object.assign(hook, { getState: () => uiState }) };
+});
 
 describe('SeekBar', () => {
   beforeEach(() => {

--- a/apps/web/src/components/player/SeekBar.test.tsx
+++ b/apps/web/src/components/player/SeekBar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SeekBar } from './SeekBar';
@@ -71,5 +71,53 @@ describe('SeekBar', () => {
     // SeekBar now clears scrubTime explicitly on commit (used to live in the
     // store's seek() action in the pre-split monolith).
     expect(uiState.setScrubTime).toHaveBeenCalledWith(null);
+  });
+
+  // Regression: the slider role used to be keyboard-dead (only onPointerDown),
+  // so keyboard / switch users could not seek the playing track at all.
+  describe('keyboard operability', () => {
+    beforeEach(() => {
+      playbackState.currentTime = 50;
+    });
+
+    it('Arrow keys seek by the small step', () => {
+      render(<SeekBar />);
+      const slider = screen.getByRole('slider');
+      fireEvent.keyDown(slider, { key: 'ArrowRight' });
+      expect(playbackState.seek).toHaveBeenLastCalledWith(55);
+      fireEvent.keyDown(slider, { key: 'ArrowUp' });
+      expect(playbackState.seek).toHaveBeenLastCalledWith(55);
+      fireEvent.keyDown(slider, { key: 'ArrowLeft' });
+      expect(playbackState.seek).toHaveBeenLastCalledWith(45);
+    });
+
+    it('PageUp / PageDown seek by the larger step', () => {
+      render(<SeekBar />);
+      const slider = screen.getByRole('slider');
+      fireEvent.keyDown(slider, { key: 'PageUp' });
+      expect(playbackState.seek).toHaveBeenLastCalledWith(60);
+      fireEvent.keyDown(slider, { key: 'PageDown' });
+      expect(playbackState.seek).toHaveBeenLastCalledWith(40);
+    });
+
+    it('Home and End jump to the bounds', () => {
+      render(<SeekBar />);
+      const slider = screen.getByRole('slider');
+      fireEvent.keyDown(slider, { key: 'Home' });
+      expect(playbackState.seek).toHaveBeenLastCalledWith(0);
+      fireEvent.keyDown(slider, { key: 'End' });
+      expect(playbackState.seek).toHaveBeenLastCalledWith(100);
+    });
+
+    it('clamps to [0, duration] and ignores unrelated keys', () => {
+      playbackState.currentTime = 3;
+      render(<SeekBar />);
+      const slider = screen.getByRole('slider');
+      fireEvent.keyDown(slider, { key: 'ArrowLeft' });
+      expect(playbackState.seek).toHaveBeenLastCalledWith(0);
+      playbackState.seek.mockClear();
+      fireEvent.keyDown(slider, { key: 'Enter' });
+      expect(playbackState.seek).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/src/components/player/SeekBar.tsx
+++ b/apps/web/src/components/player/SeekBar.tsx
@@ -109,21 +109,26 @@ export function SeekBar() {
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (!duration) return;
+      // Read the freshest time from the stores at keypress time rather than
+      // closing over `displayTime` (which changes ~once/second during playback
+      // and would rebuild this callback on every tick).
+      const current =
+        usePlayerUIStore.getState().scrubTime ?? usePlaybackStore.getState().currentTime;
       let next: number;
       switch (e.key) {
         case 'ArrowLeft':
         case 'ArrowDown':
-          next = Math.max(0, displayTime - SEEK_KEY_STEP_SECONDS);
+          next = Math.max(0, current - SEEK_KEY_STEP_SECONDS);
           break;
         case 'ArrowRight':
         case 'ArrowUp':
-          next = Math.min(duration, displayTime + SEEK_KEY_STEP_SECONDS);
+          next = Math.min(duration, current + SEEK_KEY_STEP_SECONDS);
           break;
         case 'PageDown':
-          next = Math.max(0, displayTime - SEEK_KEY_STEP_SECONDS * 2);
+          next = Math.max(0, current - SEEK_KEY_STEP_SECONDS * 2);
           break;
         case 'PageUp':
-          next = Math.min(duration, displayTime + SEEK_KEY_STEP_SECONDS * 2);
+          next = Math.min(duration, current + SEEK_KEY_STEP_SECONDS * 2);
           break;
         case 'Home':
           next = 0;
@@ -137,7 +142,7 @@ export function SeekBar() {
       e.preventDefault();
       seek(next);
     },
-    [duration, displayTime, seek]
+    [duration, seek]
   );
 
   useLayoutEffect(() => {

--- a/apps/web/src/components/player/SeekBar.tsx
+++ b/apps/web/src/components/player/SeekBar.tsx
@@ -12,6 +12,9 @@ import { formatDuration } from '@shiranami/shared';
  *  centered on the progress point regardless of the thumb's own (hover-animated)
  *  width. The percentage `left` resolves against the live track width on every
  *  layout, so this is a one-time layout on value change (not per-frame). */
+/** Seconds the seek position moves per Arrow key press (PageUp/Down move 2x). */
+const SEEK_KEY_STEP_SECONDS = 5;
+
 function applyProgress(ratio: number, fill: HTMLDivElement | null, thumb: HTMLDivElement | null) {
   const clamped = Math.max(0, Math.min(1, ratio));
   if (fill) fill.style.transform = `scaleX(${clamped})`;
@@ -100,6 +103,43 @@ export function SeekBar() {
   const staticRatio = duration > 0 ? displayTime / duration : 0;
   const needsStaticStyle = !isPlaying || scrubTime !== null;
 
+  // Keyboard operability for the slider role: Arrow keys seek by a small step,
+  // PageUp/Down by a larger one, Home/End jump to the ends. Without this the
+  // primary transport control is unusable by keyboard and switch users.
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!duration) return;
+      let next: number;
+      switch (e.key) {
+        case 'ArrowLeft':
+        case 'ArrowDown':
+          next = Math.max(0, displayTime - SEEK_KEY_STEP_SECONDS);
+          break;
+        case 'ArrowRight':
+        case 'ArrowUp':
+          next = Math.min(duration, displayTime + SEEK_KEY_STEP_SECONDS);
+          break;
+        case 'PageDown':
+          next = Math.max(0, displayTime - SEEK_KEY_STEP_SECONDS * 2);
+          break;
+        case 'PageUp':
+          next = Math.min(duration, displayTime + SEEK_KEY_STEP_SECONDS * 2);
+          break;
+        case 'Home':
+          next = 0;
+          break;
+        case 'End':
+          next = duration;
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
+      seek(next);
+    },
+    [duration, displayTime, seek]
+  );
+
   useLayoutEffect(() => {
     if (!needsStaticStyle) return;
     applyProgress(staticRatio, fillRef.current, thumbRef.current);
@@ -109,6 +149,7 @@ export function SeekBar() {
     <div
       ref={trackRef}
       onPointerDown={handlePointerDown}
+      onKeyDown={handleKeyDown}
       className="group relative flex min-w-0 flex-1 touch-none cursor-pointer select-none items-center py-1"
       role="slider"
       aria-label={t('seek')}

--- a/apps/web/src/components/player/SleepTimer.test.tsx
+++ b/apps/web/src/components/player/SleepTimer.test.tsx
@@ -22,6 +22,8 @@ const mockState = vi.hoisted(() => ({
 vi.mock('@/stores/useSleepTimerStore', () => ({
   useSleepTimerStore: <T,>(selector: (s: typeof mockState) => T) => selector(mockState),
   SLEEP_TIMER_PRESETS: [15, 30, 45, 60, 90],
+  SLEEP_TIMER_MIN_MINUTES: 1,
+  SLEEP_TIMER_MAX_MINUTES: 600,
 }));
 
 vi.mock('react-i18next', () => ({

--- a/apps/web/src/components/player/SleepTimer.tsx
+++ b/apps/web/src/components/player/SleepTimer.tsx
@@ -75,8 +75,14 @@ export function SleepTimer() {
   };
 
   const handleCustomSubmit = () => {
-    const parsed = parseInt(customValue, 10);
-    if (isNaN(parsed) || parsed < SLEEP_TIMER_MIN_MINUTES || parsed > SLEEP_TIMER_MAX_MINUTES) {
+    // Number() + isInteger rejects partial/decimal input ("12abc", "12.5", "")
+    // that parseInt would silently accept.
+    const parsed = Number(customValue);
+    if (
+      !Number.isInteger(parsed) ||
+      parsed < SLEEP_TIMER_MIN_MINUTES ||
+      parsed > SLEEP_TIMER_MAX_MINUTES
+    ) {
       setCustomError(true);
       return;
     }

--- a/apps/web/src/components/player/SleepTimer.tsx
+++ b/apps/web/src/components/player/SleepTimer.tsx
@@ -6,7 +6,12 @@ import { Input } from '@/components/ui/input';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { IconButton } from '@/components/ui/icon-button';
-import { useSleepTimerStore, SLEEP_TIMER_PRESETS } from '@/stores/useSleepTimerStore';
+import {
+  useSleepTimerStore,
+  SLEEP_TIMER_PRESETS,
+  SLEEP_TIMER_MIN_MINUTES,
+  SLEEP_TIMER_MAX_MINUTES,
+} from '@/stores/useSleepTimerStore';
 
 function formatRemaining(seconds: number): string {
   const m = Math.floor(seconds / 60);
@@ -33,7 +38,9 @@ export function SleepTimer() {
       setCustomValue(prev => {
         const n = parseInt(prev, 10);
         const base = Number.isNaN(n) ? 0 : n;
-        return String(Math.min(600, Math.max(1, base + delta)));
+        return String(
+          Math.min(SLEEP_TIMER_MAX_MINUTES, Math.max(SLEEP_TIMER_MIN_MINUTES, base + delta))
+        );
       });
       setCustomError(false);
     };
@@ -69,7 +76,7 @@ export function SleepTimer() {
 
   const handleCustomSubmit = () => {
     const parsed = parseInt(customValue, 10);
-    if (isNaN(parsed) || parsed < 1 || parsed > 600) {
+    if (isNaN(parsed) || parsed < SLEEP_TIMER_MIN_MINUTES || parsed > SLEEP_TIMER_MAX_MINUTES) {
       setCustomError(true);
       return;
     }
@@ -153,8 +160,8 @@ export function SleepTimer() {
                 type="number"
                 inputMode="numeric"
                 pattern="[0-9]*"
-                min={1}
-                max={600}
+                min={SLEEP_TIMER_MIN_MINUTES}
+                max={SLEEP_TIMER_MAX_MINUTES}
                 step={1}
                 value={customValue}
                 onChange={e => {

--- a/apps/web/src/components/playlist-import/PlaylistRow.tsx
+++ b/apps/web/src/components/playlist-import/PlaylistRow.tsx
@@ -230,6 +230,7 @@ export function PlaylistRow(props: RowComponentProps<PlaylistRowProps>) {
             }}
             className="shrink-0 relative z-10 w-9 h-9 flex items-center justify-center rounded-lg hover:bg-primary/10 transition-colors"
             title={t('downloadTrack')}
+            aria-label={t('downloadTrack')}
           >
             <Download className="w-4 h-4 text-muted-foreground/50 hover:text-primary transition-colors" />
           </button>
@@ -247,6 +248,7 @@ export function PlaylistRow(props: RowComponentProps<PlaylistRowProps>) {
             }}
             className="shrink-0 relative z-10 w-7 h-7 rounded-lg flex items-center justify-center text-muted-foreground/30 hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100"
             title={t('removeFromList')}
+            aria-label={t('removeFromList')}
           >
             <X className="w-3.5 h-3.5" />
           </button>

--- a/apps/web/src/components/playlists/PlaylistDetailHeader.tsx
+++ b/apps/web/src/components/playlists/PlaylistDetailHeader.tsx
@@ -243,6 +243,7 @@ export function PlaylistDetailHeader({
               onChange={e => setEditName(e.target.value)}
               onBlur={onSaveName}
               onKeyDown={onNameKeyDown}
+              aria-label={t('namePlaceholder')}
               className="font-display text-lg font-semibold text-foreground bg-transparent outline-none border-b border-primary/40 w-full pb-0.5"
             />
           ) : (

--- a/apps/web/src/components/playlists/PlaylistsView.tsx
+++ b/apps/web/src/components/playlists/PlaylistsView.tsx
@@ -130,6 +130,7 @@ export function PlaylistsView() {
                 onChange={e => setNewName(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder={t('namePlaceholder')}
+                aria-label={t('namePlaceholder')}
                 className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground/40 outline-none"
                 disabled={createPlaylist.isPending}
               />

--- a/apps/web/src/components/radio/RadioView.tsx
+++ b/apps/web/src/components/radio/RadioView.tsx
@@ -204,6 +204,7 @@ export function RadioView() {
             value={searchDraft}
             onChange={handleSearchInputChange}
             placeholder={t('searchPlaceholder')}
+            aria-label={t('searchPlaceholder')}
             className={cn(
               'h-auto w-full pl-10 pr-4 py-2.5 rounded-xl text-sm glass-subtle border-border/40',
               'text-foreground placeholder:text-muted-foreground/50',

--- a/apps/web/src/components/radio/StationRow.tsx
+++ b/apps/web/src/components/radio/StationRow.tsx
@@ -115,7 +115,10 @@ export function StationRow(props: RowComponentProps<StationRowProps>) {
         {/* Play/Pause indicator */}
         <div className="shrink-0 w-8 h-8 rounded-lg flex items-center justify-center">
           {isActive && isPlaying ? (
-            <EqBars />
+            <>
+              <EqBars />
+              <span className="sr-only">{t('nowPlaying', { ns: 'common' })}</span>
+            </>
           ) : (
             <Play className="w-3.5 h-3.5 text-muted-foreground/40 opacity-0 group-hover:opacity-100 transition-opacity" />
           )}

--- a/apps/web/src/components/search/SearchResultRow.tsx
+++ b/apps/web/src/components/search/SearchResultRow.tsx
@@ -46,6 +46,7 @@ export function SearchResultRow({
         onClick={() => onPreview(result)}
         className="w-11 h-11 rounded-lg overflow-hidden bg-muted shrink-0 relative z-10 group/thumb"
         title={isPreviewPlaying(result) ? t('pausePreview') : t('preview')}
+        aria-label={isPreviewPlaying(result) ? t('pausePreview') : t('preview')}
       >
         {result.thumbnail ? (
           <img

--- a/apps/web/src/components/search/SearchView.tsx
+++ b/apps/web/src/components/search/SearchView.tsx
@@ -152,6 +152,7 @@ export function SearchView() {
             onFocus={() => suggestions.length > 0 && setSuggestionsOpen(true)}
             onBlur={() => closeSuggestions()}
             placeholder={t('placeholder')}
+            aria-label={t('placeholder')}
             className={cn(
               'h-auto w-full pl-10 py-2.5 rounded-xl text-sm glass-subtle border-border/40',
               query ? 'pr-10' : 'pr-4',

--- a/apps/web/src/components/settings/AboutSection.tsx
+++ b/apps/web/src/components/settings/AboutSection.tsx
@@ -42,7 +42,11 @@ export function AboutSection() {
       <SettingsCard iconSlot={heroIcon} title="Shiranami" subtitle={heroSubtitle}>
         <div className="flex flex-wrap items-center gap-2">
           <Button variant="outline" size="sm" className="border-border/40" asChild>
-            <a href="https://github.com/Shironex/shiranami" target="_blank" rel="noreferrer">
+            <a
+              href="https://github.com/Shironex/shiranami"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <Globe className="w-3.5 h-3.5" />
               {t('abt.github')}
             </a>
@@ -51,7 +55,7 @@ export function AboutSection() {
             <a
               href="https://github.com/Shironex/shiranami/releases"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
             >
               <BookOpen className="w-3.5 h-3.5" />
               {t('abt.changelog')}

--- a/apps/web/src/components/settings/DiscordSection.tsx
+++ b/apps/web/src/components/settings/DiscordSection.tsx
@@ -76,7 +76,12 @@ export function DiscordSection() {
 
   const handleSave = useCallback(async () => {
     if (!settings) return;
-    await updateDiscord.mutateAsync(settings);
+    try {
+      await updateDiscord.mutateAsync(settings);
+    } catch {
+      // The mutation's onError already surfaced a toast; just don't show "Saved".
+      return;
+    }
     if (!mountedRef.current) return;
     setSaved(true);
     setTimeout(() => {
@@ -156,7 +161,7 @@ export function DiscordSection() {
           disabled={!settings.enabled}
         />
 
-        <Button size="sm" onClick={handleSave}>
+        <Button size="sm" onClick={handleSave} disabled={updateDiscord.isPending}>
           {saved ? <Check className="h-4 w-4" /> : null}
           {saved ? t('dsc.main.saved') : t('dsc.main.save')}
         </Button>

--- a/apps/web/src/components/settings/DiscordTemplateEditor.tsx
+++ b/apps/web/src/components/settings/DiscordTemplateEditor.tsx
@@ -66,14 +66,17 @@ export function DiscordTemplateEditor({
     >
       {/* Activity type selector */}
       <div className="space-y-1.5">
-        <label className="text-xs font-medium text-muted-foreground">
+        <label
+          htmlFor="discord-activity-type"
+          className="text-xs font-medium text-muted-foreground"
+        >
           {t('dsc.editor.activityType')}
         </label>
         <Select
           value={selectedActivity}
           onValueChange={v => onActivityChange(v as DiscordMusicActivityType)}
         >
-          <SelectTrigger className="h-8 text-sm">
+          <SelectTrigger id="discord-activity-type" className="h-8 text-sm">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -91,10 +94,11 @@ export function DiscordTemplateEditor({
       {/* Template inputs */}
       <div className="space-y-3">
         <div className="space-y-1.5">
-          <label className="text-xs font-medium text-muted-foreground">
+          <label htmlFor="discord-line1" className="text-xs font-medium text-muted-foreground">
             {t('dsc.editor.line1')}
           </label>
           <Input
+            id="discord-line1"
             className="h-8 text-sm"
             value={currentTemplate.details}
             onChange={e => onTemplateChange(selectedActivity, 'details', e.target.value)}
@@ -102,10 +106,11 @@ export function DiscordTemplateEditor({
           />
         </div>
         <div className="space-y-1.5">
-          <label className="text-xs font-medium text-muted-foreground">
+          <label htmlFor="discord-line2" className="text-xs font-medium text-muted-foreground">
             {t('dsc.editor.line2')}
           </label>
           <Input
+            id="discord-line2"
             className="h-8 text-sm"
             value={currentTemplate.state}
             onChange={e => onTemplateChange(selectedActivity, 'state', e.target.value)}

--- a/apps/web/src/components/settings/SupportSection.tsx
+++ b/apps/web/src/components/settings/SupportSection.tsx
@@ -38,13 +38,13 @@ export function SupportSection() {
 
         <div className="flex flex-wrap items-center gap-2">
           <Button size="sm" asChild onClick={setSeen}>
-            <a href={BUY_ME_A_COFFEE_URL} target="_blank" rel="noreferrer">
+            <a href={BUY_ME_A_COFFEE_URL} target="_blank" rel="noopener noreferrer">
               <Coffee className="w-3.5 h-3.5" />
               {t('sup.action')}
             </a>
           </Button>
           <Button size="sm" variant="outline" asChild onClick={setSeen}>
-            <a href={GITHUB_SPONSORS_URL} target="_blank" rel="noreferrer">
+            <a href={GITHUB_SPONSORS_URL} target="_blank" rel="noopener noreferrer">
               <HeartHandshake className="w-3.5 h-3.5" />
               {t('sup.sponsor')}
             </a>

--- a/apps/web/src/components/settings/UpdatesSection.tsx
+++ b/apps/web/src/components/settings/UpdatesSection.tsx
@@ -89,7 +89,7 @@ export function UpdatesSection() {
           <a
             href="https://github.com/Shironex/shiranami/releases/latest"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-accent hover:bg-accent/80 text-foreground transition-colors"
           >
             <ExternalLink className="w-3.5 h-3.5" />
@@ -136,7 +136,7 @@ export function UpdatesSection() {
               <a
                 href="https://shiranami.app/changelog"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
               >
                 {t('upd.viewChangelog')}

--- a/apps/web/src/components/shared/ImportDialog.tsx
+++ b/apps/web/src/components/shared/ImportDialog.tsx
@@ -33,9 +33,9 @@ export function ImportDialog({ open, onOpenChange, code }: ImportDialogProps) {
 
   const tracks =
     data?.type === 'PLAYLIST'
-      ? (data.payload.tracks ?? [])
+      ? data.payload.tracks
       : data
-        ? [{ title: data.payload.title!, artist: data.payload.artist!, ytId: data.payload.ytId! }]
+        ? [{ title: data.payload.title, artist: data.payload.artist, ytId: data.payload.ytId }]
         : [];
 
   return (

--- a/apps/web/src/components/shared/PlaylistPickerContent.tsx
+++ b/apps/web/src/components/shared/PlaylistPickerContent.tsx
@@ -144,6 +144,7 @@ export function PlaylistPickerContent({ trackIds, onDone, toastMode }: PlaylistP
               }}
               onClick={e => e.stopPropagation()}
               placeholder={tCommon('namePlaceholder')}
+              aria-label={tCommon('namePlaceholder')}
               className="flex-1 bg-transparent text-xs text-foreground placeholder:text-muted-foreground/30 outline-none min-w-0"
             />
             <Button

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -125,6 +125,7 @@ export function Sidebar() {
                   onClick={() => navigateTo(item.id)}
                   title={sidebarCollapsed ? t(item.key) : undefined}
                   aria-label={t(item.key)}
+                  aria-current={isActive ? 'page' : undefined}
                   data-view={item.id}
                   className={cn(
                     'w-full flex items-center rounded-xl text-sm font-medium transition-all duration-200 relative',

--- a/apps/web/src/components/shared/SupportBanner.tsx
+++ b/apps/web/src/components/shared/SupportBanner.tsx
@@ -28,7 +28,7 @@ export function SupportBanner() {
       <a
         href={BUY_ME_A_COFFEE_URL}
         target="_blank"
-        rel="noreferrer"
+        rel="noopener noreferrer"
         onClick={setSeen}
         className="ml-1 rounded px-1.5 py-0.5 font-medium text-primary underline underline-offset-2 transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       >
@@ -40,7 +40,7 @@ export function SupportBanner() {
       <a
         href={GITHUB_SPONSORS_URL}
         target="_blank"
-        rel="noreferrer"
+        rel="noopener noreferrer"
         onClick={setSeen}
         className="rounded px-1.5 py-0.5 font-medium text-primary underline underline-offset-2 transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       >

--- a/apps/web/src/components/shared/TrackEnrichDialog.tsx
+++ b/apps/web/src/components/shared/TrackEnrichDialog.tsx
@@ -220,6 +220,7 @@ export function TrackEnrichDialog({ open, onOpenChange, trackId }: TrackEnrichDi
                           <img
                             src={current as string}
                             alt=""
+                            aria-hidden="true"
                             className="w-8 h-8 rounded-md object-cover opacity-60"
                           />
                         ) : (
@@ -237,6 +238,7 @@ export function TrackEnrichDialog({ open, onOpenChange, trackId }: TrackEnrichDi
                           <img
                             src={proposed as string}
                             alt=""
+                            aria-hidden="true"
                             className="w-8 h-8 rounded-md object-cover"
                           />
                         ) : null}

--- a/apps/web/src/hooks/queries/useDiscordRpc.ts
+++ b/apps/web/src/hooks/queries/useDiscordRpc.ts
@@ -1,6 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import type { DiscordRpcSettings } from '@shiranami/shared';
 import { IS_ELECTRON } from '@/lib/platform';
+import i18n from '@/lib/i18n';
 
 /**
  * React Query access to the dedicated Discord RPC settings (electron-store key
@@ -35,6 +37,11 @@ export function useUpdateDiscordRpcSettingsMutation() {
     },
     onSuccess: next => {
       if (next) queryClient.setQueryData(discordRpcKeys.all, next);
+    },
+    // Covers both the DiscordSection save and the fire-and-forget onboarding
+    // toggle, which otherwise fail silently.
+    onError: () => {
+      toast.error(i18n.t('failedSaveSettings', { ns: 'toast' }));
     },
   });
 }

--- a/apps/web/src/hooks/queries/usePlaylists.ts
+++ b/apps/web/src/hooks/queries/usePlaylists.ts
@@ -5,6 +5,7 @@ import { useLibraryStore } from '@/stores/useLibraryStore';
 import { useTrackOverlayStore } from '@/stores/useTrackOverlayStore';
 import type { Playlist } from '@/types/electron';
 import type { Track } from '@/stores/types';
+import { mapDbTracksToTracks, type DbTrackRecord } from '@/lib/trackMapper';
 
 // ── Query Keys ──
 
@@ -41,7 +42,14 @@ export function usePlaylistTracksQuery(playlistId: string | null) {
   return useQuery({
     queryKey: playlistKeys.tracks(playlistId!),
     queryFn: async () => {
-      return (await window.electronAPI.db.playlists.getTracks(playlistId!)) as Track[];
+      // Collapse nullable DB columns (artist/album/duration) to display
+      // defaults via the shared mapper, exactly like the library load path
+      // (useLibrarySync). The raw rows are nullable; without this they would
+      // render as the literal string "null". Drops the prior lying `as Track[]`.
+      const rows = (await window.electronAPI.db.playlists.getTracks(
+        playlistId!
+      )) as DbTrackRecord[];
+      return mapDbTracksToTracks(rows);
     },
     enabled: !!playlistId && IS_ELECTRON,
   });

--- a/apps/web/src/hooks/queries/useSettings.ts
+++ b/apps/web/src/hooks/queries/useSettings.ts
@@ -1,5 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { IS_ELECTRON } from '@/lib/platform';
+import i18n from '@/lib/i18n';
 
 export interface ElectronSettings {
   rememberPlaybackPosition?: boolean;
@@ -35,6 +37,12 @@ export function useUpdateSettingsMutation() {
       return merged;
     },
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: settingsKeys.all });
+    },
+    // Fire-and-forget callers (settings toggles, onboarding) have no local
+    // catch, so surface the failure here and resync the cache to truth.
+    onError: () => {
+      toast.error(i18n.t('failedSaveSettings', { ns: 'toast' }));
       queryClient.invalidateQueries({ queryKey: settingsKeys.all });
     },
   });

--- a/apps/web/src/hooks/useSearch.ts
+++ b/apps/web/src/hooks/useSearch.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { IS_ELECTRON } from '@/lib/platform';
 import { useTrackImport } from '@/hooks/useTrackImport';
 import { useAudioPreview } from '@/hooks/useAudioPreview';
@@ -22,6 +22,10 @@ export function useSearch() {
   const [isSearching, setIsSearching] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
   const [downloads, setDownloads] = useState<Record<string, DownloadState>>({});
+  // Synchronous in-flight set keyed by URL. The `downloads` state can't guard
+  // against a fast double-invoke (it flushes a render later, and handleDownload
+  // doesn't close over it), so a ref is the reliable dedupe.
+  const downloadInFlightRef = useRef<Set<string>>(new Set());
 
   const { importTrack } = useTrackImport();
   const { previewLoadingId, isPreviewPlaying, handlePreview } = useAudioPreview(
@@ -80,6 +84,10 @@ export function useSearch() {
     async (result: SearchResult) => {
       if (!IS_ELECTRON) return;
       const url = result.webpage_url || result.url;
+      // Guard against a duplicate download (and the duplicate library row it
+      // would produce) from a rapid double-trigger before state flushes.
+      if (downloadInFlightRef.current.has(url)) return;
+      downloadInFlightRef.current.add(url);
 
       setDownloads(prev => ({
         ...prev,
@@ -110,6 +118,8 @@ export function useSearch() {
           [url]: { progress: 0, status: 'error', error: msg },
         }));
         toast.error(i18n.t('downloadFailed', { ns: 'toast', error: msg }));
+      } finally {
+        downloadInFlightRef.current.delete(url);
       }
     },
     [importTrack]

--- a/apps/web/src/hooks/useShareImport.ts
+++ b/apps/web/src/hooks/useShareImport.ts
@@ -1,24 +1,18 @@
 import { useCallback, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import type { TrackPayload } from '@shiranami/contracts';
+import type { ShareImportResponse } from '@shiranami/contracts';
 import { IS_ELECTRON } from '@/lib/platform';
 import { useTrackImport } from '@/hooks/useTrackImport';
 import { playlistKeys } from '@/hooks/queries/usePlaylists';
 
 export type ShareImportState = 'idle' | 'loading' | 'ready' | 'downloading' | 'done' | 'error';
 
-export interface ImportData {
-  type: 'TRACK' | 'PLAYLIST';
-  payload: {
-    title?: string;
-    artist?: string;
-    ytId?: string;
-    name?: string;
-    tracks?: TrackPayload[];
-  };
-  code: string;
-  expiresAt: string;
-}
+/**
+ * The validated import-share response. Aliased to the contract's discriminated
+ * union (shareImportResponseSchema), so the payload is narrowed by `type` — no
+ * more optional-everything fields and non-null assertions at the read sites.
+ */
+export type ImportData = ShareImportResponse;
 
 export interface UseShareImportResult {
   state: ShareImportState;
@@ -57,11 +51,10 @@ export function useShareImport(): UseShareImportResult {
 
     window.electronAPI.share
       .import(code)
-      .then(result => {
+      .then(importData => {
         if (cancelled) return;
-        const importData = result as ImportData;
         setData(importData);
-        setPlaylistName(importData.type === 'PLAYLIST' ? (importData.payload.name ?? '') : '');
+        setPlaylistName(importData.type === 'PLAYLIST' ? importData.payload.name : '');
         setState('ready');
       })
       .catch((err: Error) => {
@@ -80,12 +73,12 @@ export function useShareImport(): UseShareImportResult {
 
     const trackList =
       data.type === 'PLAYLIST'
-        ? (data.payload.tracks ?? [])
+        ? data.payload.tracks
         : [
             {
-              title: data.payload.title!,
-              artist: data.payload.artist!,
-              ytId: data.payload.ytId!,
+              title: data.payload.title,
+              artist: data.payload.artist,
+              ytId: data.payload.ytId,
             },
           ];
 

--- a/apps/web/src/locales/en/toast.json
+++ b/apps/web/src/locales/en/toast.json
@@ -40,6 +40,7 @@
   "failedRescan": "Failed to rescan library",
   "libraryCleared": "Library cleared",
   "failedClearLibrary": "Failed to clear library",
+  "failedSaveSettings": "Failed to save settings",
   "previewFailed": "Preview failed: {{error}}",
   "downloaded": "Downloaded: {{title}}",
   "trackAlreadyInLibrary": "Track already in library",

--- a/apps/web/src/locales/pl/toast.json
+++ b/apps/web/src/locales/pl/toast.json
@@ -44,6 +44,7 @@
   "failedRescan": "Nie udało się przeskanować biblioteki",
   "libraryCleared": "Biblioteka wyczyszczona",
   "failedClearLibrary": "Nie udało się wyczyścić biblioteki",
+  "failedSaveSettings": "Nie udało się zapisać ustawień",
   "previewFailed": "Nie udało się odtworzyć podglądu: {{error}}",
   "downloaded": "Pobrano: {{title}}",
   "trackAlreadyInLibrary": "Utwór jest już w bibliotece",

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,7 +6,8 @@ import App from './App';
 import ErrorBoundary from '@/components/shared/ErrorBoundary';
 import { Toaster } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
-import { initSentryRenderer } from '@/lib/sentry';
+import { initSentryRenderer, captureException } from '@/lib/sentry';
+import { logger } from '@/lib/logger';
 import './styles/globals.css';
 import '@/lib/i18n';
 
@@ -26,6 +27,20 @@ if (window.electronAPI?.__e2e) {
 // Initialize crash/error reporting. No-op unless the user opted in and this is
 // a packaged/production Electron build; events route to the main transport.
 void initSentryRenderer();
+
+// Global safety net for async failures that never reach React's render path —
+// rejected IPC promises, event-handler errors, useEffect rejections. Without
+// this they vanish (the ErrorBoundary only catches render-time errors): not
+// logged, not reported. captureException is a no-op until Sentry is initialized.
+window.addEventListener('unhandledrejection', event => {
+  logger.error('[unhandledrejection]', event.reason);
+  captureException(event.reason);
+});
+window.addEventListener('error', event => {
+  const err = event.error ?? new Error(event.message);
+  logger.error('[window.error]', err);
+  captureException(err);
+});
 
 createRoot(rootElement).render(
   <StrictMode>

--- a/apps/web/src/stores/useSleepTimerStore.test.ts
+++ b/apps/web/src/stores/useSleepTimerStore.test.ts
@@ -45,6 +45,17 @@ describe('useSleepTimerStore', () => {
 
       expect(useSleepTimerStore.getState().remaining).toBeLessThan(initialRemaining);
     });
+
+    it('clamps and truncates out-of-range or fractional minutes', () => {
+      useSleepTimerStore.getState().start(0);
+      expect(useSleepTimerStore.getState().duration).toBe(1); // clamped to min
+
+      useSleepTimerStore.getState().start(9999);
+      expect(useSleepTimerStore.getState().duration).toBe(600); // clamped to max
+
+      useSleepTimerStore.getState().start(12.9);
+      expect(useSleepTimerStore.getState().duration).toBe(12); // truncated
+    });
   });
 
   describe('cancel', () => {

--- a/apps/web/src/stores/useSleepTimerStore.ts
+++ b/apps/web/src/stores/useSleepTimerStore.ts
@@ -44,8 +44,14 @@ export const useSleepTimerStore = create<SleepTimerState & SleepTimerActions>((s
   remaining: 0,
 
   start: minutes => {
-    const endTime = Date.now() + minutes * 60 * 1000;
-    set({ endTime, duration: minutes, remaining: minutes * 60 });
+    // Enforce the bounds at the store boundary so every caller (presets, custom
+    // input, any future caller) obeys the same contract, not just the UI.
+    const normalized = Math.min(
+      SLEEP_TIMER_MAX_MINUTES,
+      Math.max(SLEEP_TIMER_MIN_MINUTES, Math.trunc(minutes))
+    );
+    const endTime = Date.now() + normalized * 60 * 1000;
+    set({ endTime, duration: normalized, remaining: normalized * 60 });
     startTick();
   },
 

--- a/apps/web/src/stores/useSleepTimerStore.ts
+++ b/apps/web/src/stores/useSleepTimerStore.ts
@@ -3,6 +3,10 @@ import { usePlaybackStore } from '@/stores/usePlaybackStore';
 
 export const SLEEP_TIMER_PRESETS = [15, 30, 45, 60, 90] as const;
 
+/** Bounds (in minutes) for the custom sleep-timer duration input. */
+export const SLEEP_TIMER_MIN_MINUTES = 1;
+export const SLEEP_TIMER_MAX_MINUTES = 600;
+
 interface SleepTimerState {
   /** Timestamp (ms) when the timer expires, or null if inactive */
   endTime: number | null;
@@ -34,36 +38,34 @@ function startTick() {
   }, 1000);
 }
 
-export const useSleepTimerStore = create<SleepTimerState & SleepTimerActions>(
-  (set, get) => ({
-    endTime: null,
-    duration: null,
-    remaining: 0,
+export const useSleepTimerStore = create<SleepTimerState & SleepTimerActions>((set, get) => ({
+  endTime: null,
+  duration: null,
+  remaining: 0,
 
-    start: (minutes) => {
-      const endTime = Date.now() + minutes * 60 * 1000;
-      set({ endTime, duration: minutes, remaining: minutes * 60 });
-      startTick();
-    },
+  start: minutes => {
+    const endTime = Date.now() + minutes * 60 * 1000;
+    set({ endTime, duration: minutes, remaining: minutes * 60 });
+    startTick();
+  },
 
-    cancel: () => {
+  cancel: () => {
+    clearTick();
+    set({ endTime: null, duration: null, remaining: 0 });
+  },
+
+  tick: () => {
+    const { endTime } = get();
+    if (!endTime) return;
+
+    const remaining = Math.max(0, Math.round((endTime - Date.now()) / 1000));
+
+    if (remaining <= 0) {
       clearTick();
       set({ endTime: null, duration: null, remaining: 0 });
-    },
-
-    tick: () => {
-      const { endTime } = get();
-      if (!endTime) return;
-
-      const remaining = Math.max(0, Math.round((endTime - Date.now()) / 1000));
-
-      if (remaining <= 0) {
-        clearTick();
-        set({ endTime: null, duration: null, remaining: 0 });
-        usePlaybackStore.getState().pause();
-      } else {
-        set({ remaining });
-      }
-    },
-  }),
-);
+      usePlaybackStore.getState().pause();
+    } else {
+      set({ remaining });
+    }
+  },
+}));

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -7,6 +7,7 @@ import type {
   GeocodeResult,
   WeatherCurrent,
   RecommendationShelves,
+  ShareImportResponse,
 } from '@shiranami/contracts';
 import type { DiscordRpcSettings, DiscordMusicPresenceActivity } from '@shiranami/shared';
 
@@ -403,12 +404,7 @@ export interface ElectronAPI {
   share: {
     track: (trackId: string) => Promise<{ code: string; url: string; expiresAt: string }>;
     playlist: (playlistId: string) => Promise<{ code: string; url: string; expiresAt: string }>;
-    import: (code: string) => Promise<{
-      type: 'TRACK' | 'PLAYLIST';
-      payload: unknown;
-      code: string;
-      expiresAt: string;
-    }>;
+    import: (code: string) => Promise<ShareImportResponse>;
     cacheYoutubeId: (trackId: string, youtubeId: string) => Promise<void>;
     onDeepLink: (callback: (code: string) => void) => () => void;
   };

--- a/packages/contracts/src/share/dto.test.ts
+++ b/packages/contracts/src/share/dto.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { createShareSchema, createTrackShareSchema, createPlaylistShareSchema } from './dto';
+import {
+  createShareSchema,
+  createTrackShareSchema,
+  createPlaylistShareSchema,
+  shareImportResponseSchema,
+} from './dto';
 
 const validTrack = { title: 'Song', artist: 'Artist', ytId: 'dQw4w9WgXcQ' };
 
@@ -152,6 +157,59 @@ describe('createShareSchema (discriminated union)', () => {
   it('rejects missing payload field', () => {
     const result = createShareSchema.safeParse({
       type: 'TRACK',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('shareImportResponseSchema (GET /api/share/:code)', () => {
+  const meta = { code: 'abc123', expiresAt: '2026-06-01T00:00:00.000Z' };
+
+  it('accepts a valid TRACK import response', () => {
+    const result = shareImportResponseSchema.safeParse({
+      type: 'TRACK',
+      payload: validTrack,
+      ...meta,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid PLAYLIST import response', () => {
+    const result = shareImportResponseSchema.safeParse({
+      type: 'PLAYLIST',
+      payload: { name: 'Playlist', tracks: [validTrack] },
+      ...meta,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a response missing code / expiresAt', () => {
+    expect(
+      shareImportResponseSchema.safeParse({ type: 'TRACK', payload: validTrack }).success
+    ).toBe(false);
+    expect(
+      shareImportResponseSchema.safeParse({
+        type: 'TRACK',
+        payload: validTrack,
+        code: 'abc123',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects a malformed/hostile payload (the bug this guards)', () => {
+    const result = shareImportResponseSchema.safeParse({
+      type: 'TRACK',
+      payload: { title: 123, artist: null },
+      ...meta,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unknown discriminator', () => {
+    const result = shareImportResponseSchema.safeParse({
+      type: 'ALBUM',
+      payload: validTrack,
+      ...meta,
     });
     expect(result.success).toBe(false);
   });

--- a/packages/contracts/src/share/dto.ts
+++ b/packages/contracts/src/share/dto.ts
@@ -37,7 +37,7 @@ export const createShareSchema = z.discriminatedUnion('type', [
 // hostile response cannot propagate as a lying type into the import UI. `code`
 // and `expiresAt` mirror the server's ShareData (expiresAt is a Date serialized
 // to an ISO string over JSON).
-const shareMeta = { code: z.string().min(1), expiresAt: z.string().min(1) };
+const shareMeta = { code: z.string().min(1), expiresAt: z.iso.datetime({ offset: true }) };
 
 export const shareImportResponseSchema = z.discriminatedUnion('type', [
   createTrackShareSchema.extend(shareMeta),

--- a/packages/contracts/src/share/dto.ts
+++ b/packages/contracts/src/share/dto.ts
@@ -31,6 +31,20 @@ export const createShareSchema = z.discriminatedUnion('type', [
   createPlaylistShareSchema,
 ]);
 
+// The GET /api/share/:code response: a stored share (type + payload) plus the
+// server-assigned code and expiry. Used by the desktop main process to validate
+// the inbound response before handing it to the renderer, so a malformed or
+// hostile response cannot propagate as a lying type into the import UI. `code`
+// and `expiresAt` mirror the server's ShareData (expiresAt is a Date serialized
+// to an ISO string over JSON).
+const shareMeta = { code: z.string().min(1), expiresAt: z.string().min(1) };
+
+export const shareImportResponseSchema = z.discriminatedUnion('type', [
+  createTrackShareSchema.extend(shareMeta),
+  createPlaylistShareSchema.extend(shareMeta),
+]);
+
 export type CreateShareDto = z.infer<typeof createShareSchema>;
+export type ShareImportResponse = z.infer<typeof shareImportResponseSchema>;
 export type TrackPayload = z.infer<typeof trackPayloadSchema>;
 export type PlaylistPayload = z.infer<typeof playlistPayloadSchema>;


### PR DESCRIPTION
## What this is

A whole-codebase tech-debt sweep (`/audit`, production mode) scoped to the core product (`apps/web`, `apps/desktop`, `packages/*`). This PR lands **every critical and high-severity finding** from that sweep. The larger structural items and the suggested/nit tiers are deliberately deferred (see **Follow-ups** below) so this PR stays focused and reviewable.

All changes are behavior-preserving except where a finding *was* a behavior bug (e.g. nullable fields rendering as the literal string `null`). Each fix was verified before commit; the full gauntlet is green.

## Fixes (by severity)

### Security (1 critical + 2 high)
- **RCE via yt-dlp argument injection** - renderer/extraction-derived URLs (download, stream-url, playlist import, discover mix) were passed positionally to `yt-dlp` with no `--` separator and only `z.string().min(1)` validation, so a `--exec=<cmd>` value from a tampered playlist/share payload could run an arbitrary command. Added `isHttpUrl` + `appendUrlArg` (scheme gate + `--` end-of-options) and `--ignore-config`.
- **SSRF** in cover-art fetch - routed `downloadImage` through the existing `isStreamUrlAllowed` private-IP guard.

### Contracts / Types (4 critical)
- Playlist tracks and listening history returned **nullable DB columns typed as non-null**, rendering as `"null"`. Routed playlist tracks through the shared mapper; coalesced history artist/album at the handler.
- **Share-import response** was cast `as ImportData` with `!` assertions on untrusted network data. Added `shareImportResponseSchema`, validated at the IPC boundary, and typed `share.import` end to end (cast + assertions removed).

### Concurrency (3 critical)
- Double-click download guard in search (synchronous in-flight ref).
- `db:tracks:add` made idempotent on the existing `UNIQUE(file_path)` (no more thrown constraint on a racing import).
- `db:playlists:add-track` read-modify-write wrapped in a transaction. *(No schema migration needed - the UNIQUE constraints already exist in `createTables` for every DB.)*

### Error handling + Observability (3 critical)
- Settings/Discord save failures now surface a toast and resync; the Discord Save button can't be double-submitted.
- Added a renderer global `unhandledrejection` / `error` handler (async failures were neither logged nor reported).
- Discord login failures are logged with the error at `warn` instead of being discarded at `debug`.

### Accessibility (3 critical + several)
- The **seek bar** is now keyboard-operable (Arrow / PageUp-Down / Home / End).
- Search/filter inputs, icon buttons, playlist-name inputs, and Discord/EQ labels got accessible names / associations; sidebar `aria-current`; radio now-playing `sr-only`; decorative images `aria-hidden`.

### Mechanical
- Magic-number constants; `rel="noopener noreferrer"` on external links.

## Verification
- `pnpm typecheck` (all packages + web + desktop): green
- `pnpm lint`: green
- `pnpm test`: **1496 passed / 117 files**, including ~95 new assertions (yt-dlp arg-injection, share schema, history null-coalesce, track/playlist idempotency, seek-bar keyboard)

## Follow-ups (deferred, not in this PR)
- **a11y (critical):** `TrackContextMenu` keyboard path - needs menu/menuitem roles, roving focus, arrow nav, submenu keyboard (a ~360-line structural rework).
- **~40 suggested:** data-integrity (orphaned album-art on single delete, recommendation cache invalidation, radio-favorites upsert), loading-states (skeleton parity, button disabled states), perf (index on `play_history.completed`, column projection on `getAll`), client-bundle (lazy-load non-active locale, slim `package.json` import), observability (correlation ids for jobs), simplify (shared `UNKNOWN_ARTIST` constant, `coerceEnum`/`clampNumber` reuse, scheme constants).
- **~28 nits:** Drizzle schema vs runtime index drift, partial cache validation, misc.