### PR TITLE
test(web): strengthen wave 4 feature stories (lyrics, search, playlist-import)

### DIFF
--- a/apps/web/src/components/lyrics/LyricsBody/LyricsBody.stories.tsx
+++ b/apps/web/src/components/lyrics/LyricsBody/LyricsBody.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { LyricLine } from '@/hooks/queries/useLyrics';
 
 import LyricsBody from './LyricsBody';
@@ -26,9 +27,23 @@ const baseArgs = {
   plainTextClassName: 'text-foreground whitespace-pre-wrap font-sans font-medium',
 };
 
+/**
+ * lyrics · LyricsBody. The shared 4-branch lyrics render (loading → synced →
+ * plain → empty) behind NowPlayingView and LyricsPanel, parameterized by each
+ * surface's size-class maps, spacing, and container classes. Synced lyrics
+ * render as a list of seekable line buttons; plain lyrics as a `<pre>`; the
+ * loading and empty branches show a labelled spinner / music glyph. Stories
+ * drive each branch via args.
+ */
 const meta: Meta<typeof LyricsBody> = {
   title: 'lyrics/LyricsBody',
   component: LyricsBody,
+  parameters: {
+    // Synced lines are real <button>s named by their text, the loading spinner
+    // and empty-state glyph are aria-hidden, and the plain branch is plain
+    // text — axe passes clean.
+    a11y: { test: 'error' },
+  },
   args: {
     ...baseArgs,
     synced: SYNCED,
@@ -47,26 +62,51 @@ export default meta;
 
 type Story = StoryObj<typeof LyricsBody>;
 
-export const Synced: Story = {};
+/** Synced lyrics — one seekable line button per timed line. */
+export const Synced: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('button', { name: 'Warm light on the windowsill' })
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Before the day begins' })).toBeInTheDocument();
+  },
+};
 
+/** Plain (untimed) lyrics — the raw text block, no per-line buttons. */
 export const Plain: Story = {
   args: {
     synced: null,
     plain: 'Line one of the plain lyrics\nLine two\nLine three',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Line one of the plain lyrics/)).toBeInTheDocument();
+    await expect(canvas.queryByRole('button')).not.toBeInTheDocument();
+  },
 };
 
+/** Loading — the centered spinner with its localized "finding" label. */
 export const Loading: Story = {
   args: {
     synced: null,
     plain: null,
     isLoading: true,
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Finding lyrics...')).toBeInTheDocument();
+  },
 };
 
+/** Empty — the fallback music glyph + "no lyrics" label. */
 export const Empty: Story = {
   args: {
     synced: null,
     plain: null,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No lyrics found')).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/lyrics/LyricsList/LyricsList.stories.tsx
+++ b/apps/web/src/components/lyrics/LyricsList/LyricsList.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, fn } from 'storybook/test';
 import type { LyricLine } from '@/hooks/queries/useLyrics';
 
 import LyricsList from './LyricsList';
@@ -18,13 +19,24 @@ const SIZED_CLASSES = {
   idleClassName: 'text-foreground/30',
 };
 
+/**
+ * lyrics · LyricsList. The scrollable synced-lyrics column: one seekable
+ * `<button>` per line (named by its text), styled past / active / idle off
+ * `activeIndex`, with the active line scrolled into view. Clicking a line calls
+ * `onLineClick` with that line's timestamp. Stories render a short line list and
+ * drive a click.
+ */
 const meta: Meta<typeof LyricsList> = {
   title: 'lyrics/LyricsList',
   component: LyricsList,
+  parameters: {
+    // Each line is a real <button> named by its lyric text — axe passes clean.
+    a11y: { test: 'error' },
+  },
   args: {
     lines: LINES,
     activeIndex: 2,
-    onLineClick: () => {},
+    onLineClick: fn(),
     spacingClassName: 'space-y-4',
     ...SIZED_CLASSES,
   },
@@ -41,4 +53,15 @@ export default meta;
 
 type Story = StoryObj<typeof LyricsList>;
 
-export const Default: Story = {};
+/** Default — clicking a line seeks to its timestamp. */
+export const Default: Story = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('button', { name: 'Coffee going cold again' })
+    ).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'A quiet morning hum' }));
+    await expect(args.onLineClick).toHaveBeenCalledWith(4);
+  },
+};

--- a/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.stories.tsx
+++ b/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { lyricsKeys, type LyricLine } from '@/hooks/queries/useLyrics';
 
 import LyricsPanel from './LyricsPanel';
 
