### PR TITLE
feat(settings): show music disk usage + free space per volume

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -19,3 +19,4 @@ export { registerMetadataEnrichHandlers, cleanupMetadataEnrichHandlers } from '.
 export { registerLoudnessHandlers, cleanupLoudnessHandlers } from './loudness';
 export { registerRecommendationsHandlers, cleanupRecommendationsHandlers } from './recommendations';
 export { registerScrobbleHandlers, cleanupScrobbleHandlers } from './scrobble';
+export { registerStorageHandlers, cleanupStorageHandlers } from './storage';

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -72,6 +72,8 @@ import {
   cleanupRecommendationsHandlers,
   registerScrobbleHandlers,
   cleanupScrobbleHandlers,
+  registerStorageHandlers,
+  cleanupStorageHandlers,
 } from './';
 
 export function registerIpcHandlers(mainWindow: BrowserWindow): void {
@@ -96,6 +98,7 @@ export function registerIpcHandlers(mainWindow: BrowserWindow): void {
   registerLoudnessHandlers();
   registerRecommendationsHandlers();
   registerScrobbleHandlers();
+  registerStorageHandlers();
 }
 
 export function cleanupIpcHandlers(): void {
@@ -120,4 +123,5 @@ export function cleanupIpcHandlers(): void {
   cleanupLoudnessHandlers();
   cleanupRecommendationsHandlers();
   cleanupScrobbleHandlers();
+  cleanupStorageHandlers();
 }

--- a/apps/desktop/src/main/ipc/schemas/storage.ts
+++ b/apps/desktop/src/main/ipc/schemas/storage.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+/**
+ * `storage:get-usage` — the watched library-folder paths. Empty strings are
+ * rejected at the boundary; the handler additionally dedupes and tolerates an
+ * empty array (returns no volumes).
+ */
+export const getUsageArgs = z.tuple([z.array(z.string().min(1))]);

--- a/apps/desktop/src/main/ipc/storage.test.ts
+++ b/apps/desktop/src/main/ipc/storage.test.ts
@@ -46,6 +46,13 @@ describe('volumeKeyFor', () => {
       expect(volumeKeyFor('D:\\Audio', 7)).toBe('D:\\');
     });
   });
