### PR TITLE
test(web): strengthen wave 3 feature stories (downloads, debug, radio, splash)

### DIFF
--- a/apps/web/src/components/debug/DebugOverlay/DebugOverlay.stories.tsx
+++ b/apps/web/src/components/debug/DebugOverlay/DebugOverlay.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { MainMetricsSnapshot } from '@shiranami/contracts';
 import { useDebugStore, type RendererMetrics } from '@/stores/useDebugStore';
 
@@ -53,36 +54,65 @@ function seed(main: MainMetricsSnapshot | null, renderer: RendererMetrics): void
   });
 }
 
+/**
+ * debug · DebugOverlay. The dev-only performance panel: a fixed translucent
+ * `role="dialog"` named "Performance debug panel" with a Close button, listing
+ * main-process per-process CPU/memory, renderer FPS/frame-time/JS-heap, React
+ * commit attribution, the active timer registry, per-store update Hz, and a
+ * long-task feed. Reads everything from `useDebugStore`; shows "waiting for
+ * samples…" placeholders until the first snapshot lands. Stories seed the store.
+ */
 const meta: Meta<typeof DebugOverlay> = {
   title: 'debug/DebugOverlay',
   component: DebugOverlay,
+  // This is a dev-only diagnostic overlay deliberately styled as low-opacity
+  // white-on-near-black mono text (text-white/40–50 on bg-black/80) for an
+  // unobtrusive HUD. axe flags that muted text on color-contrast; raising the
+  // opacity to pass would change the intentional HUD aesthetic and the overlay
+  // never ships to end users, so a11y is left at the global 'todo' default here
+  // rather than ratcheted to 'error'. The dialog/button names are still asserted
+  // in `play`.
 };
 
 export default meta;
 
 type Story = StoryObj<typeof DebugOverlay>;
 