@@ -17,14 +20,38 @@ function makeTrack(overrides: Partial<Track> = {}): Track {
   };
 }
 
-/** Seed the playback store so the panel has a current track to render for. */
-function seedTrack(track: Track | null): void {
-  usePlaybackStore.setState({ currentTrack: track });
+const SYNCED: LyricLine[] = [
+  { time: 0, text: 'Soft rain against the glass' },
+  { time: 5, text: 'A candle burning low' },
+  { time: 10, text: 'The night is slowing down' },
+];
+
+/**
+ * Pre-seed a client with the current track's lyrics so the panel renders its
+ * synced lines without IPC (and the query never resolves to `undefined`).
+ * Mirrors how SmartPlaylistsView seeds its query client.
+ */
+function seededClient(synced: LyricLine[] | null, plain: string | null): QueryClient {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  client.setQueryData(lyricsKeys.track('track-1'), { synced, plain, source: 'test' });
+  return client;
 }
 
+/**
+ * lyrics · LyricsPanel. The now-playing side panel: an uppercase "Lyrics"
+ * header (with an optional header action) over the shared `LyricsBody`. Reads
+ * the current track from `usePlaybackStore` and the lyrics from React Query —
+ * renders nothing when no track is playing. Stories seed a playing track plus a
+ * pre-filled query client so the panel renders deterministically without IPC.
+ */
 const meta: Meta<typeof LyricsPanel> = {
   title: 'lyrics/LyricsPanel',
   component: LyricsPanel,
+  parameters: {
+    // The panel title is a real <h2> and synced lines are labelled <button>s —
+    // axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="flex h-[32rem] w-[22rem] flex-col">
@@ -32,21 +59,34 @@ const meta: Meta<typeof LyricsPanel> = {
       </div>
     ),
   ],
+  beforeEach: () => {
+    usePlaybackStore.setState({ currentTrack: makeTrack() });
+  },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof LyricsPanel>;
 
+/** Default — the "Lyrics" header over the seeded synced lines. */
 export const Default: Story = {
   decorators: [
-    Story => {
-      seedTrack(makeTrack());
-      return <Story />;
-    },
+    Story => (
+      <QueryClientProvider client={seededClient(SYNCED, null)}>
+        <Story />
+      </QueryClientProvider>
+    ),
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Lyrics' })).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Soft rain against the glass' })
+    ).toBeInTheDocument();
+  },
 };
 
+/** With a header action — the optional control rendered at the header's edge. */
 export const WithHeaderAction: Story = {
   args: {
     headerAction: (
@@ -56,9 +96,15 @@ export const WithHeaderAction: Story = {
     ),
   },
   decorators: [
-    Story => {
-      seedTrack(makeTrack());
-      return <Story />;
-    },
+    Story => (
+      <QueryClientProvider client={seededClient(SYNCED, null)}>
+        <Story />
+      </QueryClientProvider>
+    ),
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Lyrics' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Flip' })).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/playlist-import/ImportBulkActionBar/ImportBulkActionBar.stories.tsx
+++ b/apps/web/src/components/playlist-import/ImportBulkActionBar/ImportBulkActionBar.stories.tsx
@@ -79,11 +79,13 @@ export const AllSelected: Story = {
   decorators: [withSelection(['a', 'b', 'c'])],
   play: async () => {
     await screen.findByRole('toolbar', { name: 'Bulk actions' });
-    // Two buttons share this label (the toggle + the trailing clear button);
-    // finding at least one confirms the all-selected relabel.
-    await expect(screen.getAllByRole('button', { name: 'Clear Selection' }).length).toBeGreaterThan(
-      0
-    );
+    // With everything selected the select-all toggle relabels from "Select All"
+    // to "Clear Selection" — so it now matches the trailing clear button, and
+    // exactly two controls carry that name (1 → 2). Asserting both the absence of
+    // "Select All" and the count of 2 pins the relabel down: the trailing clear
+    // button alone (always present) can't satisfy either check.
+    await expect(screen.queryByRole('button', { name: 'Select All' })).not.toBeInTheDocument();
+    await expect(screen.getAllByRole('button', { name: 'Clear Selection' })).toHaveLength(2);
   },
 };
 