+
+  it('normalizes Windows drive-root case so c:\\ and C:\\ bucket together', () => {
+    withPlatform('win32', () => {
+      expect(volumeKeyFor('c:\\Music', 1)).toBe(volumeKeyFor('C:\\Other', 2));
+      expect(volumeKeyFor('c:\\Music', 1)).toBe('C:\\');
+    });
+  });
 });
 
 describe('mountLabelFor', () => {

--- a/apps/desktop/src/main/ipc/storage.test.ts
+++ b/apps/desktop/src/main/ipc/storage.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { DiskUsageResult } from '@shiranami/contracts';
+import { ipcHandlers, makeTempDir, cleanupTempDir } from '../../../test/setup';
+import {
+  registerStorageHandlers,
+  cleanupStorageHandlers,
+  volumeKeyFor,
+  mountLabelFor,
+  sumDirectorySize,
+  computeDiskUsage,
+} from './storage';
+
+vi.mock('../logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const event = null as never;
+
+/** Temporarily force `process.platform` for a win32-branch assertion. */
+function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
+  const original = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  try {
+    fn();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: original, configurable: true });
+  }
+}
+
+describe('volumeKeyFor', () => {
+  it('uses the device id on POSIX', () => {
+    withPlatform('darwin', () => {
+      expect(volumeKeyFor('/Users/me/Music', 42)).toBe('42');
+    });
+  });
+
+  it('uses the drive root on Windows', () => {
+    withPlatform('win32', () => {
+      expect(volumeKeyFor('C:\\Users\\me\\Music', 42)).toBe('C:\\');
+      expect(volumeKeyFor('D:\\Audio', 7)).toBe('D:\\');
+    });
+  });
+});
+
+describe('mountLabelFor', () => {
+  it('labels an external macOS volume by name and the root as "/"', () => {
+    withPlatform('darwin', () => {
+      expect(mountLabelFor('/Volumes/Samsung T7/Music')).toBe('Samsung T7');
+      expect(mountLabelFor('/Users/me/Music')).toBe('/');
+    });
+  });
+
+  it('labels a Windows volume by drive letter without the separator', () => {
+    withPlatform('win32', () => {
+      expect(mountLabelFor('C:\\Users\\me\\Music')).toBe('C:');
+    });
+  });
+});
+
+describe('sumDirectorySize', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tmpDir);
+  });
+
+  it('sums logical file sizes across nested directories', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'a.mp3'), Buffer.alloc(1000));
+    fs.writeFileSync(path.join(tmpDir, 'cover.jpg'), Buffer.alloc(500)); // non-audio counts too
+    const sub = path.join(tmpDir, 'album');
+    fs.mkdirSync(sub);
+    fs.writeFileSync(path.join(sub, 'b.flac'), Buffer.alloc(2000));
+    const deep = path.join(sub, 'disc2');
+    fs.mkdirSync(deep);
+    fs.writeFileSync(path.join(deep, 'c.ogg'), Buffer.alloc(300));
+
+    expect(await sumDirectorySize(tmpDir)).toBe(3800);
+  });
+
+  it('returns 0 for a non-existent directory (swallowed)', async () => {
+    expect(await sumDirectorySize(path.join(tmpDir, 'nope'))).toBe(0);
+  });
+
+  it('returns 0 for an empty directory', async () => {
+    expect(await sumDirectorySize(tmpDir)).toBe(0);
+  });
+
+  it('respects maxDepth', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'top.mp3'), Buffer.alloc(100));
+    const sub = path.join(tmpDir, 'sub');
+    fs.mkdirSync(sub);
+    fs.writeFileSync(path.join(sub, 'deep.mp3'), Buffer.alloc(100));
+
+    // maxDepth 0 only reads the root level; the subdir's file is excluded.
+    expect(await sumDirectorySize(tmpDir, 0)).toBe(100);
+  });
+});
+
+describe('computeDiskUsage', () => {
+  let dirA: string;
+  let dirB: string;
+
+  beforeEach(() => {
+    dirA = makeTempDir();
+    dirB = makeTempDir();
+  });
+
+  afterEach(() => {
+    cleanupTempDir(dirA);
+    cleanupTempDir(dirB);
+  });
+
+  it('reports one volume with accurate music bytes for a single folder', async () => {
+    fs.writeFileSync(path.join(dirA, 'song.mp3'), Buffer.alloc(4096));
+
+    const result = await computeDiskUsage([dirA]);
+
+    expect(result.volumes).toHaveLength(1);
+    const [volume] = result.volumes;
+    expect(volume.folderPaths).toEqual([dirA]);
+    expect(volume.musicBytes).toBe(4096);
+    expect(volume.totalBytes).toBeGreaterThan(0);
+    expect(volume.freeBytes).toBeGreaterThan(0);
+    expect(volume.freeBytes).toBeLessThanOrEqual(volume.totalBytes);
+    expect(volume.usedBytes).toBeGreaterThanOrEqual(0);
+    expect(volume.unavailable).toBeUndefined();
+    expect(typeof result.computedAt).toBe('string');
+    expect(Number.isNaN(Date.parse(result.computedAt))).toBe(false);
+  });
+
+  it('merges folders on the same volume into one bucket and sums their bytes', async () => {
+    // Two temp dirs both live under os.tmpdir() → same volume on the test host.
+    fs.writeFileSync(path.join(dirA, 'a.mp3'), Buffer.alloc(1000));
+    fs.writeFileSync(path.join(dirB, 'b.mp3'), Buffer.alloc(2000));
+
+    const result = await computeDiskUsage([dirA, dirB]);
+
+    expect(result.volumes).toHaveLength(1);
+    const [volume] = result.volumes;
+    expect(volume.folderPaths.sort()).toEqual([dirA, dirB].sort());
+    expect(volume.musicBytes).toBe(3000);
+  });
+
+  it('dedupes duplicate folder paths', async () => {
+    fs.writeFileSync(path.join(dirA, 'a.mp3'), Buffer.alloc(1500));
+
+    const result = await computeDiskUsage([dirA, dirA]);
+
+    expect(result.volumes).toHaveLength(1);
+    expect(result.volumes[0].folderPaths).toEqual([dirA]);
+    expect(result.volumes[0].musicBytes).toBe(1500); // counted once, not 3000
+  });
+
+  it('marks a removed/unreadable folder as unavailable without failing the call', async () => {
+    fs.writeFileSync(path.join(dirA, 'a.mp3'), Buffer.alloc(1000));
+    const missing = path.join(dirB, 'ejected-drive');
+
+    const result = await computeDiskUsage([dirA, missing]);
+
+    const available = result.volumes.find(v => !v.unavailable);
+    const unavailable = result.volumes.find(v => v.unavailable);
+    expect(available?.musicBytes).toBe(1000);
+    expect(unavailable).toBeDefined();
+    expect(unavailable?.folderPaths).toEqual([missing]);
+    expect(unavailable?.totalBytes).toBe(0);
+    expect(unavailable?.freeBytes).toBe(0);
+  });
+
+  it('returns no volumes for empty input', async () => {
+    const result = await computeDiskUsage([]);
+    expect(result.volumes).toEqual([]);
+  });
+});
+
+describe('storage:get-usage handler', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    ipcHandlers.clear();
+    vi.clearAllMocks();
+    registerStorageHandlers();
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    cleanupStorageHandlers();
+    cleanupTempDir(tmpDir);
+  });
+
+  it('is registered and returns a disk-usage result', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'song.mp3'), Buffer.alloc(2048));
+    const handler = ipcHandlers.get('storage:get-usage')!;
+
+    const result = (await handler(event, [tmpDir])) as DiskUsageResult;
+
+    expect(result.volumes).toHaveLength(1);
+    expect(result.volumes[0].musicBytes).toBe(2048);
+  });
+
+  it('rejects a non-array payload (zod tuple validation)', async () => {
+    const handler = ipcHandlers.get('storage:get-usage')!;
+    await expect(handler(event, 'not-an-array')).rejects.toBeTruthy();
+  });
+
+  it('cleanupStorageHandlers removes the handler', () => {
+    expect(ipcHandlers.has('storage:get-usage')).toBe(true);
+    cleanupStorageHandlers();
+    expect(ipcHandlers.has('storage:get-usage')).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/ipc/storage.ts
+++ b/apps/desktop/src/main/ipc/storage.ts
@@ -26,8 +26,11 @@ const STAT_CONCURRENCY = 128;
 export function volumeKeyFor(folderPath: string, dev: number): string {
   // `path.win32.parse` (not `path.parse`) so the drive-root grouping is correct
   // even when this runs under test on a POSIX host; at runtime on Windows the
-  // two are identical.
-  return process.platform === 'win32' ? path.win32.parse(folderPath).root : String(dev);
+  // two are identical. Upper-case the root because Windows drive letters / UNC
+  // shares are case-insensitive — `C:\` and `c:\` must bucket as one volume.
+  return process.platform === 'win32'
+    ? path.win32.parse(folderPath).root.toUpperCase()
+    : String(dev);
 }
 
 /**

--- a/apps/desktop/src/main/ipc/storage.ts
+++ b/apps/desktop/src/main/ipc/storage.ts
@@ -1,0 +1,227 @@
+import { ipcMain } from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
+import { IPC_CHANNELS, type DiskUsageResult, type VolumeUsage } from '@shiranami/contracts';
+import { logger } from '../logger';
+import { handle } from './with-ipc-handler';
+import { getUsageArgs } from './schemas/storage';
+
+const C = IPC_CHANNELS.storage;
+
+// Bound the recursive walk so a pathological tree (or symlink cycle, though
+// symlinks are skipped — see below) can't run away. Deep enough for any real
+// Artist/Album/Disc layout.
+const WALK_MAX_DEPTH = 12;
+// Cap concurrent `stat` calls per directory, mirroring `library.ts`'s
+// VALIDATE_CONCURRENCY so a huge flat folder doesn't open thousands of FDs.
+const STAT_CONCURRENCY = 128;
+
+/**
+ * Stable per-volume bucket key. Two folders that share a key live on the same
+ * physical volume and therefore share one disk-usage bar.
+ *  - POSIX (macOS/Linux): the device id from `stat()` is the reliable signal.
+ *  - Windows: `dev` is unreliable, so group by drive/mount root (`C:\`, or the
+ *    `\\server\share` prefix for UNC paths) instead.
+ */
+export function volumeKeyFor(folderPath: string, dev: number): string {
+  // `path.win32.parse` (not `path.parse`) so the drive-root grouping is correct
+  // even when this runs under test on a POSIX host; at runtime on Windows the
+  // two are identical.
+  return process.platform === 'win32' ? path.win32.parse(folderPath).root : String(dev);
+}
+
+/**
+ * Best-effort friendly label for a volume derived from one of its folder paths.
+ *  - Windows: the drive letter without the trailing separator (`C:`).
+ *  - macOS: the volume name for `/Volumes/<name>`; `/` falls back to the root.
+ * Deriving the real internal-disk name ("Macintosh HD") needs a privileged
+ * lookup, so the root path is an acceptable v1 fallback.
+ */
+export function mountLabelFor(folderPath: string): string {
+  if (process.platform === 'win32') {
+    const root = path.win32.parse(folderPath).root; // e.g. "C:\\" or "\\\\server\\share\\"
+    return root.replace(/[\\/]+$/, '') || root;
+  }
+  const external = folderPath.match(/^\/Volumes\/([^/]+)/);
+  if (external) return external[1];
+  return '/';
+}
+
+/**
+ * Sum the logical sizes (`stat.size`) of every regular file under `dirPath`,
+ * streaming the total rather than collecting a path array first. Files are
+ * `stat`-ed in bounded batches; subdirectories recurse sequentially so total
+ * concurrency stays capped at `STAT_CONCURRENCY`.
+ *
+ * Resilience mirrors `library.ts`: an unreadable directory or a deleted/locked
+ * file is swallowed (contributes 0) so one bad entry can't sink the total.
+ *
+ * The total is best-effort by design: symlinks are skipped entirely
+ * (`entry.isDirectory()`/`isFile()` are both false for them — avoids cycles and
+ * double-counting), anything below `WALK_MAX_DEPTH` is truncated, and on the
+ * rare filesystem where `readdir` returns `DT_UNKNOWN` (no dirent `d_type`)
+ * such entries are skipped too. macOS APFS and Windows NTFS — the only targets —
+ * always populate `d_type`, so the usage bar is accurate there.
+ */
+export async function sumDirectorySize(
+  dirPath: string,
+  maxDepth = WALK_MAX_DEPTH,
+  depth = 0
+): Promise<number> {
+  if (depth > maxDepth) return 0;
+
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(dirPath, { withFileTypes: true });
+  } catch (error) {
+    logger.warn('[storage] Failed to read directory:', dirPath, error);
+    return 0;
+  }
+
+  const files: string[] = [];
+  const subdirs: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) subdirs.push(fullPath);
+    else if (entry.isFile()) files.push(fullPath);
+  }
+
+  let total = 0;
+  for (let i = 0; i < files.length; i += STAT_CONCURRENCY) {
+    const batch = files.slice(i, i + STAT_CONCURRENCY);
+    const sizes = await Promise.all(
+      batch.map(async filePath => {
+        try {
+          const stat = await fs.promises.stat(filePath);
+          return stat.size;
+        } catch {
+          return 0;
+        }
+      })
+    );
+    for (const size of sizes) total += size;
+  }
+
+  for (const subdir of subdirs) {
+    total += await sumDirectorySize(subdir, maxDepth, depth + 1);
+  }
+
+  return total;
+}
+
+interface VolumeBucket {
+  volumeKey: string;
+  mountLabel: string;
+  folderPaths: string[];
+  /** Folder used to probe the volume (`statfs`); all folders share the disk. */
+  samplePath: string;
+}
+
+/**
+ * Bucket the given folder paths by physical volume, then for each volume read
+ * its capacity (`statfs`) and sum the music bytes across its folders. A folder
+ * whose root can't be `stat`-ed (unmounted/removed drive, unreadable root) and a
+ * volume whose `statfs` throws are both reported as `unavailable: true` instead
+ * of failing the whole call.
+ */
+export async function computeDiskUsage(folderPaths: string[]): Promise<DiskUsageResult> {
+  const uniquePaths = Array.from(new Set(folderPaths.filter(p => p.length > 0)));
+
+  const buckets = new Map<string, VolumeBucket>();
+  const unavailableVolumes: VolumeUsage[] = [];
+
+  for (const folderPath of uniquePaths) {
+    let dev: number;
+    try {
+      const stat = await fs.promises.stat(folderPath);
+      dev = stat.dev;
+    } catch (error) {
+      // Folder root unreadable / drive removed — its own unavailable entry.
+      logger.warn('[storage] Folder root stat failed (unavailable):', folderPath, error);
+      unavailableVolumes.push({
+        volumeKey: `unavailable:${folderPath}`,
+        mountLabel: mountLabelFor(folderPath),
+        folderPaths: [folderPath],
+        musicBytes: 0,
+        totalBytes: 0,
+        freeBytes: 0,
+        usedBytes: 0,
+        unavailable: true,
+      });
+      continue;
+    }
+
+    const volumeKey = volumeKeyFor(folderPath, dev);
+    const existing = buckets.get(volumeKey);
+    if (existing) {
+      existing.folderPaths.push(folderPath);
+    } else {
+      buckets.set(volumeKey, {
+        volumeKey,
+        mountLabel: mountLabelFor(folderPath),
+        folderPaths: [folderPath],
+        samplePath: folderPath,
+      });
+    }
+  }
+
+  const volumes: VolumeUsage[] = [];
+  for (const bucket of buckets.values()) {
+    let statfs: fs.StatsFs;
+    try {
+      statfs = await fs.promises.statfs(bucket.samplePath);
+    } catch (error) {
+      logger.warn('[storage] statfs failed (unavailable):', bucket.samplePath, error);
+      volumes.push({
+        volumeKey: bucket.volumeKey,
+        mountLabel: bucket.mountLabel,
+        folderPaths: bucket.folderPaths,
+        musicBytes: 0,
+        totalBytes: 0,
+        freeBytes: 0,
+        usedBytes: 0,
+        unavailable: true,
+      });
+      continue;
+    }
+
+    const bsize = statfs.bsize;
+    const totalBytes = statfs.blocks * bsize;
+    const freeBytes = statfs.bavail * bsize; // bavail: user-available (quota/root aware)
+    const usedBytes = (statfs.blocks - statfs.bfree) * bsize;
+
+    let musicBytes = 0;
+    for (const folderPath of bucket.folderPaths) {
+      musicBytes += await sumDirectorySize(folderPath);
+    }
+
+    volumes.push({
+      volumeKey: bucket.volumeKey,
+      mountLabel: bucket.mountLabel,
+      folderPaths: bucket.folderPaths,
+      musicBytes,
+      totalBytes,
+      freeBytes,
+      usedBytes,
+    });
+  }
+
+  return {
+    volumes: [...volumes, ...unavailableVolumes],
+    computedAt: new Date().toISOString(),
+  };
+}
+
+export function registerStorageHandlers(): void {
+  handle(
+    C.getUsage,
+    async (_event, requestedPaths: string[]): Promise<DiskUsageResult> => {
+      return computeDiskUsage(requestedPaths);
+    },
+    { schema: getUsageArgs }
+  );
+}
+
+export function cleanupStorageHandlers(): void {
+  ipcMain.removeHandler(C.getUsage);
+}