+/** A full snapshot — every section populated with main + renderer metrics. */
 export const Default: Story = {
-  decorators: [
-    Story => {
-      seed(makeMain(), makeRenderer());
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seed(makeMain(), makeRenderer());
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The panel is a labelled dialog with a named close affordance.
+    await expect(
+      canvas.getByRole('dialog', { name: 'Performance debug panel' })
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Close debug panel' })).toBeInTheDocument();
+    // Seeded main-process rows render their per-process figures.
+    await expect(canvas.getByText('GPU')).toBeInTheDocument();
+    await expect(canvas.getByText('31.7')).toBeInTheDocument();
+  },
 };
 
+/** No main-process sample yet — the placeholders stand in for live metrics. */
 export const AwaitingSamples: Story = {
-  decorators: [
-    Story => {
-      seed(null, {
-        fps: 0,
-        frameP95: 0,
-        jsHeap: null,
-        timers: null,
-        renderStats: [],
-        storeHz: {},
-      });
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seed(null, {
+      fps: 0,
+      frameP95: 0,
+      jsHeap: null,
+      timers: null,
+      renderStats: [],
+      storeHz: {},
+    });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('dialog', { name: 'Performance debug panel' })
+    ).toBeInTheDocument();
+    await expect(canvas.getByText('waiting for samples…')).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/debug/DevProfiler/DevProfiler.stories.tsx
+++ b/apps/web/src/components/debug/DevProfiler/DevProfiler.stories.tsx
@@ -1,10 +1,24 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import DevProfiler from './DevProfiler';
 
+/**
+ * debug · DevProfiler. A dev-only wrapper that mounts a React `<Profiler>` around
+ * its subtree to feed commit count + duration into the debug render-stats
+ * collector; in production it returns `children` directly as a zero-cost
+ * pass-through. The `<Profiler>` node is transparent in the DOM, so its children
+ * render exactly as written and expose their own roles. Stories pass arbitrary
+ * children to confirm the wrapper is see-through.
+ */
 const meta: Meta<typeof DevProfiler> = {
   title: 'debug/DevProfiler',
   component: DevProfiler,
+  parameters: {
+    // DevProfiler renders nothing of its own — only its children — so axe sees
+    // exactly the wrapped markup, which is clean.
+    a11y: { test: 'error' },
+  },
   args: {
     id: 'demo',
   },
@@ -21,6 +35,7 @@ export default meta;
 
 type Story = StoryObj<typeof DevProfiler>;
 
+/** The wrapper is transparent — its child paragraph renders through unchanged. */
 export const Default: Story = {
   args: {
     children: (
@@ -28,5 +43,11 @@ export const Default: Story = {
         Profiled subtree — render cost is recorded in dev builds.
       </p>
     ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('Profiled subtree — render cost is recorded in dev builds.')
+    ).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/downloads/DownloadQueueRow/DownloadQueueRow.stories.tsx
+++ b/apps/web/src/components/downloads/DownloadQueueRow/DownloadQueueRow.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { DownloadQueueItem, DownloadQueueStatus } from '@shiranami/contracts';
 
 import DownloadQueueRow from './DownloadQueueRow';
@@ -18,9 +19,24 @@ function makeItem(overrides: Partial<DownloadQueueItem> = {}): DownloadQueueItem
   };
 }
 
+/**
+ * downloads · DownloadQueueRow. One row in the downloads queue: a thumbnail (or
+ * a decorative music glyph fallback), the track title with its lifecycle status,
+ * a presentational status button, and — while cancellable — an X cancel button
+ * named for the track. Active/converting rows also pin a labelled determinate
+ * progress bar to the bottom edge. The status glyph and progress bar carry their
+ * own accessible names; the missing-thumbnail icon and fallback glyph are
+ * decorative. Stories drive it via the `item` arg.
+ */
 const meta: Meta<typeof DownloadQueueRow> = {
   title: 'downloads/DownloadQueueRow',
   component: DownloadQueueRow,
+  parameters: {
+    // Status button + cancel button carry aria-labels, the active progress bar
+    // is a named role="progressbar", and the fallback music glyph is a
+    // presentational icon — axe passes clean.
+    a11y: { test: 'error' },
+  },
   args: {
     onCancel: () => {},
   },
@@ -37,24 +53,56 @@ export default meta;
 
 type Story = StoryObj<typeof DownloadQueueRow>;
 
+/** Active download — title, "Downloading" status, a cancel button, and a progress bar. */
 export const Active: Story = {
   args: {
     item: makeItem({ status: 'active', progress: 42 }),
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Lofi beats to relax and study to')).toBeInTheDocument();
+    // Active rows are cancellable, so the per-track cancel button renders.
+    await expect(
+      canvas.getByRole('button', { name: 'Cancel download of Lofi beats to relax and study to' })
+    ).toBeInTheDocument();
+    // Determinate progress is exposed as a named progressbar at the row's value.
+    const bar = canvas.getByRole('progressbar', {
+      name: 'Download progress for Lofi beats to relax and study to',
+    });
+    await expect(bar).toHaveAttribute('aria-valuenow', '42');
+  },
 };
 
+/** Queued download — waiting for a slot, still cancellable, no progress bar. */
 export const Queued: Story = {
   args: {
     item: makeItem({ id: 'item-queued', status: 'queued' satisfies DownloadQueueStatus }),
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Waiting')).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Cancel download of Lofi beats to relax and study to' })
+    ).toBeInTheDocument();
+    // Queued rows show no determinate progress bar.
+    await expect(canvas.queryByRole('progressbar')).not.toBeInTheDocument();
+  },
 };
 
+/** Finished download — terminal "Downloaded" status, no cancel affordance. */
 export const Done: Story = {
   args: {
     item: makeItem({ id: 'item-done', status: 'done', progress: 100 }),
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Downloaded')).toBeInTheDocument();
+    // Terminal rows aren't cancellable, so no cancel button renders.
+    await expect(canvas.queryByRole('button', { name: /Cancel download/ })).not.toBeInTheDocument();
+  },
 };
 
+/** Failed download — the raw error is appended to the "Failed" status line. */
 export const Errored: Story = {
   args: {
     item: makeItem({
@@ -62,5 +110,10 @@ export const Errored: Story = {
       status: 'error',
       error: 'yt-dlp exited with code 1',
     }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Failed.*yt-dlp exited with code 1/)).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /Cancel download/ })).not.toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/downloads/DownloadsView/DownloadsView.stories.tsx
+++ b/apps/web/src/components/downloads/DownloadsView/DownloadsView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { DownloadQueueItem, DownloadQueueSnapshot } from '@shiranami/contracts';
 import { useDownloadQueueStore } from '@/stores/useDownloadQueueStore';
 
@@ -24,12 +25,28 @@ function seedQueue(items: DownloadQueueItem[], paused = false): void {
     activeCount: items.filter(i => i.status === 'active').length,
     paused,
   };
+  // applySnapshot also flips `hydrated` true, so the view leaves its blank
+  // loading frame and renders the real queue (or the empty state).
   useDownloadQueueStore.getState().applySnapshot(snapshot);
 }
 
+/**
+ * downloads · DownloadsView. The Downloads screen: an `<h1>` title with
+ * pause/resume, cancel-all (a confirm popover), and clear-completed actions,
+ * then the queue grouped into Active / Queued / Completed `<h2>` sections of
+ * `DownloadQueueRow`s. Reads the renderer-side `useDownloadQueueStore` mirror of
+ * the main-process queue; holds a blank loading frame until the first snapshot
+ * lands, then shows either the grouped sections or an empty state. Cancellation,
+ * pause, and clear are IPC no-ops in the browser run. Stories seed the store.
+ */
 const meta: Meta<typeof DownloadsView> = {
   title: 'downloads/DownloadsView',
   component: DownloadsView,
+  parameters: {
+    // Title is a real <h1>, sections are <h2>, every toolbar button is labelled,
+    // and queue rows expose their own names — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="flex h-[36rem] flex-col">
@@ -43,41 +60,59 @@ export default meta;
 
 type Story = StoryObj<typeof DownloadsView>;
 
+/** A populated queue across every section, with the toolbar actions live. */
 export const Default: Story = {
-  decorators: [
-    Story => {
-      seedQueue([
-        makeItem({ id: 'a', status: 'active', progress: 64, title: 'Midnight study session' }),
-        makeItem({ id: 'q1', status: 'queued', title: 'Rainy day cafe' }),
-        makeItem({ id: 'q2', status: 'queued', title: 'Slow morning coffee' }),
-        makeItem({ id: 'd', status: 'done', progress: 100, title: 'Warm evening lights' }),
-        makeItem({ id: 'e', status: 'error', title: 'Broken stream', error: 'Network timeout' }),
-      ]);
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedQueue([
+      makeItem({ id: 'a', status: 'active', progress: 64, title: 'Midnight study session' }),
+      makeItem({ id: 'q1', status: 'queued', title: 'Rainy day cafe' }),
+      makeItem({ id: 'q2', status: 'queued', title: 'Slow morning coffee' }),
+      makeItem({ id: 'd', status: 'done', progress: 100, title: 'Warm evening lights' }),
+      makeItem({ id: 'e', status: 'error', title: 'Broken stream', error: 'Network timeout' }),
+    ]);
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { level: 1, name: 'Downloads' })).toBeInTheDocument();
+    // Grouped section headings carry their counts.
+    await expect(canvas.getByRole('heading', { name: /Active · 1/ })).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: /Queued · 2/ })).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: /Completed · 2/ })).toBeInTheDocument();
+    // With pending work the pause/cancel-all actions are enabled.
+    await expect(canvas.getByRole('button', { name: 'Pause the download queue' })).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: 'Cancel all downloads' })).toBeEnabled();
+  },
 };
 
