### PR TITLE
fix(library): stop fragmenting untagged various-artists albums

### DIFF
--- a/apps/desktop/e2e/album-grouping.spec.ts
+++ b/apps/desktop/e2e/album-grouping.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from './fixtures';
+import { seedTracks } from './helpers/db';
+import { createSilentAudioFiles } from './helpers/audio-fixtures';
+import { rmSync } from 'node:fs';
+
+test.describe('album grouping', () => {
+  // Regression guard for #269. An untagged various-artists compilation — same
+  // album title, different track artists, no album-artist tag — must render as
+  // ONE album, not fragment into one album per artist. v0.22.0 keyed grouping
+  // on (albumArtist || artist, album); for untagged comps the `|| artist`
+  // fallback resolved per track and split the album. The fix keys untagged
+  // albums on the title alone, so the three tracks collapse into one card.
+  test('untagged various-artists album stays one album (#269)', async ({ page }) => {
+    const { dir, files } = createSilentAudioFiles(3);
+    try {
+      // Three tracks, one album title, three distinct artists, NO albumArtist.
+      // seedTracks omits albumArtist, so the rows persist album_artist = NULL —
+      // exactly the "untagged" state the fix has to group by title.
+      await seedTracks(page, [
+        { filePath: files[0].filePath, title: 'One', artist: 'Alice', album: 'Lofi Mix' },
+        { filePath: files[1].filePath, title: 'Two', artist: 'Bob', album: 'Lofi Mix' },
+        { filePath: files[2].filePath, title: 'Three', artist: 'Carol', album: 'Lofi Mix' },
+      ]);
+
+      // Bridge the seeded rows into the library store so LibraryView renders
+      // them (mirrors search.spec — production fills the store on scan).
+      await page.waitForFunction(() => Boolean(window.__shiranami?.stores?.library));
+      await page.evaluate(async () => {
+        const rows = await window.electronAPI.db.tracks.getAll();
+        const playable = rows.map(r => ({
+          id: r.id,
+          title: r.title,
+          artist: r.artist ?? 'Unknown',
+          album: r.album ?? 'Unknown',
+          albumArtist: r.albumArtist ?? null,
+          duration: r.duration ?? 1,
+          filePath: r.filePath,
+          isFavorite: r.isFavorite,
+          playCount: r.playCount,
+        }));
+        const store = window.__shiranami!.stores.library as unknown as {
+          getState: () => { setLibrary: (tracks: unknown[]) => void };
+        };
+        store.getState().setLibrary(playable);
+      });
+
+      // Library view → Albums mode (default mode is 'tracks').
+      await page.locator('[data-view="library"]').first().click();
+      await page.getByRole('button', { name: 'Albums', exact: true }).click();
+
+      // The discriminator: one "Lofi Mix" card, not three. The single card
+      // aggregates the distinct track artists in encounter order.
+      await expect(page.getByText('Lofi Mix', { exact: true })).toHaveCount(1);
+      await expect(page.getByText('Alice, Bob, Carol', { exact: true })).toBeVisible();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop/e2e/types/electron-api.d.ts
+++ b/apps/desktop/e2e/types/electron-api.d.ts
@@ -9,6 +9,7 @@ export interface E2ETrackRow {
   title: string;
   artist: string | null;
   album: string | null;
+  albumArtist: string | null;
   duration: number | null;
   isFavorite: boolean;
   playCount: number;

--- a/apps/desktop/src/main/ipc/database/history.ts
+++ b/apps/desktop/src/main/ipc/database/history.ts
@@ -297,7 +297,7 @@ export function registerHistoryHandlers(): void {
       const albumArtistGroupKey = sql<string>`COALESCE(NULLIF(TRIM(${tracks.albumArtist}), ''), '')`;
       // Display falls back to a representative track artist so an untagged
       // album's card isn't blank.
-      const albumArtistDisplay = sql<string>`COALESCE(NULLIF(TRIM(${tracks.albumArtist}), ''), ${tracks.artist})`;
+      const albumArtistDisplay = sql<string>`COALESCE(NULLIF(TRIM(${tracks.albumArtist}), ''), NULLIF(${tracks.artist}, ''), ${UNKNOWN_ARTIST})`;
       const albumsQuery = db
         .select({
           album: albumExpression,

--- a/apps/desktop/src/main/ipc/database/history.ts
+++ b/apps/desktop/src/main/ipc/database/history.ts
@@ -290,21 +290,24 @@ export function registerHistoryHandlers(): void {
       // album rows are filtered out so untagged libraries don't show a blank
       // album dominating the chart.
       const albumExpression = sql<string>`COALESCE(NULLIF(${tracks.album}, ''), '')`;
-      // Group on (albumArtist || artist, album) — not the album title alone —
-      // so same-named albums by different artists stay separate and a
-      // compilation's varied track artists don't fragment one album. The
-      // displayed artist is the grouping anchor (album artist), not MAX(artist).
-      const albumArtistExpression = sql<string>`COALESCE(NULLIF(${tracks.albumArtist}, ''), ${tracks.artist})`;
+      // Group on the album-artist tag when present, else the album title alone
+      // — NOT the track artist, which fragments an untagged various-artists
+      // compilation into one entry per artist (#269). Same-titled albums by
+      // different artists still stay separate when they carry album-artist tags.
+      const albumArtistGroupKey = sql<string>`COALESCE(NULLIF(${tracks.albumArtist}, ''), '')`;
+      // Display falls back to a representative track artist so an untagged
+      // album's card isn't blank.
+      const albumArtistDisplay = sql<string>`COALESCE(NULLIF(${tracks.albumArtist}, ''), ${tracks.artist})`;
       const albumsQuery = db
         .select({
           album: albumExpression,
-          artist: sql<string>`MAX(${albumArtistExpression})`,
+          artist: sql<string>`MAX(${albumArtistDisplay})`,
           albumArt: sql<string | null>`MAX(${tracks.albumArt})`,
           playCount: sql<number>`COUNT(*)`,
         })
         .from(playHistory)
         .innerJoin(tracks, eq(playHistory.trackId, tracks.id))
-        .groupBy(albumArtistExpression, albumExpression)
+        .groupBy(albumArtistGroupKey, albumExpression)
         .having(sql`${albumExpression} <> ''`);
       const topAlbums = (sinceFilter ? albumsQuery.where(sinceFilter) : albumsQuery)
         .orderBy(desc(sql`COUNT(*)`))

--- a/apps/desktop/src/main/ipc/database/history.ts
+++ b/apps/desktop/src/main/ipc/database/history.ts
@@ -294,10 +294,10 @@ export function registerHistoryHandlers(): void {
       // — NOT the track artist, which fragments an untagged various-artists
       // compilation into one entry per artist (#269). Same-titled albums by
       // different artists still stay separate when they carry album-artist tags.
-      const albumArtistGroupKey = sql<string>`COALESCE(NULLIF(${tracks.albumArtist}, ''), '')`;
+      const albumArtistGroupKey = sql<string>`COALESCE(NULLIF(TRIM(${tracks.albumArtist}), ''), '')`;
       // Display falls back to a representative track artist so an untagged
       // album's card isn't blank.
-      const albumArtistDisplay = sql<string>`COALESCE(NULLIF(${tracks.albumArtist}, ''), ${tracks.artist})`;
+      const albumArtistDisplay = sql<string>`COALESCE(NULLIF(TRIM(${tracks.albumArtist}), ''), ${tracks.artist})`;
       const albumsQuery = db
         .select({
           album: albumExpression,

--- a/apps/desktop/src/main/metadata-service.ts
+++ b/apps/desktop/src/main/metadata-service.ts
@@ -45,7 +45,7 @@ export async function parseAudioMetadata(filePath: string): Promise<TrackMetadat
       // artist, or an untagged various-artists album gets a per-track album
       // artist and fragments at grouping time (#269). Null means "untagged",
       // which the grouping layer keys on the album title alone.
-      albumArtist: common.albumartist || null,
+      albumArtist: common.albumartist?.trim() || null,
       album: common.album || 'Unknown Album',
       duration: format.duration || 0,
       genre: common.genre?.[0] || '',

--- a/apps/desktop/src/main/metadata-service.ts
+++ b/apps/desktop/src/main/metadata-service.ts
@@ -41,9 +41,11 @@ export async function parseAudioMetadata(filePath: string): Promise<TrackMetadat
     return {
       title: common.title || fileName,
       artist: common.artist || 'Unknown Artist',
-      // Prefer the dedicated albumartist tag; fall back to the track artist so
-      // album grouping always has a stable key even for untagged files.
-      albumArtist: common.albumartist || common.artist || null,
+      // Only the dedicated albumartist tag — do NOT fall back to the track
+      // artist, or an untagged various-artists album gets a per-track album
+      // artist and fragments at grouping time (#269). Null means "untagged",
+      // which the grouping layer keys on the album title alone.
+      albumArtist: common.albumartist || null,
       album: common.album || 'Unknown Album',
       duration: format.duration || 0,
       genre: common.genre?.[0] || '',

--- a/apps/desktop/src/main/scan-utility.ts
+++ b/apps/desktop/src/main/scan-utility.ts
@@ -241,7 +241,11 @@ async function parseFile(s: UtilityState, filePath: string): Promise<ParseSucces
     return {
       title: common.title || fallbackTitle,
       artist: common.artist || 'Unknown Artist',
-      albumArtist: common.albumartist || common.artist || null,
+      // Only the dedicated albumartist tag — do NOT fall back to the track
+      // artist, or an untagged various-artists album gets a per-track album
+      // artist and fragments at grouping time (#269). Null means "untagged",
+      // which the grouping layer keys on the album title alone.
+      albumArtist: common.albumartist || null,
       album: common.album || 'Unknown Album',
       duration: format.duration || 0,
       genre: common.genre?.[0] || '',

--- a/apps/desktop/src/main/scan-utility.ts
+++ b/apps/desktop/src/main/scan-utility.ts
@@ -245,7 +245,7 @@ async function parseFile(s: UtilityState, filePath: string): Promise<ParseSucces
       // artist, or an untagged various-artists album gets a per-track album
       // artist and fragments at grouping time (#269). Null means "untagged",
       // which the grouping layer keys on the album title alone.
-      albumArtist: common.albumartist || null,
+      albumArtist: common.albumartist?.trim() || null,
       album: common.album || 'Unknown Album',
       duration: format.duration || 0,
       genre: common.genre?.[0] || '',

--- a/apps/web/src/lib/albumSort.test.ts
+++ b/apps/web/src/lib/albumSort.test.ts
@@ -77,14 +77,36 @@ describe('groupTracksByAlbum', () => {
     expect(group.trackCount).toBe(2);
   });
 
-  it('separates same-named albums by different album artists', () => {
-    // Two distinct "Greatest Hits" albums must not merge into one.
-    const a = makeTrack({ id: 'a', album: 'Greatest Hits', artist: 'Alice' });
-    const b = makeTrack({ id: 'b', album: 'Greatest Hits', artist: 'Bob' });
+  it('separates same-named albums by different album-artist tags', () => {
+    // Two distinct "Greatest Hits" albums with genuine album-artist tags must
+    // not merge. (Untagged same-title albums intentionally merge — they key on
+    // the title alone; see the untagged-compilation test below.)
+    const a = makeTrack({
+      id: 'a',
+      album: 'Greatest Hits',
+      artist: 'Alice',
+      albumArtist: 'Alice',
+    });
+    const b = makeTrack({ id: 'b', album: 'Greatest Hits', artist: 'Bob', albumArtist: 'Bob' });
     const groups = groupTracksByAlbum([a, b]);
     expect(groups).toHaveLength(2);
     expect(groups.map(g => g.albumArtist).sort()).toEqual(['Alice', 'Bob']);
     expect(new Set(groups.map(g => g.key)).size).toBe(2);
+  });
+
+  it('keeps an untagged various-artists album as one album (#269)', () => {
+    // A compilation with NO album-artist tag: each track has a different
+    // performing artist. Keying on the track artist (the 0.22.0 regression)
+    // fragments it into one album per artist. Without an album-artist tag we
+    // key on the album title alone, so it stays a single album.
+    const c1 = makeTrack({ id: 'x', album: 'Lofi Mix', artist: 'Alice' });
+    const c2 = makeTrack({ id: 'y', album: 'Lofi Mix', artist: 'Bob' });
+    const c3 = makeTrack({ id: 'z', album: 'Lofi Mix', artist: 'Carol' });
+    const groups = groupTracksByAlbum([c1, c2, c3]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].name).toBe('Lofi Mix');
+    expect(groups[0].artist).toBe('Alice, Bob, Carol');
+    expect(groups[0].trackCount).toBe(3);
   });
 
   it('falls back to track artist for albumArtist when the tag is absent', () => {

--- a/apps/web/src/lib/albumSort.ts
+++ b/apps/web/src/lib/albumSort.ts
@@ -4,14 +4,14 @@ import { type AlbumSortMode, type AlbumSortOrder } from '@/stores/useUIStore';
 export interface AlbumData {
   /**
    * Stable composite identity for this album: `albumArtist \u0000 album`. Two
-   * albums with the same title but different album artists stay separate, and a
-   * compilation whose tracks have varied artists stays a single album. Use this
-   * (not `name`) to select/filter an album. The NUL separator can't appear in a
-   * tag string, so it can't collide.
+   * albums with the same title but different album artists stay separate.
+   * Untagged albums have no album-artist tag and are keyed on the title alone,
+   * so an untagged various-artists compilation stays one album (#269). Use this
+   * (not `name`) to select/filter an album.
    */
   key: string;
   name: string;
-  /** Album artist — the grouping anchor. Falls back to the track artist. */
+  /** Album artist for display — the tag if present, else a representative track artist. */
   albumArtist: string;
   artist: string;
   year: number | null;
@@ -21,25 +21,40 @@ export interface AlbumData {
   tracks: Track[];
 }
 
-/** The album-artist used for grouping: explicit albumArtist, else artist. */
+/**
+ * The album-artist used for *display*: the album-artist tag if present, else
+ * the track artist as a representative fallback. NOT used for grouping — see
+ * `albumKeyOf`, which deliberately does not fall back to the track artist.
+ */
 export function albumArtistOf(track: Track): string {
   return track.albumArtist?.trim() || track.artist;
 }
 
-/** Composite album identity used as the grouping/selection key. */
+/**
+ * Composite album identity used as the grouping/selection key.
+ *
+ * Keyed on the album-artist tag when present, so identically-titled albums by
+ * different artists stay separate. Without an album-artist tag we key on the
+ * album title alone — keying on the track artist (as 0.22.0 did) fragments an
+ * untagged various-artists compilation into one album per track artist (#269).
+ * The NUL separator can't appear in a tag string, so the two key shapes can't
+ * collide.
+ */
 export function albumKeyOf(track: Track): string {
-  return `${albumArtistOf(track)}\u0000${track.album}`;
+  const albumArtist = track.albumArtist?.trim();
+  return albumArtist ? `${albumArtist}\u0000${track.album}` : `\u0000${track.album}`;
 }
 
 /**
  * Group a flat list of tracks into album buckets.
  *
- * Albums are keyed on `(albumArtist || artist, album)` rather than the album
- * title alone, so identically-named albums by different artists do not merge
- * and a compilation's varied track artists do not fragment one album. Each
- * album's displayed `artist` is still derived from the distinct track artists
- * (e.g. "Artist A, Artist B" for compilations). The album's year is taken from
- * the first track encountered for that album.
+ * Albums are keyed by `albumKeyOf` (album-artist tag when present, else the
+ * album title alone) — not by the track artist — so identically-named albums by
+ * different artists do not merge while an untagged compilation's varied track
+ * artists do not fragment one album (#269). Each album's displayed `artist` is
+ * still derived from the distinct track artists (e.g. "Artist A, Artist B" for
+ * compilations). The album's year is taken from the first track encountered for
+ * that album.
  */
 export function groupTracksByAlbum(
   tracks: Track[],

--- a/apps/web/src/lib/scanHelpers.ts
+++ b/apps/web/src/lib/scanHelpers.ts
@@ -58,7 +58,9 @@ export async function scanAndPersistFolder(dirPath: string): Promise<ScanAndPers
       filePath: r.filePath,
       title: r.metadata.title,
       artist: r.metadata.artist,
-      albumArtist: r.metadata.albumArtist ?? r.metadata.artist ?? null,
+      // Pass the album-artist tag through as-is (null = untagged); don't
+      // re-introduce the track-artist fallback removed at the scan layer (#269).
+      albumArtist: r.metadata.albumArtist ?? null,
       album: r.metadata.album,
       duration: r.metadata.duration,
       genre: r.metadata.genre ?? null,

--- a/packages/database/drizzle/20260101000006_unbake_album_artist/migration.sql
+++ b/packages/database/drizzle/20260101000006_unbake_album_artist/migration.sql
@@ -1,0 +1,1 @@
+UPDATE `tracks` SET `album_artist` = NULL WHERE `album_artist` = `artist`

--- a/packages/database/src/migrate.test.ts
+++ b/packages/database/src/migrate.test.ts
@@ -122,6 +122,71 @@ describe('runMigrations', () => {
   });
 });
 
+describe('un-bake album_artist data migration (#269)', () => {
+  // The shipped statement, pulled from the embedded list so the test can't
+  // drift from what actually runs against user databases.
+  const unbakeSql = __embeddedMigrationsForTest.find(
+    m => m.name === '20260101000006_unbake_album_artist'
+  )!.statements[0];
+
+  it('nulls album_artist that merely mirrors the track artist, preserves real tags', () => {
+    const db = new Database(':memory:');
+    runMigrations(db); // schema ready; the data migration ran on an empty table
+
+    const insert = db.prepare(
+      `INSERT INTO tracks (id, file_path, title, artist, album, album_artist) VALUES (?, ?, ?, ?, ?, ?)`
+    );
+    // Baked untagged track: album_artist was forced to equal the track artist.
+    insert.run('baked', '/m/baked.mp3', 'A', 'Alice', 'Comp', 'Alice');
+    // Genuine compilation tag: album_artist differs from the track artist.
+    insert.run('tagged', '/m/tagged.mp3', 'B', 'Bob', 'Comp', 'Various Artists');
+    // Already untagged.
+    insert.run('null', '/m/null.mp3', 'C', 'Carol', 'Comp', null);
+
+    db.prepare(unbakeSql).run();
+
+    const byId = Object.fromEntries(
+      (
+        db.prepare(`SELECT id, album_artist FROM tracks`).all() as Array<{
+          id: string;
+          album_artist: string | null;
+        }>
+      ).map(r => [r.id, r.album_artist])
+    );
+    expect(byId.baked).toBeNull(); // un-baked → grouping falls back to album title
+    expect(byId.tagged).toBe('Various Artists'); // genuine tag preserved
+    expect(byId.null).toBeNull();
+
+    db.close();
+  });
+
+  it('is idempotent — a second apply nulls nothing further', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO tracks (id, file_path, title, artist, album, album_artist) VALUES (?, ?, ?, ?, ?, ?)`
+    ).run('t', '/m/t.mp3', 'A', 'Alice', 'Comp', 'Alice');
+
+    db.prepare(unbakeSql).run();
+    const after1 = (
+      db.prepare(`SELECT album_artist FROM tracks WHERE id='t'`).get() as {
+        album_artist: string | null;
+      }
+    ).album_artist;
+    db.prepare(unbakeSql).run();
+    const after2 = (
+      db.prepare(`SELECT album_artist FROM tracks WHERE id='t'`).get() as {
+        album_artist: string | null;
+      }
+    ).album_artist;
+
+    expect(after1).toBeNull();
+    expect(after2).toBeNull();
+
+    db.close();
+  });
+});
+
 describe('assertNotDowngrade', () => {
   it('allows equal or older DB versions', () => {
     expect(() => assertNotDowngrade(SCHEMA_VERSION)).not.toThrow();

--- a/packages/database/src/migrate.ts
+++ b/packages/database/src/migrate.ts
@@ -33,7 +33,7 @@ export const BASELINE_NAME = '20260101000000_baseline';
  * Bump this whenever a migration is added so the downgrade guard can refuse to
  * open a database created by a newer build.
  */
-export const SCHEMA_VERSION = 6;
+export const SCHEMA_VERSION = 7;
 
 interface EmbeddedMigration {
   /** Folder name — used as the ledger `name` and for ordering. */
@@ -202,6 +202,23 @@ const MIGRATIONS: EmbeddedMigration[] = [
 \t\`finished_at\` integer
 )`,
     ],
+  },
+  {
+    // #269: earlier builds baked the track artist into album_artist for files
+    // with no albumartist tag, so untagged various-artists albums fragmented at
+    // grouping time. Un-bake it: where album_artist merely mirrors the track
+    // artist, reset it to NULL ("untagged") so the grouping layer falls back to
+    // the album title alone. Idempotent: once nulled, `album_artist = artist`
+    // no longer matches (NULL = artist is NULL).
+    //
+    // Tradeoff (accepted): the WHERE cannot tell a baked fallback from a genuine
+    // albumartist tag that legitimately equals the artist (a solo album). It
+    // nulls both, so two same-titled solo albums by different artists now MERGE
+    // (they key on the title alone) — same behavior as <=0.21.0, and rare. The
+    // on-disk tag is untouched: a genuine albumartist==artist tag re-populates
+    // on the next rescan (the scan layer no longer bakes), restoring separation.
+    name: '20260101000006_unbake_album_artist',
+    statements: ['UPDATE `tracks` SET `album_artist` = NULL WHERE `album_artist` = `artist`'],
   },
 ];
 


### PR DESCRIPTION
## Summary
- **Fixes #269.** A various-artists / compilation album with no `albumartist` tag was split into one album per track artist. v0.22.0 keyed grouping on `(albumArtist || artist, album)`; for untagged compilations the `|| artist` fallback resolved per track, fragmenting the album. (0.21.0 grouped by album title alone — which is why reverting fixed it.)
- `albumKeyOf` (`apps/web/src/lib/albumSort.ts`) now keys on the album-artist tag when present, else the album **title alone** — untagged compilations stay one album, while same-titled albums with genuine album-artist tags stay separate. The Top Albums history query (`apps/desktop/src/main/ipc/database/history.ts`) uses the same anchor.
- The scan layer (`scan-utility`, `metadata-service`, `scanHelpers`) stops baking the track artist into `album_artist`; untagged files now persist `null`. Migration `20260101000006_unbake_album_artist` resets already-baked rows (`album_artist = artist → NULL`) so existing libraries regroup on launch without a rescan (`SCHEMA_VERSION` 6→7).

## Test plan
- [ ] Albums view: a compilation whose tracks have different artists and **no** album-artist tag shows as ONE album, not one per artist.
- [ ] An album tagged with a real `albumartist` (e.g. "Various Artists") stays one album; two same-titled albums with different album-artist tags stay separate.
- [ ] A library scanned on an affected build regroups correctly after relaunch (migration runs on open) — no manual rescan needed.
- [ ] `pnpm --filter @shiranami/database test` (migration + lock-step) and the web `albumSort` tests pass, including the new untagged-compilation case.