--- a/apps/desktop/src/main/preload/api/storage.ts
+++ b/apps/desktop/src/main/preload/api/storage.ts
@@ -1,0 +1,16 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS, type DiskUsageResult } from '@shiranami/contracts';
+
+const C = IPC_CHANNELS.storage;
+
+export interface StorageApi {
+  /**
+   * Compute disk usage for the given watched library-folder paths. Returns one
+   * entry per physical volume the folders live on.
+   */
+  getUsage: (folderPaths: string[]) => Promise<DiskUsageResult>;
+}
+
+export const storageApi: StorageApi = {
+  getUsage: folderPaths => ipcRenderer.invoke(C.getUsage, folderPaths),
+};

--- a/apps/desktop/src/main/preload/index.ts
+++ b/apps/desktop/src/main/preload/index.ts
@@ -29,6 +29,7 @@ import { recommendationsApi, type RecommendationsApi } from './api/recommendatio
 import { scrobbleApi, type ScrobbleApi } from './api/scrobble';
 import { shareApi, type ShareApi } from './api/share';
 import { shellApi, type ShellApi } from './api/shell';
+import { storageApi, type StorageApi } from './api/storage';
 import { storeApi, type StoreApi } from './api/store';
 import { updaterApi, type UpdaterApi } from './api/updater';
 import { windowApi, type WindowApi } from './api/window';