+/** A paused queue — the banner shows and the toolbar offers Resume. */
 export const Paused: Story = {
-  decorators: [
-    Story => {
-      seedQueue(
-        [
-          makeItem({ id: 'a', status: 'active', progress: 12, title: 'Lo-fi hip hop radio' }),
-          makeItem({ id: 'q', status: 'queued', title: 'Chillhop essentials' }),
-        ],
-        true
-      );
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedQueue(
+      [
+        makeItem({ id: 'a', status: 'active', progress: 12, title: 'Lo-fi hip hop radio' }),
+        makeItem({ id: 'q', status: 'queued', title: 'Chillhop essentials' }),
+      ],
+      true
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Queue paused/)).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Resume the download queue' })
+    ).toBeInTheDocument();
+  },
 };
 
+/** Hydrated with no items — the empty state replaces the queue. */
 export const Empty: Story = {
-  decorators: [
-    Story => {
-      seedQueue([]);
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedQueue([]);
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No downloads yet')).toBeInTheDocument();
+    // No queue chrome renders in the empty state.
+    await expect(canvas.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/radio/FilterPopover/FilterPopover.stories.tsx
+++ b/apps/web/src/components/radio/FilterPopover/FilterPopover.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Globe } from 'lucide-react';
+import { screen, within, userEvent, expect, waitFor } from 'storybook/test';
 import type { IFilterOption } from './FilterPopover.types';
 
 import FilterPopover from './FilterPopover';
@@ -11,9 +12,22 @@ const countries: IFilterOption[] = [
   { value: 'PL', label: 'Poland', prefix: '🇵🇱', count: 312 },
 ];
 
+/**
+ * radio · FilterPopover. A compact filter trigger that opens a searchable
+ * command list of options (flag prefix · label · count). The trigger button is
+ * named by its `label` and shows the selected option (or the placeholder);
+ * picking an option calls `onSelect` and closes the popover, and re-picking the
+ * active option clears it. The list portals out of the trigger, so stories query
+ * it via `screen`. The trigger is disabled when `disabled` is set.
+ */
 const meta: Meta<typeof FilterPopover> = {
   title: 'radio/FilterPopover',
   component: FilterPopover,
+  parameters: {
+    // The trigger button carries an aria-label, the search input has its
+    // placeholder, and the options expose option roles — axe passes clean.
+    a11y: { test: 'error' },
+  },
   args: {
     label: 'Country',
     placeholder: 'All countries',
@@ -37,17 +51,46 @@ export default meta;
 
 type Story = StoryObj<typeof FilterPopover>;
 
-export const Default: Story = {};
+/** Unselected — opening the popover reveals the searchable option list. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The trigger is named by its label and shows the placeholder when empty.
+    const trigger = canvas.getByRole('button', { name: 'Country' });
+    await expect(trigger).toHaveTextContent('All countries');
 
+    // The list portals out of the canvas, so query the opened options via screen.
+    await userEvent.click(trigger);
+    await expect(await screen.findByText('United States')).toBeInTheDocument();
+    await expect(screen.getByText('Japan')).toBeInTheDocument();
+
+    // Picking an option closes the popover, unmounting the option list.
+    await userEvent.click(screen.getByText('United States'));
+    await waitFor(() => expect(screen.queryByText('Japan')).not.toBeInTheDocument());
+  },
+};
+
+/** Selected — the trigger shows the chosen option's flag + label. */
 export const Selected: Story = {
   args: {
     value: 'GB',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Country' })).toHaveTextContent(
+      'United Kingdom'
+    );
+  },
 };
 
+/** Disabled — the trigger can't be opened (e.g. before options have loaded). */
 export const Disabled: Story = {
   args: {
     options: [],
     disabled: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Country' })).toBeDisabled();
   },
 };

--- a/apps/web/src/components/radio/RadioView/RadioView.stories.tsx
+++ b/apps/web/src/components/radio/RadioView/RadioView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { Station } from 'radio-browser-api';
 import { useRadioStore } from '@/stores/useRadioStore';
 
@@ -55,9 +56,25 @@ function seedRadio(state: Partial<Parameters<typeof useRadioStore.setState>[0]>)
   });
 }
 
+/**
+ * radio · RadioView. The Radio screen: a "Radio" page header, a labelled search
+ * box, browse/favorites mode tabs, country/language/tag `FilterPopover`s, genre
+ * pills, active-filter chips, and a virtualized list of `StationRow`s — with
+ * loading skeletons, an empty state, and an error+retry card. Reads
+ * `useRadioStore`; on mount it kicks off a top-stations fetch, so the result
+ * region is non-deterministic under the headless browser run — `play` asserts
+ * the stable page chrome (header + search), while the seeded states drive the
+ * visual variants for docs.
+ */
 const meta: Meta<typeof RadioView> = {
   title: 'radio/RadioView',
   component: RadioView,
+  parameters: {
+    // The page title is a real <h1>, the search input is aria-labelled, mode
+    // tabs / pills are real buttons, and the mascot art is aria-hidden — the
+    // persistent chrome axe sees is clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="flex h-[40rem] flex-col">
@@ -71,38 +88,49 @@ export default meta;
 
 type Story = StoryObj<typeof RadioView>;
 
+/** Seeded with stations — the page chrome (header + search) renders. */
 export const Default: Story = {
-  decorators: [
-    Story => {
-      seedRadio({ stations });
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedRadio({ stations });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Radio' })).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('textbox', { name: 'Search radio stations...' })
+    ).toBeInTheDocument();
+  },
 };
 
+/** Loading — skeleton rows fill the result region while a fetch is in flight. */
 export const Loading: Story = {
-  decorators: [
-    Story => {
-      seedRadio({ isLoading: true });
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedRadio({ isLoading: true });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Radio' })).toBeInTheDocument();
+  },
 };
 
+/** Empty — no stations and no active filters fall back to the empty state. */
 export const Empty: Story = {
-  decorators: [
-    Story => {
-      seedRadio({ stations: [] });
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedRadio({ stations: [] });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Radio' })).toBeInTheDocument();
+  },
 };
 
+/** Error — the directory failed to load, offering a retry. */
 export const Error: Story = {
-  decorators: [
-    Story => {
-      seedRadio({ error: 'Could not reach the radio directory.' });
-      return <Story />;
-    },
-  ],
+  beforeEach: () => {
+    seedRadio({ error: 'Could not reach the radio directory.' });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Radio' })).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/radio/StationRow/StationRow.stories.tsx
+++ b/apps/web/src/components/radio/StationRow/StationRow.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { Station } from 'radio-browser-api';
 
 import StationRow from './StationRow';
@@ -35,9 +36,24 @@ function makeStation(overrides: Partial<Station> = {}): Station {
 
 const station = makeStation();
 
+/**
+ * radio · StationRow. One virtualized row in the radio directory: a favicon (or
+ * decorative radio glyph), the station name + its first two tags, an optional
+ * country flag + codec badge, a labelled favorite toggle ("Add to favorites" /
+ * "Remove from favorites"), and a play affordance that becomes an animated EQ
+ * indicator with an sr-only "Now Playing" while active. Resolves its station
+ * from `stations[index]` and renders null past the end. Stories pass a one-item
+ * list and toggle the favorite / playing flags via args.
+ */
 const meta: Meta<typeof StationRow> = {
   title: 'radio/StationRow',
   component: StationRow,
+  parameters: {
+    // The favorite button is aria-labelled, the active-state EQ carries an
+    // sr-only "Now Playing" name, and the radio fallback glyph is presentational
+    // — axe passes clean.
+    a11y: { test: 'error' },
+  },
   args: {
     index: 0,
     style: { position: 'relative', height: 56 },
@@ -61,17 +77,35 @@ export default meta;
 
 type Story = StoryObj<typeof StationRow>;
 
-export const Default: Story = {};
+/** Idle row — station name, tags, and an unfilled "Add to favorites" toggle. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Lofi Radio')).toBeInTheDocument();
+    await expect(canvas.getByText('lofi, chillout')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Add to favorites' })).toBeInTheDocument();
+  },
+};
 
+/** Favorited row — the toggle reads as the "remove" action. */
 export const Favorited: Story = {
   args: {
     favorites: [station.id],
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Remove from favorites' })).toBeInTheDocument();
+  },
 };
 
+/** Active + playing — the EQ indicator exposes its sr-only "Now Playing" name. */
 export const Playing: Story = {
   args: {
     currentTrackId: `radio:${station.id}`,
     isPlaying: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Now Playing')).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/splash/SplashDroplets/SplashDroplets.stories.tsx
+++ b/apps/web/src/components/splash/SplashDroplets/SplashDroplets.stories.tsx
@@ -1,10 +1,23 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import SplashDroplets from './SplashDroplets';
 
+/**
+ * splash · SplashDroplets. A purely decorative glass layer: ~34 static SVG
+ * droplet ellipses clinging to the pane plus 5 thin running-water streaks
+ * (motion-only, hidden under reduced-motion / low-perf). The whole layer lives
+ * inside an `aria-hidden` container and exposes no roles or text, so it carries
+ * no accessible information. Stories render it over a dark splash backdrop.
+ */
 const meta: Meta<typeof SplashDroplets> = {
   title: 'splash/SplashDroplets',
   component: SplashDroplets,
+  parameters: {
+    // The layer is wrapped in aria-hidden and is pure SVG/CSS decoration — it
+    // exposes no roles, names, or text, so axe finds nothing to flag.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="relative h-[36rem] w-full overflow-hidden bg-background">
@@ -18,4 +31,14 @@ export default meta;
 
 type Story = StoryObj<typeof SplashDroplets>;
 
-export const Default: Story = {};
+/** Renders the full set of static droplets + streaks, all decorative. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The decoration renders its full droplet/streak set...
+    await expect(canvasElement.querySelectorAll('ellipse')).toHaveLength(34);
+    await expect(canvasElement.querySelectorAll('.splash-streak')).toHaveLength(5);
+    // ...but leaks no role/image into the a11y tree (the layer is aria-hidden).
+    await expect(canvas.queryByRole('img')).not.toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/splash/SplashGlass/SplashGlass.stories.tsx
+++ b/apps/web/src/components/splash/SplashGlass/SplashGlass.stories.tsx
@@ -1,10 +1,23 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import SplashGlass from './SplashGlass';
 
+/**
+ * splash · SplashGlass. The decorative wet-pane layer between the viewer and the
+ * night scene: a condensation-film haze + edge vignette (carrying the
+ * `.splash-glass-blur` class, dropped under low-perf) and a single faint texture
+ * mullion. All derived from `--foreground`, wrapped in an `aria-hidden`
+ * container, so it adds glass texture without exposing any roles or text.
+ */
 const meta: Meta<typeof SplashGlass> = {
   title: 'splash/SplashGlass',
   component: SplashGlass,
+  parameters: {
+    // Pure aria-hidden CSS decoration — no roles, names, or text reach the a11y
+    // tree, so axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="relative h-[36rem] w-full overflow-hidden bg-background">
@@ -18,4 +31,16 @@ export default meta;
 
 type Story = StoryObj<typeof SplashGlass>;
 
-export const Default: Story = {};
+/** The aria-hidden glass texture renders its blur layer and stays role-free. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The decorative root is hidden from assistive tech...
+    const root = canvasElement.querySelector('[aria-hidden="true"]');
+    await expect(root).not.toBeNull();
+    // ...and the blur film layer is present.
+    await expect(canvasElement.querySelector('.splash-glass-blur')).not.toBeNull();
+    // No interactive role or image leaks out of the decoration.
+    await expect(canvas.queryByRole('img')).not.toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/splash/SplashScene/SplashScene.stories.tsx
+++ b/apps/web/src/components/splash/SplashScene/SplashScene.stories.tsx
@@ -1,10 +1,24 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import SplashScene from './SplashScene';
 
+/**
+ * splash · SplashScene. The decorative night-scene base behind the wet glass: a
+ * violet sky-glow gradient, an SVG skyline silhouette, a warm moon, and ~15
+ * distant window lights that flicker. The `reducedMotion` prop (and the global
+ * reduced-motion / low-perf guards) freezes the lights at their base opacity by
+ * dropping the inline animation. The whole layer is wrapped in `aria-hidden`, so
+ * it exposes no roles or text.
+ */
 const meta: Meta<typeof SplashScene> = {
   title: 'splash/SplashScene',
   component: SplashScene,
+  parameters: {
+    // Decorative aria-hidden art (gradients + SVG skyline + light dots) with no
+    // roles, names, or text — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="relative h-[36rem] w-full overflow-hidden bg-background">
@@ -18,14 +32,29 @@ export default meta;
 
 type Story = StoryObj<typeof SplashScene>;
 
+/** Animated — the full set of flickering window lights renders. */
 export const Default: Story = {
   args: {
     reducedMotion: false,
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvasElement.querySelectorAll('.splash-light')).toHaveLength(15);
+    // The night scene is decorative and leaks no role into the a11y tree.
+    await expect(canvas.queryByRole('img')).not.toBeInTheDocument();
+  },
 };
 
+/** Reduced motion — the lights render but their flicker animation is dropped. */
 export const ReducedMotion: Story = {
   args: {
     reducedMotion: true,
+  },
+  play: async ({ canvasElement }) => {
+    const lights = canvasElement.querySelectorAll<HTMLElement>('.splash-light');
+    await expect(lights).toHaveLength(15);
+    // None of the dots carry an inline flicker animation under reduced motion.
+    const animated = Array.from(lights).filter(light => light.style.animation !== '');
+    await expect(animated).toHaveLength(0);
   },
 };

--- a/apps/web/src/components/splash/SplashScreen/SplashScreen.stories.tsx
+++ b/apps/web/src/components/splash/SplashScreen/SplashScreen.stories.tsx
@@ -64,10 +64,13 @@ export const Error: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByText('Could not read your music library.')).toBeInTheDocument();
-    // The status block fades in on a timer, so query the retry by its text and
-    // confirm it's a real button rather than relying on its (initially hidden) role.
-    const retry = canvas.getByText('Try again');
-    await expect(retry.closest('button')).not.toBeNull();
+    await expect(await canvas.findByText('Could not read your music library.')).toBeInTheDocument();
+    // The error + retry block is mounted but aria-hidden behind a 600ms spinner
+    // delay, then fades in. Await the retry BY ROLE so the assertion reflects the
+    // shown, accessible state (the button entering the a11y tree) rather than a
+    // structural check against a still-hidden element.
+    await expect(
+      await canvas.findByRole('button', { name: 'Try again' }, { timeout: 2000 })
+    ).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/splash/SplashScreen/SplashScreen.stories.tsx
+++ b/apps/web/src/components/splash/SplashScreen/SplashScreen.stories.tsx
@@ -1,13 +1,29 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, expect } from 'storybook/test';
 
 import SplashScreen from './SplashScreen';
 
 const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
+/**
+ * splash · SplashScreen. The composed boot splash — "Cafe Window / Rain on Glass
+ * at night". Stacks every decorative layer (night scene, lamp, wordmark
+ * reflection, droplets, rAF rain, glass, steam, cup) behind the meta corner and
+ * the bottom-left brand block. The brand block carries the only accessible
+ * content: the "Shiranami" `<h1>` wordmark and a `role="status"` region that
+ * holds either the rotating loader message or, in the error variant, the error
+ * text plus a "Try again" retry. Renders nothing once dismissed. In the browser
+ * run `IS_ELECTRON` is false, so the drag region and rounded-top chrome are off.
+ */
 const meta: Meta<typeof SplashScreen> = {
   title: 'splash/SplashScreen',
   component: SplashScreen,
+  // a11y is left at the global 'todo' default (not ratcheted to 'error'): the
+  // brand block's wordmark + status region fade in on a timer, so at axe-time
+  // their opacity is mid-transition and color-contrast is non-deterministic.
+  // The decorative sub-layers (SplashScene/Droplets/Glass) are ratcheted to
+  // 'error' in their own stories; their accessible content is asserted in `play`.
   parameters: { layout: 'fullscreen' },
   decorators: [
     Story => (
@@ -22,17 +38,34 @@ export default meta;
 
 type Story = StoryObj<typeof SplashScreen>;
 
+/** Loading — the brand wordmark + live status region mount over the scene. */
 export const Loading: Story = {
   args: {
     isLoading: true,
     isError: false,
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The wordmark renders "Shira" + an <em>nami</em>, so match the leading text.
+    await expect(canvas.getByText('Shira')).toBeInTheDocument();
+    // The brand block exposes its polite status region while loading.
+    await expect(canvas.getByRole('status')).toBeInTheDocument();
+  },
 };
 
+/** Error — the failure message and a retry control replace the loader. */
 export const Error: Story = {
   args: {
     isLoading: false,
     isError: true,
     error: 'Could not read your music library.',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Could not read your music library.')).toBeInTheDocument();
+    // The status block fades in on a timer, so query the retry by its text and
+    // confirm it's a real button rather than relying on its (initially hidden) role.
+    const retry = canvas.getByText('Try again');
+    await expect(retry.closest('button')).not.toBeNull();
   },
 };

--- a/apps/web/src/components/splash/SplashScreen/SplashScreen.stories.tsx
+++ b/apps/web/src/components/splash/SplashScreen/SplashScreen.stories.tsx
@@ -46,10 +46,12 @@ export const Loading: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    // The wordmark + polite status region are always mounted (they sit outside
+    // the timer-gated loader block), but use async queries so the assertions are
+    // resilient regardless of mount/animation timing.
     // The wordmark renders "Shira" + an <em>nami</em>, so match the leading text.
-    await expect(canvas.getByText('Shira')).toBeInTheDocument();
-    // The brand block exposes its polite status region while loading.
-    await expect(canvas.getByRole('status')).toBeInTheDocument();
+    await expect(await canvas.findByText('Shira')).toBeInTheDocument();
+    await expect(await canvas.findByRole('status')).toBeInTheDocument();
   },
 };
 


### PR DESCRIPTION
## Summary
- Strengthens the render-only Storybook stories for four features — **downloads**, **debug**, **radio**, **splash** (11 component story files) — into real-browser tests: render smoke + `play` interaction/assertion + axe a11y + autodocs JSDoc. Continues the batched waves after #291 (onboarding) and #296 (favorites/now-playing/mixes/smart-playlists).
- Highlights: downloads asserts the named `role="progressbar"` + cancel affordances; radio's `FilterPopover` drives a real `userEvent` open→select→close on the portalled list; splash's decorative layers (Droplets/Glass/Scene) assert element counts with zero a11y-role leakage.
- **a11y ratcheted to `error`** on 9 of 11 components. Two intentional `todo` deferrals, each documented inline: **DebugOverlay** (dev-only HUD with deliberate low-opacity text that trips axe contrast; never ships to users) and **SplashScreen** (brand wordmark + status region fade in on a timer, so contrast is non-deterministic at axe-time). No component or shared `ui/` changes were needed.

## Test plan
- [ ] `pnpm --filter @shiranami/web test:storybook` → 273 passing
- [ ] CI **Storybook Tests** job green
- [ ] Storybook autodocs render for downloads / debug / radio / splash

> Note: `RadioView` kicks off a real top-stations fetch on mount (not IPC-gated), so its result region is non-deterministic under headless Chromium — `play` asserts only the stable page chrome (header + search). A future pass could stub `radioApi.searchStations` for deterministic result-state stories.