--- a/apps/web/src/components/playlist-import/ImportBulkActionBar/ImportBulkActionBar.stories.tsx
+++ b/apps/web/src/components/playlist-import/ImportBulkActionBar/ImportBulkActionBar.stories.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { screen, userEvent, expect, fn } from 'storybook/test';
 import type { SearchResult } from '@shiranami/contracts';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 import type { PlaylistTrack } from '@/stores/usePlaylistImportStore';
@@ -32,14 +33,27 @@ function withSelection(ids: string[]) {
   };
 }
 
+/**
+ * playlist-import · ImportBulkActionBar. The floating multi-select dock for the
+ * import view: a selected-count label, a select-all / clear toggle, and
+ * download + remove actions (both hidden while an import is running). Reads the
+ * shared `useSelectionStore` and renders nothing with an empty selection. It
+ * portals to `document.body` as a labelled `role="toolbar"`, so stories query it
+ * via `screen`. Stories seed a selection and drive the actions.
+ */
 const meta: Meta<typeof ImportBulkActionBar> = {
   title: 'playlist-import/ImportBulkActionBar',
   component: ImportBulkActionBar,
+  parameters: {
+    // The dock is a labelled role="toolbar" and every action button carries an
+    // aria-label (icons are decorative) — axe passes clean.
+    a11y: { test: 'error' },
+  },
   args: {
     tracks: TRACKS,
     isImporting: false,
-    onDownloadSelected: () => {},
-    onRemoveSelected: () => {},
+    onDownloadSelected: fn(),
+    onRemoveSelected: fn(),
   },
 };
 
@@ -47,15 +61,39 @@ export default meta;
 
 type Story = StoryObj<typeof ImportBulkActionBar>;
 
+/** Two of three selected — download + remove actions; download fires its callback. */
 export const Default: Story = {
   decorators: [withSelection(['a', 'b'])],
+  play: async ({ args }) => {
+    const toolbar = await screen.findByRole('toolbar', { name: 'Bulk actions' });
+    await expect(toolbar).toHaveTextContent('2 selected');
+    await expect(screen.getByRole('button', { name: 'Select All' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /^Download/ }));
+    await expect(args.onDownloadSelected).toHaveBeenCalled();
+  },
 };
 
+/** All selected — the toggle reads as "Clear Selection". */
 export const AllSelected: Story = {
   decorators: [withSelection(['a', 'b', 'c'])],
+  play: async () => {
+    await screen.findByRole('toolbar', { name: 'Bulk actions' });
+    // Two buttons share this label (the toggle + the trailing clear button);
+    // finding at least one confirms the all-selected relabel.
+    await expect(screen.getAllByRole('button', { name: 'Clear Selection' }).length).toBeGreaterThan(
+      0
+    );
+  },
 };
 
