### PR TITLE
fix(ui): use the app's thin scrollbar in import empty state and debug overlay

### DIFF
--- a/apps/web/src/components/debug/DebugOverlay.tsx
+++ b/apps/web/src/components/debug/DebugOverlay.tsx
@@ -67,7 +67,7 @@ export function DebugOverlay() {
         </button>
       </div>
 
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto scrollbar-thin">
         <Section title="Processes (main)">
           {main ? (
             <table className="w-full font-mono tabular-nums">

--- a/apps/web/src/components/playlist-import/PlaylistImportView.tsx
+++ b/apps/web/src/components/playlist-import/PlaylistImportView.tsx
@@ -190,7 +190,7 @@ export function PlaylistImportView() {
 
       {/* Track list or empty state */}
       {!hasResults ? (
-        <div className="flex-1 min-h-0 flex overflow-y-auto">
+        <div className="flex-1 min-h-0 flex">
           <ViewEmptyState
             title={t('emptyTitle')}
             subtitle={t('emptySubtitle')}


### PR DESCRIPTION
## Summary
- Import Playlist empty state rendered the chunky native OS scrollbar (issue #241): the wrapper had `overflow-y-auto` and `ViewEmptyState` is `min-h-full`, so the centered card always overflowed by a hair. Removed `overflow-y-auto` to match the `RadioView` sibling pattern; the empty state is centered and not meant to scroll.
- Debug overlay scroll container was missing the `scrollbar-thin` class every other scroll region uses, so it also showed the native bar. Added the class (found via a repo-wide grep while verifying #241).
- Import results list scrolling is untouched: that is a separate ternary branch using a virtualized `List` with its own `scrollbar-thin` viewport.

## Test plan
- [x] Open Import Playlist with no URL extracted -> empty-state card is centered with no scrollbar (was a thick native bar at 1080p).
- [x] Paste a playlist, extract -> the track list still scrolls normally with the thin scrollbar.
- [x] Open the debug overlay (long process list) -> it scrolls with the thin scrollbar, not the native one.

Closes #241.