### PR TITLE
fix: now-playing title, control overflow, and low-perf chrome washout

### DIFF
--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -187,8 +187,8 @@ export function NowPlayingView() {
                 // shrinks the art so the controls always clear the window bottom
                 // instead of sliding under the OS taskbar.
                 panelVisible
-                  ? 'w-[55%] min-w-[180px] max-w-[240px] @3xl:w-full @3xl:max-w-[min(calc(100vh-28rem),clamp(280px,22vw,480px))]'
-                  : 'w-full max-w-[min(calc(100vh-30rem),clamp(300px,24vw,440px))]'
+                  ? 'w-[55%] min-w-[180px] max-w-[240px] @3xl:w-full @3xl:max-w-[min(calc(100vh_-_28rem),clamp(280px,22vw,480px))]'
+                  : 'w-full max-w-[min(calc(100vh_-_30rem),clamp(300px,24vw,440px))]'
               )}
             >
               {currentTrack.albumArt ? (

--- a/apps/web/src/components/now-playing/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView.tsx
@@ -101,7 +101,10 @@ export function NowPlayingView() {
         <motion.button
           whileTap={{ scale: 0.9 }}
           onClick={exitNowPlaying}
-          className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+          // glass-subtle backing matches the panel-toggle group on the right and
+          // keeps the icon legible: this button sits over the bare theme image,
+          // so a transparent background washes out on bright themes (summer).
+          className="glass-subtle rounded-lg border border-border/20 p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
           aria-label={t('back')}
         >
           <ArrowLeft className="w-4 h-4" />
@@ -175,9 +178,17 @@ export function NowPlayingView() {
               className={cn(
                 'shrink-0 aspect-square rounded-2xl @5xl:rounded-3xl overflow-hidden',
                 'shadow-2xl shadow-black/40 bg-muted flex items-center justify-center',
+                // The art is sized by max-width, and the box is aspect-square, so
+                // capping max-width also caps its height. The `calc(100vh - …)`
+                // term is a height budget that reserves room for the header, track
+                // info, seek bar and controls: on tall viewports the width clamp
+                // wins (art stays large), but on short ones (e.g. a 1080p screen at
+                // 150% display scaling → ~720px tall) the height budget wins and
+                // shrinks the art so the controls always clear the window bottom
+                // instead of sliding under the OS taskbar.
                 panelVisible
-                  ? 'w-[55%] min-w-[180px] max-w-[240px] @3xl:w-full @3xl:max-w-[min(48vh,clamp(280px,22vw,480px))]'
-                  : 'w-full max-w-[min(52vh,clamp(300px,24vw,440px))]'
+                  ? 'w-[55%] min-w-[180px] max-w-[240px] @3xl:w-full @3xl:max-w-[min(calc(100vh-28rem),clamp(280px,22vw,480px))]'
+                  : 'w-full max-w-[min(calc(100vh-30rem),clamp(300px,24vw,440px))]'
               )}
             >
               {currentTrack.albumArt ? (

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -65,7 +65,13 @@ export function Sidebar() {
   return (
     <div
       className={cn(
-        'shrink-0 flex flex-col h-full glass border-r border-border/50 transition-[width] duration-200',
+        // `relative z-10` gives the sidebar its own stacking context so its
+        // opaque glass background always paints ABOVE the fixed `z-0`
+        // ThemeBackground image. Without it the sidebar is position:static and,
+        // in low-performance mode (where the override drops `backdrop-filter`
+        // and with it the stacking context blur used to create), the theme
+        // image paints over the sidebar and washes the nav chrome out.
+        'app-sidebar relative z-10 shrink-0 flex flex-col h-full glass border-r border-border/50 transition-[width] duration-200',
         sidebarCollapsed ? 'w-[5.25rem]' : 'w-[12.5rem]'
       )}
     >

--- a/apps/web/src/components/shared/TopBar.test.tsx
+++ b/apps/web/src/components/shared/TopBar.test.tsx
@@ -38,4 +38,10 @@ describe('TopBar page title', () => {
     render(<TopBar />);
     expect(screen.getByRole('heading', { level: 1 }).textContent).toBe(expectedKey);
   });
+
+  it('hides the page title on the now-playing view (it carries its own header)', () => {
+    activeView = 'now-playing';
+    render(<TopBar />);
+    expect(screen.queryByRole('heading', { level: 1 })).toBeNull();
+  });
 });

--- a/apps/web/src/components/shared/TopBar.tsx
+++ b/apps/web/src/components/shared/TopBar.tsx
@@ -54,13 +54,17 @@ export function TopBar({ onAddFile, onAddFolder, isScanning }: TopBarProps) {
   }, [dropdownOpen]);
 
   return (
-    <div className="drag h-11 flex items-center shrink-0 border-b border-border/20 relative z-10">
-      {/* Page title */}
-      <div className="no-drag flex items-center px-5">
-        <h1 className="font-display text-sm font-semibold text-foreground">
-          {t(VIEW_TITLE_KEYS[activeView] || 'library', { ns: 'sidebar' })}
-        </h1>
-      </div>
+    <div className="app-topbar drag h-11 flex items-center shrink-0 border-b border-border/20 relative z-10">
+      {/* Page title — skipped on the now-playing view, which carries its own
+          header chrome (back button + panel toggles), so a duplicate page
+          title would just be redundant noise. */}
+      {activeView !== 'now-playing' && (
+        <div className="no-drag flex items-center px-5">
+          <h1 className="font-display text-sm font-semibold text-foreground">
+            {t(VIEW_TITLE_KEYS[activeView] || 'library', { ns: 'sidebar' })}
+          </h1>
+        </div>
+      )}
 
       <div className="flex-1" />
 

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -711,6 +711,44 @@
   backdrop-filter: none;
 }
 
+/* The TopBar is intentionally transparent over the solid 'none' theme. Under an
+   image theme it sits directly over the photo (the fixed z-0 ThemeBackground),
+   so the page title, language toggle and window controls wash out on bright
+   themes (summer). Add a frosted backing ONLY when an image theme is active,
+   matching the .glass / now-playing-hero pattern; the 'none' theme keeps its
+   backing-free bar. */
+[data-theme] .app-topbar {
+  background: oklch(0.08 0.02 280 / 0.38);
+  backdrop-filter: blur(8px) saturate(1.2);
+}
+
+/* Low-perf drops the blur (compositor cost); compensate with a little more
+   opacity so the chrome stays legible over a bright photo — same intent as the
+   .glass low-perf override, but kept as light as legibility allows. */
+[data-perf-mode='low'][data-theme] .app-topbar {
+  background: oklch(0.08 0.02 280 / 0.62);
+  backdrop-filter: none;
+}
+
+/* Sidebar frosted backing on image themes — lighter than the shared .glass so
+   the theme photo reads softly through it (matching the airy glass aesthetic of
+   the rest of the chrome) while keeping the nav legible. Placed AFTER the
+   [data-perf-mode='low'] .glass overrides so the equal-specificity low-perf rule
+   below wins by source order (the sidebar carries both `glass` and
+   `app-sidebar`). The left strip behind the sidebar is the dark room interior of
+   every theme, so it tolerates more transparency than the bright top strip. */
+[data-theme] .app-sidebar {
+  background: oklch(0.1 0.02 280 / 0.55);
+  backdrop-filter: blur(12px) saturate(1.3);
+}
+
+/* Low-perf has no blur to soften the bright window/lantern highlights in the
+   photo, so keep more opacity here than in normal mode to protect nav contrast. */
+[data-perf-mode='low'][data-theme] .app-sidebar {
+  background: oklch(0.1 0.02 280 / 0.82);
+  backdrop-filter: none;
+}
+
 /* prefers-reduced-transparency: drop backdrop blur on glass, stay legible via
    higher opacity. Mirrors the low-perf .glass override intent. Kept outside
    @layer (same region as the low-perf rules) so it reliably beats the


### PR DESCRIPTION
## Summary
- Now Playing no longer shows a stale "Library" heading: `TopBar` had no `now-playing` entry in `VIEW_TITLE_KEYS` and fell through to the `'library'` default. The view already carries its own header (back button + panel toggles), so the page title is skipped there.
- Root-caused the low-performance-mode chrome washout: the sidebar was `position: static`, so the fixed `z-0` `ThemeBackground` painted over its background. Normal mode masked this via `backdrop-filter`'s stacking context, which low-perf strips. Fixed with `relative z-10`. Added theme-gated frosted backings for the top bar (`app-topbar`) and a lighter frosted sidebar (`app-sidebar`) so chrome stays legible over image themes; the solid `none` theme is untouched.
- Now Playing album art now uses a `calc(100vh - …)` height budget so the player controls clear the window bottom at scaled resolutions (a 1080p display at 150% scaling is ~720px tall, where controls previously slid under the taskbar). Native 1080 art size is unchanged. The back arrow also gets a glass backing.

Closes #242

## Test plan
- [x] Image theme (summer) + low-performance mode ON, open the sidebar: it stays a solid/frosted bar with the nav, logo and collapse button legible (not see-through).
- [x] Open Now Playing: the top bar shows no "Library" title; the back arrow is legible over the photo.
- [x] 1080p display at 150% scaling, open Now Playing with lyrics open and closed: the player controls sit clear of the taskbar.
- [x] Toggle low-perf off: top bar and sidebar show the frosted blur; toggle on: they stay legible without blur.
- [x] `none` theme: top bar and sidebar render with no added backing (unchanged).