+/** Importing — download + remove are suppressed; only the toggle + clear remain. */
 export const Importing: Story = {
   args: { isImporting: true },
   decorators: [withSelection(['a', 'b'])],
+  play: async () => {
+    await screen.findByRole('toolbar', { name: 'Bulk actions' });
+    await expect(screen.queryByRole('button', { name: /^Download/ })).not.toBeInTheDocument();
+    await expect(screen.queryByRole('button', { name: 'Remove selected' })).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/playlist-import/PlaylistImportView/PlaylistImportView.stories.tsx
+++ b/apps/web/src/components/playlist-import/PlaylistImportView/PlaylistImportView.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { SearchResult } from '@shiranami/contracts';
 import { usePlaylistImportStore } from '@/stores/usePlaylistImportStore';
+import { useSelectionStore } from '@/stores/useSelectionStore';
 
 import PlaylistImportView from './PlaylistImportView';
 
@@ -23,9 +25,22 @@ function seedTracks(results: SearchResult[], sourceTitle: string | null = null):
   usePlaylistImportStore.getState().setTracks(results, sourceTitle);
 }
 
+/**
+ * playlist-import · PlaylistImportView. The playlist-import surface: a page
+ * header, a URL field + Extract control, extraction progress / error states,
+ * a download / cancel / reset action row once tracks resolve, and either the
+ * empty state or a virtualized list of `PlaylistRow`s. Reads the
+ * `usePlaylistImportStore` (tracks, extraction state) and `useSelectionStore`;
+ * stories seed the store so the view renders deterministically without IPC.
+ */
 const meta: Meta<typeof PlaylistImportView> = {
   title: 'playlist-import/PlaylistImportView',
   component: PlaylistImportView,
+  parameters: {
+    // The page title is a real <h1>, the URL field is a labelled textbox, and
+    // controls are labelled buttons — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="flex h-[40rem] flex-col">
@@ -33,12 +48,17 @@ const meta: Meta<typeof PlaylistImportView> = {
       </div>
     ),
   ],
+  // The view + its rows read the shared selection store; start unselected.
+  beforeEach: () => {
+    useSelectionStore.getState().clearSelection();
+  },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof PlaylistImportView>;
 
+/** Empty — the header, URL field, and the "import a playlist" empty state. */
 export const Empty: Story = {
   decorators: [
     Story => {
@@ -46,8 +66,17 @@ export const Empty: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Import playlist' })).toBeInTheDocument();
+    await expect(
+      canvas.getByPlaceholderText(/Paste a YouTube or Spotify playlist URL/)
+    ).toBeInTheDocument();
+    await expect(canvas.getByText('Import a playlist')).toBeInTheDocument();
+  },
 };
 
+/** With results — the resolved track list plus the download-all action row. */
 export const WithResults: Story = {
   decorators: [
     Story => {
@@ -62,4 +91,9 @@ export const WithResults: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Midnight study session')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: /Download All/ })).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/playlist-import/PlaylistRow/PlaylistRow.stories.tsx
+++ b/apps/web/src/components/playlist-import/PlaylistRow/PlaylistRow.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { SearchResult } from '@shiranami/contracts';
+import { useSelectionStore } from '@/stores/useSelectionStore';
 import type { PlaylistTrack } from '@/stores/usePlaylistImportStore';
 
 import PlaylistRow from './PlaylistRow';
@@ -29,9 +31,23 @@ function makeTrack(overrides: Partial<PlaylistTrack> = {}): PlaylistTrack {
   };
 }
 
+/**
+ * playlist-import · PlaylistRow. One virtualized row in the import track list:
+ * an index, a selectable thumbnail (preview overlay or a check when selected),
+ * the title + uploader with an optional low-confidence badge and a status badge,
+ * the duration, the shared download/retry button, and a hover-revealed remove
+ * button (pending rows only). Reads selection from `useSelectionStore`. Resolves
+ * its track from `tracks[index]` and renders null past the end. Stories pass a
+ * one-item list and vary the track status.
+ */
 const meta: Meta<typeof PlaylistRow> = {
   title: 'playlist-import/PlaylistRow',
   component: PlaylistRow,
+  parameters: {
+    // The download/retry and remove buttons are aria-labelled and all glyphs
+    // are decorative — axe passes clean.
+    a11y: { test: 'error' },
+  },
   args: {
     index: 0,
     style: { position: 'relative', height: 52 },
@@ -49,32 +65,64 @@ const meta: Meta<typeof PlaylistRow> = {
       </div>
     ),
   ],
+  // Rows read the shared selection store; start each story unselected so the
+  // thumbnail/affordances are deterministic regardless of story order.
+  beforeEach: () => {
+    useSelectionStore.getState().clearSelection();
+  },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof PlaylistRow>;
 
+/** Pending — the title, the "Waiting" download button, and a remove affordance. */
 export const Default: Story = {
   args: {
     tracks: [makeTrack()],
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Lofi beats to relax and study to')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Waiting' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Remove from list' })).toBeInTheDocument();
+  },
 };
 
+/** Downloading — the active progress bar; the remove affordance is gone. */
 export const Downloading: Story = {
   args: {
     tracks: [makeTrack({ status: 'downloading', progress: 42 })],
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Downloading')).toBeInTheDocument();
+    await expect(canvas.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '42');
+    await expect(
+      canvas.queryByRole('button', { name: 'Remove from list' })
+    ).not.toBeInTheDocument();
+  },
 };
 
+/** Failed — the error status badge and a labelled retry button. */
 export const Failed: Story = {
   args: {
     tracks: [makeTrack({ status: 'error', error: 'yt-dlp exited with code 1' })],
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/yt-dlp exited with code 1/)).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Retry download' })).toBeInTheDocument();
+  },
 };
 
+/** Low confidence — the uncertain-match badge on the meta line. */
 export const LowConfidence: Story = {
   args: {
     tracks: [makeTrack({ searchResult: makeResult({ matchFlag: 'low' }) })],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Uncertain match')).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/search/DependencyInstallCard/DependencyInstallCard.stories.tsx
+++ b/apps/web/src/components/search/DependencyInstallCard/DependencyInstallCard.stories.tsx
@@ -1,10 +1,25 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, fn } from 'storybook/test';
 
 import DependencyInstallCard from './DependencyInstallCard';
 
+/**
+ * search · DependencyInstallCard. The "tools missing" state card shown by
+ * SearchView when yt-dlp (and optionally ffmpeg) need installing. Renders inside
+ * the shared status card and switches between an install button (with an inline
+ * error), a determinate download progress block, and a success confirmation —
+ * driven entirely by `installStatus` / `isInstallInProgress`. Stories cover each
+ * branch via args.
+ */
 const meta: Meta<typeof DependencyInstallCard> = {
   title: 'search/DependencyInstallCard',
   component: DependencyInstallCard,
+  parameters: {
+    // The install button is a real labelled <button>, the progress bar carries
+    // its role, and the status-card mascot is decorative (alt="") — axe passes
+    // clean.
+    a11y: { test: 'error' },
+  },
   args: {
     ffmpegInstalled: false,
     installStatus: 'idle',
@@ -12,7 +27,7 @@ const meta: Meta<typeof DependencyInstallCard> = {
     isInstallInProgress: false,
     installProgress: 0,
     installLabel: '',
-    onInstall: () => {},
+    onInstall: fn(),
   },
   decorators: [
     Story => (
@@ -27,8 +42,19 @@ export default meta;
 
 type Story = StoryObj<typeof DependencyInstallCard>;
 
-export const Default: Story = {};
+/** Idle — the install CTA; clicking it fires `onInstall`. */
+export const Default: Story = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Search tools missing')).toBeInTheDocument();
 
+    const install = canvas.getByRole('button', { name: 'Install Missing Tools' });
+    await userEvent.click(install);
+    await expect(args.onInstall).toHaveBeenCalled();
+  },
+};
+
+/** Installing — the determinate progress block replaces the install button. */
 export const Installing: Story = {
   args: {
     installStatus: 'downloading',
@@ -36,17 +62,36 @@ export const Installing: Story = {
     installProgress: 55,
     installLabel: 'Downloading yt-dlp',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '55');
+    await expect(canvas.getByText(/Downloading yt-dlp\.\.\. 55%/)).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Install Missing Tools' })
+    ).not.toBeInTheDocument();
+  },
 };
 
+/** Done — the success confirmation, no install button. */
 export const Done: Story = {
   args: {
     installStatus: 'done',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Search tools installed')).toBeInTheDocument();
+  },
 };
 
+/** Errored — the install button with the inline error message beneath it. */
 export const Errored: Story = {
   args: {
     installStatus: 'error',
     installError: 'Network timeout',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Install Missing Tools' })).toBeInTheDocument();
+    await expect(canvas.getByText('Network timeout')).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/search/SearchResultRow/SearchResultRow.stories.tsx
+++ b/apps/web/src/components/search/SearchResultRow/SearchResultRow.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, fn } from 'storybook/test';
 import type { SearchResult } from '@/types/electron';
 import type { DownloadState } from '@/hooks/useSearch';
 
@@ -23,14 +24,28 @@ function makeState(overrides: Partial<DownloadState> = {}): DownloadState {
   return { progress: 0, status: 'idle', ...overrides };
 }
 
+/**
+ * search · SearchResultRow. One row in the YouTube results list: a preview
+ * toggle over the thumbnail, the track title + uploader / view-count meta line
+ * (which swaps to a status subtitle while downloading / done / errored), the
+ * duration, and the shared download-progress button. Downloading rows add a
+ * determinate progress bar. Stories cover each download state and drive a
+ * download click.
+ */
 const meta: Meta<typeof SearchResultRow> = {
   title: 'search/SearchResultRow',
   component: SearchResultRow,
+  parameters: {
+    // The preview and download buttons are aria-labelled, the progress bar
+    // carries its role, and the thumbnail image is named by the track title —
+    // axe passes clean.
+    a11y: { test: 'error' },
+  },
   args: {
     previewLoadingId: null,
     isPreviewPlaying: () => false,
-    onPreview: () => {},
-    onDownload: () => {},
+    onPreview: fn(),
+    onDownload: fn(),
   },
   decorators: [
     Story => (
@@ -45,30 +60,64 @@ export default meta;
 
 type Story = StoryObj<typeof SearchResultRow>;
 
+/** Idle — preview + download affordances; clicking download fires `onDownload`. */
 export const Default: Story = {
   args: {
     result: makeResult(),
     downloadState: makeState(),
   },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Lofi beats to relax and study to')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Preview' })).toBeInTheDocument();
+
+    const download = canvas.getByRole('button', {
+      name: 'Download Lofi beats to relax and study to',
+    });
+    await userEvent.click(download);
+    await expect(args.onDownload).toHaveBeenCalled();
+  },
 };
 
+/** Downloading — the status subtitle + a determinate progress bar. */
 export const Downloading: Story = {
   args: {
     result: makeResult({ id: 'vid-dl', title: 'Midnight study session' }),
     downloadState: makeState({ status: 'downloading', progress: 42 }),
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Adding…')).toBeInTheDocument();
+    await expect(canvas.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '42');
+  },
 };
 
+/** Done — the "in your library" subtitle; the download button reads as added. */
 export const Done: Story = {
   args: {
     result: makeResult({ id: 'vid-done', title: 'Warm evening lights' }),
     downloadState: makeState({ status: 'done', progress: 100 }),
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('In your library')).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Warm evening lights added to your library' })
+    ).toBeInTheDocument();
+  },
 };
 
+/** Errored — the retry affordance with the error subtitle. */
 export const Errored: Story = {
   args: {
     result: makeResult({ id: 'vid-err', title: 'Broken stream' }),
     downloadState: makeState({ status: 'error', error: 'Network timeout' }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Couldn't add · retry")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Retry adding Broken stream' })
+    ).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/search/SearchView/SearchView.stories.tsx
+++ b/apps/web/src/components/search/SearchView/SearchView.stories.tsx
@@ -1,10 +1,27 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import SearchView from './SearchView';
 
+/**
+ * search · SearchView. The YouTube search surface: a search field with live
+ * suggestions, the results list of `SearchResultRow`s, and the dependency
+ * gate (checking → install-tools → ready). The view checks yt-dlp/ffmpeg on
+ * mount, but that check is Electron-gated — in the Storybook browser run
+ * (`IS_ELECTRON === false`) the on-mount effect is a no-op, so the view stays in
+ * its initial "checking" state and renders the "Preparing search" status card.
+ * Stories assert that stable chrome; the search field and results list are
+ * exercised by `SearchResultRow` and the jsdom unit tests (which mock the
+ * dependency hook).
+ */
 const meta: Meta<typeof SearchView> = {
   title: 'search/SearchView',
   component: SearchView,
+  parameters: {
+    // The status card's mascot is decorative (alt="") and its title/description
+    // are plain text — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="flex h-[40rem] flex-col">
@@ -18,4 +35,11 @@ export default meta;
 
 type Story = StoryObj<typeof SearchView>;
 
-export const Default: Story = {};
+/** Checking — the dependency-preparation card the browser run lands on. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Preparing search')).toBeInTheDocument();
+    await expect(canvas.getByText(/Checking yt-dlp and ffmpeg/)).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
## Summary
- Strengthens the render-only Storybook stories for three features — **lyrics**, **search**, **playlist-import** (9 component story files) — into real-browser tests: render smoke + `play` interaction/assertion + axe a11y `'error'` + autodocs JSDoc. Continues the batched waves after #291, #296, #299.
- Interactions use real `fn()` spies + `userEvent`: LyricsList click → `onLineClick(time)`; DependencyInstallCard install button → `onInstall`; SearchResultRow download → `onDownload`; ImportBulkActionBar (a portalled `role="toolbar"` queried via `screen`) download → `onDownloadSelected`, plus the all-selected relabel and importing-suppression states.
- **a11y ratcheted to `error` on all 9** — no component or shared `ui/` changes were needed. LyricsPanel seeds its React Query client (`client.setQueryData(lyricsKeys.track(...), …)`) so the panel renders deterministically without IPC.

## Test plan
- [ ] `pnpm --filter @shiranami/web test:storybook` → 273 passing
- [ ] CI **Storybook Tests** job green
- [ ] Storybook autodocs render for lyrics / search / playlist-import

> Note: `SearchView`'s on-mount dependency check is `IS_ELECTRON`-gated, so under the headless browser run (`IS_ELECTRON === false`) it stays in the "checking" state and renders the "Preparing search" card — `play` asserts that stable chrome; the search field / results paths stay covered by `SearchResultRow` + the jsdom unit tests (which mock the dependency hook).