### PR TITLE
test(web): strengthen wave 2 feature stories (play, a11y, autodocs)

### DIFF
--- a/apps/web/src/components/favorites/FavoritesView/FavoritesView.stories.tsx
+++ b/apps/web/src/components/favorites/FavoritesView/FavoritesView.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 import { useLibraryStore } from '@/stores/useLibraryStore';
+import { useUIStore } from '@/stores/useUIStore';
+import { useSelectionStore } from '@/stores/useSelectionStore';
 
 import FavoritesView from './FavoritesView';
 
@@ -23,9 +26,22 @@ function seedLibrary(tracks: Track[], libraryLoaded = true): void {
   useLibraryStore.setState({ library: tracks, libraryLoaded });
 }
 
+/**
+ * favorites · FavoritesView. The page shell for liked tracks: a page header, an
+ * optional now-playing hero, and a virtualized `TrackRow` list filtered to
+ * favorited tracks. Reads `useLibraryStore` (the tracks) and `useUIStore` (the
+ * hero toggle); shows a skeleton until the library loads and an empty state
+ * once loaded with no favorites. Stories seed the stores so the list is
+ * deterministic, and keep the hero card off to stay focused on the list.
+ */
 const meta: Meta<typeof FavoritesView> = {
   title: 'favorites/FavoritesView',
   component: FavoritesView,
+  parameters: {
+    // Header is a real <h1>, the empty state's mascot art is aria-hidden, and
+    // the skeleton marks itself aria-busy — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="flex h-[36rem] flex-col">
@@ -33,39 +49,58 @@ const meta: Meta<typeof FavoritesView> = {
       </div>
     ),
   ],
+  beforeEach: () => {
+    // Keep the hero card off so the view stays focused on the list (and needs no
+    // playback seed); selection cleared so the bulk action bar stays hidden.
+    useUIStore.setState({ libraryHeroCardEnabled: false });
+    useSelectionStore.setState({ selectedTrackIds: new Set() });
+  },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof FavoritesView>;
 
+/** Loaded library with three favorited tracks — header + virtualized list. */
 export const Default: Story = {
-  decorators: [
-    Story => {
-      seedLibrary([
-        makeTrack({ id: 'a', title: 'Midnight study session', artist: 'Idealism' }),
-        makeTrack({ id: 'b', title: 'Rainy day cafe', artist: 'Aso' }),
-        makeTrack({ id: 'c', title: 'Slow morning coffee', artist: 'Kupla' }),
-      ]);
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedLibrary([
+      makeTrack({ id: 'a', title: 'Midnight study session', artist: 'Idealism' }),
+      makeTrack({ id: 'b', title: 'Rainy day cafe', artist: 'Aso' }),
+      makeTrack({ id: 'c', title: 'Slow morning coffee', artist: 'Kupla' }),
+    ]);
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Your favorites' })).toBeInTheDocument();
+    // First virtualized row renders its title; the list is the favorited tracks.
+    await expect(canvas.getByText('Midnight study session')).toBeInTheDocument();
+  },
 };
 
+/** Library loaded but no favorites — the page header above an empty state. */
 export const Empty: Story = {
-  decorators: [
-    Story => {
-      seedLibrary([]);
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedLibrary([]);
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The header stays (the empty state renders inside the same page shell)…
+    await expect(canvas.getByRole('heading', { name: 'Your favorites' })).toBeInTheDocument();
+    // …but the body is the empty-state prompt, not a track list.
+    await expect(canvas.getByText('No favorites yet')).toBeInTheDocument();
+  },
 };
 
+/** Cold start — library not loaded yet, so the skeleton shows instead of an empty flash. */
 export const Loading: Story = {
-  decorators: [
-    Story => {
-      seedLibrary([], false);
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedLibrary([], false);
+  },
+  play: async ({ canvasElement }) => {
+    // The skeleton marks itself aria-busy and renders no page header.
+    await expect(canvasElement.querySelector('[aria-busy="true"]')).not.toBeNull();
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('heading', { name: 'Your favorites' })).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/mixes/ArtCollage/ArtCollage.stories.tsx
+++ b/apps/web/src/components/mixes/ArtCollage/ArtCollage.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 
 import ArtCollage from './ArtCollage';
@@ -24,9 +25,21 @@ function makeLibrary(count: number): Track[] {
   return Array.from({ length: count }).map((_, i) => makeTrack({ id: `track-${i}` }));
 }
 
+/**
+ * mixes · ArtCollage. A purely decorative strip of album-art thumbnails pulled
+ * from the library, shown at the foot of the mixes overview. Every thumbnail is
+ * an `aria-hidden`, empty-`alt` image (it carries no information of its own), so
+ * the collage exposes no roles to assistive tech — axe passes clean. It hides
+ * itself entirely when too few tracks carry artwork.
+ */
 const meta: Meta<typeof ArtCollage> = {
   title: 'mixes/ArtCollage',
   component: ArtCollage,
+  parameters: {
+    // Thumbnails are decorative: every <img> is aria-hidden with an empty alt,
+    // so axe finds nothing to name — passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="w-[32rem] p-4">
@@ -40,14 +53,33 @@ export default meta;
 
 type Story = StoryObj<typeof ArtCollage>;
 
+/** Enough artwork to fill the strip — caps at 12 decorative thumbnails. */
 export const Default: Story = {
   args: {
     library: makeLibrary(12),
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The thumbnails are decorative (aria-hidden), so they expose no role —
+    // assert the rendered count via the underlying <img> tags instead.
+    const thumbs = canvasElement.querySelectorAll('img');
+    await expect(thumbs).toHaveLength(12);
+    for (const img of thumbs) {
+      await expect(img).toHaveAttribute('aria-hidden', 'true');
+      await expect(img).toHaveAttribute('alt', '');
+    }
+    // No decorative image leaks an accessible name into the a11y tree.
+    await expect(canvas.queryByRole('img')).not.toBeInTheDocument();
+  },
 };
 
+/** Too few tracks carry artwork — the collage hides itself entirely. */
 export const TooFew: Story = {
   args: {
     library: makeLibrary(2),
+  },
+  play: async ({ canvasElement }) => {
+    // Below the threshold the component returns null, so nothing renders.
+    await expect(canvasElement.querySelector('img')).toBeNull();
   },
 };

--- a/apps/web/src/components/mixes/MixesView/MixesView.stories.tsx
+++ b/apps/web/src/components/mixes/MixesView/MixesView.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 import { useLibraryStore } from '@/stores/useLibraryStore';
+import { useSelectionStore } from '@/stores/useSelectionStore';
 
 import MixesView from './MixesView';
 
@@ -23,9 +25,22 @@ function seedLibrary(tracks: Track[], libraryLoaded = true): void {
   useLibraryStore.setState({ library: tracks, libraryLoaded });
 }
 
+/**
+ * mixes · MixesView. The mixes overview: a page header, the curated mix grid
+ * (each a clickable `MixGridRow` button that opens its mix detail), an optional
+ * "for you right now" smart-mix section, and a decorative `ArtCollage` strip.
+ * Reads the merged library via `useLibraryStore`; shows a skeleton before the
+ * library loads and an empty state once loaded with no tracks. Stories seed the
+ * library so the grid is deterministic.
+ */
 const meta: Meta<typeof MixesView> = {
   title: 'mixes/MixesView',
   component: MixesView,
+  parameters: {
+    // Header is a real <h1>, each grid card is a labelled <button>, mosaic +
+    // collage art is aria-hidden, and the skeleton is aria-busy — axe clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="flex h-[36rem] flex-col">
@@ -33,39 +48,56 @@ const meta: Meta<typeof MixesView> = {
       </div>
     ),
   ],
+  beforeEach: () => {
+    // Selection cleared so the bulk action bar stays hidden.
+    useSelectionStore.setState({ selectedTrackIds: new Set() });
+  },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof MixesView>;
 
+/** Loaded library — page header plus the curated mix grid of openable cards. */
 export const Default: Story = {
-  decorators: [
-    Story => {
-      seedLibrary([
-        makeTrack({ id: 'a', title: 'Midnight study session', artist: 'Idealism', playCount: 12 }),
-        makeTrack({ id: 'b', title: 'Rainy day cafe', artist: 'Aso', playCount: 5 }),
-        makeTrack({ id: 'c', title: 'Slow morning coffee', artist: 'Kupla', playCount: 0 }),
-      ]);
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedLibrary([
+      makeTrack({ id: 'a', title: 'Midnight study session', artist: 'Idealism', playCount: 12 }),
+      makeTrack({ id: 'b', title: 'Rainy day cafe', artist: 'Aso', playCount: 5 }),
+      makeTrack({ id: 'c', title: 'Slow morning coffee', artist: 'Kupla', playCount: 0 }),
+    ]);
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Your mixes' })).toBeInTheDocument();
+    // Each curated mix is a button whose accessible name starts with its title.
+    await expect(canvas.getByRole('button', { name: /Most Played/ })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: /Recently Added/ })).toBeInTheDocument();
+  },
 };
 
+/** Empty library — the mixes overview yields to a single empty state. */
 export const Empty: Story = {
-  decorators: [
-    Story => {
-      seedLibrary([]);
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedLibrary([]);
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('Add tracks to your library to unlock smart mixes')
+    ).toBeInTheDocument();
+    await expect(canvas.queryByRole('heading', { name: 'Your mixes' })).not.toBeInTheDocument();
+  },
 };
 
+/** Cold start — library not loaded yet, so the skeleton shows. */
 export const Loading: Story = {
-  decorators: [
-    Story => {
-      seedLibrary([], false);
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedLibrary([], false);
+  },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector('[aria-busy="true"]')).not.toBeNull();
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('heading', { name: 'Your mixes' })).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.stories.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
 import type { Track } from '@/stores/types';
 import type { NowPlayingPanel } from '@/stores/useUIStore';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
@@ -30,10 +31,24 @@ function seedNowPlaying(panel: NowPlayingPanel): void {
   useViewStore.setState({ activeView: 'now-playing', previousView: 'library' });
 }
 
+/**
+ * now-playing · NowPlayingView. The full-screen player: a back button, a
+ * lyrics / queue / equalizer panel-toggle group, large album art with track
+ * info, the seek bar + time, transport controls + volume, and the active
+ * right-column panel. Reads `usePlaybackStore` (the track), `useUIStore` (the
+ * active panel), and `useViewStore`; renders nothing when no track is playing.
+ * Stories seed a playing track and a chosen panel so the view is deterministic.
+ */
 const meta: Meta<typeof NowPlayingView> = {
   title: 'now-playing/NowPlayingView',
   component: NowPlayingView,
-  parameters: { layout: 'fullscreen' },
+  parameters: {
+    layout: 'fullscreen',
+    // Track title is a real <h1>, the toggle group + its buttons are labelled
+    // and aria-pressed, the back button is labelled, and the player children
+    // forward their accessible names to the slider thumbs — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <QueryClientProvider
@@ -53,29 +68,49 @@ export default meta;
 
 type Story = StoryObj<typeof NowPlayingView>;
 
+/** Lyrics panel active — track info, transport, and the lyrics column. */
 export const Lyrics: Story = {
-  decorators: [
-    Story => {
-      seedNowPlaying('lyrics');
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedNowPlaying('lyrics');
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Midnight Tapes' })).toBeInTheDocument();
+    await expect(canvas.getByRole('group', { name: 'Now playing panels' })).toBeInTheDocument();
+    // The lyrics panel is active, so its toggle reads as the "hide" action.
+    await expect(canvas.getByRole('button', { name: 'Hide lyrics' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Show queue' })).toBeInTheDocument();
+  },
 };
 
+/** Queue panel active — pressing a different toggle swaps the active panel. */
 export const Queue: Story = {
-  decorators: [
-    Story => {
-      seedNowPlaying('queue');
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedNowPlaying('queue');
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The queue toggle is the active (pressed) one here.
+    const queueToggle = canvas.getByRole('button', { name: 'Hide queue' });
+    await expect(queueToggle).toHaveAttribute('aria-pressed', 'true');
+
+    // Switching to lyrics drives the shared UI store and re-labels the toggles.
+    await userEvent.click(canvas.getByRole('button', { name: 'Show lyrics' }));
+    await waitFor(() => expect(useUIStore.getState().nowPlayingPanel).toBe('lyrics'));
+    await expect(canvas.getByRole('button', { name: 'Hide lyrics' })).toBeInTheDocument();
+  },
 };
 
+/** No panel — the centered layout with art + transport and all toggles inactive. */
 export const NoPanel: Story = {
-  decorators: [
-    Story => {
-      seedNowPlaying(null);
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedNowPlaying(null);
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Midnight Tapes' })).toBeInTheDocument();
+    // With no active panel every toggle reads as a "show" action.
+    await expect(canvas.getByRole('button', { name: 'Show lyrics' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Show queue' })).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/smart-playlists/SmartPlaylistFormDialog/SmartPlaylistFormDialog.stories.tsx
+++ b/apps/web/src/components/smart-playlists/SmartPlaylistFormDialog/SmartPlaylistFormDialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { screen, within, userEvent, expect, waitFor } from 'storybook/test';
 import type { SmartPlaylist } from '@shiranami/contracts';
 
 import SmartPlaylistFormDialog from './SmartPlaylistFormDialog';
@@ -16,9 +17,24 @@ const samplePlaylist: SmartPlaylist = {
   updatedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
 };
 
+/**
+ * smart-playlists · SmartPlaylistFormDialog. The create/edit dialog for a
+ * rule-based playlist: a name field, a match-type select ("all" / "any"), a
+ * repeatable list of field · operator · value rule rows (add/remove), a live
+ * matching-track count, and Cancel / Create (or Save) actions. Driven by
+ * `useSmartPlaylistFormDialog`, which seeds the form from the edited playlist or
+ * a single blank rule, and only dismisses on a successful save. The dialog
+ * renders into a portal, so stories query it via `screen` rather than the canvas.
+ */
 const meta: Meta<typeof SmartPlaylistFormDialog> = {
   title: 'smart-playlists/SmartPlaylistFormDialog',
   component: SmartPlaylistFormDialog,
+  parameters: {
+    // Dialog is labelled by its title + described by its description, every
+    // select trigger and value input carries an aria-label, the name input is
+    // bound to its <label>, and the close button has an sr-only name — axe clean.
+    a11y: { test: 'error' },
+  },
   args: {
     open: true,
     onOpenChange: () => {},
@@ -29,10 +45,40 @@ export default meta;
 
 type Story = StoryObj<typeof SmartPlaylistFormDialog>;
 
-export const Default: Story = {};
+/** Create mode — blank name, a single seeded rule row, and a working Add rule. */
+export const Default: Story = {
+  play: async () => {
+    const dialog = await screen.findByRole('dialog');
+    await expect(
+      within(dialog).getByRole('heading', { name: 'New Smart Playlist' })
+    ).toBeInTheDocument();
 
+    // Type into the name field (bound to its <label>) and confirm it sticks.
+    const name = within(dialog).getByLabelText('Name');
+    await userEvent.type(name, 'Late-night focus');
+    await waitFor(() => expect(name).toHaveValue('Late-night focus'));
+
+    // Adding a rule appends a second field/operator row.
+    await expect(within(dialog).getAllByRole('combobox', { name: 'Field' })).toHaveLength(1);
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Add rule' }));
+    await waitFor(() =>
+      expect(within(dialog).getAllByRole('combobox', { name: 'Field' })).toHaveLength(2)
+    );
+  },
+};
+
+/** Edit mode — the form is seeded from an existing playlist (name + two rules). */
 export const Edit: Story = {
   args: {
     playlist: samplePlaylist,
+  },
+  play: async () => {
+    const dialog = await screen.findByRole('dialog');
+    await expect(
+      within(dialog).getByRole('heading', { name: 'Edit Smart Playlist' })
+    ).toBeInTheDocument();
+    await expect(within(dialog).getByLabelText('Name')).toHaveValue('Late-night focus');
+    // Both seeded rules render as field-select rows.
+    await expect(within(dialog).getAllByRole('combobox', { name: 'Field' })).toHaveLength(2);
   },
 };

--- a/apps/web/src/components/smart-playlists/SmartPlaylistFormDialog/SmartPlaylistFormDialog.stories.tsx
+++ b/apps/web/src/components/smart-playlists/SmartPlaylistFormDialog/SmartPlaylistFormDialog.stories.tsx
@@ -53,10 +53,12 @@ export const Default: Story = {
       within(dialog).getByRole('heading', { name: 'New Smart Playlist' })
     ).toBeInTheDocument();
 
-    // Type into the name field (bound to its <label>) and confirm it sticks.
+    // Type into the name field (bound to its <label>) and confirm it sticks. A
+    // value distinct from the Edit story's seeded name keeps this assertion from
+    // passing on leaked cross-story state.
     const name = within(dialog).getByLabelText('Name');
-    await userEvent.type(name, 'Late-night focus');
-    await waitFor(() => expect(name).toHaveValue('Late-night focus'));
+    await userEvent.type(name, 'Deep work sprint');
+    await waitFor(() => expect(name).toHaveValue('Deep work sprint'));
 
     // Adding a rule appends a second field/operator row.
     await expect(within(dialog).getAllByRole('combobox', { name: 'Field' })).toHaveLength(1);

--- a/apps/web/src/components/smart-playlists/SmartPlaylistsView/SmartPlaylistsView.stories.tsx
+++ b/apps/web/src/components/smart-playlists/SmartPlaylistsView/SmartPlaylistsView.stories.tsx
@@ -80,8 +80,9 @@ export const Default: Story = {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole('heading', { name: 'Smart Playlists' })).toBeInTheDocument();
     await expect(canvas.getByRole('button', { name: 'New Smart Playlist' })).toBeInTheDocument();
-    // Each playlist is a card button; names sort alphabetically.
+    // Every seeded playlist renders as its own card button.
     await expect(canvas.getByRole('button', { name: /Late-night focus/ })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: /Rainy day cafe/ })).toBeInTheDocument();
     await expect(canvas.getByRole('button', { name: /Morning warm-up/ })).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/smart-playlists/SmartPlaylistsView/SmartPlaylistsView.stories.tsx
+++ b/apps/web/src/components/smart-playlists/SmartPlaylistsView/SmartPlaylistsView.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, expect } from 'storybook/test';
 import type { SmartPlaylist } from '@shiranami/contracts';
 import { useViewStore } from '@/stores/useViewStore';
 import { smartPlaylistKeys } from '@/hooks/queries/useSmartPlaylists';
@@ -28,9 +29,23 @@ function seededClient(playlists: SmartPlaylist[]): QueryClient {
   return client;
 }
 
+/**
+ * smart-playlists · SmartPlaylistsView. The overview grid of rule-based
+ * playlists: a section header, a "New Smart Playlist" button, and one
+ * `SmartPlaylistCard` button per playlist (opening it routes to the detail
+ * view). Reads the list via React Query and `useViewStore` for the selected id;
+ * shows a skeleton while loading, an error state on failure, and an empty state
+ * with a create CTA when there are none. Stories pre-seed a query client so the
+ * grid renders deterministically without IPC.
+ */
 const meta: Meta<typeof SmartPlaylistsView> = {
   title: 'smart-playlists/SmartPlaylistsView',
   component: SmartPlaylistsView,
+  parameters: {
+    // Section header is a real <h2>, each card + CTA is a labelled <button>, and
+    // the card/empty-state icons are aria-hidden — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="flex h-[36rem] flex-col">
@@ -44,6 +59,7 @@ export default meta;
 
 type Story = StoryObj<typeof SmartPlaylistsView>;
 
+/** Three smart playlists — section header, create button, and the card grid. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -60,8 +76,17 @@ export const Default: Story = {
       );
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Smart Playlists' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'New Smart Playlist' })).toBeInTheDocument();
+    // Each playlist is a card button; names sort alphabetically.
+    await expect(canvas.getByRole('button', { name: /Late-night focus/ })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: /Morning warm-up/ })).toBeInTheDocument();
+  },
 };
 
+/** No smart playlists — the empty state with a create call-to-action. */
 export const Empty: Story = {
   decorators: [
     Story => {
@@ -74,4 +99,13 @@ export const Empty: Story = {
       );
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No smart playlists yet')).toBeInTheDocument();
+    // The empty state surfaces its own create CTA (so does the toolbar) —
+    // assert at least one create button is reachable.
+    await expect(
+      canvas.getAllByRole('button', { name: 'New Smart Playlist' }).length
+    ).toBeGreaterThan(0);
+  },
 };


### PR DESCRIPTION
## Summary
- Strengthens the render-only Storybook stories for four leaf features — **favorites**, **now-playing**, **mixes**, **smart-playlists** (6 component story files) — into real-browser tests: render smoke + `play` interaction/assertion + axe a11y ratcheted to `'error'` + autodocs JSDoc. Continues the Wave 1 onboarding pilot (#291) across the next batch.
- Each `meta` now carries JSDoc (feeds autodocs) and `parameters.a11y.test: 'error'`; primary stories assert against ARIA roles / accessible names (headings, labelled buttons, the now-playing panel-toggle group, the smart-playlist dialog's add-rule flow).
- No component or shared `ui/` changes were needed — all six components were axe-clean at `'error'` out of the box (the Wave 1 slider-thumb aria fix already covers the now-playing player children).

## Test plan
- [ ] `pnpm --filter @shiranami/web test:storybook` → 273 passing (15 strengthened stories across the 4 features carry `play` functions)
- [ ] CI **Storybook Tests** job green
- [ ] Storybook autodocs render for favorites / now-playing / mixes / smart-playlists