### PR TITLE
feat(settings): add accent picker, ui toggles, resizable panels, system prefs

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -8,6 +8,7 @@ import { cleanupIpcHandlers } from './ipc/register';
 import { initializeAutoUpdater } from './updater';
 import { logger, flushLogs } from './logger';
 import { createTray, destroyTray } from './tray';
+import { initializeSystemBehavior, attachTrayWindowBehavior } from './system-behavior';
 import { initializeMediaControls, cleanupMediaControls } from './media-controls';
 import { initializeDiscordRpc, cleanupDiscordRpc } from './discord-rpc';
 import { registerAudioProtocol } from './audio-protocol';
@@ -187,6 +188,13 @@ async function bootstrap(): Promise<void> {
     }
 
     try {
+      initializeSystemBehavior();
+      attachTrayWindowBehavior(mainWindow);
+    } catch (error) {
+      logger.warn('Failed to initialize system behavior prefs:', error);
+    }
+
+    try {
       initializeMediaControls(mainWindow);
     } catch (error) {
       logger.warn('Failed to initialize media controls:', error);
@@ -247,6 +255,7 @@ app.on('activate', async () => {
     if (!isE2E) {
       try {
         createTray(mainWindow);
+        attachTrayWindowBehavior(mainWindow);
       } catch (error) {
         logger.warn('Failed to create system tray on activate:', error);
       }

--- a/apps/desktop/src/main/ipc/schemas/store.ts
+++ b/apps/desktop/src/main/ipc/schemas/store.ts
@@ -24,6 +24,9 @@ const RENDERER_STORE_KEYS = [
   'app.telemetryEnabled',
   'app.performanceMonitoringEnabled',
   'metadata-enrich.skippedIds',
+  'system.launchAtStartup',
+  'system.minimizeToTray',
+  'system.closeToTray',
 ] as const;
 
 // Compile-time guarantee: every entry is a StoreSchema key.

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -53,6 +53,13 @@ export interface StoreSchema {
   'app.performanceMonitoringEnabled': boolean;
   'metadata-enrich.skippedIds': string[];
 
+  // System behavior prefs. Renderer-writable (settings UI); the main process
+  // reads them in window/login-item handlers (system-behavior.ts). All default
+  // to implicit `undefined` → off, preserving pre-feature behavior.
+  'system.launchAtStartup': boolean;
+  'system.minimizeToTray': boolean;
+  'system.closeToTray': boolean;
+
   // Main-only (downloader.ts).
   'downloads.location': string;
   'downloads.toolStatusCache': ToolStatusCache;

--- a/apps/desktop/src/main/system-behavior.ts
+++ b/apps/desktop/src/main/system-behavior.ts
@@ -1,0 +1,68 @@
+import { app, type BrowserWindow } from 'electron';
+import { store } from './store';
+import { logger } from './logger';
+
+/**
+ * System behavior prefs: launch-at-startup and tray-keep-alive window
+ * handling. The renderer writes the `system.*` store keys from the Settings ·
+ * System section; this module is the main-process side that makes them real.
+ * All prefs default to off, so nothing here changes behavior until the user
+ * opts in.
+ */
+
+// Flips on the first 'before-quit' so an explicit quit (tray menu, Cmd+Q,
+// updater restart) is never intercepted by the close-to-tray handler.
+let isQuitting = false;
+
+function applyLaunchAtStartup(enabled: boolean): void {
+  // setLoginItemSettings is a no-op concept on Linux (and unsupported in
+  // unpackaged dev builds on macOS, where the bundle path isn't registered).
+  if (process.platform !== 'win32' && process.platform !== 'darwin') return;
+  try {
+    app.setLoginItemSettings({ openAtLogin: enabled });
+    logger.info(`[system] Launch at startup ${enabled ? 'enabled' : 'disabled'}`);
+  } catch (err) {
+    logger.warn('[system] Failed to update login item settings:', err);
+  }
+}
+
+/**
+ * Apply the persisted launch-at-startup state and keep following renderer
+ * writes. Call once at bootstrap; returns the watcher unsubscribe.
+ */
+export function initializeSystemBehavior(): () => void {
+  app.on('before-quit', () => {
+    isQuitting = true;
+  });
+
+  const persisted = store.get('system.launchAtStartup');
+  // Only touch the OS login item when the user has expressed a preference —
+  // never write OS state on a fresh install.
+  if (typeof persisted === 'boolean') {
+    applyLaunchAtStartup(persisted);
+  }
+
+  return store.onDidChange('system.launchAtStartup', value => {
+    applyLaunchAtStartup(value === true);
+  });
+}
+
+/**
+ * Intercept close/minimize on the main window and hide to tray instead when
+ * the matching pref is on. Prefs are read at event time so toggling in
+ * Settings applies immediately, without re-attaching.
+ */
+export function attachTrayWindowBehavior(win: BrowserWindow): void {
+  win.on('close', event => {
+    if (isQuitting || win.isDestroyed()) return;
+    if (store.get('system.closeToTray') !== true) return;
+    event.preventDefault();
+    win.hide();
+  });
+
+  win.on('minimize', () => {
+    if (win.isDestroyed()) return;
+    if (store.get('system.minimizeToTray') !== true) return;
+    win.hide();
+  });
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -17,6 +17,7 @@ import { FavoritesView } from '@/components/favorites/FavoritesView';
 import { PlaylistsView } from '@/components/playlists/PlaylistsView';
 import { AmbientBackground } from '@/components/shared/AmbientBackground';
 import { ThemeBackground } from '@/components/shared/ThemeBackground';
+import { PanelResizeHandle } from '@/components/shared/PanelResizeHandle';
 import { SupportBanner } from '@/components/shared/SupportBanner';
 import ErrorBoundary from '@/components/shared/ErrorBoundary';
 
@@ -56,6 +57,11 @@ import { useDebugPanel } from '@/hooks/useDebugPanel';
 import { DevProfiler } from '@/components/debug/DevProfiler';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useUIStore } from '@/stores/useUIStore';
+import {
+  usePanelSizeStore,
+  RIGHT_PANEL_WIDTH_MIN,
+  RIGHT_PANEL_WIDTH_MAX,
+} from '@/stores/usePanelSizeStore';
 import { useCompactStore } from '@/stores/useCompactStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { useDownloadStore } from '@/stores/useDownloadStore';
@@ -158,6 +164,9 @@ function App() {
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const activeView = useViewStore(s => s.activeView);
   const rightPanel = useViewStore(s => s.rightPanel);
+  const rightPanelWidth = usePanelSizeStore(s => s.rightPanelWidth);
+  const setRightPanelWidth = usePanelSizeStore(s => s.setRightPanelWidth);
+  const resetRightPanelWidth = usePanelSizeStore(s => s.resetRightPanelWidth);
   const selectedPlaylistId = useViewStore(s => s.selectedPlaylistId);
   const showVisualizer = useUIStore(s => s.showVisualizer);
   const visualizerStyle = useUIStore(s => s.visualizerStyle);
@@ -463,7 +472,19 @@ function App() {
                     {currentTrack &&
                       activeView !== 'now-playing' &&
                       (rightPanel === 'lyrics' || rightPanel === 'queue') && (
-                        <div className="w-[320px] border-l border-border/30 shrink-0 flex flex-col overflow-hidden bg-surface/30">
+                        <div
+                          className="relative border-l border-border/30 shrink-0 flex flex-col overflow-hidden bg-surface/30"
+                          style={{ width: rightPanelWidth }}
+                        >
+                          <PanelResizeHandle
+                            edge="left"
+                            value={rightPanelWidth}
+                            min={RIGHT_PANEL_WIDTH_MIN}
+                            max={RIGHT_PANEL_WIDTH_MAX}
+                            onChange={setRightPanelWidth}
+                            onReset={resetRightPanelWidth}
+                            aria-label={t('resizeRightPanel', { ns: 'common' })}
+                          />
                           <ErrorBoundary viewName="RightPanel">
                             <Suspense fallback={null}>
                               {rightPanel === 'lyrics' ? <LyricsPanel /> : <QueuePanel />}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -69,6 +69,10 @@ import { useLibraryStore } from '@/stores/useLibraryStore';
 import { useOnboardingStore } from '@/stores/useOnboardingStore';
 import { useSupportBannerStore } from '@/stores/useSupportBannerStore';
 import { useTelemetryStore } from '@/stores/useTelemetryStore';
+// Side-effect import: rehydrates the persisted accent override and applies it
+// to :root at startup. The store's only UI lives in lazy-loaded Settings, so
+// without this a custom accent would not apply until Settings is opened.
+import '@/stores/useAccentStore';
 import { AmbientColorProvider } from '@/hooks/useAmbientColor';
 import { CommandPalette } from '@/components/shared/CommandPalette';
 import { hydrateLanguageFromStore } from '@/lib/i18n';

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -473,6 +473,7 @@ function App() {
                       activeView !== 'now-playing' &&
                       (rightPanel === 'lyrics' || rightPanel === 'queue') && (
                         <div
+                          id="player-side-panel"
                           className="relative border-l border-border/30 shrink-0 flex flex-col overflow-hidden bg-surface/30"
                           style={{ width: rightPanelWidth }}
                         >
@@ -484,6 +485,7 @@ function App() {
                             onChange={setRightPanelWidth}
                             onReset={resetRightPanelWidth}
                             aria-label={t('resizeRightPanel', { ns: 'common' })}
+                            aria-controls="player-side-panel"
                           />
                           <ErrorBoundary viewName="RightPanel">
                             <Suspense fallback={null}>

--- a/apps/web/src/components/overview/OverviewView.tsx
+++ b/apps/web/src/components/overview/OverviewView.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { AlertCircle, Disc3, LayoutDashboard } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { ViewEmptyState } from '@/components/shared/ViewEmptyState';
 import { useLibraryActions } from '@/hooks/useLibraryActions';
 import { useViewStore } from '@/stores/useViewStore';
@@ -13,6 +14,7 @@ import { RecentlyAdded } from '@/components/overview/RecentlyAdded';
 import { RecommendationsShelf } from '@/components/overview/RecommendationsShelf';
 import { SmartMixesShelf } from '@/components/overview/SmartMixesShelf';
 import { OverviewViewSkeleton } from '@/components/overview/OverviewViewSkeleton';
+import { useInterfaceStore } from '@/stores/useInterfaceStore';
 
 export default function OverviewView() {
   const { t } = useTranslation('overview');
@@ -35,6 +37,16 @@ export default function OverviewView() {
   } = useOverviewData();
   const { handleOpenFolder } = useLibraryActions();
   const navigateTo = useViewStore(s => s.navigateTo);
+  const showStats = useInterfaceStore(s => s.overviewStats);
+  const showTopWeek = useInterfaceStore(s => s.overviewTopWeek);
+  const showClock = useInterfaceStore(s => s.overviewClock);
+  const showTopAlbums = useInterfaceStore(s => s.overviewTopAlbums);
+  const showMixes = useInterfaceStore(s => s.overviewMixes);
+  const showRecommendations = useInterfaceStore(s => s.overviewRecommendations);
+  const showRecentlyAdded = useInterfaceStore(s => s.overviewRecentlyAdded);
+  // The week grid collapses to one column when either side is hidden, so a
+  // lone widget never floats beside an empty grid track.
+  const showRightColumn = showClock || showTopAlbums;
 
   if (isError) {
     return (
@@ -82,24 +94,37 @@ export default function OverviewView() {
 
         {hasHistory ? (
           <>
-            <StatStrip
-              summary={summary}
-              newInLibraryCount={newInLibraryCount}
-              trendDeltaMinutes={trendDeltaMinutes}
-              sessionCount={sessionCount}
-            />
-
-            <div className="grid gap-6 xl:grid-cols-[1.3fr_1fr]">
-              <TopThisWeek
-                tracks={summary.topTracks}
-                onPlay={handlePlayTrack}
-                onOpenLibrary={() => navigateTo('library')}
+            {showStats && (
+              <StatStrip
+                summary={summary}
+                newInLibraryCount={newInLibraryCount}
+                trendDeltaMinutes={trendDeltaMinutes}
+                sessionCount={sessionCount}
               />
-              <div className="flex flex-col gap-6">
-                <ListeningClock heatmap={heatmap} />
-                <TopAlbums albums={topAlbums} />
+            )}
+
+            {(showTopWeek || showRightColumn) && (
+              <div
+                className={cn(
+                  'grid gap-6',
+                  showTopWeek && showRightColumn && 'xl:grid-cols-[1.3fr_1fr]'
+                )}
+              >
+                {showTopWeek && (
+                  <TopThisWeek
+                    tracks={summary.topTracks}
+                    onPlay={handlePlayTrack}
+                    onOpenLibrary={() => navigateTo('library')}
+                  />
+                )}
+                {showRightColumn && (
+                  <div className="flex flex-col gap-6">
+                    {showClock && <ListeningClock heatmap={heatmap} />}
+                    {showTopAlbums && <TopAlbums albums={topAlbums} />}
+                  </div>
+                )}
               </div>
-            </div>
+            )}
           </>
         ) : (
           <ViewEmptyState
@@ -110,11 +135,13 @@ export default function OverviewView() {
           />
         )}
 
-        <SmartMixesShelf />
+        {showMixes && <SmartMixesShelf />}
 
-        <RecommendationsShelf onPlay={handlePlayTrack} hasLibrary={hasLibrary} />
+        {showRecommendations && (
+          <RecommendationsShelf onPlay={handlePlayTrack} hasLibrary={hasLibrary} />
+        )}
 
-        {recentlyAdded.length > 0 && (
+        {showRecentlyAdded && recentlyAdded.length > 0 && (
           <RecentlyAdded tracks={recentlyAdded} onPlay={handlePlayTrack} />
         )}
       </div>

--- a/apps/web/src/components/player/PlayerBar.tsx
+++ b/apps/web/src/components/player/PlayerBar.tsx
@@ -3,6 +3,7 @@ import { useLibraryStore } from '@/stores/useLibraryStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useTrack } from '@/hooks/useTrack';
 import { useUIStore } from '@/stores/useUIStore';
+import { useInterfaceStore } from '@/stores/useInterfaceStore';
 import { useCompactStore } from '@/stores/useCompactStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { cn, isRadioTrack } from '@/lib/utils';
@@ -44,6 +45,23 @@ export function PlayerBar() {
   const nowPlayingViewEnabled = useUIStore(s => s.nowPlayingViewEnabled);
   const enterNowPlaying = useViewStore(s => s.enterNowPlaying);
 
+  // Element visibility (Settings · Interface · Player bar). Core playback
+  // controls and the seek bar are not toggleable.
+  const showAlbumArt = useInterfaceStore(s => s.playerAlbumArt);
+  const showFavorite = useInterfaceStore(s => s.playerFavorite);
+  const showTimeLabels = useInterfaceStore(s => s.playerTimeLabels);
+  const showSleepTimer = useInterfaceStore(s => s.playerSleepTimer);
+  const showEqualizer = useInterfaceStore(s => s.playerEqualizer);
+  const showCompactButton = useInterfaceStore(s => s.playerCompactButton);
+  const showVisualizerButton = useInterfaceStore(s => s.playerVisualizerButton);
+  const showLyricsButton = useInterfaceStore(s => s.playerLyricsButton);
+  const showQueueButton = useInterfaceStore(s => s.playerQueueButton);
+  const showVolume = useInterfaceStore(s => s.playerVolume);
+
+  const hasUtilityButtons =
+    showSleepTimer || showEqualizer || showCompactButton || showVisualizerButton;
+  const hasButtonCluster = hasUtilityButtons || showLyricsButton || showQueueButton;
+
   return (
     <AnimatePresence>
       {currentTrack && (
@@ -72,27 +90,29 @@ export function PlayerBar() {
 
           {/* Track info - left (adaptive width) */}
           <div className="flex items-center gap-3 min-[900px]:gap-3.5 w-[180px] min-[900px]:w-[220px] min-[1200px]:w-[280px] min-w-0 relative">
-            <AnimatePresence mode="wait">
-              <motion.div
-                key={currentTrack.id}
-                initial={{ scale: 0.85, opacity: 0, rotate: -3 }}
-                animate={{ scale: 1, opacity: 1, rotate: 0 }}
-                exit={{ scale: 0.85, opacity: 0, rotate: 3 }}
-                transition={{ type: 'spring', damping: 20, stiffness: 300 }}
-                onDoubleClick={nowPlayingViewEnabled ? enterNowPlaying : undefined}
-                className={cn(
-                  'w-14 h-14 rounded-xl bg-muted flex items-center justify-center shrink-0 overflow-hidden shadow-lg shadow-black/20',
-                  nowPlayingViewEnabled && 'cursor-pointer'
-                )}
-              >
-                <TrackThumbnail
-                  fill
-                  albumArt={currentTrack.albumArt}
-                  alt={currentTrack.album}
-                  fallback={<Music className="w-6 h-6 text-muted-foreground/50" />}
-                />
-              </motion.div>
-            </AnimatePresence>
+            {showAlbumArt && (
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={currentTrack.id}
+                  initial={{ scale: 0.85, opacity: 0, rotate: -3 }}
+                  animate={{ scale: 1, opacity: 1, rotate: 0 }}
+                  exit={{ scale: 0.85, opacity: 0, rotate: 3 }}
+                  transition={{ type: 'spring', damping: 20, stiffness: 300 }}
+                  onDoubleClick={nowPlayingViewEnabled ? enterNowPlaying : undefined}
+                  className={cn(
+                    'w-14 h-14 rounded-xl bg-muted flex items-center justify-center shrink-0 overflow-hidden shadow-lg shadow-black/20',
+                    nowPlayingViewEnabled && 'cursor-pointer'
+                  )}
+                >
+                  <TrackThumbnail
+                    fill
+                    albumArt={currentTrack.albumArt}
+                    alt={currentTrack.album}
+                    fallback={<Music className="w-6 h-6 text-muted-foreground/50" />}
+                  />
+                </motion.div>
+              </AnimatePresence>
+            )}
 
             <AnimatePresence mode="wait">
               <motion.div
@@ -120,7 +140,7 @@ export function PlayerBar() {
               </motion.div>
             </AnimatePresence>
 
-            {!isRadioTrack(currentTrack.filePath) && (
+            {showFavorite && !isRadioTrack(currentTrack.filePath) && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
@@ -148,96 +168,114 @@ export function PlayerBar() {
             <PlayerControls />
             {!(currentTrack && isRadioTrack(currentTrack.filePath)) && (
               <div className="w-full flex items-center gap-2.5">
-                <span className="text-[10px] text-muted-foreground/70 tabular-nums w-9 text-right font-medium">
-                  <TimeDisplay />
-                </span>
+                {showTimeLabels && (
+                  <span className="text-[10px] text-muted-foreground/70 tabular-nums w-9 text-right font-medium">
+                    <TimeDisplay />
+                  </span>
+                )}
                 <SeekBar />
-                <span className="text-[10px] text-muted-foreground/70 tabular-nums w-9 font-medium">
-                  {formatDuration(duration)}
-                </span>
+                {showTimeLabels && (
+                  <span className="text-[10px] text-muted-foreground/70 tabular-nums w-9 font-medium">
+                    {formatDuration(duration)}
+                  </span>
+                )}
               </div>
             )}
           </div>
 
           {/* Right - volume + panel toggles (adaptive) */}
           <div className="shrink-0 min-[900px]:w-[264px] flex items-center justify-end gap-2 min-[900px]:gap-2.5 relative">
-            <div className="glass-subtle flex items-center gap-0.5 rounded-xl border border-border/20 p-1">
-              {/* Collapsed into overflow on < 900px */}
-              <div className="flex items-center gap-0.5 min-[900px]:hidden">
-                <PlayerOverflowMenu />
-              </div>
+            {hasButtonCluster && (
+              <div className="glass-subtle flex items-center gap-0.5 rounded-xl border border-border/20 p-1">
+                {/* Collapsed into overflow on < 900px */}
+                {hasUtilityButtons && (
+                  <div className="flex items-center gap-0.5 min-[900px]:hidden">
+                    <PlayerOverflowMenu />
+                  </div>
+                )}
 
-              {/* Expanded inline on >= 900px */}
-              <div className="hidden min-[900px]:flex items-center gap-0.5">
-                <SleepTimer />
-                <EqualizerPanel />
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <IconButton
-                      onClick={() => void setCompactMode(true)}
-                      aria-label={t('compactMode')}
-                    >
-                      <Minimize2 />
-                    </IconButton>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">
-                    {t('compactModeTooltip', { shortcut: `${MOD}+Shift+M` })}
-                  </TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <IconButton
-                      onClick={toggleVisualizer}
-                      className={cn(
-                        showVisualizer &&
-                          'text-primary bg-primary/10 hover:bg-primary/15 hover:text-primary'
-                      )}
-                      aria-label={t('toggleVisualizer')}
-                    >
-                      <AudioLines />
-                    </IconButton>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">{t('visualizerTooltip')}</TooltipContent>
-                </Tooltip>
-              </div>
+                {/* Expanded inline on >= 900px */}
+                {hasUtilityButtons && (
+                  <div className="hidden min-[900px]:flex items-center gap-0.5">
+                    {showSleepTimer && <SleepTimer />}
+                    {showEqualizer && <EqualizerPanel />}
+                    {showCompactButton && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <IconButton
+                            onClick={() => void setCompactMode(true)}
+                            aria-label={t('compactMode')}
+                          >
+                            <Minimize2 />
+                          </IconButton>
+                        </TooltipTrigger>
+                        <TooltipContent side="top">
+                          {t('compactModeTooltip', { shortcut: `${MOD}+Shift+M` })}
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                    {showVisualizerButton && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <IconButton
+                            onClick={toggleVisualizer}
+                            className={cn(
+                              showVisualizer &&
+                                'text-primary bg-primary/10 hover:bg-primary/15 hover:text-primary'
+                            )}
+                            aria-label={t('toggleVisualizer')}
+                          >
+                            <AudioLines />
+                          </IconButton>
+                        </TooltipTrigger>
+                        <TooltipContent side="top">{t('visualizerTooltip')}</TooltipContent>
+                      </Tooltip>
+                    )}
+                  </div>
+                )}
 
-              {/* Always visible — highest-priority actions */}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <IconButton
-                    onClick={() => toggleRightPanel('lyrics')}
-                    className={cn(
-                      rightPanel === 'lyrics' &&
-                        'text-primary bg-primary/10 hover:bg-primary/15 hover:text-primary'
-                    )}
-                    aria-label={t('toggleLyrics')}
-                  >
-                    <Mic2 />
-                  </IconButton>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  {t('lyricsTooltip', { shortcut: `${MOD}+L` })}
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <IconButton
-                    onClick={() => toggleRightPanel('queue')}
-                    className={cn(
-                      rightPanel === 'queue' &&
-                        'text-primary bg-primary/10 hover:bg-primary/15 hover:text-primary'
-                    )}
-                    aria-label={t('toggleQueue')}
-                  >
-                    <ListMusic />
-                  </IconButton>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  {t('queueTooltip', { shortcut: `${MOD}+Q` })}
-                </TooltipContent>
-              </Tooltip>
-            </div>
-            <VolumeControl sliderClassName="w-20" />
+                {/* Highest-priority actions — hideable, but shown by default */}
+                {showLyricsButton && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <IconButton
+                        onClick={() => toggleRightPanel('lyrics')}
+                        className={cn(
+                          rightPanel === 'lyrics' &&
+                            'text-primary bg-primary/10 hover:bg-primary/15 hover:text-primary'
+                        )}
+                        aria-label={t('toggleLyrics')}
+                      >
+                        <Mic2 />
+                      </IconButton>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      {t('lyricsTooltip', { shortcut: `${MOD}+L` })}
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+                {showQueueButton && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <IconButton
+                        onClick={() => toggleRightPanel('queue')}
+                        className={cn(
+                          rightPanel === 'queue' &&
+                            'text-primary bg-primary/10 hover:bg-primary/15 hover:text-primary'
+                        )}
+                        aria-label={t('toggleQueue')}
+                      >
+                        <ListMusic />
+                      </IconButton>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      {t('queueTooltip', { shortcut: `${MOD}+Q` })}
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
+            )}
+            {showVolume && <VolumeControl sliderClassName="w-20" />}
           </div>
         </motion.div>
       )}

--- a/apps/web/src/components/player/PlayerOverflowMenu.tsx
+++ b/apps/web/src/components/player/PlayerOverflowMenu.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { MoreHorizontal, Minimize2, AudioLines } from 'lucide-react';
 import { useUIStore } from '@/stores/useUIStore';
+import { useInterfaceStore } from '@/stores/useInterfaceStore';
 import { useCompactStore } from '@/stores/useCompactStore';
 import { useEqStore } from '@/stores/useEqStore';
 import { cn } from '@/lib/utils';
@@ -24,8 +25,16 @@ export function PlayerOverflowMenu() {
   const setCompactMode = useCompactStore(s => s.setCompactMode);
   const eqEnabled = useEqStore(s => s.enabled);
   const eqPreset = useEqStore(s => s.preset);
+  // Mirror the PlayerBar element toggles so a hidden control stays hidden in
+  // the narrow-width overflow too. The parent renders this menu only when at
+  // least one of the four is visible.
+  const showSleepTimer = useInterfaceStore(s => s.playerSleepTimer);
+  const showEqualizer = useInterfaceStore(s => s.playerEqualizer);
+  const showCompactButton = useInterfaceStore(s => s.playerCompactButton);
+  const showVisualizerButton = useInterfaceStore(s => s.playerVisualizerButton);
 
-  const hasActive = showVisualizer || (eqEnabled && eqPreset !== 'flat');
+  const hasActive =
+    (showVisualizerButton && showVisualizer) || (showEqualizer && eqEnabled && eqPreset !== 'flat');
 
   return (
     <Popover>
@@ -45,33 +54,37 @@ export function PlayerOverflowMenu() {
 
       <PopoverContent side="top" align="end" className="w-auto p-1.5">
         <div className="flex items-center gap-0.5">
-          <SleepTimer />
-          <EqualizerPanel />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <IconButton onClick={() => void setCompactMode(true)} aria-label={t('compactMode')}>
-                <Minimize2 />
-              </IconButton>
-            </TooltipTrigger>
-            <TooltipContent side="top">
-              {t('compactModeTooltip', { shortcut: `${MOD}+Shift+M` })}
-            </TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <IconButton
-                onClick={toggleVisualizer}
-                className={cn(
-                  showVisualizer &&
-                    'text-primary bg-primary/10 hover:bg-primary/15 hover:text-primary'
-                )}
-                aria-label={t('toggleVisualizer')}
-              >
-                <AudioLines />
-              </IconButton>
-            </TooltipTrigger>
-            <TooltipContent side="top">{t('visualizerTooltip')}</TooltipContent>
-          </Tooltip>
+          {showSleepTimer && <SleepTimer />}
+          {showEqualizer && <EqualizerPanel />}
+          {showCompactButton && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <IconButton onClick={() => void setCompactMode(true)} aria-label={t('compactMode')}>
+                  <Minimize2 />
+                </IconButton>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {t('compactModeTooltip', { shortcut: `${MOD}+Shift+M` })}
+              </TooltipContent>
+            </Tooltip>
+          )}
+          {showVisualizerButton && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <IconButton
+                  onClick={toggleVisualizer}
+                  className={cn(
+                    showVisualizer &&
+                      'text-primary bg-primary/10 hover:bg-primary/15 hover:text-primary'
+                  )}
+                  aria-label={t('toggleVisualizer')}
+                >
+                  <AudioLines />
+                </IconButton>
+              </TooltipTrigger>
+              <TooltipContent side="top">{t('visualizerTooltip')}</TooltipContent>
+            </Tooltip>
+          )}
         </div>
       </PopoverContent>
     </Popover>

--- a/apps/web/src/components/settings/AccentColorPicker.tsx
+++ b/apps/web/src/components/settings/AccentColorPicker.tsx
@@ -1,0 +1,105 @@
+import { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Check, Pipette, Slash } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useAccentStore, ACCENT_PRESETS } from '@/stores/useAccentStore';
+
+const SWATCH_BASE = cn(
+  'relative grid place-items-center size-9 rounded-full border transition-all',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+);
+
+function swatchRing(isActive: boolean) {
+  return isActive
+    ? 'border-primary/70 ring-2 ring-primary/40 scale-110'
+    : 'border-border/40 hover:border-border-strong hover:scale-105';
+}
+
+/**
+ * Accent override picker: "auto" (follow the theme), preset swatches, and a
+ * free custom color via the native color input. Lives in Settings ·
+ * Appearance under the theme card.
+ */
+export function AccentColorPicker() {
+  const { t } = useTranslation('settings');
+  const accentColor = useAccentStore(s => s.accentColor);
+  const setAccentColor = useAccentStore(s => s.setAccentColor);
+  const customInputRef = useRef<HTMLInputElement>(null);
+
+  const isPreset = ACCENT_PRESETS.some(p => p.hex === accentColor);
+  const isCustom = accentColor !== null && !isPreset;
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={t('app.accent.title')}
+      className="flex flex-wrap items-center gap-2.5"
+    >
+      {/* Auto — follow the active theme's accent */}
+      <button
+        type="button"
+        role="radio"
+        aria-checked={accentColor === null}
+        aria-label={t('app.accent.auto')}
+        title={t('app.accent.auto')}
+        onClick={() => setAccentColor(null)}
+        className={cn(SWATCH_BASE, 'bg-background', swatchRing(accentColor === null))}
+      >
+        <Slash className="size-4 text-muted-foreground" />
+        {accentColor === null && <ActiveCheck />}
+      </button>
+
+      {ACCENT_PRESETS.map(preset => {
+        const isActive = accentColor === preset.hex;
+        const name = t(`app.accent.names.${preset.nameKey}`);
+        return (
+          <button
+            key={preset.hex}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            aria-label={t('app.accent.apply', { name })}
+            title={name}
+            onClick={() => setAccentColor(preset.hex)}
+            style={{ backgroundColor: preset.hex }}
+            className={cn(SWATCH_BASE, swatchRing(isActive))}
+          >
+            {isActive && <ActiveCheck />}
+          </button>
+        );
+      })}
+
+      {/* Custom — opens the native color dialog; swatch reflects the picked
+          color once one is active, a neutral pipette tile otherwise. */}
+      <button
+        type="button"
+        role="radio"
+        aria-checked={isCustom}
+        aria-label={t('app.accent.custom')}
+        title={t('app.accent.custom')}
+        onClick={() => customInputRef.current?.click()}
+        style={isCustom ? { backgroundColor: accentColor } : undefined}
+        className={cn(SWATCH_BASE, !isCustom && 'bg-secondary', swatchRing(isCustom))}
+      >
+        {isCustom ? <ActiveCheck /> : <Pipette className="size-3.5 text-muted-foreground" />}
+        <input
+          ref={customInputRef}
+          type="color"
+          tabIndex={-1}
+          aria-hidden="true"
+          value={accentColor ?? '#9b7deb'}
+          onChange={e => setAccentColor(e.target.value)}
+          className="absolute inset-0 opacity-0 pointer-events-none"
+        />
+      </button>
+    </div>
+  );
+}
+
+function ActiveCheck() {
+  return (
+    <span className="absolute -top-0.5 -right-0.5 grid place-items-center size-4 rounded-full bg-primary text-primary-foreground shadow">
+      <Check className="size-2.5" />
+    </span>
+  );
+}

--- a/apps/web/src/components/settings/AccentPreview.tsx
+++ b/apps/web/src/components/settings/AccentPreview.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from 'react-i18next';
+import { Heart, Music2, Play } from 'lucide-react';
+import { SettingsPreview } from '@/components/settings/SettingsPreview';
+
+/**
+ * Sample chrome rendered entirely from the accent tokens (`bg-primary`,
+ * `text-primary-foreground`, `--primary-rgb`), so it live-updates as the user
+ * picks a swatch — including the computed foreground, which is the part a
+ * bare color chip can't show.
+ */
+export function AccentPreview() {
+  const { t } = useTranslation('settings');
+
+  return (
+    <SettingsPreview title={t('app.accent.previewTitle')}>
+      <div
+        className="rounded-xl border border-border/30 bg-background/40 p-3"
+        role="img"
+        aria-label={t('app.accent.previewTitle')}
+      >
+        <div className="mx-auto max-w-[340px] rounded-xl border border-border/25 bg-surface/60 p-3">
+          {/* Fake track row: icon tile + title bars + favorite */}
+          <div className="flex items-center gap-3">
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-primary">
+              <Music2 className="size-4" />
+            </div>
+            <div className="min-w-0 flex-1 space-y-1.5">
+              <div className="h-2.5 w-28 rounded-full bg-foreground/25" />
+              <div className="h-2 w-20 rounded-full bg-muted-foreground/25" />
+            </div>
+            <Heart className="size-4 shrink-0 fill-primary/80 text-primary" />
+          </div>
+
+          {/* Progress bar with accent glow */}
+          <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted/35">
+            <div
+              className="h-full w-[62%] rounded-full bg-primary/70"
+              style={{ boxShadow: '0 0 10px rgba(var(--primary-rgb), 0.5)' }}
+            />
+          </div>
+
+          {/* Control row: play button (shows the computed foreground), active
+              nav pill, and an "on" switch — the accent in its real habitats */}
+          <div className="mt-3 flex items-center justify-between">
+            <div className="grid size-8 place-items-center rounded-full bg-primary text-primary-foreground shadow">
+              <Play className="size-3.5 fill-current" />
+            </div>
+            <div className="rounded-md bg-primary/15 px-2.5 py-1 ring-1 ring-primary/35">
+              <div className="h-1.5 w-10 rounded-full bg-primary/80" />
+            </div>
+            <div className="flex h-4.5 w-8 items-center rounded-full bg-primary p-0.5">
+              <div className="ml-auto size-3.5 rounded-full bg-primary-foreground/95 shadow" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </SettingsPreview>
+  );
+}

--- a/apps/web/src/components/settings/AppearanceSection.tsx
+++ b/apps/web/src/components/settings/AppearanceSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Languages, Palette, RotateCcw } from 'lucide-react';
+import { Languages, Paintbrush, Palette, RotateCcw } from 'lucide-react';
 import { SettingsCard } from '@/components/settings/SettingsCard';
 import { Slider } from '@/components/ui/slider';
 import {
@@ -28,6 +28,8 @@ import {
 } from '@/stores/useThemeBgStore';
 import { cn } from '@/lib/utils';
 import { ThemeTileGrid } from '@/components/shared/theme/ThemeTileGrid';
+import { AccentColorPicker } from '@/components/settings/AccentColorPicker';
+import { useAccentStore } from '@/stores/useAccentStore';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { ThemeBackgroundPreview } from '@/components/settings/ThemeBackgroundPreview';
 import { SUPPORTED_LANGUAGES, persistLanguage, type SupportedLanguage } from '@/lib/i18n';
@@ -47,6 +49,8 @@ export function AppearanceSection() {
   const bgDim = useThemeBgStore(s => s.bgDim);
   const setBgDim = useThemeBgStore(s => s.setBgDim);
   const resetBg = useThemeBgStore(s => s.resetBg);
+  const accentColor = useAccentStore(s => s.accentColor);
+  const resetAccent = useAccentStore(s => s.resetAccent);
 
   const isBgModified =
     bgOpacity !== THEME_BG_OPACITY_DEFAULT ||
@@ -214,6 +218,29 @@ export function AppearanceSection() {
             </SettingsCard>
           </div>
         )}
+      </SettingsCard>
+
+      {/* Card 3 — Accent color */}
+      <SettingsCard
+        icon={Paintbrush}
+        title={t('app.accent.title')}
+        subtitle={t('app.accent.desc')}
+        headerRight={
+          accentColor !== null ? (
+            <button
+              onClick={resetAccent}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              aria-label={t('app.accent.reset')}
+            >
+              <RotateCcw className="size-3" />
+              {t('app.accent.reset')}
+            </button>
+          ) : undefined
+        }
+      >
+        <div className="px-3 pb-1">
+          <AccentColorPicker />
+        </div>
       </SettingsCard>
     </div>
   );

--- a/apps/web/src/components/settings/AppearanceSection.tsx
+++ b/apps/web/src/components/settings/AppearanceSection.tsx
@@ -29,6 +29,8 @@ import {
 import { cn } from '@/lib/utils';
 import { ThemeTileGrid } from '@/components/shared/theme/ThemeTileGrid';
 import { AccentColorPicker } from '@/components/settings/AccentColorPicker';
+import { AccentPreview } from '@/components/settings/AccentPreview';
+import { UiScalePreview } from '@/components/settings/UiScalePreview';
 import { useAccentStore } from '@/stores/useAccentStore';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { ThemeBackgroundPreview } from '@/components/settings/ThemeBackgroundPreview';
@@ -132,6 +134,10 @@ export function AppearanceSection() {
                 </button>
               )}
             </div>
+
+            <SettingsCard tone="info" className="!p-3 mt-4">
+              <UiScalePreview scale={uiScale} />
+            </SettingsCard>
           </div>
         </div>
       </SettingsCard>
@@ -241,6 +247,10 @@ export function AppearanceSection() {
         <div className="px-3 pb-1">
           <AccentColorPicker />
         </div>
+
+        <SettingsCard tone="info" className="!p-3">
+          <AccentPreview />
+        </SettingsCard>
       </SettingsCard>
     </div>
   );

--- a/apps/web/src/components/settings/InterfacePreview.tsx
+++ b/apps/web/src/components/settings/InterfacePreview.tsx
@@ -1,4 +1,17 @@
 import { useTranslation } from 'react-i18next';
+import {
+  AudioLines,
+  Heart,
+  ListMusic,
+  Mic2,
+  Minimize2,
+  Moon,
+  Play,
+  SkipBack,
+  SkipForward,
+  SlidersHorizontal,
+  Volume2,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useInterfaceStore, type InterfaceElementKey } from '@/stores/useInterfaceStore';
@@ -47,7 +60,8 @@ export function TopBarPreview({ enabled }: TopBarPreviewProps) {
   );
 }
 
-type OverviewWidgetKey = Exclude<InterfaceElementKey, 'topBarLanguageSwitcher'>;
+type OverviewWidgetKey = Extract<InterfaceElementKey, `overview${string}`>;
+type PlayerElementKey = Extract<InterfaceElementKey, `player${string}`>;
 
 interface OverviewLayoutPreviewProps {
   /** Widget to spotlight in the mock (mirrors the row hovered in settings). */
@@ -230,6 +244,148 @@ export function OverviewLayoutPreview({ highlightedKey = null }: OverviewLayoutP
               ))}
             </div>
           </Block>
+        </div>
+      </div>
+    </SettingsPreview>
+  );
+}
+
+interface PlayerBarPreviewProps {
+  /** Element to spotlight in the mock (mirrors the row hovered in settings). */
+  highlightedKey?: PlayerElementKey | null;
+}
+
+interface ElProps {
+  visible: boolean;
+  highlighted: boolean;
+  /** max-w-* class for the expanded state (collapse animates via max-width). */
+  expandedClass: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+/** Horizontally-collapsible mock element (the player-bar analog of Block). */
+function El({ visible, highlighted, expandedClass, children, className }: ElProps) {
+  return (
+    <div
+      className={cn(
+        'flex shrink-0 items-center overflow-hidden rounded-md transition-all duration-300',
+        visible ? cn(expandedClass, 'opacity-100') : 'max-w-0 opacity-0',
+        highlighted && visible && 'ring-1 ring-primary/40 bg-primary/10',
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Scaled mock of the player bar reading the real interface store: hidden
+ * elements collapse away live, hovered settings rows spotlight their element.
+ * Core controls (prev/play/next, seek) render unconditionally, matching the
+ * real bar.
+ */
+export function PlayerBarPreview({ highlightedKey = null }: PlayerBarPreviewProps) {
+  const { t } = useTranslation('settings');
+  const s = useInterfaceStore();
+  const spotlight = (key: PlayerElementKey) => highlightedKey === key;
+
+  const utilityIcons: Array<{ key: PlayerElementKey; Icon: typeof Moon }> = [
+    { key: 'playerSleepTimer', Icon: Moon },
+    { key: 'playerEqualizer', Icon: SlidersHorizontal },
+    { key: 'playerCompactButton', Icon: Minimize2 },
+    { key: 'playerVisualizerButton', Icon: AudioLines },
+    { key: 'playerLyricsButton', Icon: Mic2 },
+    { key: 'playerQueueButton', Icon: ListMusic },
+  ];
+
+  return (
+    <SettingsPreview title={t('app.interface.playerPreview')}>
+      <div
+        className="rounded-xl border border-border/30 bg-background/40 p-3"
+        role="img"
+        aria-label={t('app.interface.playerPreview')}
+      >
+        <div className="mx-auto flex h-14 max-w-[360px] items-center gap-2 rounded-xl border border-border/25 bg-surface/60 px-2.5">
+          {/* Left: album art + title + favorite */}
+          <El
+            visible={s.playerAlbumArt}
+            highlighted={spotlight('playerAlbumArt')}
+            expandedClass="max-w-10"
+          >
+            <div className="size-8 rounded-md bg-primary/20" />
+          </El>
+          <div className="min-w-0 space-y-1">
+            <div className="h-1.5 w-16 rounded-full bg-foreground/25" />
+            <div className="h-1 w-11 rounded-full bg-muted-foreground/25" />
+          </div>
+          <El
+            visible={s.playerFavorite}
+            highlighted={spotlight('playerFavorite')}
+            expandedClass="max-w-6"
+            className="p-1"
+          >
+            <Heart className="size-3 fill-favorite/70 text-favorite/70" />
+          </El>
+
+          {/* Center: controls + seek (always shown) */}
+          <div className="flex min-w-0 flex-1 flex-col items-center gap-1 px-1">
+            <div className="flex items-center gap-1.5">
+              <SkipBack className="size-2.5 text-muted-foreground/60" />
+              <div className="grid size-5 place-items-center rounded-full bg-primary/35">
+                <Play className="size-2 fill-foreground/80 text-foreground/80" />
+              </div>
+              <SkipForward className="size-2.5 text-muted-foreground/60" />
+            </div>
+            <div className="flex w-full items-center gap-1.5">
+              <El
+                visible={s.playerTimeLabels}
+                highlighted={spotlight('playerTimeLabels')}
+                expandedClass="max-w-8"
+                className="px-0.5"
+              >
+                <span className="text-[8px] tabular-nums text-muted-foreground/70">1:24</span>
+              </El>
+              <div className="h-1 min-w-0 flex-1 overflow-hidden rounded-full bg-muted/35">
+                <div className="h-full w-[38%] rounded-full bg-primary/55" />
+              </div>
+              <El
+                visible={s.playerTimeLabels}
+                highlighted={spotlight('playerTimeLabels')}
+                expandedClass="max-w-8"
+                className="px-0.5"
+              >
+                <span className="text-[8px] tabular-nums text-muted-foreground/70">3:45</span>
+              </El>
+            </div>
+          </div>
+
+          {/* Right: utility buttons + volume */}
+          <div className="flex items-center gap-0.5">
+            {utilityIcons.map(({ key, Icon }) => (
+              <El
+                key={key}
+                visible={s[key]}
+                highlighted={spotlight(key)}
+                expandedClass="max-w-6"
+                className="p-1"
+              >
+                <Icon className="size-3 text-muted-foreground/70" />
+              </El>
+            ))}
+            <El
+              visible={s.playerVolume}
+              highlighted={spotlight('playerVolume')}
+              expandedClass="max-w-14"
+              className="gap-1 p-1"
+            >
+              <Volume2 className="size-3 shrink-0 text-muted-foreground/70" />
+              <div className="h-1 w-7 shrink-0 overflow-hidden rounded-full bg-muted/35">
+                <div className="h-full w-2/3 rounded-full bg-foreground/40" />
+              </div>
+            </El>
+          </div>
         </div>
       </div>
     </SettingsPreview>

--- a/apps/web/src/components/settings/InterfacePreview.tsx
+++ b/apps/web/src/components/settings/InterfacePreview.tsx
@@ -1,0 +1,237 @@
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import { SettingsPreview } from '@/components/settings/SettingsPreview';
+import { useInterfaceStore, type InterfaceElementKey } from '@/stores/useInterfaceStore';
+
+interface TopBarPreviewProps {
+  /** Whether the language switcher chip group is shown. */
+  enabled: boolean;
+}
+
+/** Mini top bar: page title, add button, and the collapsible language chips. */
+export function TopBarPreview({ enabled }: TopBarPreviewProps) {
+  const { t } = useTranslation('settings');
+
+  return (
+    <SettingsPreview title={t('app.interface.topBarPreview')}>
+      <div
+        className="rounded-xl border border-border/30 bg-background/40 p-3"
+        role="img"
+        aria-label={t('app.interface.topBarPreview')}
+      >
+        <div className="mx-auto flex h-10 max-w-[340px] items-center gap-2 rounded-xl border border-border/25 bg-surface/60 px-3">
+          <div className="h-2 w-14 rounded-full bg-foreground/25" />
+          <div className="flex-1" />
+          <div className="h-5 w-12 rounded-md border border-border/30 bg-muted/25" />
+          <div
+            className={cn(
+              'flex items-center gap-0.5 overflow-hidden transition-all duration-300',
+              enabled ? 'max-w-16 opacity-100' : 'max-w-0 opacity-0'
+            )}
+          >
+            <span className="rounded bg-primary/15 px-1.5 py-0.5 text-[9px] font-medium text-primary">
+              EN
+            </span>
+            <span className="px-1.5 py-0.5 text-[9px] font-medium text-muted-foreground/60">
+              PL
+            </span>
+          </div>
+          <div className="flex items-center gap-1" aria-hidden="true">
+            <div className="size-1.5 rounded-full bg-muted-foreground/30" />
+            <div className="size-1.5 rounded-full bg-muted-foreground/30" />
+            <div className="size-1.5 rounded-full bg-muted-foreground/30" />
+          </div>
+        </div>
+      </div>
+    </SettingsPreview>
+  );
+}
+
+type OverviewWidgetKey = Exclude<InterfaceElementKey, 'topBarLanguageSwitcher'>;
+
+interface OverviewLayoutPreviewProps {
+  /** Widget to spotlight in the mock (mirrors the row hovered in settings). */
+  highlightedKey?: OverviewWidgetKey | null;
+}
+
+interface BlockProps {
+  visible: boolean;
+  highlighted: boolean;
+  /** max-h-* class for the expanded state (collapse animates via max-height). */
+  expandedClass: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+/** Collapsible mock block: fades + folds away when its toggle is off. */
+function Block({ visible, highlighted, expandedClass, children, className }: BlockProps) {
+  return (
+    <div
+      className={cn(
+        'overflow-hidden rounded-lg transition-all duration-300',
+        visible ? cn(expandedClass, 'opacity-100') : 'max-h-0 opacity-0',
+        highlighted && visible && 'ring-1 ring-primary/40 bg-primary/10',
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Scaled mock of the Overview page that reads the real interface store, so
+ * widgets fold away live as the toggles flip. Mirrors SidebarPreview's
+ * hover-spotlight wiring: the hovered settings row highlights its block.
+ */
+export function OverviewLayoutPreview({ highlightedKey = null }: OverviewLayoutPreviewProps) {
+  const { t } = useTranslation('settings');
+  const showStats = useInterfaceStore(s => s.overviewStats);
+  const showTopWeek = useInterfaceStore(s => s.overviewTopWeek);
+  const showClock = useInterfaceStore(s => s.overviewClock);
+  const showTopAlbums = useInterfaceStore(s => s.overviewTopAlbums);
+  const showMixes = useInterfaceStore(s => s.overviewMixes);
+  const showRecommendations = useInterfaceStore(s => s.overviewRecommendations);
+  const showRecentlyAdded = useInterfaceStore(s => s.overviewRecentlyAdded);
+
+  const spotlight = (key: OverviewWidgetKey) => highlightedKey === key;
+  const showRightColumn = showClock || showTopAlbums;
+
+  return (
+    <SettingsPreview title={t('app.interface.overviewPreview')}>
+      <div
+        className="rounded-xl border border-border/30 bg-background/40 p-3"
+        role="img"
+        aria-label={t('app.interface.overviewPreview')}
+      >
+        <div className="mx-auto flex max-w-[360px] flex-col gap-1.5 rounded-xl border border-border/25 bg-surface/60 p-3">
+          {/* Greeting hero — always shown, not toggleable */}
+          <div className="flex h-9 shrink-0 items-center gap-2 rounded-lg bg-gradient-to-r from-primary/15 to-transparent px-2">
+            <div className="size-5 rounded-full bg-primary/30" />
+            <div className="space-y-1">
+              <div className="h-1.5 w-20 rounded-full bg-foreground/25" />
+              <div className="h-1 w-14 rounded-full bg-muted-foreground/25" />
+            </div>
+          </div>
+
+          {/* Stats strip */}
+          <Block
+            visible={showStats}
+            highlighted={spotlight('overviewStats')}
+            expandedClass="max-h-8"
+          >
+            <div className="grid grid-cols-4 gap-1.5 p-0.5">
+              {[0, 1, 2, 3].map(i => (
+                <div key={i} className="h-6 rounded-md border border-border/25 bg-muted/20" />
+              ))}
+            </div>
+          </Block>
+
+          {/* Week grid: top tracks + clock/albums column */}
+          {(showTopWeek || showRightColumn) && (
+            <div className="flex gap-1.5">
+              <Block
+                visible={showTopWeek}
+                highlighted={spotlight('overviewTopWeek')}
+                expandedClass="max-h-24"
+                className="flex-[1.3] border border-border/25 bg-muted/15"
+              >
+                <div className="space-y-1.5 p-2">
+                  {[24, 20, 16].map(w => (
+                    <div key={w} className="flex items-center gap-1.5">
+                      <div className="size-3.5 rounded bg-primary/20" />
+                      <div
+                        className="h-1.5 rounded-full bg-foreground/20"
+                        style={{ width: `${w * 4}px` }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </Block>
+              {showRightColumn && (
+                <div className="flex flex-1 flex-col gap-1.5">
+                  <Block
+                    visible={showClock}
+                    highlighted={spotlight('overviewClock')}
+                    expandedClass="max-h-11"
+                    className="border border-border/25 bg-muted/15"
+                  >
+                    <div className="flex h-10 items-end justify-between gap-0.5 px-2 pb-1.5 pt-2">
+                      {[30, 55, 80, 45, 95, 60, 35].map((h, i) => (
+                        <div
+                          key={i}
+                          className="w-full rounded-sm bg-primary/35"
+                          style={{ height: `${h}%` }}
+                        />
+                      ))}
+                    </div>
+                  </Block>
+                  <Block
+                    visible={showTopAlbums}
+                    highlighted={spotlight('overviewTopAlbums')}
+                    expandedClass="max-h-11"
+                    className="border border-border/25 bg-muted/15"
+                  >
+                    <div className="flex gap-1.5 p-2">
+                      {[0, 1, 2].map(i => (
+                        <div key={i} className="size-6 rounded-md bg-primary/20" />
+                      ))}
+                    </div>
+                  </Block>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Smart mixes shelf */}
+          <Block
+            visible={showMixes}
+            highlighted={spotlight('overviewMixes')}
+            expandedClass="max-h-10"
+          >
+            <div className="flex gap-1.5 p-0.5">
+              {[0, 1, 2, 3].map(i => (
+                <div
+                  key={i}
+                  className="h-8 w-12 rounded-md border border-border/25 bg-gradient-to-br from-primary/20 to-muted/20"
+                />
+              ))}
+            </div>
+          </Block>
+
+          {/* Recommendations shelf */}
+          <Block
+            visible={showRecommendations}
+            highlighted={spotlight('overviewRecommendations')}
+            expandedClass="max-h-9"
+          >
+            <div className="flex gap-1.5 p-0.5">
+              {[0, 1, 2, 3, 4].map(i => (
+                <div key={i} className="size-7 rounded-md border border-border/25 bg-muted/25" />
+              ))}
+            </div>
+          </Block>
+
+          {/* Recently added rows */}
+          <Block
+            visible={showRecentlyAdded}
+            highlighted={spotlight('overviewRecentlyAdded')}
+            expandedClass="max-h-12"
+          >
+            <div className="space-y-1.5 p-0.5">
+              {[28, 20].map(w => (
+                <div key={w} className="flex items-center gap-1.5">
+                  <div className="size-4 rounded bg-muted/35" />
+                  <div
+                    className="h-1.5 rounded-full bg-muted-foreground/25"
+                    style={{ width: `${w * 4}px` }}
+                  />
+                </div>
+              ))}
+            </div>
+          </Block>
+        </div>
+      </div>
+    </SettingsPreview>
+  );
+}

--- a/apps/web/src/components/settings/InterfacePreview.tsx
+++ b/apps/web/src/components/settings/InterfacePreview.tsx
@@ -307,7 +307,10 @@ export function PlayerBarPreview({ highlightedKey = null }: PlayerBarPreviewProp
         role="img"
         aria-label={t('app.interface.playerPreview')}
       >
-        <div className="mx-auto flex h-14 max-w-[360px] items-center gap-2 rounded-xl border border-border/25 bg-surface/60 px-2.5">
+        {/* Full width on purpose (unlike the capped sibling mocks): the bar
+            packs ~330px of fixed-width elements, so any tighter cap starves
+            the flex-1 seek section into a centered clump. */}
+        <div className="flex h-14 w-full items-center gap-2 rounded-xl border border-border/25 bg-surface/60 px-3">
           {/* Left: album art + title + favorite */}
           <El
             visible={s.playerAlbumArt}

--- a/apps/web/src/components/settings/InterfaceSection.tsx
+++ b/apps/web/src/components/settings/InterfaceSection.tsx
@@ -1,13 +1,17 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LayoutDashboard, PanelTop, RotateCcw } from 'lucide-react';
 import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsCard';
+import { TopBarPreview, OverviewLayoutPreview } from '@/components/settings/InterfacePreview';
 import {
   useInterfaceStore,
   INTERFACE_DEFAULTS,
   type InterfaceElementKey,
 } from '@/stores/useInterfaceStore';
 
-const OVERVIEW_TOGGLES: InterfaceElementKey[] = [
+type OverviewWidgetKey = Exclude<InterfaceElementKey, 'topBarLanguageSwitcher'>;
+
+const OVERVIEW_TOGGLES: OverviewWidgetKey[] = [
   'overviewStats',
   'overviewTopWeek',
   'overviewClock',
@@ -21,6 +25,9 @@ export function InterfaceSection() {
   const { t } = useTranslation('settings');
   const state = useInterfaceStore();
   const { setVisible, resetInterface } = state;
+  // Hovered settings row → spotlighted block in the Overview mock (mirrors
+  // the SidebarSection ↔ SidebarPreview wiring).
+  const [hoveredKey, setHoveredKey] = useState<OverviewWidgetKey | null>(null);
 
   const isModified = (Object.keys(INTERFACE_DEFAULTS) as InterfaceElementKey[]).some(
     key => state[key] !== INTERFACE_DEFAULTS[key]
@@ -51,6 +58,7 @@ export function InterfaceSection() {
           checked={state.topBarLanguageSwitcher}
           onCheckedChange={v => setVisible('topBarLanguageSwitcher', v)}
         />
+        <TopBarPreview enabled={state.topBarLanguageSwitcher} />
       </SettingsCard>
 
       <SettingsCard
@@ -58,15 +66,21 @@ export function InterfaceSection() {
         title={t('app.interface.overviewTitle')}
         subtitle={t('app.interface.overviewDesc')}
       >
+        <OverviewLayoutPreview highlightedKey={hoveredKey} />
         {OVERVIEW_TOGGLES.map((key, index) => (
-          <SettingsToggleRow
+          <div
             key={key}
-            label={t(`app.interface.elements.${key}`)}
-            description={t(`app.interface.elements.${key}Desc`)}
-            checked={state[key]}
-            onCheckedChange={v => setVisible(key, v)}
-            divider={index > 0}
-          />
+            onMouseEnter={() => setHoveredKey(key)}
+            onMouseLeave={() => setHoveredKey(current => (current === key ? null : current))}
+          >
+            <SettingsToggleRow
+              label={t(`app.interface.elements.${key}`)}
+              description={t(`app.interface.elements.${key}Desc`)}
+              checked={state[key]}
+              onCheckedChange={v => setVisible(key, v)}
+              divider={index > 0}
+            />
+          </div>
         ))}
       </SettingsCard>
     </div>

--- a/apps/web/src/components/settings/InterfaceSection.tsx
+++ b/apps/web/src/components/settings/InterfaceSection.tsx
@@ -1,15 +1,20 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { LayoutDashboard, PanelTop, RotateCcw } from 'lucide-react';
+import { LayoutDashboard, PanelBottom, PanelTop, RotateCcw } from 'lucide-react';
 import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsCard';
-import { TopBarPreview, OverviewLayoutPreview } from '@/components/settings/InterfacePreview';
+import {
+  TopBarPreview,
+  OverviewLayoutPreview,
+  PlayerBarPreview,
+} from '@/components/settings/InterfacePreview';
 import {
   useInterfaceStore,
   INTERFACE_DEFAULTS,
   type InterfaceElementKey,
 } from '@/stores/useInterfaceStore';
 
-type OverviewWidgetKey = Exclude<InterfaceElementKey, 'topBarLanguageSwitcher'>;
+type OverviewWidgetKey = Extract<InterfaceElementKey, `overview${string}`>;
+type PlayerElementKey = Extract<InterfaceElementKey, `player${string}`>;
 
 const OVERVIEW_TOGGLES: OverviewWidgetKey[] = [
   'overviewStats',
@@ -21,13 +26,27 @@ const OVERVIEW_TOGGLES: OverviewWidgetKey[] = [
   'overviewRecentlyAdded',
 ];
 
+const PLAYER_TOGGLES: PlayerElementKey[] = [
+  'playerAlbumArt',
+  'playerFavorite',
+  'playerTimeLabels',
+  'playerSleepTimer',
+  'playerEqualizer',
+  'playerCompactButton',
+  'playerVisualizerButton',
+  'playerLyricsButton',
+  'playerQueueButton',
+  'playerVolume',
+];
+
 export function InterfaceSection() {
   const { t } = useTranslation('settings');
   const state = useInterfaceStore();
   const { setVisible, resetInterface } = state;
-  // Hovered settings row → spotlighted block in the Overview mock (mirrors
+  // Hovered settings row → spotlighted block in the matching mock (mirrors
   // the SidebarSection ↔ SidebarPreview wiring).
-  const [hoveredKey, setHoveredKey] = useState<OverviewWidgetKey | null>(null);
+  const [hoveredOverviewKey, setHoveredOverviewKey] = useState<OverviewWidgetKey | null>(null);
+  const [hoveredPlayerKey, setHoveredPlayerKey] = useState<PlayerElementKey | null>(null);
 
   const isModified = (Object.keys(INTERFACE_DEFAULTS) as InterfaceElementKey[]).some(
     key => state[key] !== INTERFACE_DEFAULTS[key]
@@ -66,12 +85,37 @@ export function InterfaceSection() {
         title={t('app.interface.overviewTitle')}
         subtitle={t('app.interface.overviewDesc')}
       >
-        <OverviewLayoutPreview highlightedKey={hoveredKey} />
+        <OverviewLayoutPreview highlightedKey={hoveredOverviewKey} />
         {OVERVIEW_TOGGLES.map((key, index) => (
           <div
             key={key}
-            onMouseEnter={() => setHoveredKey(key)}
-            onMouseLeave={() => setHoveredKey(current => (current === key ? null : current))}
+            onMouseEnter={() => setHoveredOverviewKey(key)}
+            onMouseLeave={() =>
+              setHoveredOverviewKey(current => (current === key ? null : current))
+            }
+          >
+            <SettingsToggleRow
+              label={t(`app.interface.elements.${key}`)}
+              description={t(`app.interface.elements.${key}Desc`)}
+              checked={state[key]}
+              onCheckedChange={v => setVisible(key, v)}
+              divider={index > 0}
+            />
+          </div>
+        ))}
+      </SettingsCard>
+
+      <SettingsCard
+        icon={PanelBottom}
+        title={t('app.interface.playerTitle')}
+        subtitle={t('app.interface.playerDesc')}
+      >
+        <PlayerBarPreview highlightedKey={hoveredPlayerKey} />
+        {PLAYER_TOGGLES.map((key, index) => (
+          <div
+            key={key}
+            onMouseEnter={() => setHoveredPlayerKey(key)}
+            onMouseLeave={() => setHoveredPlayerKey(current => (current === key ? null : current))}
           >
             <SettingsToggleRow
               label={t(`app.interface.elements.${key}`)}

--- a/apps/web/src/components/settings/InterfaceSection.tsx
+++ b/apps/web/src/components/settings/InterfaceSection.tsx
@@ -1,0 +1,74 @@
+import { useTranslation } from 'react-i18next';
+import { LayoutDashboard, PanelTop, RotateCcw } from 'lucide-react';
+import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsCard';
+import {
+  useInterfaceStore,
+  INTERFACE_DEFAULTS,
+  type InterfaceElementKey,
+} from '@/stores/useInterfaceStore';
+
+const OVERVIEW_TOGGLES: InterfaceElementKey[] = [
+  'overviewStats',
+  'overviewTopWeek',
+  'overviewClock',
+  'overviewTopAlbums',
+  'overviewMixes',
+  'overviewRecommendations',
+  'overviewRecentlyAdded',
+];
+
+export function InterfaceSection() {
+  const { t } = useTranslation('settings');
+  const state = useInterfaceStore();
+  const { setVisible, resetInterface } = state;
+
+  const isModified = (Object.keys(INTERFACE_DEFAULTS) as InterfaceElementKey[]).some(
+    key => state[key] !== INTERFACE_DEFAULTS[key]
+  );
+
+  return (
+    <div className="space-y-4">
+      <SettingsCard
+        icon={PanelTop}
+        title={t('app.interface.topBarTitle')}
+        subtitle={t('app.interface.topBarDesc')}
+        headerRight={
+          isModified ? (
+            <button
+              onClick={resetInterface}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              aria-label={t('app.interface.reset')}
+            >
+              <RotateCcw className="size-3" />
+              {t('app.interface.reset')}
+            </button>
+          ) : undefined
+        }
+      >
+        <SettingsToggleRow
+          label={t('app.interface.elements.topBarLanguageSwitcher')}
+          description={t('app.interface.elements.topBarLanguageSwitcherDesc')}
+          checked={state.topBarLanguageSwitcher}
+          onCheckedChange={v => setVisible('topBarLanguageSwitcher', v)}
+        />
+      </SettingsCard>
+
+      <SettingsCard
+        icon={LayoutDashboard}
+        title={t('app.interface.overviewTitle')}
+        subtitle={t('app.interface.overviewDesc')}
+      >
+        {OVERVIEW_TOGGLES.map((key, index) => (
+          <SettingsToggleRow
+            key={key}
+            label={t(`app.interface.elements.${key}`)}
+            description={t(`app.interface.elements.${key}Desc`)}
+            checked={state[key]}
+            onCheckedChange={v => setVisible(key, v)}
+            divider={index > 0}
+          />
+        ))}
+      </SettingsCard>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/PlaybackPreferencePreview.tsx
+++ b/apps/web/src/components/settings/PlaybackPreferencePreview.tsx
@@ -1,7 +1,11 @@
-import { Clock3, Music2, RadioTower } from 'lucide-react';
+import { Clock3, Moon, Music2, RadioTower } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
-import { LOUDNESS_TARGET_MIN_LUFS, LOUDNESS_TARGET_MAX_LUFS } from '@/stores/usePlaybackStore';
+import {
+  LOUDNESS_TARGET_MIN_LUFS,
+  LOUDNESS_TARGET_MAX_LUFS,
+  SLEEP_FADE_MAX_SECONDS,
+} from '@/stores/usePlaybackStore';
 
 interface ResumePreviewProps {
   enabled: boolean;
@@ -143,6 +147,46 @@ export function LoudnessPreview({ enabled, target }: LoudnessPreviewProps) {
 
         <p className="mt-2 text-[10px] text-muted-foreground">
           {enabled ? t('play.loudnessPreviewOn') : t('play.loudnessPreviewOff')}
+        </p>
+      </div>
+    </SettingsPreview>
+  );
+}
+
+interface SleepFadePreviewProps {
+  /** Current fade-out duration in seconds; drives the ramp slope. */
+  duration: number;
+}
+
+const SLEEP_FADE_BARS = 14;
+
+export function SleepFadePreview({ duration }: SleepFadePreviewProps) {
+  const { t } = useTranslation('settings');
+
+  // The tail of the bar row ramps to silence; a longer fade claims more bars,
+  // so the slope visibly flattens as the slider grows.
+  const fadeBars = Math.max(2, Math.round((duration / SLEEP_FADE_MAX_SECONDS) * SLEEP_FADE_BARS));
+  const fadeStart = SLEEP_FADE_BARS - fadeBars;
+  const heightFor = (i: number) =>
+    i < fadeStart ? 1 : Math.max(0.06, 1 - (i - fadeStart + 1) / fadeBars);
+
+  return (
+    <SettingsPreview title={t('play.sleepFadePreview')}>
+      <div className="rounded-xl border border-border/30 bg-background/40 p-3">
+        <div className="relative h-16 rounded-lg border border-border/25 bg-surface/60 px-3 pt-2 pb-2">
+          <Moon className="absolute right-2 top-2 size-3.5 text-primary/60" aria-hidden="true" />
+          <div className="flex h-full items-end gap-1">
+            {Array.from({ length: SLEEP_FADE_BARS }, (_, i) => (
+              <div
+                key={i}
+                className="w-full rounded-full bg-primary/45 transition-[height] duration-300"
+                style={{ height: `${heightFor(i) * 100}%` }}
+              />
+            ))}
+          </div>
+        </div>
+        <p className="mt-2 text-[10px] text-muted-foreground">
+          {t('play.sleepFadePreviewCaption', { seconds: duration })}
         </p>
       </div>
     </SettingsPreview>

--- a/apps/web/src/components/settings/PlaybackSection.tsx
+++ b/apps/web/src/components/settings/PlaybackSection.tsx
@@ -5,6 +5,7 @@ import {
   CrossfadePreview,
   ResumePreview,
   LoudnessPreview,
+  SleepFadePreview,
 } from '@/components/settings/PlaybackPreferencePreview';
 import { Slider } from '@/components/ui/slider';
 import { Button } from '@/components/ui/button';
@@ -163,6 +164,7 @@ export function PlaybackSection() {
             <span className="text-[10px] text-muted-foreground/60">{SLEEP_FADE_MAX_SECONDS}s</span>
           </div>
         </div>
+        <SleepFadePreview duration={sleepFadeDuration} />
       </div>
     </SettingsCard>
   );

--- a/apps/web/src/components/settings/SettingsView.tsx
+++ b/apps/web/src/components/settings/SettingsView.tsx
@@ -21,6 +21,7 @@ import {
   Radio,
   ShieldCheck,
   CloudSun,
+  MonitorCog,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { SettingsHeader } from '@/components/settings/SettingsHeader';
@@ -44,6 +45,7 @@ import { DiscordSection } from '@/components/settings/DiscordSection';
 import { PrivacySection } from '@/components/settings/PrivacySection';
 import { WeatherSection } from '@/components/settings/WeatherSection';
 import { ScrobbleSection } from '@/components/settings/ScrobbleSection';
+import { SystemSection } from '@/components/settings/SystemSection';
 
 type SettingsSection =
   | 'folders'
@@ -60,6 +62,7 @@ type SettingsSection =
   | 'interface'
   | 'sidebar'
   | 'weather'
+  | 'system'
   | 'scrobble'
   | 'discord'
   | 'updates'
@@ -184,6 +187,13 @@ const SECTIONS: {
     group: 'appearance',
   },
   {
+    id: 'system',
+    labelKey: 'system',
+    subtitleKey: 'subtitles.system',
+    Icon: MonitorCog,
+    group: 'system',
+  },
+  {
     id: 'scrobble',
     labelKey: 'scrobble',
     subtitleKey: 'subtitles.scrobble',
@@ -236,6 +246,7 @@ const SECTION_PANEL: Record<SettingsSection, ComponentType> = {
   interface: InterfaceSection,
   sidebar: SidebarSection,
   weather: WeatherSection,
+  system: SystemSection,
   scrobble: ScrobbleSection,
   discord: DiscordSection,
   updates: UpdatesSection,

--- a/apps/web/src/components/settings/SettingsView.tsx
+++ b/apps/web/src/components/settings/SettingsView.tsx
@@ -13,6 +13,7 @@ import {
   Monitor,
   Sparkles,
   PanelLeft,
+  PanelTop,
   RefreshCcw,
   Info,
   Heart,
@@ -34,6 +35,7 @@ import { UpdatesSection } from '@/components/settings/UpdatesSection';
 import { AppearanceSection } from '@/components/settings/AppearanceSection';
 import { SidebarSection } from '@/components/settings/SidebarSection';
 import { VisualEffectsSection } from '@/components/settings/VisualEffectsSection';
+import { InterfaceSection } from '@/components/settings/InterfaceSection';
 import { LyricsSection } from '@/components/settings/LyricsSection';
 import { CompactSection } from '@/components/settings/CompactSection';
 import { AboutSection } from '@/components/settings/AboutSection';
@@ -55,6 +57,7 @@ type SettingsSection =
   | 'compact'
   | 'appearance'
   | 'effects'
+  | 'interface'
   | 'sidebar'
   | 'weather'
   | 'scrobble'
@@ -160,6 +163,13 @@ const SECTIONS: {
     group: 'appearance',
   },
   {
+    id: 'interface',
+    labelKey: 'interface',
+    subtitleKey: 'subtitles.interface',
+    Icon: PanelTop,
+    group: 'appearance',
+  },
+  {
     id: 'sidebar',
     labelKey: 'sidebar',
     subtitleKey: 'subtitles.sidebar',
@@ -223,6 +233,7 @@ const SECTION_PANEL: Record<SettingsSection, ComponentType> = {
   compact: CompactSection,
   appearance: AppearanceSection,
   effects: VisualEffectsSection,
+  interface: InterfaceSection,
   sidebar: SidebarSection,
   weather: WeatherSection,
   scrobble: ScrobbleSection,

--- a/apps/web/src/components/settings/SystemSection.tsx
+++ b/apps/web/src/components/settings/SystemSection.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'react-i18next';
+import { Info, MonitorCog } from 'lucide-react';
+import { IS_MAC, IS_ELECTRON } from '@/lib/platform';
+import {
+  SettingsCard,
+  SettingsToggleRow,
+  SettingsInfoCallout,
+} from '@/components/settings/SettingsCard';
+import {
+  useSystemPrefsQuery,
+  useUpdateSystemPrefMutation,
+  type SystemPrefKey,
+} from '@/hooks/queries/useSystemPrefs';
+
+const TOGGLES: SystemPrefKey[] = ['launchAtStartup', 'minimizeToTray', 'closeToTray'];
+
+export function SystemSection() {
+  const { t } = useTranslation('settings');
+  const { data: prefs } = useSystemPrefsQuery();
+  const updatePref = useUpdateSystemPrefMutation();
+
+  return (
+    <div className="space-y-4">
+      <SettingsCard
+        icon={MonitorCog}
+        title={t('sys.behaviorTitle')}
+        subtitle={t('sys.behaviorDesc')}
+      >
+        {TOGGLES.map((key, index) => (
+          <SettingsToggleRow
+            key={key}
+            label={t(`sys.${key}`)}
+            description={t(`sys.${key}Desc`)}
+            checked={prefs?.[key] ?? false}
+            onCheckedChange={value => updatePref.mutate({ key, value })}
+            disabled={!IS_ELECTRON || !prefs}
+            divider={index > 0}
+          />
+        ))}
+      </SettingsCard>
+
+      {IS_MAC && <SettingsInfoCallout icon={Info}>{t('sys.macTrayNote')}</SettingsInfoCallout>}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/UiScalePreview.tsx
+++ b/apps/web/src/components/settings/UiScalePreview.tsx
@@ -1,0 +1,104 @@
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import { SettingsPreview } from '@/components/settings/SettingsPreview';
+import { UI_SCALE_DEFAULT } from '@/stores/useUIStore';
+
+interface UiScalePreviewProps {
+  /** Current interface scale percentage from the slider. */
+  scale: number;
+}
+
+interface SampleTileProps {
+  label: string;
+  factor: number;
+  title: string;
+  subtitle: string;
+  active?: boolean;
+}
+
+/**
+ * One sample card rendered at a fixed pixel base × `factor`. Inline px sizing
+ * is deliberate: the real scale setting works through the root font-size, so
+ * rem-based classes inside the settings page already follow it — a px-based
+ * mock is the only stable reference point for a side-by-side comparison.
+ */
+function SampleTile({ label, factor, title, subtitle, active }: SampleTileProps) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div
+        className={cn(
+          'rounded-lg border bg-surface/60 p-3',
+          active ? 'border-primary/35' : 'border-border/25'
+        )}
+      >
+        <p
+          className="truncate font-medium text-foreground"
+          style={{ fontSize: `${13 * factor}px`, lineHeight: 1.4 }}
+        >
+          {title}
+        </p>
+        <p
+          className="truncate text-muted-foreground"
+          style={{ fontSize: `${11 * factor}px`, lineHeight: 1.4 }}
+        >
+          {subtitle}
+        </p>
+        <div
+          className="grid place-items-center bg-primary/15 ring-1 ring-primary/35"
+          style={{
+            height: `${22 * factor}px`,
+            width: `${64 * factor}px`,
+            borderRadius: `${7 * factor}px`,
+            marginTop: `${8 * factor}px`,
+          }}
+        >
+          <div
+            className="rounded-full bg-primary/70"
+            style={{ height: `${5 * factor}px`, width: `${32 * factor}px` }}
+          />
+        </div>
+      </div>
+      <p
+        className={cn(
+          'mt-1.5 text-center text-[10px] tabular-nums',
+          active ? 'text-primary/80' : 'text-muted-foreground/60'
+        )}
+      >
+        {label}
+      </p>
+    </div>
+  );
+}
+
+/** Side-by-side default-vs-chosen sample so the slider's effect stays legible. */
+export function UiScalePreview({ scale }: UiScalePreviewProps) {
+  const { t } = useTranslation('settings');
+  const title = t('app.scaleSampleTitle');
+  const subtitle = t('app.scaleSampleSubtitle');
+
+  return (
+    <SettingsPreview title={t('app.scalePreview')}>
+      <div
+        className="rounded-xl border border-border/30 bg-background/40 p-3"
+        role="img"
+        aria-label={t('app.scalePreview')}
+      >
+        <div className="mx-auto flex max-w-[340px] items-start gap-3">
+          <SampleTile
+            label={t('app.scalePreviewBase', { value: UI_SCALE_DEFAULT })}
+            factor={1}
+            title={title}
+            subtitle={subtitle}
+          />
+          <SampleTile
+            label={t('app.scalePreviewCurrent', { value: scale })}
+            factor={scale / 100}
+            title={title}
+            subtitle={subtitle}
+            active
+          />
+        </div>
+      </div>
+    </SettingsPreview>
+  );
+}

--- a/apps/web/src/components/shared/PanelResizeHandle.tsx
+++ b/apps/web/src/components/shared/PanelResizeHandle.tsx
@@ -19,6 +19,8 @@ interface PanelResizeHandleProps {
   /** Fires on pointer drag start/end so the panel can suspend width transitions. */
   onDraggingChange?: (dragging: boolean) => void;
   'aria-label': string;
+  /** id of the panel element this separator resizes (a11y wiring). */
+  'aria-controls'?: string;
   className?: string;
 }
 
@@ -37,6 +39,7 @@ export function PanelResizeHandle({
   onDraggingChange,
   className,
   'aria-label': ariaLabel,
+  'aria-controls': ariaControls,
 }: PanelResizeHandleProps) {
   // Read through a ref during drag so the pointermove math always starts from
   // the width at drag start, not a stale render closure.
@@ -95,6 +98,7 @@ export function PanelResizeHandle({
       role="separator"
       aria-orientation="vertical"
       aria-label={ariaLabel}
+      aria-controls={ariaControls}
       aria-valuenow={Math.round(value)}
       aria-valuemin={min}
       aria-valuemax={max}

--- a/apps/web/src/components/shared/PanelResizeHandle.tsx
+++ b/apps/web/src/components/shared/PanelResizeHandle.tsx
@@ -1,0 +1,119 @@
+import { useCallback, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+const KEYBOARD_STEP = 16;
+
+interface PanelResizeHandleProps {
+  /**
+   * Which edge of the panel the handle sits on. Dragging away from the panel
+   * grows it: a `right`-edge handle grows the panel when dragged right, a
+   * `left`-edge handle grows it when dragged left.
+   */
+  edge: 'left' | 'right';
+  value: number;
+  min: number;
+  max: number;
+  onChange: (width: number) => void;
+  /** Double-click (or Home key) restores the default width. */
+  onReset: () => void;
+  /** Fires on pointer drag start/end so the panel can suspend width transitions. */
+  onDraggingChange?: (dragging: boolean) => void;
+  'aria-label': string;
+  className?: string;
+}
+
+/**
+ * Invisible-until-hovered vertical drag handle for resizable shell panels.
+ * Pointer-based (works with mouse/touch/pen) with full keyboard support:
+ * role="separator", arrow keys nudge, Home resets.
+ */
+export function PanelResizeHandle({
+  edge,
+  value,
+  min,
+  max,
+  onChange,
+  onReset,
+  onDraggingChange,
+  className,
+  'aria-label': ariaLabel,
+}: PanelResizeHandleProps) {
+  // Read through a ref during drag so the pointermove math always starts from
+  // the width at drag start, not a stale render closure.
+  const dragStart = useRef<{ x: number; width: number } | null>(null);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      dragStart.current = { x: e.clientX, width: value };
+      onDraggingChange?.(true);
+      const target = e.currentTarget;
+      target.setPointerCapture(e.pointerId);
+    },
+    [value, onDraggingChange]
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const start = dragStart.current;
+      if (!start) return;
+      const delta = e.clientX - start.x;
+      const next = edge === 'right' ? start.width + delta : start.width - delta;
+      onChange(Math.min(max, Math.max(min, next)));
+    },
+    [edge, min, max, onChange]
+  );
+
+  const endDrag = useCallback(() => {
+    if (!dragStart.current) return;
+    dragStart.current = null;
+    onDraggingChange?.(false);
+  }, [onDraggingChange]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      let next: number | null = null;
+      if (e.key === 'ArrowLeft')
+        next = edge === 'right' ? value - KEYBOARD_STEP : value + KEYBOARD_STEP;
+      if (e.key === 'ArrowRight')
+        next = edge === 'right' ? value + KEYBOARD_STEP : value - KEYBOARD_STEP;
+      if (e.key === 'Home') {
+        e.preventDefault();
+        onReset();
+        return;
+      }
+      if (next === null) return;
+      e.preventDefault();
+      onChange(Math.min(max, Math.max(min, next)));
+    },
+    [edge, value, min, max, onChange, onReset]
+  );
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={ariaLabel}
+      aria-valuenow={Math.round(value)}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      tabIndex={0}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onDoubleClick={onReset}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        'absolute top-0 bottom-0 z-20 w-1.5 cursor-col-resize touch-none select-none',
+        edge === 'right' ? '-right-0.75' : '-left-0.75',
+        // Invisible by default; a subtle primary line appears on hover/focus/drag.
+        'after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 after:-translate-x-1/2 after:rounded-full after:bg-primary/0 after:transition-colors',
+        'hover:after:bg-primary/40 focus-visible:after:bg-primary/60 active:after:bg-primary/60',
+        'focus-visible:outline-none',
+        className
+      )}
+    />
+  );
+}

--- a/apps/web/src/components/shared/Sidebar.test.tsx
+++ b/apps/web/src/components/shared/Sidebar.test.tsx
@@ -187,18 +187,18 @@ describe('Sidebar', () => {
     setStoreState({ sidebarCollapsed: true });
     const { container } = render(<Sidebar />);
 
-    const sidebarDiv = container.firstElementChild!;
+    const sidebarDiv = container.firstElementChild as HTMLElement;
     expect(sidebarDiv.className).toContain('w-[5.25rem]');
-    expect(sidebarDiv.className).not.toContain('w-[12.5rem]');
+    expect(sidebarDiv.style.width).toBe('');
   });
 
-  // 4d. Expanded sidebar uses wider width
-  it('uses wider width class when expanded', () => {
+  // 4d. Expanded sidebar uses the persisted resizable width (inline style)
+  it('uses the persisted resizable width when expanded', () => {
     setStoreState({ sidebarCollapsed: false });
     const { container } = render(<Sidebar />);
 
-    const sidebarDiv = container.firstElementChild!;
-    expect(sidebarDiv.className).toContain('w-[12.5rem]');
+    const sidebarDiv = container.firstElementChild as HTMLElement;
+    expect(sidebarDiv.style.width).toBe('200px');
     expect(sidebarDiv.className).not.toContain('w-[5.25rem]');
   });
 

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -88,6 +88,7 @@ export function Sidebar() {
         sidebarCollapsed && 'w-[5.25rem]'
       )}
       style={sidebarCollapsed ? undefined : { width: sidebarWidth }}
+      id="app-sidebar"
     >
       {!sidebarCollapsed && (
         <PanelResizeHandle
@@ -99,6 +100,7 @@ export function Sidebar() {
           onReset={resetSidebarWidth}
           onDraggingChange={setIsResizing}
           aria-label={t('resizeSidebar')}
+          aria-controls="app-sidebar"
         />
       )}
       <div

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -5,6 +5,12 @@ import { IS_MAC } from '@/lib/platform';
 import { useAppVersion } from '@/hooks/useAppVersion';
 import { useUIStore } from '@/stores/useUIStore';
 import { useViewStore } from '@/stores/useViewStore';
+import {
+  usePanelSizeStore,
+  SIDEBAR_WIDTH_MIN,
+  SIDEBAR_WIDTH_MAX,
+} from '@/stores/usePanelSizeStore';
+import { PanelResizeHandle } from './PanelResizeHandle';
 import type { Playlist } from '@/types/electron';
 import { usePlaylistsQuery } from '@/hooks/queries/usePlaylists';
 import { Loader2, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
@@ -32,6 +38,10 @@ export function Sidebar() {
   const navigateTo = useViewStore(s => s.navigateTo);
   const toggleSidebarCollapsed = useUIStore(s => s.toggleSidebarCollapsed);
   const version = useAppVersion();
+  const sidebarWidth = usePanelSizeStore(s => s.sidebarWidth);
+  const setSidebarWidth = usePanelSizeStore(s => s.setSidebarWidth);
+  const resetSidebarWidth = usePanelSizeStore(s => s.resetSidebarWidth);
+  const [isResizing, setIsResizing] = useState(false);
   const { data: playlists = [], isLoading: isLoadingPlaylists } = usePlaylistsQuery();
   const [contextMenuState, setContextMenuState] = useState<{
     playlist: Playlist;
@@ -71,10 +81,26 @@ export function Sidebar() {
         // in low-performance mode (where the override drops `backdrop-filter`
         // and with it the stacking context blur used to create), the theme
         // image paints over the sidebar and washes the nav chrome out.
-        'app-sidebar relative z-10 shrink-0 flex flex-col h-full glass border-r border-border/50 transition-[width] duration-200',
-        sidebarCollapsed ? 'w-[5.25rem]' : 'w-[12.5rem]'
+        'app-sidebar relative z-10 shrink-0 flex flex-col h-full glass border-r border-border/50',
+        // Suspend the width transition while dragging so the panel tracks the
+        // pointer 1:1 instead of easing behind it.
+        !isResizing && 'transition-[width] duration-200',
+        sidebarCollapsed && 'w-[5.25rem]'
       )}
+      style={sidebarCollapsed ? undefined : { width: sidebarWidth }}
     >
+      {!sidebarCollapsed && (
+        <PanelResizeHandle
+          edge="right"
+          value={sidebarWidth}
+          min={SIDEBAR_WIDTH_MIN}
+          max={SIDEBAR_WIDTH_MAX}
+          onChange={setSidebarWidth}
+          onReset={resetSidebarWidth}
+          onDraggingChange={setIsResizing}
+          aria-label={t('resizeSidebar')}
+        />
+      )}
       <div
         className={cn(
           'drag flex shrink-0',

--- a/apps/web/src/components/shared/TopBar.tsx
+++ b/apps/web/src/components/shared/TopBar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Plus, FolderOpen, File, RefreshCw, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useViewStore } from '@/stores/useViewStore';
+import { useInterfaceStore } from '@/stores/useInterfaceStore';
 import { WindowControls } from '@/components/shared/WindowControls';
 import { useLibraryRescan } from '@/hooks/useLibraryRescan';
 import { isScanLocked } from '@/lib/scanLock';
@@ -33,6 +34,7 @@ export function TopBar({ onAddFile, onAddFolder, isScanning }: TopBarProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { isScanning: isRescanning, rescan } = useLibraryRescan();
+  const showLanguageSwitcher = useInterfaceStore(s => s.topBarLanguageSwitcher);
 
   const scanBlocked = isScanning || isRescanning || isScanLocked();
 
@@ -128,25 +130,28 @@ export function TopBar({ onAddFile, onAddFolder, isScanning }: TopBarProps) {
         </div>
       )}
 
-      {/* Language segmented control */}
-      <div className="no-drag flex items-center gap-0.5 mr-2">
-        {SUPPORTED_LANGUAGES.map(lang => (
-          <button
-            key={lang.code}
-            type="button"
-            onClick={() => handleLanguageChange(lang.code)}
-            aria-label={t(`language.${lang.code}`)}
-            className={cn(
-              'px-2 py-1 rounded-md text-xs font-medium transition-colors',
-              i18n.language === lang.code
-                ? 'bg-primary/15 text-primary'
-                : 'text-muted-foreground/60 hover:text-foreground hover:bg-accent'
-            )}
-          >
-            {t(`language.${lang.code}`)}
-          </button>
-        ))}
-      </div>
+      {/* Language segmented control — hideable via Settings · Interface
+          (the picker also lives in Settings · Appearance, so nothing is lost) */}
+      {showLanguageSwitcher && (
+        <div className="no-drag flex items-center gap-0.5 mr-2">
+          {SUPPORTED_LANGUAGES.map(lang => (
+            <button
+              key={lang.code}
+              type="button"
+              onClick={() => handleLanguageChange(lang.code)}
+              aria-label={t(`language.${lang.code}`)}
+              className={cn(
+                'px-2 py-1 rounded-md text-xs font-medium transition-colors',
+                i18n.language === lang.code
+                  ? 'bg-primary/15 text-primary'
+                  : 'text-muted-foreground/60 hover:text-foreground hover:bg-accent'
+              )}
+            >
+              {t(`language.${lang.code}`)}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Window controls (Windows only) */}
       <WindowControls className="pr-1.5" />

--- a/apps/web/src/hooks/queries/useSystemPrefs.ts
+++ b/apps/web/src/hooks/queries/useSystemPrefs.ts
@@ -1,0 +1,73 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { IS_ELECTRON } from '@/lib/platform';
+import i18n from '@/lib/i18n';
+
+/**
+ * System behavior prefs stored as individual `system.*` electron-store keys
+ * (not the renderer-owned `settings` blob) because the MAIN process consumes
+ * them: login-item registration and tray window behavior in
+ * system-behavior.ts. Defaults are implicit `undefined` → off.
+ */
+
+export interface SystemPrefs {
+  launchAtStartup: boolean;
+  minimizeToTray: boolean;
+  closeToTray: boolean;
+}
+
+export type SystemPrefKey = keyof SystemPrefs;
+
+const STORE_KEY_BY_PREF: Record<SystemPrefKey, string> = {
+  launchAtStartup: 'system.launchAtStartup',
+  minimizeToTray: 'system.minimizeToTray',
+  closeToTray: 'system.closeToTray',
+};
+
+export const systemPrefsKeys = {
+  all: ['system-prefs'] as const,
+};
+
+export function useSystemPrefsQuery() {
+  return useQuery({
+    queryKey: systemPrefsKeys.all,
+    queryFn: async (): Promise<SystemPrefs> => {
+      const [launchAtStartup, minimizeToTray, closeToTray] = await Promise.all([
+        window.electronAPI.store.get<boolean>(STORE_KEY_BY_PREF.launchAtStartup),
+        window.electronAPI.store.get<boolean>(STORE_KEY_BY_PREF.minimizeToTray),
+        window.electronAPI.store.get<boolean>(STORE_KEY_BY_PREF.closeToTray),
+      ]);
+      return {
+        launchAtStartup: launchAtStartup === true,
+        minimizeToTray: minimizeToTray === true,
+        closeToTray: closeToTray === true,
+      };
+    },
+    enabled: IS_ELECTRON,
+    staleTime: Infinity,
+  });
+}
+
+export function useUpdateSystemPrefMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ key, value }: { key: SystemPrefKey; value: boolean }) => {
+      if (!IS_ELECTRON) return;
+      await window.electronAPI.store.set(STORE_KEY_BY_PREF[key], value);
+    },
+    // Optimistic flip so the switch tracks the click; rolled back by the
+    // invalidate below if the write fails.
+    onMutate: async ({ key, value }) => {
+      await queryClient.cancelQueries({ queryKey: systemPrefsKeys.all });
+      const previous = queryClient.getQueryData<SystemPrefs>(systemPrefsKeys.all);
+      if (previous) {
+        queryClient.setQueryData<SystemPrefs>(systemPrefsKeys.all, { ...previous, [key]: value });
+      }
+    },
+    onError: () => {
+      toast.error(i18n.t('failedSaveSettings', { ns: 'toast' }));
+      queryClient.invalidateQueries({ queryKey: systemPrefsKeys.all });
+    },
+  });
+}

--- a/apps/web/src/lib/color.ts
+++ b/apps/web/src/lib/color.ts
@@ -1,0 +1,45 @@
+/**
+ * Minimal color math for the accent customization feature. The app's palette
+ * is authored in oklch, but user-picked accents arrive as #rrggbb from the
+ * native color input, and the canvas visualizers consume raw RGB triplets —
+ * so hex/RGB is the interchange format here.
+ */
+
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+const HEX_COLOR_RE = /^#[0-9a-f]{6}$/i;
+
+/** Strict #rrggbb check — the only shape the native color input emits. */
+export function isHexColor(v: unknown): v is string {
+  return typeof v === 'string' && HEX_COLOR_RE.test(v);
+}
+
+/** Parse #rrggbb into 0-255 channels. Returns null for malformed input. */
+export function hexToRgb(hex: string): Rgb | null {
+  if (!isHexColor(hex)) return null;
+  return {
+    r: parseInt(hex.slice(1, 3), 16),
+    g: parseInt(hex.slice(3, 5), 16),
+    b: parseInt(hex.slice(5, 7), 16),
+  };
+}
+
+function linearize(channel: number): number {
+  const c = channel / 255;
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+/** WCAG relative luminance (0 = black, 1 = white) of 0-255 channels. */
+export function relativeLuminance({ r, g, b }: Rgb): number {
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+/** WCAG contrast ratio between two luminances (order-independent). */
+export function contrastRatio(l1: number, l2: number): number {
+  const [hi, lo] = l1 >= l2 ? [l1, l2] : [l2, l1];
+  return (hi + 0.05) / (lo + 0.05);
+}

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -24,5 +24,6 @@
   "selectAll": "Select All",
   "clearSelection": "Clear Selection",
   "more": "More",
-  "bulkActionsLabel": "Bulk actions"
+  "bulkActionsLabel": "Bulk actions",
+  "resizeRightPanel": "Resize side panel"
 }

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -17,6 +17,7 @@
     "compact": "Mini-player window settings",
     "appearance": "Interface look and feel",
     "effects": "Immersive UI effects",
+    "interface": "Show or hide interface elements",
     "sidebar": "Main navigation visibility",
     "weather": "Weather on the Overview clock",
     "scrobble": "Scrobble to Last.fm and ListenBrainz",
@@ -37,6 +38,7 @@
   "compact": "Compact mode",
   "appearance": "Appearance",
   "effects": "Visual effects",
+  "interface": "Interface",
   "sidebar": "Sidebar",
   "weather": "Weather",
   "scrobble": "Scrobbling",
@@ -434,6 +436,31 @@
         "coral": "Coral",
         "rose": "Rose",
         "lavender": "Lavender"
+      }
+    },
+    "interface": {
+      "topBarTitle": "Top bar",
+      "topBarDesc": "Elements shown in the bar at the top of the window",
+      "overviewTitle": "Overview widgets",
+      "overviewDesc": "Choose which sections appear on your Overview page",
+      "reset": "Reset",
+      "elements": {
+        "topBarLanguageSwitcher": "Language switcher",
+        "topBarLanguageSwitcherDesc": "Quick language toggle in the top bar. The language picker stays available in Appearance settings.",
+        "overviewStats": "Stats strip",
+        "overviewStatsDesc": "Listening time, sessions, and trend for the week",
+        "overviewTopWeek": "Top this week",
+        "overviewTopWeekDesc": "Your most played tracks of the last 7 days",
+        "overviewClock": "Listening clock",
+        "overviewClockDesc": "Hour-by-hour heatmap of when you listen",
+        "overviewTopAlbums": "Top albums",
+        "overviewTopAlbumsDesc": "Your most played albums of the week",
+        "overviewMixes": "Smart mixes",
+        "overviewMixesDesc": "Auto-generated mixes built from your library",
+        "overviewRecommendations": "Recommendations",
+        "overviewRecommendationsDesc": "Suggested tracks based on your listening",
+        "overviewRecentlyAdded": "Recently added",
+        "overviewRecentlyAddedDesc": "The newest tracks imported into your library"
       }
     },
     "bgAdjust": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -182,6 +182,8 @@
     "sleepFade": "Sleep timer fade-out",
     "sleepFadeDesc": "Gently fade to silence before the sleep timer pauses",
     "sleepFadeDuration": "Fade duration",
+    "sleepFadePreview": "Fade preview",
+    "sleepFadePreviewCaption": "Volume eases out over {{seconds}}s when the sleep timer ends",
     "previewTrack": "Midnight Rain",
     "previewOutgoing": "Current track",
     "previewIncoming": "Next track"
@@ -367,6 +369,11 @@
     "subtitle": "Customize the look and feel of the app",
     "interfaceScale": "Interface scale",
     "scaleDesc": "Adjust the size of text and UI elements",
+    "scalePreview": "Scale preview",
+    "scalePreviewBase": "Default ({{value}}%)",
+    "scalePreviewCurrent": "Your scale ({{value}}%)",
+    "scaleSampleTitle": "Evening Rain",
+    "scaleSampleSubtitle": "Lofi Collective",
     "languageTitle": "Language",
     "languageScaleTitle": "Language & scale",
     "languageDesc": "Choose the display language for the app",
@@ -427,6 +434,7 @@
       "custom": "Custom color",
       "apply": "Use {{name}} accent",
       "reset": "Reset",
+      "previewTitle": "Accent preview",
       "names": {
         "violet": "Violet",
         "periwinkle": "Periwinkle",
@@ -443,8 +451,10 @@
     "interface": {
       "topBarTitle": "Top bar",
       "topBarDesc": "Elements shown in the bar at the top of the window",
+      "topBarPreview": "Top bar preview",
       "overviewTitle": "Overview widgets",
       "overviewDesc": "Choose which sections appear on your Overview page",
+      "overviewPreview": "Overview preview",
       "reset": "Reset",
       "elements": {
         "topBarLanguageSwitcher": "Language switcher",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -416,6 +416,26 @@
         "wisteria": "Wisteria"
       }
     },
+    "accent": {
+      "title": "Accent color",
+      "desc": "Pick the highlight color used across the app. Auto follows the active theme.",
+      "auto": "Auto (theme accent)",
+      "custom": "Custom color",
+      "apply": "Use {{name}} accent",
+      "reset": "Reset",
+      "names": {
+        "violet": "Violet",
+        "periwinkle": "Periwinkle",
+        "sky": "Sky",
+        "mint": "Mint",
+        "matcha": "Matcha",
+        "gold": "Gold",
+        "peach": "Peach",
+        "coral": "Coral",
+        "rose": "Rose",
+        "lavender": "Lavender"
+      }
+    },
     "bgAdjust": {
       "title": "Background adjustments",
       "opacity": "Image opacity",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -455,6 +455,9 @@
       "overviewTitle": "Overview widgets",
       "overviewDesc": "Choose which sections appear on your Overview page",
       "overviewPreview": "Overview preview",
+      "playerTitle": "Player bar",
+      "playerDesc": "Choose which elements appear in the player bar. Playback controls and the seek bar always stay.",
+      "playerPreview": "Player bar preview",
       "reset": "Reset",
       "elements": {
         "topBarLanguageSwitcher": "Language switcher",
@@ -472,7 +475,27 @@
         "overviewRecommendations": "Recommendations",
         "overviewRecommendationsDesc": "Suggested tracks based on your listening",
         "overviewRecentlyAdded": "Recently added",
-        "overviewRecentlyAddedDesc": "The newest tracks imported into your library"
+        "overviewRecentlyAddedDesc": "The newest tracks imported into your library",
+        "playerAlbumArt": "Album art",
+        "playerAlbumArtDesc": "Cover thumbnail next to the track title",
+        "playerFavorite": "Favorite button",
+        "playerFavoriteDesc": "Heart toggle next to the track info",
+        "playerTimeLabels": "Time labels",
+        "playerTimeLabelsDesc": "Elapsed and total time around the seek bar",
+        "playerSleepTimer": "Sleep timer",
+        "playerSleepTimerDesc": "Moon button that fades music out after a delay",
+        "playerEqualizer": "Equalizer button",
+        "playerEqualizerDesc": "Quick access to the 10-band equalizer panel",
+        "playerCompactButton": "Compact mode button",
+        "playerCompactButtonDesc": "Shrinks the app into the mini player (Ctrl+Shift+M still works)",
+        "playerVisualizerButton": "Visualizer button",
+        "playerVisualizerButtonDesc": "Toggles the visualizer strip (the V key still works)",
+        "playerLyricsButton": "Lyrics button",
+        "playerLyricsButtonDesc": "Opens the lyrics panel (Ctrl+L still works)",
+        "playerQueueButton": "Queue button",
+        "playerQueueButtonDesc": "Opens the queue panel (Ctrl+Q still works)",
+        "playerVolume": "Volume control",
+        "playerVolumeDesc": "Volume slider on the right side of the bar"
       }
     },
     "bgAdjust": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -20,6 +20,7 @@
     "interface": "Show or hide interface elements",
     "sidebar": "Main navigation visibility",
     "weather": "Weather on the Overview clock",
+    "system": "Startup and tray behavior",
     "scrobble": "Scrobble to Last.fm and ListenBrainz",
     "discord": "Discord integration settings",
     "updates": "Application update channel",
@@ -41,6 +42,7 @@
   "interface": "Interface",
   "sidebar": "Sidebar",
   "weather": "Weather",
+  "system": "System",
   "scrobble": "Scrobbling",
   "discord": "Discord",
   "updates": "Updates",
@@ -629,5 +631,16 @@
     "pending_one": "{{count}} play waiting to be submitted",
     "pending_other": "{{count}} plays waiting to be submitted",
     "note": "Your session key and token are stored locally and never leave your device except to scrobble. Scrobbling never blocks playback."
+  },
+  "sys": {
+    "behaviorTitle": "System behavior",
+    "behaviorDesc": "How Shiranami starts and stays in the background",
+    "launchAtStartup": "Launch at startup",
+    "launchAtStartupDesc": "Start Shiranami automatically when you sign in to your computer",
+    "minimizeToTray": "Minimize to tray",
+    "minimizeToTrayDesc": "Minimizing the window hides it; music keeps playing and the tray icon brings it back",
+    "closeToTray": "Close to tray",
+    "closeToTrayDesc": "Closing the window keeps Shiranami running in the tray instead of quitting",
+    "macTrayNote": "On macOS the hidden window can be reopened from the menu bar icon or the Dock. Use Quit in the menu bar to exit completely."
   }
 }

--- a/apps/web/src/locales/en/sidebar.json
+++ b/apps/web/src/locales/en/sidebar.json
@@ -17,5 +17,6 @@
   "collapseSidebar": "Collapse sidebar",
   "yourPlaylists": "Your Playlists",
   "all": "All",
-  "allPlaylists": "All playlists"
+  "allPlaylists": "All playlists",
+  "resizeSidebar": "Resize sidebar"
 }

--- a/apps/web/src/locales/pl/common.json
+++ b/apps/web/src/locales/pl/common.json
@@ -28,5 +28,6 @@
   "selectAll": "Zaznacz wszystko",
   "clearSelection": "Wyczyść zaznaczenie",
   "more": "Więcej",
-  "bulkActionsLabel": "Akcje zbiorcze"
+  "bulkActionsLabel": "Akcje zbiorcze",
+  "resizeRightPanel": "Zmień szerokość panelu bocznego"
 }

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -471,6 +471,9 @@
       "overviewTitle": "Widżety przeglądu",
       "overviewDesc": "Wybierz, które sekcje pojawiają się na stronie przeglądu",
       "overviewPreview": "Podgląd przeglądu",
+      "playerTitle": "Pasek odtwarzacza",
+      "playerDesc": "Wybierz, które elementy pojawiają się na pasku odtwarzacza. Sterowanie odtwarzaniem i pasek przewijania zawsze pozostają.",
+      "playerPreview": "Podgląd paska odtwarzacza",
       "reset": "Resetuj",
       "elements": {
         "topBarLanguageSwitcher": "Przełącznik języka",
@@ -488,7 +491,27 @@
         "overviewRecommendations": "Rekomendacje",
         "overviewRecommendationsDesc": "Propozycje utworów na podstawie Twojego słuchania",
         "overviewRecentlyAdded": "Ostatnio dodane",
-        "overviewRecentlyAddedDesc": "Najnowsze utwory zaimportowane do biblioteki"
+        "overviewRecentlyAddedDesc": "Najnowsze utwory zaimportowane do biblioteki",
+        "playerAlbumArt": "Okładka albumu",
+        "playerAlbumArtDesc": "Miniatura okładki obok tytułu utworu",
+        "playerFavorite": "Przycisk ulubionych",
+        "playerFavoriteDesc": "Serduszko obok informacji o utworze",
+        "playerTimeLabels": "Etykiety czasu",
+        "playerTimeLabelsDesc": "Czas odtwarzania i całkowity wokół paska przewijania",
+        "playerSleepTimer": "Wyłącznik czasowy",
+        "playerSleepTimerDesc": "Przycisk księżyca wyciszający muzykę po określonym czasie",
+        "playerEqualizer": "Przycisk korektora",
+        "playerEqualizerDesc": "Szybki dostęp do 10-pasmowego korektora",
+        "playerCompactButton": "Przycisk trybu kompaktowego",
+        "playerCompactButtonDesc": "Zmniejsza aplikację do mini odtwarzacza (Ctrl+Shift+M nadal działa)",
+        "playerVisualizerButton": "Przycisk wizualizera",
+        "playerVisualizerButtonDesc": "Przełącza pasek wizualizera (klawisz V nadal działa)",
+        "playerLyricsButton": "Przycisk tekstów",
+        "playerLyricsButtonDesc": "Otwiera panel tekstów (Ctrl+L nadal działa)",
+        "playerQueueButton": "Przycisk kolejki",
+        "playerQueueButtonDesc": "Otwiera panel kolejki (Ctrl+Q nadal działa)",
+        "playerVolume": "Regulacja głośności",
+        "playerVolumeDesc": "Suwak głośności po prawej stronie paska"
       }
     },
     "bgAdjust": {

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -20,6 +20,7 @@
     "interface": "Pokaż lub ukryj elementy interfejsu",
     "sidebar": "Widoczność głównej nawigacji",
     "weather": "Pogoda na zegarze w Przeglądzie",
+    "system": "Uruchamianie i zachowanie w zasobniku",
     "scrobble": "Scrobblowanie do Last.fm i ListenBrainz",
     "discord": "Ustawienia integracji Discord",
     "updates": "Kanał aktualizacji aplikacji",
@@ -41,6 +42,7 @@
   "interface": "Interfejs",
   "sidebar": "Panel boczny",
   "weather": "Pogoda",
+  "system": "System",
   "scrobble": "Scrobblowanie",
   "discord": "Discord",
   "updates": "Aktualizacje",
@@ -647,5 +649,16 @@
     "pending_many": "{{count}} odtworzeń oczekuje na wysłanie",
     "pending_other": "{{count}} odtworzeń oczekuje na wysłanie",
     "note": "Twój klucz sesji i token są przechowywane lokalnie i nie opuszczają urządzenia poza scrobblowaniem. Scrobblowanie nigdy nie blokuje odtwarzania."
+  },
+  "sys": {
+    "behaviorTitle": "Zachowanie systemowe",
+    "behaviorDesc": "Jak Shiranami uruchamia się i działa w tle",
+    "launchAtStartup": "Uruchamiaj przy starcie",
+    "launchAtStartupDesc": "Uruchamiaj Shiranami automatycznie po zalogowaniu do komputera",
+    "minimizeToTray": "Minimalizuj do zasobnika",
+    "minimizeToTrayDesc": "Minimalizacja ukrywa okno; muzyka gra dalej, a ikona w zasobniku przywraca okno",
+    "closeToTray": "Zamykaj do zasobnika",
+    "closeToTrayDesc": "Zamknięcie okna pozostawia Shiranami działające w zasobniku zamiast kończyć aplikację",
+    "macTrayNote": "Na macOS ukryte okno można otworzyć ponownie z ikony na pasku menu lub z Docka. Aby całkowicie zakończyć, użyj Zakończ na pasku menu."
   }
 }

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -17,6 +17,7 @@
     "compact": "Ustawienia mini-odtwarzacza",
     "appearance": "Wygląd i styl interfejsu",
     "effects": "Efekty interfejsu",
+    "interface": "Pokaż lub ukryj elementy interfejsu",
     "sidebar": "Widoczność głównej nawigacji",
     "weather": "Pogoda na zegarze w Przeglądzie",
     "scrobble": "Scrobblowanie do Last.fm i ListenBrainz",
@@ -37,6 +38,7 @@
   "compact": "Tryb kompaktowy",
   "appearance": "Wygląd",
   "effects": "Efekty wizualne",
+  "interface": "Interfejs",
   "sidebar": "Panel boczny",
   "weather": "Pogoda",
   "scrobble": "Scrobblowanie",
@@ -450,6 +452,31 @@
         "coral": "Koral",
         "rose": "Róż",
         "lavender": "Lawenda"
+      }
+    },
+    "interface": {
+      "topBarTitle": "Górny pasek",
+      "topBarDesc": "Elementy widoczne na pasku u góry okna",
+      "overviewTitle": "Widżety przeglądu",
+      "overviewDesc": "Wybierz, które sekcje pojawiają się na stronie przeglądu",
+      "reset": "Resetuj",
+      "elements": {
+        "topBarLanguageSwitcher": "Przełącznik języka",
+        "topBarLanguageSwitcherDesc": "Szybka zmiana języka na górnym pasku. Wybór języka pozostaje dostępny w ustawieniach wyglądu.",
+        "overviewStats": "Pasek statystyk",
+        "overviewStatsDesc": "Czas słuchania, sesje i trend w tym tygodniu",
+        "overviewTopWeek": "Top tego tygodnia",
+        "overviewTopWeekDesc": "Najczęściej grane utwory z ostatnich 7 dni",
+        "overviewClock": "Zegar słuchania",
+        "overviewClockDesc": "Godzinowa mapa cieplna Twojego słuchania",
+        "overviewTopAlbums": "Top albumy",
+        "overviewTopAlbumsDesc": "Najczęściej grane albumy tygodnia",
+        "overviewMixes": "Inteligentne miksy",
+        "overviewMixesDesc": "Automatyczne miksy tworzone z Twojej biblioteki",
+        "overviewRecommendations": "Rekomendacje",
+        "overviewRecommendationsDesc": "Propozycje utworów na podstawie Twojego słuchania",
+        "overviewRecentlyAdded": "Ostatnio dodane",
+        "overviewRecentlyAddedDesc": "Najnowsze utwory zaimportowane do biblioteki"
       }
     },
     "bgAdjust": {

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -198,6 +198,8 @@
     "sleepFade": "Wyciszanie wyłącznika czasowego",
     "sleepFadeDesc": "Delikatnie wycisz dźwięk, zanim wyłącznik czasowy wstrzyma odtwarzanie",
     "sleepFadeDuration": "Czas wyciszania",
+    "sleepFadePreview": "Podgląd wyciszania",
+    "sleepFadePreviewCaption": "Głośność wycisza się przez {{seconds}} s po zakończeniu wyłącznika czasowego",
     "previewTrack": "Midnight Rain",
     "previewOutgoing": "Bieżący utwór",
     "previewIncoming": "Następny utwór"
@@ -383,6 +385,11 @@
     "subtitle": "Dostosuj wygląd aplikacji",
     "interfaceScale": "Skala interfejsu",
     "scaleDesc": "Dostosuj rozmiar tekstu i elementów UI",
+    "scalePreview": "Podgląd skali",
+    "scalePreviewBase": "Domyślna ({{value}}%)",
+    "scalePreviewCurrent": "Twoja skala ({{value}}%)",
+    "scaleSampleTitle": "Evening Rain",
+    "scaleSampleSubtitle": "Lofi Collective",
     "languageTitle": "Język",
     "languageScaleTitle": "Język i skala",
     "languageDesc": "Wybierz język wyświetlania aplikacji",
@@ -443,6 +450,7 @@
       "custom": "Własny kolor",
       "apply": "Użyj akcentu {{name}}",
       "reset": "Resetuj",
+      "previewTitle": "Podgląd akcentu",
       "names": {
         "violet": "Fiolet",
         "periwinkle": "Barwinek",
@@ -459,8 +467,10 @@
     "interface": {
       "topBarTitle": "Górny pasek",
       "topBarDesc": "Elementy widoczne na pasku u góry okna",
+      "topBarPreview": "Podgląd górnego paska",
       "overviewTitle": "Widżety przeglądu",
       "overviewDesc": "Wybierz, które sekcje pojawiają się na stronie przeglądu",
+      "overviewPreview": "Podgląd przeglądu",
       "reset": "Resetuj",
       "elements": {
         "topBarLanguageSwitcher": "Przełącznik języka",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -432,6 +432,26 @@
         "wisteria": "Glicynia"
       }
     },
+    "accent": {
+      "title": "Kolor akcentu",
+      "desc": "Wybierz kolor wyróżnień używany w całej aplikacji. Auto podąża za aktywnym motywem.",
+      "auto": "Auto (akcent motywu)",
+      "custom": "Własny kolor",
+      "apply": "Użyj akcentu {{name}}",
+      "reset": "Resetuj",
+      "names": {
+        "violet": "Fiolet",
+        "periwinkle": "Barwinek",
+        "sky": "Błękit",
+        "mint": "Mięta",
+        "matcha": "Matcha",
+        "gold": "Złoto",
+        "peach": "Brzoskwinia",
+        "coral": "Koral",
+        "rose": "Róż",
+        "lavender": "Lawenda"
+      }
+    },
     "bgAdjust": {
       "title": "Regulacja tła",
       "opacity": "Widoczność obrazu",
@@ -541,29 +561,29 @@
     "github": "GitHub",
     "changelog": "Historia zmian",
     "storyTitle": "Historia",
-    "storySubtitle": "Od autora. Po prostu chcia\u0142em, \u017ceby taka aplikacja istnia\u0142a.",
+    "storySubtitle": "Od autora. Po prostu chciałem, żeby taka aplikacja istniała.",
     "storyP1": "Shiranami zaczęło się od prostej myśli. Nie chciałem płacić co miesiąc za Spotify tylko po to, żeby mieć <1>muzykę grającą w tle podczas pracy</1>. Więc zrobiłem własny.",
     "storyP2": "To część Shiro Suite, niewielkiego zestawu narzędzi, który buduję. Na razie są trzy: <1>Shiranami · ShiroAni · KireiManga</1>. Każda aplikacja robi jedną rzecz tak, jak chciałem, żeby działała.",
     "storyP3": "Lubię tworzyć narzędzia, które działają dla mnie, a okazują się działać też dla kogoś innego. Jeśli to o Tobie, <1>cieszę się, że tu jesteś</1>.",
     "logsTitle": "Logi aplikacji",
-    "logsSubtitle": "Otw\u00f3rz folder z logami w eksploratorze plik\u00f3w",
-    "openLogs": "Otw\u00f3rz folder log\u00f3w",
-    "replayTitle": "Powt\u00f3rz wprowadzenie",
-    "replaySubtitle": "Przejd\u017a ponownie przez konfiguracj\u0119 pierwszego uruchomienia",
-    "replayButton": "Powt\u00f3rz konfiguracj\u0119"
+    "logsSubtitle": "Otwórz folder z logami w eksploratorze plików",
+    "openLogs": "Otwórz folder logów",
+    "replayTitle": "Powtórz wprowadzenie",
+    "replaySubtitle": "Przejdź ponownie przez konfigurację pierwszego uruchomienia",
+    "replayButton": "Powtórz konfigurację"
   },
   "sup": {
     "title": "Wsparcie",
-    "subtitle": "Od autora. Je\u015bli Shiranami znalaz\u0142o miejsce w Twoim dniu.",
-    "p1": "Shiranami jest darmowe, bez reklam i takie pozostanie. Tworz\u0119 je po godzinach, bo chcia\u0142em <1>odtwarzacz, kt\u00f3ry po prostu gra</1>: bez konta, bez subskrypcji, bez szumu.",
-    "p2": "Je\u015bli wesz\u0142o Ci w nawyk i chcesz si\u0119 odwdzi\u0119czy\u0107, mo\u017cesz <1>postawi\u0107 mi kaw\u0119</1>. To ca\u0142kowicie opcjonalne i znaczy wi\u0119cej, ni\u017c my\u015blisz.",
-    "p3": "Tak czy inaczej, czy dorzucisz si\u0119, czy po prostu s\u0142uchasz dalej, <1>dzi\u0119kuj\u0119, \u017ce tu jeste\u015b</1>.",
-    "action": "Postaw mi kaw\u0119",
+    "subtitle": "Od autora. Jeśli Shiranami znalazło miejsce w Twoim dniu.",
+    "p1": "Shiranami jest darmowe, bez reklam i takie pozostanie. Tworzę je po godzinach, bo chciałem <1>odtwarzacz, który po prostu gra</1>: bez konta, bez subskrypcji, bez szumu.",
+    "p2": "Jeśli weszło Ci w nawyk i chcesz się odwdzięczyć, możesz <1>postawić mi kawę</1>. To całkowicie opcjonalne i znaczy więcej, niż myślisz.",
+    "p3": "Tak czy inaczej, czy dorzucisz się, czy po prostu słuchasz dalej, <1>dziękuję, że tu jesteś</1>.",
+    "action": "Postaw mi kawę",
     "sponsor": "Wesprzyj na GitHubie"
   },
   "supportBanner": {
-    "message": "Podoba Ci si\u0119 Shiranami? Jest darmowe i bez reklam, tworzone przez jedn\u0105 osob\u0119.",
-    "action": "Postaw mi kaw\u0119",
+    "message": "Podoba Ci się Shiranami? Jest darmowe i bez reklam, tworzone przez jedną osobę.",
+    "action": "Postaw mi kawę",
     "sponsor": "Wesprzyj na GitHubie",
     "dismiss": "Zamknij"
   },

--- a/apps/web/src/locales/pl/sidebar.json
+++ b/apps/web/src/locales/pl/sidebar.json
@@ -17,5 +17,6 @@
   "collapseSidebar": "Zwiń panel boczny",
   "yourPlaylists": "Twoje playlisty",
   "all": "Wszystkie",
-  "allPlaylists": "Wszystkie playlisty"
+  "allPlaylists": "Wszystkie playlisty",
+  "resizeSidebar": "Zmień szerokość paska bocznego"
 }

--- a/apps/web/src/stores/useAccentStore.test.ts
+++ b/apps/web/src/stores/useAccentStore.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAccentStore, ACCENT_DEFAULT, ACCENT_PRESETS, applyAccent } from './useAccentStore';
+
+const STORE_KEY = 'shiranami.accent-store';
+
+function readPersisted(): Record<string, unknown> {
+  const raw = localStorage.getItem(STORE_KEY);
+  if (!raw) return {};
+  const parsed = JSON.parse(raw) as { state?: Record<string, unknown> };
+  return parsed.state ?? {};
+}
+
+function rootStyle() {
+  return document.documentElement.style;
+}
+
+describe('useAccentStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAccentStore.setState({ accentColor: ACCENT_DEFAULT });
+    applyAccent(null);
+  });
+
+  it('ships a null default that leaves the theme accent untouched', () => {
+    expect(ACCENT_DEFAULT).toBeNull();
+    expect(rootStyle().getPropertyValue('--primary')).toBe('');
+  });
+
+  it('sets the accent vars on the document root and persists', () => {
+    useAccentStore.getState().setAccentColor('#60b8e0');
+    expect(rootStyle().getPropertyValue('--primary')).toBe('#60b8e0');
+    expect(rootStyle().getPropertyValue('--primary-rgb')).toBe('96, 184, 224');
+    expect(rootStyle().getPropertyValue('--ring')).toBe('#60b8e0');
+    expect(readPersisted().accentColor).toBe('#60b8e0');
+  });
+
+  it('lowercases the stored hex', () => {
+    useAccentStore.getState().setAccentColor('#F09E60');
+    expect(useAccentStore.getState().accentColor).toBe('#f09e60');
+  });
+
+  it('coerces malformed input to the default (no override)', () => {
+    useAccentStore.getState().setAccentColor('#60b8e0');
+    useAccentStore.getState().setAccentColor('not-a-color');
+    expect(useAccentStore.getState().accentColor).toBeNull();
+    expect(rootStyle().getPropertyValue('--primary')).toBe('');
+  });
+
+  it('picks a dark foreground for light accents and a light one for dark accents', () => {
+    useAccentStore.getState().setAccentColor('#fcd34d'); // light gold
+    expect(rootStyle().getPropertyValue('--primary-foreground')).toBe('oklch(0.1 0.02 280)');
+    useAccentStore.getState().setAccentColor('#5b21b6'); // deep violet
+    expect(rootStyle().getPropertyValue('--primary-foreground')).toBe('oklch(0.97 0.01 280)');
+  });
+
+  it('resetAccent clears the override vars entirely', () => {
+    useAccentStore.getState().setAccentColor('#ef7bae');
+    useAccentStore.getState().resetAccent();
+    expect(useAccentStore.getState().accentColor).toBeNull();
+    expect(rootStyle().getPropertyValue('--primary')).toBe('');
+    expect(rootStyle().getPropertyValue('--primary-rgb')).toBe('');
+    expect(rootStyle().getPropertyValue('--primary-foreground')).toBe('');
+    expect(rootStyle().getPropertyValue('--ring')).toBe('');
+  });
+
+  it('exposes only valid #rrggbb presets', () => {
+    for (const preset of ACCENT_PRESETS) {
+      expect(preset.hex).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+});
+
+describe('useAccentStore rehydration sanitizing', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it('drops a malformed persisted accent on load', async () => {
+    localStorage.setItem(
+      STORE_KEY,
+      JSON.stringify({ state: { accentColor: 'javascript:alert(1)' }, version: 1 })
+    );
+    const mod = await import('./useAccentStore');
+    expect(mod.useAccentStore.getState().accentColor).toBeNull();
+  });
+
+  it('applies a valid persisted accent to the DOM on load', async () => {
+    localStorage.setItem(
+      STORE_KEY,
+      JSON.stringify({ state: { accentColor: '#6ee7b7' }, version: 1 })
+    );
+    const mod = await import('./useAccentStore');
+    expect(mod.useAccentStore.getState().accentColor).toBe('#6ee7b7');
+    expect(document.documentElement.style.getPropertyValue('--primary')).toBe('#6ee7b7');
+  });
+});

--- a/apps/web/src/stores/useAccentStore.ts
+++ b/apps/web/src/stores/useAccentStore.ts
@@ -1,0 +1,104 @@
+import { createPersistedStore, acceptStoreHmr } from '@/lib/createPersistedStore';
+import { hexToRgb, isHexColor, relativeLuminance, contrastRatio } from '@/lib/color';
+
+/**
+ * Preset accent swatches. The first five mirror the per-theme accents in
+ * globals.css (violet = :root, periwinkle = snow, sky = summer, peach =
+ * sunset, lavender = wisteria) so a familiar palette is one click away; the
+ * rest fill out the lofi-pastel range. `nameKey` indexes
+ * settings:app.accent.names.* for the a11y label.
+ */
+export const ACCENT_PRESETS: ReadonlyArray<{ hex: string; nameKey: string }> = [
+  { hex: '#9b7deb', nameKey: 'violet' },
+  { hex: '#8aaaeb', nameKey: 'periwinkle' },
+  { hex: '#60b8e0', nameKey: 'sky' },
+  { hex: '#6ee7b7', nameKey: 'mint' },
+  { hex: '#a3cc8f', nameKey: 'matcha' },
+  { hex: '#fcd34d', nameKey: 'gold' },
+  { hex: '#f09e60', nameKey: 'peach' },
+  { hex: '#f08080', nameKey: 'coral' },
+  { hex: '#ef7bae', nameKey: 'rose' },
+  { hex: '#cd8ee6', nameKey: 'lavender' },
+];
+
+/** null = follow the theme's accent (no override). */
+export const ACCENT_DEFAULT = null;
+
+const STORE_KEY = 'shiranami.accent-store';
+
+// Foreground candidates for text rendered on the accent. Values mirror
+// --primary-foreground (:root) and --foreground so overridden accents keep
+// the same ink colors the rest of the palette uses.
+const DARK_FOREGROUND = 'oklch(0.1 0.02 280)';
+const LIGHT_FOREGROUND = 'oklch(0.97 0.01 280)';
+const DARK_FOREGROUND_LUMINANCE = 0.012;
+const LIGHT_FOREGROUND_LUMINANCE = 0.92;
+
+const ACCENT_PROPS = ['--primary', '--primary-rgb', '--primary-foreground', '--ring'] as const;
+
+function coerceAccent(v: unknown): string | null {
+  return isHexColor(v) ? v.toLowerCase() : ACCENT_DEFAULT;
+}
+
+/**
+ * Side-effect — inline styles on <html> beat both :root and [data-theme]
+ * blocks, so a custom accent overrides whatever theme is active; clearing
+ * them falls straight back to the theme's own accent. --primary-rgb must be
+ * kept in lockstep because canvas visualizers and inline glows read the raw
+ * triplet instead of the resolved color.
+ */
+export function applyAccent(accentColor: string | null): void {
+  if (typeof document === 'undefined') return;
+  const style = document.documentElement.style;
+  const rgb = accentColor ? hexToRgb(accentColor) : null;
+  if (!rgb) {
+    for (const prop of ACCENT_PROPS) style.removeProperty(prop);
+    return;
+  }
+  const luminance = relativeLuminance(rgb);
+  const foreground =
+    contrastRatio(luminance, DARK_FOREGROUND_LUMINANCE) >=
+    contrastRatio(luminance, LIGHT_FOREGROUND_LUMINANCE)
+      ? DARK_FOREGROUND
+      : LIGHT_FOREGROUND;
+  style.setProperty('--primary', accentColor);
+  style.setProperty('--primary-rgb', `${rgb.r}, ${rgb.g}, ${rgb.b}`);
+  style.setProperty('--primary-foreground', foreground);
+  style.setProperty('--ring', accentColor);
+}
+
+interface AccentState {
+  /** #rrggbb override, or null to follow the active theme's accent. */
+  accentColor: string | null;
+  setAccentColor: (hex: string | null) => void;
+  resetAccent: () => void;
+}
+
+export const useAccentStore = createPersistedStore<AccentState>(
+  set => ({
+    accentColor: ACCENT_DEFAULT,
+    setAccentColor: hex => {
+      const next = coerceAccent(hex);
+      applyAccent(next);
+      set({ accentColor: next });
+    },
+    resetAccent: () => {
+      applyAccent(ACCENT_DEFAULT);
+      set({ accentColor: ACCENT_DEFAULT });
+    },
+  }),
+  {
+    name: STORE_KEY,
+    version: 1,
+    partialize: s => ({ accentColor: s.accentColor }),
+    sanitize: (persisted, current) => ({
+      ...current,
+      accentColor: coerceAccent((persisted as Partial<AccentState> | undefined)?.accentColor),
+    }),
+    onRehydrate: state => applyAccent(state.accentColor),
+  }
+);
+
+acceptStoreHmr(useAccentStore, import.meta.hot, state =>
+  applyAccent(coerceAccent(state.accentColor))
+);

--- a/apps/web/src/stores/useInterfaceStore.ts
+++ b/apps/web/src/stores/useInterfaceStore.ts
@@ -1,0 +1,79 @@
+import { createPersistedStore, acceptStoreHmr } from '@/lib/createPersistedStore';
+
+/**
+ * Visibility of optional interface chrome — the top-bar language switcher and
+ * the individual Overview widgets. Everything defaults to visible so the
+ * store is a pure opt-out surface; the greeting hero stays unconditional
+ * (it anchors the view and hosts the separately-toggled weather widget).
+ */
+
+const STORE_KEY = 'shiranami.interface-store';
+
+interface PersistedInterfaceState {
+  topBarLanguageSwitcher: boolean;
+  overviewStats: boolean;
+  overviewTopWeek: boolean;
+  overviewClock: boolean;
+  overviewTopAlbums: boolean;
+  overviewMixes: boolean;
+  overviewRecommendations: boolean;
+  overviewRecentlyAdded: boolean;
+}
+
+export const INTERFACE_DEFAULTS: PersistedInterfaceState = {
+  topBarLanguageSwitcher: true,
+  overviewStats: true,
+  overviewTopWeek: true,
+  overviewClock: true,
+  overviewTopAlbums: true,
+  overviewMixes: true,
+  overviewRecommendations: true,
+  overviewRecentlyAdded: true,
+};
+
+const INTERFACE_KEYS = Object.keys(INTERFACE_DEFAULTS) as Array<keyof PersistedInterfaceState>;
+
+function sanitize(
+  persisted: Partial<PersistedInterfaceState> | undefined
+): Partial<PersistedInterfaceState> {
+  if (!persisted || typeof persisted !== 'object') return {};
+  const out: Partial<PersistedInterfaceState> = {};
+  for (const key of INTERFACE_KEYS) {
+    if (typeof persisted[key] === 'boolean') out[key] = persisted[key];
+  }
+  return out;
+}
+
+interface InterfaceActions {
+  setVisible: (key: keyof PersistedInterfaceState, visible: boolean) => void;
+  resetInterface: () => void;
+}
+
+export type InterfaceElementKey = keyof PersistedInterfaceState;
+
+export const useInterfaceStore = createPersistedStore<PersistedInterfaceState & InterfaceActions>(
+  set => ({
+    ...INTERFACE_DEFAULTS,
+    setVisible: (key, visible) => {
+      set({ [key]: visible } as Partial<PersistedInterfaceState>);
+    },
+    resetInterface: () => {
+      set({ ...INTERFACE_DEFAULTS });
+    },
+  }),
+  {
+    name: STORE_KEY,
+    version: 1,
+    partialize: (s): PersistedInterfaceState => {
+      const out = {} as PersistedInterfaceState;
+      for (const key of INTERFACE_KEYS) out[key] = s[key];
+      return out;
+    },
+    sanitize: (persisted, current) => ({
+      ...current,
+      ...sanitize(persisted as Partial<PersistedInterfaceState>),
+    }),
+  }
+);
+
+acceptStoreHmr(useInterfaceStore, import.meta.hot);

--- a/apps/web/src/stores/useInterfaceStore.ts
+++ b/apps/web/src/stores/useInterfaceStore.ts
@@ -1,10 +1,10 @@
 import { createPersistedStore, acceptStoreHmr } from '@/lib/createPersistedStore';
 
 /**
- * Visibility of optional interface chrome — the top-bar language switcher and
- * the individual Overview widgets. Everything defaults to visible so the
- * store is a pure opt-out surface; the greeting hero stays unconditional
- * (it anchors the view and hosts the separately-toggled weather widget).
+ * Visibility of optional interface chrome — the top-bar language switcher,
+ * the individual Overview widgets, and the player bar's secondary elements.
+ * Everything defaults to visible so the store is a pure opt-out surface; the
+ * greeting hero and core playback controls (play/seek) stay unconditional.
  */
 
 const STORE_KEY = 'shiranami.interface-store';
@@ -18,6 +18,16 @@ interface PersistedInterfaceState {
   overviewMixes: boolean;
   overviewRecommendations: boolean;
   overviewRecentlyAdded: boolean;
+  playerAlbumArt: boolean;
+  playerFavorite: boolean;
+  playerTimeLabels: boolean;
+  playerSleepTimer: boolean;
+  playerEqualizer: boolean;
+  playerCompactButton: boolean;
+  playerVisualizerButton: boolean;
+  playerLyricsButton: boolean;
+  playerQueueButton: boolean;
+  playerVolume: boolean;
 }
 
 export const INTERFACE_DEFAULTS: PersistedInterfaceState = {
@@ -29,6 +39,16 @@ export const INTERFACE_DEFAULTS: PersistedInterfaceState = {
   overviewMixes: true,
   overviewRecommendations: true,
   overviewRecentlyAdded: true,
+  playerAlbumArt: true,
+  playerFavorite: true,
+  playerTimeLabels: true,
+  playerSleepTimer: true,
+  playerEqualizer: true,
+  playerCompactButton: true,
+  playerVisualizerButton: true,
+  playerLyricsButton: true,
+  playerQueueButton: true,
+  playerVolume: true,
 };
 
 const INTERFACE_KEYS = Object.keys(INTERFACE_DEFAULTS) as Array<keyof PersistedInterfaceState>;

--- a/apps/web/src/stores/usePanelSizeStore.ts
+++ b/apps/web/src/stores/usePanelSizeStore.ts
@@ -1,0 +1,85 @@
+import { createPersistedStore, clampNumber, acceptStoreHmr } from '@/lib/createPersistedStore';
+
+export const SIDEBAR_WIDTH_MIN = 160;
+export const SIDEBAR_WIDTH_MAX = 320;
+export const SIDEBAR_WIDTH_DEFAULT = 200; // matches the former fixed w-[12.5rem]
+
+export const RIGHT_PANEL_WIDTH_MIN = 260;
+export const RIGHT_PANEL_WIDTH_MAX = 480;
+export const RIGHT_PANEL_WIDTH_DEFAULT = 320; // matches the former fixed w-[320px]
+
+const STORE_KEY = 'shiranami.panel-size-store';
+
+interface PersistedPanelSizeState {
+  sidebarWidth: number;
+  rightPanelWidth: number;
+}
+
+interface PanelSizeState extends PersistedPanelSizeState {
+  setSidebarWidth: (v: number) => void;
+  setRightPanelWidth: (v: number) => void;
+  resetSidebarWidth: () => void;
+  resetRightPanelWidth: () => void;
+}
+
+function sanitize(
+  persisted: Partial<PersistedPanelSizeState> | undefined
+): Partial<PersistedPanelSizeState> {
+  if (!persisted || typeof persisted !== 'object') return {};
+  const out: Partial<PersistedPanelSizeState> = {};
+  if (persisted.sidebarWidth !== undefined)
+    out.sidebarWidth = clampNumber(
+      persisted.sidebarWidth,
+      SIDEBAR_WIDTH_MIN,
+      SIDEBAR_WIDTH_MAX,
+      SIDEBAR_WIDTH_DEFAULT
+    );
+  if (persisted.rightPanelWidth !== undefined)
+    out.rightPanelWidth = clampNumber(
+      persisted.rightPanelWidth,
+      RIGHT_PANEL_WIDTH_MIN,
+      RIGHT_PANEL_WIDTH_MAX,
+      RIGHT_PANEL_WIDTH_DEFAULT
+    );
+  return out;
+}
+
+/** Widths of the user-resizable shell panels, persisted across sessions. */
+export const usePanelSizeStore = createPersistedStore<PanelSizeState>(
+  set => ({
+    sidebarWidth: SIDEBAR_WIDTH_DEFAULT,
+    rightPanelWidth: RIGHT_PANEL_WIDTH_DEFAULT,
+
+    setSidebarWidth: v => {
+      set({
+        sidebarWidth: clampNumber(v, SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX, SIDEBAR_WIDTH_DEFAULT),
+      });
+    },
+    setRightPanelWidth: v => {
+      set({
+        rightPanelWidth: clampNumber(
+          v,
+          RIGHT_PANEL_WIDTH_MIN,
+          RIGHT_PANEL_WIDTH_MAX,
+          RIGHT_PANEL_WIDTH_DEFAULT
+        ),
+      });
+    },
+    resetSidebarWidth: () => set({ sidebarWidth: SIDEBAR_WIDTH_DEFAULT }),
+    resetRightPanelWidth: () => set({ rightPanelWidth: RIGHT_PANEL_WIDTH_DEFAULT }),
+  }),
+  {
+    name: STORE_KEY,
+    version: 1,
+    partialize: (s): PersistedPanelSizeState => ({
+      sidebarWidth: s.sidebarWidth,
+      rightPanelWidth: s.rightPanelWidth,
+    }),
+    sanitize: (persisted, current) => ({
+      ...current,
+      ...sanitize(persisted as Partial<PersistedPanelSizeState>),
+    }),
+  }
+);
+
+acceptStoreHmr(usePanelSizeStore, import.meta.hot);


### PR DESCRIPTION
## Summary
- Adds a customization pass ahead of v1: a custom accent color picker (persisted `--primary`/`--primary-rgb`/`--ring`/foreground override with WCAG-contrast foreground), a new Settings · Interface section with visibility toggles for the top-bar language switcher, all seven Overview widgets, and ten player-bar elements, and drag-resizable sidebar + lyrics/queue panel (160–320px / 260–480px, persisted).
- Adds a Settings · System section backed by new main-process `system-behavior.ts`: launch-at-startup via `setLoginItemSettings` (electron-store watcher, mirroring the telemetry-consent pattern) and minimize/close-to-tray window interception that reads prefs at event time; all default off.
- Every new settings surface ships with the house live-preview treatment (accent chrome sample, collapsing Overview/player-bar/top-bar mocks with hover spotlight, sleep-fade ramp, UI-scale comparison), full en+pl locales, and store sanitizers; includes a new accent-store test suite and an updated Sidebar width test.

## Test plan
- [ ] Settings · Appearance: pick preset/custom accents — buttons, glows, and visualizers recolor live; foreground stays readable on light and dark accents; Auto restores the theme accent after relaunch.
- [ ] Settings · Interface: flip Overview/player-bar/top-bar toggles — previews collapse live and the real surfaces match; defaults leave the UI pixel-identical.
- [ ] Drag the sidebar and lyrics/queue panel edges (double-click resets, arrow keys nudge); widths persist across relaunch.
- [ ] Settings · System: enable launch-at-startup (OS notification appears), minimize/close-to-tray hide the window with audio playing, and tray Quit still exits.