### PR TITLE
feat(landing): add 404 page, robots.txt, and SEO meta for search indexing

### DIFF
--- a/apps/landing/public/robots.txt
+++ b/apps/landing/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://shiranami.app/sitemap-index.xml

--- a/apps/landing/src/components/BaseHead.astro
+++ b/apps/landing/src/components/BaseHead.astro
@@ -5,14 +5,64 @@ import '../styles/global.css';
 interface Props {
   title: string;
   description?: string;
+  /** Emit the homepage structured-data block (Organization + WebSite + SoftwareApplication). */
+  structuredData?: boolean;
+  /** Allow opting a page out of indexing (e.g. the 404 page). */
+  noindex?: boolean;
 }
 
 const {
   title,
   description = 'Shiranami is a desktop music sanctuary for local libraries, playlists, synced lyrics, internet radio, crossfade, and one-step YouTube downloads.',
+  structuredData = false,
+  noindex = false,
 } = Astro.props;
 
-const ogImage = new URL('/og-default.png', Astro.site ?? Astro.url);
+const siteOrigin = Astro.site ?? new URL(Astro.url.origin);
+
+// Self-referencing canonical. Keep the trailing slash so it matches the
+// sitemap output (e.g. /download/, /changelog/).
+const canonicalURL = new URL(Astro.url.pathname, siteOrigin);
+
+const ogImage = new URL('/og-default.png', siteOrigin);
+const ogImageAlt = 'Shiranami — a calm dark-lavender desktop music player';
+
+const orgJsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'Organization',
+      '@id': `${siteOrigin.href}#organization`,
+      name: 'Shiranami',
+      url: siteOrigin.href,
+      logo: new URL('/favicon.png', siteOrigin).href,
+      image: ogImage.href,
+    },
+    {
+      '@type': 'WebSite',
+      '@id': `${siteOrigin.href}#website`,
+      name: 'Shiranami',
+      url: siteOrigin.href,
+      publisher: { '@id': `${siteOrigin.href}#organization` },
+      inLanguage: 'en',
+    },
+    {
+      '@type': 'SoftwareApplication',
+      name: 'Shiranami',
+      url: siteOrigin.href,
+      applicationCategory: 'MultimediaApplication',
+      operatingSystem: 'Windows, macOS',
+      description:
+        'A local-first desktop music sanctuary for local libraries, playlists, synced lyrics, internet radio, crossfade, and one-step YouTube downloads.',
+      image: ogImage.href,
+      offers: {
+        '@type': 'Offer',
+        price: '0',
+        priceCurrency: 'USD',
+      },
+    },
+  ],
+};
 ---
 
 <meta charset="UTF-8" />
@@ -21,6 +71,7 @@ const ogImage = new URL('/og-default.png', Astro.site ?? Astro.url);
 <script is:inline>document.documentElement.classList.add('js');</script>
 <ClientRouter />
 <link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="canonical" href={canonicalURL} />
 <link rel="sitemap" href="/sitemap-index.xml" />
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -32,20 +83,33 @@ const ogImage = new URL('/og-default.png', Astro.site ?? Astro.url);
 
 <title>{title}</title>
 <meta name="description" content={description} />
+{
+  noindex ? (
+    <meta name="robots" content="noindex,nofollow" />
+  ) : (
+    <meta name="robots" content="index,follow" />
+  )
+}
 
 <meta property="og:type" content="website" />
-<meta property="og:url" content={Astro.url} />
-<meta property="og:title" content="Shiranami · white waves — a quiet place for your music" />
-<meta
-  property="og:description"
-  content="A local-first desktop sanctuary for your music library, internet radio, synced lyrics, crossfade, and one-step downloads — wrapped in a calm dark lavender theme."
-/>
+<meta property="og:site_name" content="Shiranami" />
+<meta property="og:locale" content="en" />
+<meta property="og:url" content={canonicalURL} />
+<meta property="og:title" content={title} />
+<meta property="og:description" content={description} />
 <meta property="og:image" content={ogImage} />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content={ogImageAlt} />
 
 <meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:title" content="Shiranami · white waves — a quiet place for your music" />
-<meta
-  name="twitter:description"
-  content="A desktop player built for local libraries, playlists, internet radio, crossfade, downloads, and a softer late-night listening flow."
-/>
+<meta name="twitter:title" content={title} />
+<meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={ogImage} />
+<meta name="twitter:image:alt" content={ogImageAlt} />
+
+{
+  structuredData && (
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(orgJsonLd)} />
+  )
+}