@@ -57,6 +58,7 @@ export interface ElectronAPI {
   share: ShareApi;
   debug: DebugApi;
   system: SystemApi;
+  storage: StorageApi;
   errors: {
     isIpcError: (e: unknown) => e is { code: string; message: string; details?: unknown };
     SHARE_ERROR_CODES: typeof SHARE_ERROR_CODES;
@@ -97,6 +99,7 @@ const electronAPI: ElectronAPI = {
   share: shareApi,
   debug: debugApi,
   system: systemApi,
+  storage: storageApi,
   errors: {
     isIpcError,
     SHARE_ERROR_CODES,

--- a/apps/web/src/components/settings/DiskUsageBar.tsx
+++ b/apps/web/src/components/settings/DiskUsageBar.tsx
@@ -1,0 +1,93 @@
+import { useTranslation } from 'react-i18next';
+import type { VolumeUsage } from '@shiranami/contracts';
+import { formatBytes } from '@/lib/formatBytes';
+import { computeDiskSegments } from '@/lib/diskSegments';
+import { cn } from '@/lib/utils';
+
+interface DiskUsageBarProps {
+  volume: VolumeUsage;
+}
+
+interface LegendItemProps {
+  swatchClassName: string;
+  label: string;
+  value: string;
+}
+
+function LegendItem({ swatchClassName, label, value }: LegendItemProps) {
+  return (
+    <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <span
+        className={cn('inline-block w-2.5 h-2.5 rounded-sm', swatchClassName)}
+        aria-hidden="true"
+      />
+      <span className="text-foreground">{label}</span>
+      <span className="tabular-nums">{value}</span>
+    </span>
+  );
+}
+
+/**
+ * Custom segmented progress bar for one volume: music · other-used · free.
+ *
+ * The three segments are derived defensively here (clamped, non-negative, always
+ * summing to total) so reserved blocks or logical-vs-allocated skew (APFS/NTFS
+ * compression, sparse files) can't produce a negative or overflowing slice —
+ * `free` uses `bavail`-derived `freeBytes`, never `usedBytes - musicBytes`. See
+ * docs/research/2026-06-06-disk-space-usage.md §3.
+ */
+export function DiskUsageBar({ volume }: DiskUsageBarProps) {
+  const { t } = useTranslation('settings');
+  const { musicBytes, totalBytes, freeBytes } = volume;
+
+  const { music, other, free } = computeDiskSegments(musicBytes, totalBytes, freeBytes);
+  const pct = (n: number) => (totalBytes > 0 ? (n / totalBytes) * 100 : 0);
+
+  const ariaLabel = t('diskUsage.barAria', {
+    music: formatBytes(music),
+    other: formatBytes(other),
+    free: formatBytes(free),
+    total: formatBytes(totalBytes),
+  });
+
+  return (
+    <div className="space-y-2.5">
+      <p className="text-xs text-muted-foreground">
+        {t('diskUsage.ofTotal', {
+          used: formatBytes(totalBytes - free),
+          total: formatBytes(totalBytes),
+        })}
+      </p>
+      <div
+        role="img"
+        aria-label={ariaLabel}
+        className="flex w-full h-2.5 rounded-full overflow-hidden bg-muted"
+      >
+        <div className="h-full bg-primary" style={{ width: `${pct(music)}%` }} aria-hidden="true" />
+        <div
+          className="h-full bg-muted-foreground/40"
+          style={{ width: `${pct(other)}%` }}
+          aria-hidden="true"
+        />
+        {/* The remaining track background represents free space. */}
+      </div>
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
+        <LegendItem
+          swatchClassName="bg-primary"
+          label={t('diskUsage.musicLabel')}
+          value={formatBytes(music)}
+        />
+        <LegendItem
+          swatchClassName="bg-muted-foreground/40"
+          label={t('diskUsage.otherLabel')}
+          value={formatBytes(other)}
+        />
+        <LegendItem
+          swatchClassName="bg-muted border border-border/40"
+          label={t('diskUsage.freeLabel')}
+          value={formatBytes(free)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/DiskUsageSection.tsx
+++ b/apps/web/src/components/settings/DiskUsageSection.tsx
@@ -16,7 +16,7 @@ import { cn } from '@/lib/utils';
  */
 export function DiskUsageSection() {
   const { t } = useTranslation('settings');
-  const { data: folders = [] } = useFoldersQuery();
+  const { data: folders = [], isLoading: isFoldersLoading } = useFoldersQuery();
   const { data, isLoading, isError, isFetching, refetch } = useDiskUsageQuery();
 
   const hasFolders = folders.length > 0;
@@ -39,15 +39,17 @@ export function DiskUsageSection() {
         ) : undefined
       }
     >
-      {!hasFolders ? (
-        <p className="text-sm text-muted-foreground/60 py-3 text-center">
-          {t('diskUsage.noFolders')}
-        </p>
-      ) : isLoading ? (
+      {isFoldersLoading || isLoading ? (
+        // Show the spinner while folders are still loading too, so the
+        // "no folders" empty state never flashes before the list arrives.
         <div className="flex items-center justify-center py-6 text-muted-foreground">
           <Loader2 className="w-4 h-4 animate-spin mr-2" aria-hidden="true" />
           <span className="text-sm">{t('diskUsage.loading')}</span>
         </div>
+      ) : !hasFolders ? (
+        <p className="text-sm text-muted-foreground/60 py-3 text-center">
+          {t('diskUsage.noFolders')}
+        </p>
       ) : isError ? (
         <div className="space-y-3 py-1">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/apps/web/src/components/settings/DiskUsageSection.tsx
+++ b/apps/web/src/components/settings/DiskUsageSection.tsx
@@ -1,0 +1,93 @@
+import { useTranslation } from 'react-i18next';
+import { HardDrive, RefreshCw, Loader2, AlertTriangle, FolderX } from 'lucide-react';
+import { SettingsCard } from '@/components/settings/SettingsCard';
+import { DiskUsageBar } from '@/components/settings/DiskUsageBar';
+import { IconButton } from '@/components/ui/icon-button';
+import { Button } from '@/components/ui/button';
+import { useFoldersQuery } from '@/hooks/queries/useFolders';
+import { useDiskUsageQuery } from '@/hooks/queries/useDiskUsage';
+import { cn } from '@/lib/utils';
+
+/**
+ * Shows, per physical volume, how much disk the watched library folders occupy
+ * and how much free space remains. Rendered inside the Library settings section
+ * (Electron only — gated at the call site). The size figure comes from a
+ * main-process FS walk; see docs/research/2026-06-06-disk-space-usage.md.
+ */
+export function DiskUsageSection() {
+  const { t } = useTranslation('settings');
+  const { data: folders = [] } = useFoldersQuery();
+  const { data, isLoading, isError, isFetching, refetch } = useDiskUsageQuery();
+
+  const hasFolders = folders.length > 0;
+
+  return (
+    <SettingsCard
+      icon={HardDrive}
+      title={t('diskUsage.title')}
+      subtitle={t('diskUsage.subtitle')}
+      headerRight={
+        hasFolders ? (
+          <IconButton
+            onClick={() => refetch()}
+            disabled={isFetching}
+            title={t('diskUsage.refresh')}
+            aria-label={t('diskUsage.refresh')}
+          >
+            <RefreshCw className={cn(isFetching && 'animate-spin')} aria-hidden="true" />
+          </IconButton>
+        ) : undefined
+      }
+    >
+      {!hasFolders ? (
+        <p className="text-sm text-muted-foreground/60 py-3 text-center">
+          {t('diskUsage.noFolders')}
+        </p>
+      ) : isLoading ? (
+        <div className="flex items-center justify-center py-6 text-muted-foreground">
+          <Loader2 className="w-4 h-4 animate-spin mr-2" aria-hidden="true" />
+          <span className="text-sm">{t('diskUsage.loading')}</span>
+        </div>
+      ) : isError ? (
+        <div className="space-y-3 py-1">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <AlertTriangle className="w-4 h-4 text-destructive shrink-0" aria-hidden="true" />
+            <span>{t('diskUsage.error')}</span>
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => refetch()}
+            className="rounded-lg [&_svg]:size-3.5"
+          >
+            <RefreshCw />
+            {t('diskUsage.retry')}
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-5">
+          {data?.volumes.map(volume => (
+            <div key={volume.volumeKey} className="space-y-2.5">
+              <div className="flex items-baseline gap-2">
+                <span className="text-sm font-medium text-foreground">{volume.mountLabel}</span>
+                {volume.folderPaths.length > 1 && (
+                  <span className="text-xs text-muted-foreground">
+                    {t('diskUsage.folderCount', { count: volume.folderPaths.length })}
+                  </span>
+                )}
+              </div>
+              {volume.unavailable ? (
+                <div className="flex items-center gap-2 px-3 py-2.5 rounded-xl bg-background/50 border border-border/20 text-sm text-muted-foreground">
+                  <FolderX className="w-4 h-4 shrink-0" aria-hidden="true" />
+                  <span>{t('diskUsage.volumeUnavailable')}</span>
+                </div>
+              ) : (
+                <DiskUsageBar volume={volume} />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </SettingsCard>
+  );
+}

--- a/apps/web/src/components/settings/LibrarySection.tsx
+++ b/apps/web/src/components/settings/LibrarySection.tsx
@@ -2,7 +2,16 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { useLibraryStore } from '@/stores/useLibraryStore';
-import { HardDrive, Music, RefreshCw, Trash2, Loader2, Download, Upload, DatabaseBackup } from 'lucide-react';
+import {
+  HardDrive,
+  Music,
+  RefreshCw,
+  Trash2,
+  Loader2,
+  Download,
+  Upload,
+  DatabaseBackup,
+} from 'lucide-react';
 import { SettingsCard } from '@/components/settings/SettingsCard';
 import { Button } from '@/components/ui/button';
 import { SubfolderPlaylistDialog } from '@/components/settings/SubfolderPlaylistDialog';
@@ -11,6 +20,7 @@ import { useLibraryRescan } from '@/hooks/useLibraryRescan';
 import { isScanLocked } from '@/lib/scanLock';
 import { IS_ELECTRON } from '@/lib/platform';
 import { ScanProgressCard } from '@/components/library/ScanProgressCard';
+import { DiskUsageSection } from '@/components/settings/DiskUsageSection';
 import { mapDbTracksToTracks, type DbTrackRecord } from '@/lib/trackMapper';
 
 export function LibrarySection() {
@@ -112,6 +122,8 @@ export function LibrarySection() {
           <ScanProgressCard />
         </div>
       </SettingsCard>
+
+      {IS_ELECTRON && <DiskUsageSection />}
 
       {IS_ELECTRON && (
         <SettingsCard

--- a/apps/web/src/hooks/queries/useDiskUsage.ts
+++ b/apps/web/src/hooks/queries/useDiskUsage.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
+import type { DiskUsageResult } from '@shiranami/contracts';
+import { IS_ELECTRON } from '@/lib/platform';
+import { useFoldersQuery } from '@/hooks/queries/useFolders';
+
+export const diskUsageKeys = {
+  /** Prefix for invalidation — matches every path-specific key below. */
+  all: ['disk-usage'] as const,
+  forPaths: (paths: string[]) => ['disk-usage', ...paths] as const,
+};
+
+/**
+ * Disk usage for the watched library folders, grouped by physical volume.
+ *
+ * The query key embeds the (sorted) folder paths, so adding/removing a folder
+ * changes the key and refetches automatically. This TanStack Query cache IS the
+ * cache — there is no main-side cache — so `staleTime` controls how often the
+ * O(files) FS walk actually runs. Invalidate `diskUsageKeys.all` after a rescan
+ * or download to recompute when bytes change but paths don't; the panel's manual
+ * refresh button calls `refetch()` directly.
+ */
+export function useDiskUsageQuery() {
+  const { data: folders = [] } = useFoldersQuery();
+  const folderPaths = folders.map(f => f.path).sort();
+
+  return useQuery({
+    queryKey: diskUsageKeys.forPaths(folderPaths),
+    queryFn: async (): Promise<DiskUsageResult> => {
+      return window.electronAPI.storage.getUsage(folderPaths);
+    },
+    enabled: IS_ELECTRON && folderPaths.length > 0,
+    staleTime: 30_000,
+  });
+}

--- a/apps/web/src/hooks/useLibraryRescan.ts
+++ b/apps/web/src/hooks/useLibraryRescan.ts
@@ -10,6 +10,7 @@ import { acquireScanLock, releaseScanLock } from '@/lib/scanLock';
 import { scanAndPersistFolder, type SubfolderGroup } from '@/lib/scanHelpers';
 import { folderKeys } from '@/hooks/queries/useFolders';
 import { libraryKeys } from '@/hooks/queries/useLibrary';
+import { diskUsageKeys } from '@/hooks/queries/useDiskUsage';
 import { playlistKeys, usePlaylistsQuery } from '@/hooks/queries/usePlaylists';
 import type { Playlist } from '@/types/electron';
 import type { WatchedFolder } from '@/components/settings/MusicFoldersSection';
@@ -106,6 +107,8 @@ export function useLibraryRescan(): UseLibraryRescanResult {
 
       queryClient.invalidateQueries({ queryKey: libraryKeys.all });
       queryClient.invalidateQueries({ queryKey: folderKeys.all });
+      // Files were added/removed on disk — recompute disk usage.
+      queryClient.invalidateQueries({ queryKey: diskUsageKeys.all });
 
       if (totalAdded > 0 && totalRemoved > 0) {
         toast.success(

--- a/apps/web/src/lib/diskSegments.test.ts
+++ b/apps/web/src/lib/diskSegments.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { computeDiskSegments } from './diskSegments';
+
+describe('computeDiskSegments', () => {
+  it('splits a normal disk into music / other / free', () => {
+    const { music, other, free } = computeDiskSegments(100, 1000, 400);
+    expect(music).toBe(100);
+    expect(free).toBe(400);
+    expect(other).toBe(500);
+    expect(music + other + free).toBe(1000);
+  });
+
+  it('clamps music to the space left after free (logical > allocated skew)', () => {
+    // musicBytes (logical) can exceed allocated bytes under compression/sparse.
+    const { music, other, free } = computeDiskSegments(900, 1000, 400);
+    expect(free).toBe(400);
+    expect(music).toBe(600); // clamped to total - free, never overflows
+    expect(other).toBe(0);
+    expect(music + other + free).toBe(1000);
+  });
+
+  it('never produces a negative segment', () => {
+    const segments = computeDiskSegments(-50, 1000, -10);
+    expect(segments.music).toBeGreaterThanOrEqual(0);
+    expect(segments.other).toBeGreaterThanOrEqual(0);
+    expect(segments.free).toBeGreaterThanOrEqual(0);
+  });
+
+  it('clamps free that exceeds total', () => {
+    const { music, other, free } = computeDiskSegments(100, 1000, 1200);
+    expect(free).toBe(1000);
+    expect(music).toBe(0);
+    expect(other).toBe(0);
+  });
+
+  it('returns all-zero for an unavailable (zero-capacity) volume', () => {
+    expect(computeDiskSegments(0, 0, 0)).toEqual({ music: 0, other: 0, free: 0 });
+  });
+
+  it('always sums to total across a range of inputs', () => {
+    const cases: Array<[number, number, number]> = [
+      [250, 1000, 500],
+      [0, 1000, 1000],
+      [1000, 1000, 0],
+      [333, 999, 333],
+    ];
+    for (const [musicBytes, total, freeBytes] of cases) {
+      const { music, other, free } = computeDiskSegments(musicBytes, total, freeBytes);
+      expect(music + other + free).toBe(total);
+    }
+  });
+});

--- a/apps/web/src/lib/diskSegments.ts
+++ b/apps/web/src/lib/diskSegments.ts
@@ -1,0 +1,31 @@
+export interface DiskSegments {
+  /** Music-folder bytes, clamped so it never overflows the available space. */
+  music: number;
+  /** Everything else on the disk (other apps + reserved blocks + skew). */
+  other: number;
+  /** User-available free space. */
+  free: number;
+}
+
+/**
+ * Derive the three disk-usage bar segments defensively so they ALWAYS sum to
+ * `totalBytes` and no segment can go negative.
+ *
+ * `free` comes from `bavail`-derived `freeBytes`; `music` is clamped to the
+ * space actually left for it; `other` absorbs reserved blocks and any
+ * logical-vs-allocated skew (APFS/NTFS compression, sparse files). Never compute
+ * `other = usedBytes - musicBytes` — `free`/`used` use different `statfs` fields,
+ * so the subtraction can leak a reserved sliver or go negative. See
+ * docs/research/2026-06-06-disk-space-usage.md §3.
+ */
+export function computeDiskSegments(
+  musicBytes: number,
+  totalBytes: number,
+  freeBytes: number
+): DiskSegments {
+  const total = Math.max(0, totalBytes);
+  const free = Math.max(0, Math.min(freeBytes, total));
+  const music = Math.max(0, Math.min(musicBytes, total - free));
+  const other = Math.max(0, total - free - music);
+  return { music, other, free };
+}

--- a/apps/web/src/lib/formatBytes.test.ts
+++ b/apps/web/src/lib/formatBytes.test.ts
@@ -13,6 +13,14 @@ describe('formatBytes', () => {
     expect(formatBytes(512)).toBe('512 B');
   });
 
+  it('handles fractional bytes without underflowing the unit index', () => {
+    // 0 < bytes < 1 → negative log; exponent must clamp to 0, not -1 (which
+    // would index UNITS out of bounds and render "undefined").
+    const out = formatBytes(0.5);
+    expect(out).not.toContain('undefined');
+    expect(out).toBe('1 B');
+  });
+
   it('uses decimal (1000-base) units, not binary', () => {
     expect(formatBytes(1000)).toBe('1 KB');
     expect(formatBytes(1_000_000)).toBe('1 MB');

--- a/apps/web/src/lib/formatBytes.test.ts
+++ b/apps/web/src/lib/formatBytes.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes } from './formatBytes';
+
+describe('formatBytes', () => {
+  it('returns "0 B" for zero, negative, and non-finite input', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(-100)).toBe('0 B');
+    expect(formatBytes(NaN)).toBe('0 B');
+    expect(formatBytes(Infinity)).toBe('0 B');
+  });
+
+  it('shows whole bytes without a decimal', () => {
+    expect(formatBytes(512)).toBe('512 B');
+  });
+
+  it('uses decimal (1000-base) units, not binary', () => {
+    expect(formatBytes(1000)).toBe('1 KB');
+    expect(formatBytes(1_000_000)).toBe('1 MB');
+    expect(formatBytes(1_500_000_000)).toBe('1.5 GB');
+    expect(formatBytes(2_000_000_000_000)).toBe('2 TB');
+  });
+
+  it('strips a trailing .0 but keeps real fractions', () => {
+    expect(formatBytes(2_000_000)).toBe('2 MB');
+    expect(formatBytes(2_300_000)).toBe('2.3 MB');
+  });
+
+  it('caps at the largest known unit', () => {
+    expect(formatBytes(5_000_000_000_000_000)).toContain('PB');
+  });
+});

--- a/apps/web/src/lib/formatBytes.ts
+++ b/apps/web/src/lib/formatBytes.ts
@@ -14,7 +14,13 @@ const BASE = 1000;
 export function formatBytes(bytes: number, fractionDigits = 1): string {
   if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
 
-  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(BASE)), UNITS.length - 1);
+  // Clamp the low end too: a fractional byte count (0 < bytes < 1) yields a
+  // negative log, which would underflow `exponent` to -1 and index UNITS out of
+  // bounds ("500 undefined").
+  const exponent = Math.max(
+    0,
+    Math.min(Math.floor(Math.log(bytes) / Math.log(BASE)), UNITS.length - 1)
+  );
   const value = bytes / BASE ** exponent;
   // Whole bytes never need a decimal; larger units show one by default.
   const digits = exponent === 0 ? 0 : fractionDigits;

--- a/apps/web/src/lib/formatBytes.ts
+++ b/apps/web/src/lib/formatBytes.ts
@@ -1,0 +1,22 @@
+/**
+ * Format a byte count as a human-readable size using DECIMAL (1000-base) units
+ * (KB/MB/GB/TB), not binary (1024-base) units.
+ *
+ * Decimal is deliberate: macOS Finder / "Get Info" has reported decimal GB since
+ * 10.6, so a 1000-base label matches the free-space figure users compare against
+ * on a Mac. Windows Explorer uses 1024 (labelled "GB"), so the two OSes never
+ * fully agree — decimal is the safer default for a user-facing capacity figure,
+ * and it keeps the disk-usage panel's numbers checkable against Finder.
+ */
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const;
+const BASE = 1000;
+
+export function formatBytes(bytes: number, fractionDigits = 1): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(BASE)), UNITS.length - 1);
+  const value = bytes / BASE ** exponent;
+  // Whole bytes never need a decimal; larger units show one by default.
+  const digits = exponent === 0 ? 0 : fractionDigits;
+  return `${value.toFixed(digits).replace(/\.0+$/, '')} ${UNITS[exponent]}`;
+}

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -124,6 +124,22 @@
     "scanCancel": "Cancel",
     "scanCancelling": "Cancelling..."
   },
+  "diskUsage": {
+    "title": "Disk Usage",
+    "subtitle": "How much space your music takes and what's free on each drive",
+    "musicLabel": "Music",
+    "otherLabel": "Other",
+    "freeLabel": "Free",
+    "ofTotal": "{{used}} of {{total}} used",
+    "barAria": "Music {{music}}, other {{other}}, free {{free}} of {{total}} total",
+    "folderCount": "{{count}} folders",
+    "volumeUnavailable": "Drive unavailable",
+    "noFolders": "Add a music folder to see disk usage",
+    "loading": "Calculating disk usage...",
+    "error": "Couldn't calculate disk usage",
+    "retry": "Retry",
+    "refresh": "Refresh disk usage"
+  },
   "enr": {
     "previewTitle": "Before / after",
     "beforeLabel": "From filename",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -140,6 +140,22 @@
     "scanCancel": "Anuluj",
     "scanCancelling": "Anulowanie..."
   },
+  "diskUsage": {
+    "title": "Wykorzystanie dysku",
+    "subtitle": "Ile miejsca zajmuje Twoja muzyka i ile jest wolne na każdym dysku",
+    "musicLabel": "Muzyka",
+    "otherLabel": "Inne",
+    "freeLabel": "Wolne",
+    "ofTotal": "{{used}} z {{total}} zajęte",
+    "barAria": "Muzyka {{music}}, inne {{other}}, wolne {{free}} z {{total}} łącznie",
+    "folderCount": "{{count}} folderów",
+    "volumeUnavailable": "Dysk niedostępny",
+    "noFolders": "Dodaj folder z muzyką, aby zobaczyć wykorzystanie dysku",
+    "loading": "Obliczanie wykorzystania dysku...",
+    "error": "Nie udało się obliczyć wykorzystania dysku",
+    "retry": "Ponów",
+    "refresh": "Odśwież wykorzystanie dysku"
+  },
   "enr": {
     "previewTitle": "Przed / po",
     "beforeLabel": "Z nazwy pliku",

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -314,6 +314,9 @@ function createElectronAPIMock(): ElectronAPI {
     system: {
       onNotice: vi.fn(() => noopUnsub()),
     },
+    storage: {
+      getUsage: asyncFn({ volumes: [], computedAt: '1970-01-01T00:00:00.000Z' }),
+    },
     recommendations: {
       get: asyncFn({
         library: { kind: 'library', items: [], generatedAt: null, stale: true },

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -28,6 +28,7 @@ import type {
   SmartPlaylistMatchType,
   DownloadQueueSnapshot,
   EnqueueDownloadInput,
+  DiskUsageResult,
 } from '@shiranami/contracts';
 import type { DiscordRpcSettings, DiscordMusicPresenceActivity } from '@shiranami/shared';
 
@@ -494,6 +495,9 @@ export interface ElectronAPI {
   };
   system: {
     onNotice: (callback: (notice: SystemNotice) => void) => () => void;
+  };
+  storage: {
+    getUsage: (folderPaths: string[]) => Promise<DiskUsageResult>;
   };
   platform: NodeJS.Platform;
   /** True when the main process was launched with SHIRANAMI_E2E=1. */

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -13,4 +13,5 @@ export * from './ipc/metadata';
 export * from './ipc/loudness';
 export * from './ipc/database';
 export * from './ipc/system';
+export * from './ipc/storage';
 export * from './share/dto';

--- a/packages/contracts/src/ipc/channels.ts
+++ b/packages/contracts/src/ipc/channels.ts
@@ -250,6 +250,12 @@ export const IPC_CHANNELS = {
     // of being swallowed in the logs.
     notice: 'system:notice',
   },
+  storage: {
+    // Renderer→main: compute how much disk the watched library folders occupy
+    // and how much free space each host volume has. Returns one entry per
+    // physical volume (folders are bucketed by device id / drive root).
+    getUsage: 'storage:get-usage',
+  },
 } as const;
 
 /** Recursively extract every string-leaf value from a nested const object. */

--- a/packages/contracts/src/ipc/storage.ts
+++ b/packages/contracts/src/ipc/storage.ts
@@ -1,0 +1,39 @@
+// Wire types for the storage / disk-usage IPC surface.
+//
+// The renderer passes the watched library-folder paths; the main process buckets
+// them by physical volume (POSIX device id / Windows drive root), walks each
+// folder for its logical size, and reads the host volume's capacity via
+// `fs.statfs`. One `VolumeUsage` is returned per distinct volume so the renderer
+// can render one segmented bar per disk. See
+// docs/research/2026-06-06-disk-space-usage.md for the full rationale.
+
+/** One physical volume that hosts one or more watched library folders. */
+export interface VolumeUsage {
+  /** Stable bucket key (POSIX device id as string, or Windows drive root). */
+  volumeKey: string;
+  /** Friendly label for the bar header (volume name / drive letter). */
+  mountLabel: string;
+  /** Folder paths (from the `folders` table) that live on this volume. */
+  folderPaths: string[];
+  /** Sum of logical file sizes (`stat.size`) inside those folders (the FS walk). */
+  musicBytes: number;
+  /** Whole-disk capacity: `blocks * bsize`. */
+  totalBytes: number;
+  /** User-available free space: `bavail * bsize`. */
+  freeBytes: number;
+  /**
+   * Whole-disk used across all apps: `(blocks - bfree) * bsize`. For captions
+   * only — the bar segment widths use the clamped formula in the renderer, never
+   * a raw `usedBytes - musicBytes` subtraction.
+   */
+  usedBytes: number;
+  /** True if `statfs`/`stat` failed for this volume (unmounted/removed drive). */
+  unavailable?: boolean;
+}
+
+/** Result of a disk-usage computation across every watched folder. */
+export interface DiskUsageResult {
+  volumes: VolumeUsage[];
+  /** ISO timestamp the result was computed (for "updated x ago" / cache age). */
+  computedAt: string;
+}


### PR DESCRIPTION
## Summary
- Adds a **Disk Usage** card to Settings → Library showing, per physical volume, a segmented music/other/free bar — how much space the music library takes and how much is free. Cross-platform via Node's native `fs.statfs` (no C++/native code, no new dependency).
- Main process (`storage:get-usage` IPC) buckets watched folders by volume (POSIX device id / Windows drive root), walks each with bounded `stat` concurrency, and reports capacity; an unmounted/removed drive degrades to an "unavailable" row instead of failing the whole call.
- Renderer adds a decimal byte formatter, a clamped-segment helper, a TanStack Query hook (the sole cache, invalidated after rescans), en/pl strings, and loading / error+retry / no-folders / per-volume-unavailable states.

## Test plan
- [x] macOS: Settings → Library shows the Disk Usage bar with non-zero music/free/total for the watched folder's volume (cross-check free vs Finder Get Info — decimal). Verified live: 363.3 MB music, 44.3 GB free of 494.4 GB.
- [ ] Add a folder on a second drive → second per-volume bar; eject + Refresh → "Drive unavailable", internal bar still works.
- [ ] Rescan / refresh button → music segment updates.
- [ ] **Windows runtime smoke test pending** — non-zero capacity, drive-letter labels (`C:`/`D:`) and grouping (covered by libuv-source research + `path.win32` unit tests, not yet run live).
- [ ] \`pnpm typecheck\` + \`pnpm test\` pass (1665 tests; +27 for this feature).

Design rationale: \`docs/research/2026-06-06-disk-space-usage.md\`.