--- a/apps/landing/src/components/DownloadPage.tsx
+++ b/apps/landing/src/components/DownloadPage.tsx
@@ -1,12 +1,5 @@
 import { AnimatePresence, MotionConfig, motion } from 'framer-motion';
-import {
-  type MouseEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { type MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { LandingLanguage } from '@/lib/i18n';
 import { GITHUB_RELEASES_API_URL, GITHUB_RELEASES_LATEST_URL } from '@/lib/site';
 
@@ -77,9 +70,7 @@ function detectPlatform(): Platform {
 
 function formatBytes(bytes: number, locale: string): string {
   if (bytes < 1024 * 1024) {
-    return `${new Intl.NumberFormat(locale, { maximumFractionDigits: 0 }).format(
-      bytes / 1024
-    )} KB`;
+    return `${new Intl.NumberFormat(locale, { maximumFractionDigits: 0 }).format(bytes / 1024)} KB`;
   }
   return `${new Intl.NumberFormat(locale, {
     minimumFractionDigits: 1,
@@ -147,7 +138,7 @@ function useConfetti() {
 
   const layer = (
     <AnimatePresence>
-      {particles.map((p) => {
+      {particles.map(p => {
         const rad = (p.angle * Math.PI) / 180;
         return (
           <motion.div
@@ -190,8 +181,7 @@ export function DownloadPage({ translations }: DownloadPageProps) {
 
   useEffect(() => {
     const sync = () => {
-      const next: LandingLanguage =
-        document.documentElement.lang === 'pl' ? 'pl' : 'en';
+      const next: LandingLanguage = document.documentElement.lang === 'pl' ? 'pl' : 'en';
       setLang(next);
     };
     sync();
@@ -218,7 +208,7 @@ export function DownloadPage({ translations }: DownloadPageProps) {
   useEffect(() => {
     const ctrl = new AbortController();
     fetch(GITHUB_RELEASES_API_URL, { signal: ctrl.signal })
-      .then((res) => {
+      .then(res => {
         if (!res.ok) throw new Error('Failed to fetch latest release');
         return res.json() as Promise<ReleaseData>;
       })
@@ -243,7 +233,7 @@ export function DownloadPage({ translations }: DownloadPageProps) {
     const map = new Map<Platform, ReleaseAsset>();
     if (!release) return map;
     for (const platform of PLATFORMS) {
-      const asset = release.assets.find((a) => platform.pattern.test(a.name));
+      const asset = release.assets.find(a => platform.pattern.test(a.name));
       if (asset) map.set(platform.key, asset);
     }
     return map;
@@ -273,7 +263,7 @@ export function DownloadPage({ translations }: DownloadPageProps) {
               <span aria-hidden="true">●</span>{' '}
               <span>Section · DL &nbsp;·&nbsp; {t('download.eyebrow')}</span>
             </div>
-            <h2>
+            <h1>
               {downloaded ? (
                 <>
                   <span>{t('download.headingAfterLead')}</span>{' '}
@@ -281,11 +271,10 @@ export function DownloadPage({ translations }: DownloadPageProps) {
                 </>
               ) : (
                 <>
-                  <span>{t('download.headingLead')}</span>{' '}
-                  <em>{t('download.headingAccent')}</em>.
+                  <span>{t('download.headingLead')}</span> <em>{t('download.headingAccent')}</em>.
                 </>
               )}
-            </h2>
+            </h1>
 
             <p className="dl-body" key={downloaded ? 'after' : 'before'}>
               {downloaded ? t('download.bodyAfter') : t('download.body')}
@@ -317,9 +306,7 @@ export function DownloadPage({ translations }: DownloadPageProps) {
                   <span className="rv">
                     <span className="rv-dot" aria-hidden="true" />v{version}
                   </span>
-                  <span className="rd">
-                    {formatPublishedDate(release.published_at, locale)}
-                  </span>
+                  <span className="rd">{formatPublishedDate(release.published_at, locale)}</span>
                 </div>
               ) : (
                 <div className="dl-release-chip dl-release-chip-loading">
@@ -343,12 +330,14 @@ export function DownloadPage({ translations }: DownloadPageProps) {
                   className="btn-ghost"
                 >
                   <span>{t('download.getFromGithub')}</span>
-                  <span className="arr" aria-hidden="true">→</span>
+                  <span className="arr" aria-hidden="true">
+                    →
+                  </span>
                 </a>
               </div>
             ) : !release ? (
               <div className="platforms">
-                {PLATFORMS.map((p) => (
+                {PLATFORMS.map(p => (
                   <div key={p.key} className="platform platform-skeleton">
                     <div className="l">
                       <span className="platform-icon">
@@ -365,7 +354,7 @@ export function DownloadPage({ translations }: DownloadPageProps) {
               </div>
             ) : (
               <div className="platforms">
-                {PLATFORMS.map((p) => {
+                {PLATFORMS.map(p => {
                   const asset = assetMap.get(p.key);
                   const isPrimary = p.key === detectedPlatform;
                   const label = t(p.labelKey);
@@ -401,9 +390,7 @@ export function DownloadPage({ translations }: DownloadPageProps) {
                           <div className="pn">
                             {label}
                             {isPrimary && (
-                              <span className="pn-badge">
-                                {t('download.yourSystem')}
-                              </span>
+                              <span className="pn-badge">{t('download.yourSystem')}</span>
                             )}
                           </div>
                           <div className="ps">

--- a/apps/landing/src/layouts/BaseLayout.astro
+++ b/apps/landing/src/layouts/BaseLayout.astro
@@ -4,15 +4,22 @@ import BaseHead from '../components/BaseHead.astro';
 interface Props {
   title: string;
   description?: string;
+  structuredData?: boolean;
+  noindex?: boolean;
 }
 
-const { title, description } = Astro.props;
+const { title, description, structuredData, noindex } = Astro.props;
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead
+      title={title}
+      description={description}
+      structuredData={structuredData}
+      noindex={noindex}
+    />
   </head>
   <body>
     <a href="#main" class="skip-link" data-i18n="layout.skipToContent">Skip to content</a>

--- a/apps/landing/src/lib/i18n.ts
+++ b/apps/landing/src/lib/i18n.ts
@@ -219,6 +219,14 @@ export const translations: Record<LandingLanguage, Record<string, string>> = {
     'changelog.jump.title': '● All releases · jump to an entry',
     'changelog.stamp': '● End of archive · 白波 · 2026',
     'changelog.quietNote': 'The first quiet note. More pages, soon.',
+
+    // 404 page
+    'notFound.pill': 'Error 404',
+    'notFound.heading': 'This track skipped.',
+    'notFound.body':
+      'The page you were looking for has drifted off the shelf. Let’s get you back to a quieter room.',
+    'notFound.home': 'Back home',
+    'notFound.download': 'Download the app',
   },
   pl: {
     // Shared
@@ -437,5 +445,13 @@ export const translations: Record<LandingLanguage, Record<string, string>> = {
     'changelog.jump.title': '● Wszystkie wydania · przejdź do wpisu',
     'changelog.stamp': '● Koniec archiwum · 白波 · 2026',
     'changelog.quietNote': 'Pierwsza cicha nuta. Więcej stron wkrótce.',
+
+    // 404 page
+    'notFound.pill': 'Błąd 404',
+    'notFound.heading': 'Ten utwór przeskoczył.',
+    'notFound.body':
+      'Strona, której szukasz, zsunęła się z półki. Wróćmy do spokojniejszego pokoju.',
+    'notFound.home': 'Powrót do strony głównej',
+    'notFound.download': 'Pobierz aplikację',
   },
 };

--- a/apps/landing/src/pages/404.astro
+++ b/apps/landing/src/pages/404.astro
@@ -1,0 +1,48 @@
+---
+import Footer from '../components/Footer.astro';
+import Navbar from '../components/Navbar.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="Not found · Shiranami"
+  description="The page you were looking for could not be found on Shiranami."
+  noindex
+>
+  <Navbar />
+  <main id="main" class="bay page">
+    <div class="page-shell not-found">
+      <div class="section-heading">
+        <span class="pill" data-i18n="notFound.pill">Error 404</span>
+        <h1 data-i18n="notFound.heading">This track skipped.</h1>
+        <p data-i18n="notFound.body">
+          The page you were looking for has drifted off the shelf. Let’s get you
+          back to a quieter room.
+        </p>
+      </div>
+      <div class="not-found-actions">
+        <a class="button-primary" href="/" data-i18n="notFound.home">Back home</a>
+        <a class="button-secondary" href="/download/" data-i18n="notFound.download">
+          Download the app
+        </a>
+      </div>
+    </div>
+  </main>
+  <Footer />
+</BaseLayout>
+
+<style>
+  .not-found {
+    min-height: 52vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .not-found-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.4rem;
+  }
+</style>

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -14,6 +14,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout
   title="白波 · Shiranami — a quiet place for your music"
   description="A local-first desktop sanctuary for your music library, internet radio, synced lyrics, crossfade, and one-step downloads — wrapped in a calm dark lavender theme."
+  structuredData
 >
   <Navbar />
   <main id="main">

--- a/apps/landing/src/styles/components/download.css
+++ b/apps/landing/src/styles/components/download.css
@@ -226,7 +226,7 @@
     gap: 6px;
   }
 
-  .dl-copy h2 {
+  .dl-copy h1 {
     margin: 0;
     font-family: var(--font-display);
     font-weight: 400;
@@ -235,7 +235,7 @@
     letter-spacing: -0.025em;
   }
 
-  .dl-copy h2 em {
+  .dl-copy h1 em {
     color: var(--primary);
     font-style: italic;
   }


### PR DESCRIPTION
## Summary

Closes the highest-impact SEO/indexing gaps on the landing site (`apps/landing`) found in a read-only audit. All copy follows the existing runtime localStorage i18n pattern (`data-i18n` + `src/lib/i18n.ts`, EN + PL).

- **`public/robots.txt`** — allow all crawlers and declare `Sitemap: https://shiranami.app/sitemap-index.xml` so Google can actually discover the sitemap (the `<link rel="sitemap">` in `<head>` is not a discovery mechanism).
- **`src/pages/404.astro`** — on-brand, `noindex,nofollow` 404 reusing the existing `page-shell` / `section-heading` / `pill` / `button-*` styles, Navbar + Footer, with EN + PL i18n keys and links back home and to download. Statically renders to `dist/404.html`.
- **`BaseHead.astro` SEO meta** — self-referencing `<link rel="canonical">` from `Astro.url` (trailing-slash preserved to match the sitemap); per-page–bound Open Graph (`og:title`/`og:description`/`og:url`) plus `og:site_name`, `og:locale`, and `og:image:width`/`height`/`alt`; per-page–bound Twitter `summary_large_image` card with `twitter:image:alt`; explicit `robots` meta (`index,follow`, or `noindex,nofollow` on the 404); and JSON-LD (`Organization` + `WebSite` + `SoftwareApplication`, price 0, OS "Windows, macOS") emitted on the homepage only.
- **Download page heading** — promoted the lead `<h2>` to `<h1>` (it previously had no `<h1>`); CSS selector updated to match.

No hreflang: i18n is runtime localStorage with a single URL per page and server HTML always `lang="en"`, so there are no per-locale URLs to point to (per the audit).

## SEO audit — what was found and how it was resolved

| Finding (severity) | Resolution |
| --- | --- |
| No `robots.txt` / no `Sitemap:` directive (high) | Added `public/robots.txt` with allow-all + Sitemap directive. |
| No canonical tag (high) | Added self-referencing canonical, trailing-slash matched to sitemap. |
| OG `title`/`description` hardcoded to homepage copy; `og:site_name`/`og:locale` missing (medium) | Bound OG title/description to per-page props; added `og:site_name`, `og:locale`. |
| Twitter `title`/`description` hardcoded (medium) | Bound Twitter title/description to per-page props; added `twitter:image:alt`. |
| No JSON-LD structured data (medium) | Added Organization + WebSite + SoftwareApplication on the homepage. |
| `og:image` missing width/height/alt (low) | Added `og:image:width=1200`, `height=630`, and alt text. |
| No robots meta (low) | Added explicit `index,follow` (and `noindex,nofollow` on 404). |
| No 404 page (low) | Added on-brand `noindex` 404. |
| Download page lacked an `<h1>` (low) | Promoted lead heading to `<h1>`. |
| Sitemap working; 404 must not be indexed | Verified: sitemap still lists `/`, `/changelog/`, `/download/` only; 404 excluded. |

## Test plan

- `pnpm --filter @shiranami/landing check` — passes (0 errors).
- `pnpm --filter @shiranami/landing build` — succeeds and emits:
  - `dist/404.html` (with `noindex,nofollow`)
  - `dist/robots.txt` (copied from `public/`)
  - `dist/sitemap-index.xml` + `dist/sitemap-0.xml` (3 real pages, trailing slashes, no 404)
- Verified per-page canonical/OG (`/download/` emits its own `og:title`), JSON-LD on index only, single `<h1>` on download.
- To validate post-deploy: in Google Search Console submit `https://shiranami.app/sitemap-index.xml`, use the URL Inspection tool on `/`, `/download/`, `/changelog/` to confirm canonical + indexable status, and the Rich Results test on `/` for the SoftwareApplication schema.
