### PR TITLE
test(web): strengthen remaining Storybook stories (library → settings) with play, a11y, autodocs

### DIFF
--- a/apps/web/src/components/history/HistoryActivityGraph/HistoryActivityGraph.stories.tsx
+++ b/apps/web/src/components/history/HistoryActivityGraph/HistoryActivityGraph.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { ListeningActivityPoint } from '@/types/electron';
 
 import HistoryActivityGraph from './HistoryActivityGraph';
@@ -18,9 +19,23 @@ function makeSeries(days: number): ListeningActivityPoint[] {
   });
 }
 
+/**
+ * history · HistoryActivityGraph. The daily-listens bar chart for the History
+ * dashboard. With data it renders a single `role="img"` wrapper whose aria-label
+ * summarizes the window ("Listening activity: N plays over D days") and one bar
+ * per day; with no points it renders the colocated `HistoryEmptyState`
+ * ("No activity yet"). Stories assert the accessible graph label and the empty
+ * fallback.
+ */
 const meta: Meta<typeof HistoryActivityGraph> = {
   title: 'history/HistoryActivityGraph',
   component: HistoryActivityGraph,
+  // a11y is left at the global 'todo' default (not ratcheted to 'error'): the
+  // per-bar date labels render with a very low-opacity muted token
+  // (`text-muted-foreground/55`) and the empty fallback adds `/65` copy, both
+  // over translucent panels — so axe's color-contrast ratio is non-deterministic
+  // against the layered backdrop. The graph is decorative-by-design (it exposes
+  // a single summarizing `role="img"` label, asserted in `play`).
   decorators: [
     Story => (
       <div className="w-[40rem] rounded-[24px] border border-border/25 p-4">
@@ -34,23 +49,45 @@ export default meta;
 
 type Story = StoryObj<typeof HistoryActivityGraph>;
 
+/** 7-day window — the graph exposes a single summarizing image label. */
 export const Default: Story = {
   args: {
     range: '7d',
     points: makeSeries(7),
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // playCounts for 7 days = (i*7)%11 → 0+7+3+10+6+2+9 = 37 total plays.
+    await expect(
+      canvas.getByRole('img', { name: 'Listening activity: 37 plays over 7 days' })
+    ).toBeInTheDocument();
+  },
 };
 
+/** 30-day window — the label scales to the longer range. */
 export const ThirtyDays: Story = {
   args: {
     range: '30d',
     points: makeSeries(30),
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('img', { name: /^Listening activity: \d+ plays over 30 days$/ })
+    ).toBeInTheDocument();
+  },
 };
 
+/** No data — the colocated "No activity yet" empty state replaces the bars. */
 export const Empty: Story = {
   args: {
     range: '7d',
     points: [],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The empty branch renders HistoryEmptyState, not the role="img" graph.
+    await expect(canvas.queryByRole('img')).not.toBeInTheDocument();
+    await expect(canvas.getByText('No activity yet')).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/history/HistoryEmptyState/HistoryEmptyState.stories.tsx
+++ b/apps/web/src/components/history/HistoryEmptyState/HistoryEmptyState.stories.tsx
@@ -1,10 +1,26 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import HistoryEmptyState from './HistoryEmptyState';
 
+/**
+ * history · HistoryEmptyState. The dashed-border placeholder a history section
+ * renders when its range has no data — a `title` line over a smaller `copy`
+ * line. Pure presentational: it has no interactive elements, no roles, and no
+ * images, so stories assert the literal title + copy text it was handed.
+ */
 const meta: Meta<typeof HistoryEmptyState> = {
   title: 'history/HistoryEmptyState',
   component: HistoryEmptyState,
+  // a11y is left at the global 'todo' default (not ratcheted to 'error'): both
+  // lines render with sub-opacity muted tokens (`text-muted-foreground/65`) over
+  // a translucent `bg-background/20`, so axe's color-contrast ratio is
+  // non-deterministic against the layered backdrop. The visible content (title +
+  // copy) is asserted in `play` instead.
+  args: {
+    title: 'No top tracks in this range',
+    copy: 'Once enough listens are logged in the selected period, your most-played tracks will surface here.',
+  },
   decorators: [
     Story => (
       <div className="w-[28rem] p-4">
@@ -18,9 +34,11 @@ export default meta;
 
 type Story = StoryObj<typeof HistoryEmptyState>;
 
+/** The default placeholder — its title and copy both render. */
 export const Default: Story = {
-  args: {
-    title: 'No top tracks in this range',
-    copy: 'Once enough listens are logged in the selected period, your most-played tracks will surface here.',
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(args.title)).toBeInTheDocument();
+    await expect(canvas.getByText(args.copy)).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/history/HistoryHeroSection/HistoryHeroSection.stories.tsx
+++ b/apps/web/src/components/history/HistoryHeroSection/HistoryHeroSection.stories.tsx
@@ -1,18 +1,52 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, fn } from 'storybook/test';
 import type { HistoryRange } from '@/components/history/historyUtils';
 
 import HistoryHeroSection from './HistoryHeroSection';
 
-/** Stateful harness so the range pills toggle live in the story. */
-function HistoryHeroSectionHarness() {
-  const [range, setRange] = useState<HistoryRange>('all');
-  return <HistoryHeroSection selectedRange={range} onRangeChange={setRange} />;
+/**
+ * Stateful harness so the range pills toggle live in the story while still
+ * forwarding every selection to the `onRangeChange` spy for assertions.
+ */
+function HistoryHeroSectionHarness({
+  initialRange = 'all',
+  onRangeChange,
+}: {
+  initialRange?: HistoryRange;
+  onRangeChange: (range: HistoryRange) => void;
+}) {
+  const [range, setRange] = useState<HistoryRange>(initialRange);
+  return (
+    <HistoryHeroSection
+      selectedRange={range}
+      onRangeChange={next => {
+        setRange(next);
+        onRangeChange(next);
+      }}
+    />
+  );
 }
 
+/**
+ * history · HistoryHeroSection. The History dashboard header: an eyebrow, the
+ * serif `<h1>` headline, a range-scoped subtitle, and three range pills
+ * ("7 Days" / "30 Days" / "All Time") rendered as buttons. Selecting a pill
+ * calls `onRangeChange(id)` and re-highlights the active pill. Stories assert the
+ * heading + pills and that clicking a pill fires the callback with its range id.
+ */
 const meta: Meta<typeof HistoryHeroSection> = {
   title: 'history/HistoryHeroSection',
   component: HistoryHeroSection,
+  // a11y is left at the global 'todo' default (not ratcheted to 'error'): the
+  // eyebrow + subtitle + inactive pills render with sub-opacity muted tokens
+  // (`text-muted-foreground/55`, `/75`, and the base muted token) over the
+  // panel's radial-gradient glass backdrop, so axe's color-contrast ratio is
+  // non-deterministic against the layered background. The heading, pills, and
+  // selection callback are asserted in `play`.
+  args: {
+    onRangeChange: fn(),
+  },
   decorators: [
     Story => (
       <div className="w-[48rem] p-4">
@@ -26,6 +60,22 @@ export default meta;
 
 type Story = StoryObj<typeof HistoryHeroSection>;
 
+/** Headline + three range pills; clicking "7 Days" reports the "7d" range. */
 export const Default: Story = {
-  render: () => <HistoryHeroSectionHarness />,
+  render: args => <HistoryHeroSectionHarness onRangeChange={args.onRangeChange} />,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('heading', {
+        level: 1,
+        name: 'A running picture of what you actually stick with.',
+      })
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: '7 Days' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: '30 Days' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'All Time' })).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: '7 Days' }));
+    await expect(args.onRangeChange).toHaveBeenCalledWith('7d');
+  },
 };

--- a/apps/web/src/components/history/HistoryRecentRow/HistoryRecentRow.stories.tsx
+++ b/apps/web/src/components/history/HistoryRecentRow/HistoryRecentRow.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, fn } from 'storybook/test';
 import type { ListeningHistoryEntry } from '@/types/electron';
 
 import HistoryRecentRow from './HistoryRecentRow';
@@ -21,11 +22,25 @@ function makeEntry(overrides: Partial<ListeningHistoryEntry> = {}): ListeningHis
   };
 }
 
+/**
+ * history · HistoryRecentRow. One row in the "Recent Plays" list: a full-width
+ * `<button>` holding the album-art tile, the track title over an
+ * "Artist / Album" subtitle, and the played duration over a timestamp. Clicking
+ * the row plays the track via `onPlay(trackId)`. Stories assert the row is a
+ * button carrying the title + subtitle and that clicking fires the callback with
+ * the entry's track id.
+ */
 const meta: Meta<typeof HistoryRecentRow> = {
   title: 'history/HistoryRecentRow',
   component: HistoryRecentRow,
+  // a11y is left at the global 'todo' default (not ratcheted to 'error'): the
+  // subtitle + timestamp lines use sub-opacity muted tokens (`text-muted-
+  // foreground` and `/65`) over the row's translucent `bg-background/25`, so
+  // axe's color-contrast ratio is non-deterministic against the layered
+  // backdrop. The button role/name and click behaviour are asserted in `play`.
   args: {
-    onPlay: () => {},
+    onPlay: fn(),
+    entry: makeEntry(),
   },
   decorators: [
     Story => (
@@ -40,8 +55,16 @@ export default meta;
 
 type Story = StoryObj<typeof HistoryRecentRow>;
 
+/** The row reads as a button with the track title; clicking plays the track. */
 export const Default: Story = {
-  args: {
-    entry: makeEntry(),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    // The button's accessible name is its concatenated text; match on the title
+    // (the timestamp segment is locale/timezone dependent, so we don't pin it).
+    const row = canvas.getByRole('button', { name: /Rainy day cafe/ });
+    await expect(row).toHaveTextContent('Lofi Collective / Late Nights');
+
+    await userEvent.click(row);
+    await expect(args.onPlay).toHaveBeenCalledWith('track-1');
   },
 };

--- a/apps/web/src/components/history/HistoryTopArtistRow/HistoryTopArtistRow.stories.tsx
+++ b/apps/web/src/components/history/HistoryTopArtistRow/HistoryTopArtistRow.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { ListeningStatsArtist } from '@/types/electron';
 
 import HistoryTopArtistRow from './HistoryTopArtistRow';
@@ -12,9 +13,21 @@ function makeArtist(overrides: Partial<ListeningStatsArtist> = {}): ListeningSta
   };
 }
 
+/**
+ * history · HistoryTopArtistRow. One static row in the "Top Artists" panel —
+ * the artist name over a listened-time label, with the localized play count
+ * pinned to the right. Non-interactive (no button). When the artist name is
+ * blank it falls back to the localized "Unknown Artist". Stories cover the named
+ * and the unknown-fallback branches.
+ */
 const meta: Meta<typeof HistoryTopArtistRow> = {
   title: 'history/HistoryTopArtistRow',
   component: HistoryTopArtistRow,
+  // a11y is left at the global 'todo' default (not ratcheted to 'error'): the
+  // listened-time line uses a sub-opacity muted token (`text-muted-foreground/
+  // 65`) over the row's translucent `bg-background/25`, so axe's color-contrast
+  // ratio is non-deterministic against the layered backdrop. The visible text is
+  // asserted in `play`.
   decorators: [
     Story => (
       <div className="w-[28rem] p-4">
@@ -28,14 +41,26 @@ export default meta;
 
 type Story = StoryObj<typeof HistoryTopArtistRow>;
 
+/** A named artist — name + localized "28 plays" both render. */
 export const Default: Story = {
   args: {
     artist: makeArtist(),
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Lofi Collective')).toBeInTheDocument();
+    // The localized "{{count}} plays" label resolves from the history namespace.
+    await expect(canvas.getByText('28 plays')).toBeInTheDocument();
+  },
 };
 
+/** Blank artist — the localized "Unknown Artist" fallback stands in. */
 export const Unknown: Story = {
   args: {
     artist: makeArtist({ artist: '' }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Unknown Artist')).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/history/HistoryTopTrackRow/HistoryTopTrackRow.stories.tsx
+++ b/apps/web/src/components/history/HistoryTopTrackRow/HistoryTopTrackRow.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, fn } from 'storybook/test';
 import type { ListeningStatsTrack } from '@/types/electron';
 
 import HistoryTopTrackRow from './HistoryTopTrackRow';
@@ -17,11 +18,24 @@ function makeTrack(overrides: Partial<ListeningStatsTrack> = {}): ListeningStats
   };
 }
 
+/**
+ * history · HistoryTopTrackRow. One row in the "Top Tracks" leaderboard: a
+ * full-width `<button>` holding the album-art tile, the track title over its
+ * artist, and the localized play count over the listened-time label. Clicking
+ * plays the track via `onPlay(trackId)`. Stories assert the button name + play
+ * count and that a click fires the callback with the track id.
+ */
 const meta: Meta<typeof HistoryTopTrackRow> = {
   title: 'history/HistoryTopTrackRow',
   component: HistoryTopTrackRow,
+  // a11y is left at the global 'todo' default (not ratcheted to 'error'): the
+  // artist + listened-time lines use sub-opacity muted tokens (`text-muted-
+  // foreground` and `/65`) over the row's translucent `bg-background/25`, so
+  // axe's color-contrast ratio is non-deterministic against the layered
+  // backdrop. The button role/name and click behaviour are asserted in `play`.
   args: {
-    onPlay: () => {},
+    onPlay: fn(),
+    track: makeTrack(),
   },
   decorators: [
     Story => (
@@ -36,8 +50,15 @@ export default meta;
 
 type Story = StoryObj<typeof HistoryTopTrackRow>;
 
+/** The row reads as a button with the title + "12 plays"; clicking plays it. */
 export const Default: Story = {
-  args: {
-    track: makeTrack(),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const row = canvas.getByRole('button', { name: /Midnight study session/ });
+    // The localized "{{count}} plays" label resolves from the history namespace.
+    await expect(row).toHaveTextContent('12 plays');
+
+    await userEvent.click(row);
+    await expect(args.onPlay).toHaveBeenCalledWith('track-1');
   },
 };

--- a/apps/web/src/components/history/HistoryTrackArtwork/HistoryTrackArtwork.stories.tsx
+++ b/apps/web/src/components/history/HistoryTrackArtwork/HistoryTrackArtwork.stories.tsx
@@ -1,10 +1,28 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import HistoryTrackArtwork from './HistoryTrackArtwork';
 
+// A 1×1 transparent PNG so the artwork story renders a real <img> without a
+// network fetch.
+const PIXEL_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+/**
+ * history · HistoryTrackArtwork. The 44px album-art tile used by the history
+ * rows. Wraps the shared `TrackThumbnail`: when `albumArt` is present it renders
+ * an `<img>` whose `alt` is the track title; when it's `null` it renders the
+ * decorative `Music` fallback icon. Stories cover both branches.
+ */
 const meta: Meta<typeof HistoryTrackArtwork> = {
   title: 'history/HistoryTrackArtwork',
   component: HistoryTrackArtwork,
+  parameters: {
+    // The artwork branch renders an <img> with a real `alt` (the title); the
+    // fallback branch is a bare decorative icon with no accessible name. Neither
+    // is an axe violation, so the component is ratcheted to error.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="p-4">
@@ -18,9 +36,28 @@ export default meta;
 
 type Story = StoryObj<typeof HistoryTrackArtwork>;
 
-export const Default: Story = {
+/** No cover art — the decorative fallback icon stands in (no image rendered). */
+export const Fallback: Story = {
   args: {
     albumArt: null,
     title: 'Midnight study session',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The null branch renders the Music icon, not an <img>, so no image is in
+    // the accessibility tree.
+    await expect(canvas.queryByRole('img')).not.toBeInTheDocument();
+  },
+};
+
+/** With cover art — the image renders with the track title as its alt text. */
+export const WithArtwork: Story = {
+  args: {
+    albumArt: PIXEL_PNG,
+    title: 'Midnight study session',
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('img', { name: args.title })).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/history/HistoryView/HistoryView.stories.tsx
+++ b/apps/web/src/components/history/HistoryView/HistoryView.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, expect } from 'storybook/test';
 import type {
   ListeningActivityPoint,
   ListeningHistoryEntry,
@@ -63,9 +64,26 @@ function seededClient(data: HistoryData): QueryClient {
   return client;
 }
 
+/**
+ * history · HistoryView. The full Listening History dashboard: the hero header
+ * (range pills), four summary stat cards, the daily-activity graph, the Top
+ * Tracks / Top Artists panels, and a Recent Plays list. It reads everything from
+ * one React Query (`historyKeys.data('all')` — "all" is the default range), so
+ * stories pre-seed a client with `HistoryData` to render the loaded dashboard or
+ * its per-section empty states deterministically without IPC. In the browser run
+ * the query is disabled (`IS_ELECTRON === false`); the seeded cache supplies the
+ * data the disabled query reads.
+ */
 const meta: Meta<typeof HistoryView> = {
   title: 'history/HistoryView',
   component: HistoryView,
+  // a11y is left at the global 'todo' default (not ratcheted to 'error'): the
+  // dashboard layers many sub-opacity muted tokens (stat hints, captions, row
+  // subtitles, graph labels at `/55`–`/75`) over translucent glass panels, so
+  // axe's color-contrast ratio is non-deterministic against the layered
+  // background. The real headings (h1 hero + h2 section titles) and seeded
+  // content are asserted in `play`; the leaf rows carry the same documented
+  // deferral in their own stories.
   decorators: [
     Story => (
       <div className="flex h-[48rem] flex-col">
@@ -79,6 +97,7 @@ export default meta;
 
 type Story = StoryObj<typeof HistoryView>;
 
+/** Loaded dashboard — hero, stat cards, activity graph, and populated panels. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -108,8 +127,44 @@ export const Default: Story = {
       );
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Hero headline (h1) — once it's mounted the loaded dashboard has rendered.
+    await expect(
+      await canvas.findByRole('heading', {
+        level: 1,
+        name: 'A running picture of what you actually stick with.',
+      })
+    ).toBeInTheDocument();
+
+    // Every section panel exposes a real <h2>.
+    await expect(canvas.getByRole('heading', { level: 2, name: 'Activity' })).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { level: 2, name: 'Top Tracks' })).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('heading', { level: 2, name: 'Top Artists' })
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('heading', { level: 2, name: 'Recent Plays' })
+    ).toBeInTheDocument();
+
+    // The "Logged Plays" stat card surfaces the seeded total (248).
+    await expect(canvas.getByText('Logged Plays')).toBeInTheDocument();
+    await expect(canvas.getByText('248')).toBeInTheDocument();
+
+    // The activity graph renders as a single summarizing role="img".
+    await expect(
+      canvas.getByRole('img', { name: /^Listening activity: \d+ plays over \d+ days$/ })
+    ).toBeInTheDocument();
+
+    // Seeded top track + recent entry both render as play buttons.
+    await expect(
+      canvas.getByRole('button', { name: /Midnight study session/ })
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: /Slow morning coffee/ })).toBeInTheDocument();
+  },
 };
 
+/** No data for the range — every section falls back to its empty state. */
 export const Empty: Story = {
   decorators: [
     Story => {
@@ -133,4 +188,19 @@ export const Empty: Story = {
       );
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The hero still renders; the section bodies swap to their empty states.
+    await expect(
+      await canvas.findByRole('heading', {
+        level: 1,
+        name: 'A running picture of what you actually stick with.',
+      })
+    ).toBeInTheDocument();
+
+    await expect(canvas.getByText('No activity yet')).toBeInTheDocument();
+    await expect(canvas.getByText('No top tracks in this range')).toBeInTheDocument();
+    await expect(canvas.getByText('No artist trends yet')).toBeInTheDocument();
+    await expect(canvas.getByText('No recent plays in this range')).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/library/AlbumDetailView/AlbumDetailView.stories.tsx
+++ b/apps/web/src/components/library/AlbumDetailView/AlbumDetailView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { useViewStore } from '@/stores/useViewStore';
@@ -30,9 +31,22 @@ function seedAlbum(tracks: Track[]): void {
   useViewStore.setState({ selectedAlbumKey: albumKeyOf(tracks[0]) });
 }
 
+/**
+ * library · AlbumDetailView. The detail page for a selected album: a header with
+ * back / play-all / shuffle actions, the album metadata, and the album's track
+ * rows (each a play `<button>` named "title artist"). Multi-disc albums render
+ * "Disc N" subheaders. It reads the library + selected album from the stores.
+ * Stories seed an album and assert the header actions and the first track row.
+ */
 const meta: Meta<typeof AlbumDetailView> = {
   title: 'library/AlbumDetailView',
   component: AlbumDetailView,
+  parameters: {
+    // Back action is an aria-labelled icon button; play-all / shuffle and each
+    // track row are text-labelled buttons; cover fallback icons are decorative —
+    // axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="flex h-[36rem] flex-col">
@@ -46,6 +60,7 @@ export default meta;
 
 type Story = StoryObj<typeof AlbumDetailView>;
 
+/** A three-track single-disc album — header actions and the first track row. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -53,8 +68,17 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Back to albums' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Play all' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Shuffle' })).toBeInTheDocument();
+    // Track rows expose a play button whose name is "title artist".
+    await expect(canvas.getByRole('button', { name: /Intro\s+Idealism/ })).toBeInTheDocument();
+  },
 };
 
+/** A multi-disc album — the "Disc 1" / "Disc 2" subheaders appear. */
 export const MultiDisc: Story = {
   decorators: [
     Story => {
@@ -66,4 +90,12 @@ export const MultiDisc: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Disc 1')).toBeInTheDocument();
+    await expect(canvas.getByText('Disc 2')).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: /Disc two opener\s+Idealism/ })
+    ).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/library/AlbumGrid/AlbumGrid.stories.tsx
+++ b/apps/web/src/components/library/AlbumGrid/AlbumGrid.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 
 import AlbumGrid from './AlbumGrid';
@@ -24,9 +25,22 @@ const library: Track[] = [
   makeTrack({ id: 'c1', title: 'Coffee', album: 'Slow Morning', artist: 'Kupla' }),
 ];
 
+/**
+ * library · AlbumGrid. The virtualized album grid for the library's albums view:
+ * tracks are grouped into albums and rendered as `react-window` cells, each a
+ * labelled `<button>` (album name + artist + track count) that opens the album.
+ * A live filter count appears while searching and a compact empty state shows on
+ * no matches. Stories assert a representative rendered card, the filter-count
+ * chrome, and the empty state.
+ */
 const meta: Meta<typeof AlbumGrid> = {
   title: 'library/AlbumGrid',
   component: AlbumGrid,
+  parameters: {
+    // Each album cell is a labelled <button>, the cover fallback icon is a
+    // decorative SVG, and the empty state is plain text — axe passes clean.
+    a11y: { test: 'error' },
+  },
   args: {
     library,
     searchQuery: '',
@@ -44,16 +58,36 @@ export default meta;
 
 type Story = StoryObj<typeof AlbumGrid>;
 
-export const Default: Story = {};
+/** All three albums — assert a representative card button renders. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Grid cells mount only after the container is measured, so wait for the
+    // first card; its accessible name is album + artist + track count.
+    await expect(await canvas.findByRole('button', { name: /Midnight Tapes/ })).toBeInTheDocument();
+  },
+};
 
+/** Filtered to "rainy" — the filter-count chrome and the matching album card. */
 export const Filtered: Story = {
   args: {
     searchQuery: 'rainy',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('1 of 3 albums')).toBeInTheDocument();
+    await expect(await canvas.findByRole('button', { name: /Rainy Day/ })).toBeInTheDocument();
+  },
 };
 
+/** No matches — the compact empty state. */
 export const NoMatches: Story = {
   args: {
     searchQuery: 'zzz-no-such-album',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No matching tracks')).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /Midnight Tapes/ })).not.toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/library/LibraryView/LibraryView.stories.tsx
+++ b/apps/web/src/components/library/LibraryView/LibraryView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { useUIStore } from '@/stores/useUIStore';
@@ -31,9 +32,21 @@ function seed(tracks: Track[], mode: 'tracks' | 'albums' = 'tracks'): void {
   useViewStore.setState({ selectedAlbumKey: null });
 }
 
+/**
+ * library · LibraryView. The top-level library page: an `<h1>` title, a search
+ * box, a Tracks/Albums view toggle, and either the virtualized track list, the
+ * album grid, or an empty state. It reads tracks + view mode from the stores.
+ * Stories seed each mode and assert the page chrome (heading, search, toggle)
+ * plus the mode-specific body.
+ */
 const meta: Meta<typeof LibraryView> = {
   title: 'library/LibraryView',
   component: LibraryView,
+  parameters: {
+    // The page title is a real <h1>, the search input is aria-labelled, and the
+    // view-toggle buttons carry aria-labels (decorative icons) — axe clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="flex h-[40rem] flex-col">
@@ -47,6 +60,7 @@ export default meta;
 
 type Story = StoryObj<typeof LibraryView>;
 
+/** Tracks mode — heading, search, toggle, and a rendered track row. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -54,8 +68,22 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Your library' })).toBeInTheDocument();
+    await expect(canvas.getByRole('textbox', { name: 'Search tracks...' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Tracks', pressed: true })).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Albums', pressed: false })
+    ).toBeInTheDocument();
+    // The virtualized list mounts rows after measuring — wait for the first.
+    await expect(
+      await canvas.findByRole('button', { name: /Intro\s+Idealism/ })
+    ).toBeInTheDocument();
+  },
 };
 
+/** Albums mode — the Albums toggle reads as pressed and the album grid renders. */
 export const Albums: Story = {
   decorators: [
     Story => {
@@ -63,8 +91,15 @@ export const Albums: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('textbox', { name: 'Search albums...' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Albums', pressed: true })).toBeInTheDocument();
+    await expect(await canvas.findByRole('button', { name: /Midnight Tapes/ })).toBeInTheDocument();
+  },
 };
 
+/** No tracks — the full empty state with onboarding hints. */
 export const Empty: Story = {
   decorators: [
     Story => {
@@ -72,4 +107,11 @@ export const Empty: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Your library' })).toBeInTheDocument();
+    await expect(canvas.getByText('No tracks yet')).toBeInTheDocument();
+    // The search box is hidden when the library is empty.
+    await expect(canvas.queryByRole('textbox')).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/library/ScanProgressCard/ScanProgressCard.stories.tsx
+++ b/apps/web/src/components/library/ScanProgressCard/ScanProgressCard.stories.tsx
@@ -1,11 +1,26 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 
 import ScanProgressCard from './ScanProgressCard';
 
+/**
+ * library · ScanProgressCard. The inline card shown in settings while a library
+ * scan runs: a status line ("Scanning N of M…"), the current file, a determinate
+ * progress bar, and a cancel button. It reads `scanState` + `scanProgress` from
+ * `useLibraryStore` and renders nothing when idle. Stories seed the store to the
+ * scanning and cancelling states and assert the progress bar value + cancel
+ * control.
+ */
 const meta: Meta<typeof ScanProgressCard> = {
   title: 'library/ScanProgressCard',
   component: ScanProgressCard,
+  parameters: {
+    // ProgressBar exposes role="progressbar" with aria-valuenow, the cancel
+    // button has a visible text label, and the spinner icons are decorative
+    // SVGs — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="w-[20rem] p-4">
@@ -19,6 +34,7 @@ export default meta;
 
 type Story = StoryObj<typeof ScanProgressCard>;
 
+/** Mid-scan — progress at 35% with a live cancel button. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -33,8 +49,20 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // 42 / 120 = 35%.
+    const progress = canvas.getByRole('progressbar');
+    await expect(progress).toHaveAttribute('aria-valuenow', '35');
+    await expect(canvas.getByText('Scanning 42 of 120...')).toBeInTheDocument();
+    await expect(canvas.getByText('Lofi beats/Midnight study session.flac')).toBeInTheDocument();
+
+    const cancel = canvas.getByRole('button', { name: 'Cancel' });
+    await expect(cancel).toBeEnabled();
+  },
 };
 
+/** Cancellation in flight — the cancel button relabels and disables. */
 export const Cancelling: Story = {
   decorators: [
     Story => {
@@ -49,4 +77,9 @@ export const Cancelling: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const cancel = canvas.getByRole('button', { name: 'Cancelling...' });
+    await expect(cancel).toBeDisabled();
+  },
 };

--- a/apps/web/src/components/library/ViewModeButton/ViewModeButton.stories.tsx
+++ b/apps/web/src/components/library/ViewModeButton/ViewModeButton.stories.tsx
@@ -1,13 +1,26 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, fn } from 'storybook/test';
 import { LayoutGrid, List } from 'lucide-react';
 
 import ViewModeButton from './ViewModeButton';
 
+/**
+ * library · ViewModeButton. The icon-only toggle used in the library's view
+ * switcher to flip between the track list and the album grid. It renders a
+ * single `<button>` whose accessible name comes from `label` (also the tooltip)
+ * and whose `aria-pressed` reflects the active state. Stories assert the pressed
+ * state per variant and that a click invokes `onClick`.
+ */
 const meta: Meta<typeof ViewModeButton> = {
   title: 'library/ViewModeButton',
   component: ViewModeButton,
+  parameters: {
+    // Icon-only button carries an aria-label + title (the icon is decorative)
+    // and exposes aria-pressed — axe passes clean.
+    a11y: { test: 'error' },
+  },
   args: {
-    onClick: () => {},
+    onClick: fn(),
     label: 'Tracks',
     icon: List,
   },
@@ -24,18 +37,33 @@ export default meta;
 
 type Story = StoryObj<typeof ViewModeButton>;
 
+/** Active mode — the button reads as pressed and still fires on click. */
 export const Default: Story = {
   args: {
     active: true,
     icon: List,
     label: 'Tracks',
   },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Tracks', pressed: true });
+
+    await userEvent.click(button);
+    await expect(args.onClick).toHaveBeenCalled();
+  },
 };
 
+/** Inactive mode — the button reads as not pressed. */
 export const Inactive: Story = {
   args: {
     active: false,
     icon: LayoutGrid,
     label: 'Albums',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('button', { name: 'Albums', pressed: false })
+    ).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/overview/ClockCard/ClockCard.stories.tsx
+++ b/apps/web/src/components/overview/ClockCard/ClockCard.stories.tsx
@@ -1,10 +1,26 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import ClockCard from './ClockCard';
 
+/**
+ * overview · ClockCard. The live ticking clock card. A 1s interval re-renders
+ * only this subtree; the time digits and the day-period are intentionally
+ * `aria-hidden` and the container carries a single stable `aria-label` ("Current
+ * time, …") so a screen reader isn't told the time every second. The bottom row
+ * shows a decorative mood glyph beside either an injected weather row or a
+ * fallback mood line. The wall-clock time is non-deterministic, so stories
+ * assert the stable labelled `group` and the injected weather row rather than a
+ * specific time string.
+ */
 const meta: Meta<typeof ClockCard> = {
   title: 'overview/ClockCard',
   component: ClockCard,
+  parameters: {
+    // The container exposes a stable aria-label; every time digit and the mood
+    // glyph are aria-hidden — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="w-60">
@@ -18,8 +34,17 @@ export default meta;
 
 type Story = StoryObj<typeof ClockCard>;
 
-export const TimeOfDay: Story = {};
+/** No weather row — the time-of-day glyph + a quiet mood line, zero network calls. */
+export const TimeOfDay: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The whole card is a labelled group; the time itself is aria-hidden and
+    // changes every second, so we assert the stable accessible label.
+    await expect(canvas.getByRole('group', { name: /Current time/ })).toBeInTheDocument();
+  },
+};
 
+/** Weather override — an injected weather row replaces the fallback mood line. */
 export const WithWeatherGlyph: Story = {
   args: {
     glyph: '雨',
@@ -29,5 +54,12 @@ export const WithWeatherGlyph: Story = {
         <p className="truncate text-xs text-muted-foreground/60">A good night for slow records.</p>
       </div>
     ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('group', { name: /Current time/ })).toBeInTheDocument();
+    // The injected weather row renders in place of the fallback mood line. The
+    // mood glyph itself is decorative (aria-hidden), so we assert the row text.
+    await expect(canvas.getByText('Rain · 12°C')).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/overview/GreetingHero/GreetingHero.stories.tsx
+++ b/apps/web/src/components/overview/GreetingHero/GreetingHero.stories.tsx
@@ -1,21 +1,48 @@
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, expect } from 'storybook/test';
+import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { useWeatherStore } from '@/stores/useWeatherStore';
 
 import GreetingHero from './GreetingHero';
 
-const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-
+/**
+ * overview · GreetingHero. The Overview hero: a greeting headline (`<h2>`) + a
+ * session-summary line on the left, and the live `ClockCard` on the right. The
+ * greeting and decorative kanji watermark depend on the current time of day, and
+ * the session line depends on the playback store; the weather row only appears
+ * when the user has opted in. Stories seed the playback + weather stores to the
+ * "nothing playing, weather off" baseline so the deterministic chrome — eyebrow,
+ * greeting heading, no-tracks subtitle, and the labelled clock group — can be
+ * asserted without a fixed clock.
+ */
 const meta: Meta<typeof GreetingHero> = {
   title: 'overview/GreetingHero',
   component: GreetingHero,
+  parameters: {
+    // The greeting is a real <h2>, the watermark + eyebrow dot are decorative,
+    // and the clock group is labelled (weather off by default) — axe passes
+    // clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
-    Story => (
-      <QueryClientProvider client={client}>
-        <div className="w-[48rem]">
-          <Story />
-        </div>
-      </QueryClientProvider>
-    ),
+    Story => {
+      // Baseline: nothing playing, weather off — matches the no-tracks subtitle
+      // and suppresses the weather row, so the hero renders deterministically.
+      useWeatherStore.setState({ enabled: false, coords: null });
+      usePlaybackStore.setState({ currentTrack: null });
+      const [client] = useState(
+        () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      );
+      return (
+        <QueryClientProvider client={client}>
+          <div className="w-[48rem]">
+            <Story />
+          </div>
+        </QueryClientProvider>
+      );
+    },
   ],
 };
 
@@ -23,4 +50,19 @@ export default meta;
 
 type Story = StoryObj<typeof GreetingHero>;
 
-export const Default: Story = {};
+/** Nothing playing, weather off — eyebrow, greeting heading, and the clock group. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Your sanctuary')).toBeInTheDocument();
+    // The greeting copy varies by hour; assert the heading exists rather than a
+    // specific greeting string.
+    await expect(canvas.getByRole('heading')).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Nothing playing yet. Press play and the evening begins.')
+    ).toBeInTheDocument();
+    // The clock card is always present; the weather row is opt-in (off here).
+    await expect(canvas.getByRole('group', { name: /Current time/ })).toBeInTheDocument();
+    await expect(canvas.queryByText('Weather unavailable')).not.toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/overview/ListeningClock/ListeningClock.stories.tsx
+++ b/apps/web/src/components/overview/ListeningClock/ListeningClock.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { ListeningHourlyActivityPoint } from '@/types/electron';
 import { buildHeatmap } from '../overviewUtils';
 
@@ -11,9 +12,23 @@ const points: ListeningHourlyActivityPoint[] = [
   { dayOfWeek: 5, hour: 21, playCount: 9, listenedMinutes: 27 },
 ];
 
+/**
+ * overview · ListeningClock. The last-7-days listening heatmap — 7 weekday rows
+ * × 24 hours. The card has a real `<h2>` ("Listening clock") and a "Last 7 days"
+ * eyebrow; the grid is a single `role="img"` with an accessible summary label so
+ * a screen reader gets one description instead of 168 cells. Intensity is also
+ * cued by a non-color ring on the busiest cells. When there are no plays the
+ * grid is replaced by an empty-state line. Stories cover the populated grid (+
+ * peak label) and the empty state.
+ */
 const meta: Meta<typeof ListeningClock> = {
   title: 'overview/ListeningClock',
   component: ListeningClock,
+  parameters: {
+    // Real heading, the grid is a labelled role="img", legend swatches are
+    // aria-hidden, and intensity has a non-color cue — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="w-[28rem]">
@@ -27,14 +42,31 @@ export default meta;
 
 type Story = StoryObj<typeof ListeningClock>;
 
+/** A week with a clear evening peak — heading, the labelled grid, and the peak line. */
 export const Default: Story = {
   args: {
     heatmap: buildHeatmap(points),
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Listening clock' })).toBeInTheDocument();
+    // The 168-cell grid collapses to one accessible image.
+    await expect(canvas.getByRole('img', { name: /Listening clock/ })).toBeInTheDocument();
+    // The busiest window (21:00, two days) surfaces as the peak label.
+    await expect(canvas.getByText(/Loudest at 21:00/)).toBeInTheDocument();
+  },
 };
 
+/** No listening data — the grid is replaced by the empty-state copy. */
 export const Empty: Story = {
   args: {
     heatmap: buildHeatmap([]),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Listening clock' })).toBeInTheDocument();
+    await expect(canvas.getByText(/Your listening clock fills in/)).toBeInTheDocument();
+    // The grid only renders when there's data.
+    await expect(canvas.queryByRole('img', { name: /Listening clock/ })).not.toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/overview/OverviewCover/OverviewCover.stories.tsx
+++ b/apps/web/src/components/overview/OverviewCover/OverviewCover.stories.tsx
@@ -1,10 +1,24 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import OverviewCover from './OverviewCover';
 
+/**
+ * overview · OverviewCover. Cover art for Overview rows and cards. With album
+ * art it renders a labelled `<img>` (alt = the title); without it, a
+ * deterministic theme-tinted gradient + a representative glyph stand in — that
+ * fallback layer is decorative and `aria-hidden`, so it never reaches the a11y
+ * tree. The glyph prefers the first CJK character in the seed, else a hashed
+ * pick. Stories assert the labelled image vs. the decorative-glyph fallback.
+ */
 const meta: Meta<typeof OverviewCover> = {
   title: 'overview/OverviewCover',
   component: OverviewCover,
+  parameters: {
+    // The fallback gradient + glyph are wrapped in an aria-hidden layer; the
+    // real-art variant exposes a single alt-labelled <img> — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="size-24">
@@ -18,27 +32,46 @@ export default meta;
 
 type Story = StoryObj<typeof OverviewCover>;
 
+/** No album art — the decorative gradient + a hashed glyph (no image in the a11y tree). */
 export const Fallback: Story = {
   args: {
     title: 'Midnight Tapes',
     seed: 'Idealism',
     className: 'size-24',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The fallback is decorative, so no labelled image is exposed.
+    await expect(canvas.queryByRole('img')).not.toBeInTheDocument();
+    // The decorative glyph layer is aria-hidden but still rendered with content.
+    const fallback = canvasElement.querySelector('[aria-hidden="true"] span');
+    await expect(fallback?.textContent?.length ?? 0).toBeGreaterThan(0);
+  },
 };
 
+/** CJK seed — the glyph prefers the first CJK character ("夜") from the seed. */
 export const CjkSeed: Story = {
   args: {
     title: '夜のしらべ',
     seed: '夜のしらべ',
     className: 'size-24',
   },
+  play: async ({ canvasElement }) => {
+    const glyph = canvasElement.querySelector('[aria-hidden="true"] span');
+    await expect(glyph?.textContent).toBe('夜');
+  },
 };
 
+/** Real album art — a single image labelled by its title. */
 export const WithArt: Story = {
   args: {
     title: 'Midnight Tapes',
     seed: 'Idealism',
     albumArt: 'https://placehold.co/96x96/png',
     className: 'size-24',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('img', { name: 'Midnight Tapes' })).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/overview/OverviewView/OverviewView.stories.tsx
+++ b/apps/web/src/components/overview/OverviewView/OverviewView.stories.tsx
@@ -1,9 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, expect } from 'storybook/test';
 import type { HistoryData } from '@/hooks/queries/useHistory';
 import { historyKeys } from '@/hooks/queries/useHistory';
 import type { Track } from '@/stores/types';
 import { useLibraryStore } from '@/stores/useLibraryStore';
+import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { useWeatherStore } from '@/stores/useWeatherStore';
 
 import OverviewView from './OverviewView';
 
@@ -55,22 +58,46 @@ const historyData: HistoryData = {
 
 function seededClient(): QueryClient {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  useLibraryStore.setState({ library, libraryLoaded: true });
+  // hasHistory is derived from the summary's totalPlays, so seeding the 7d
+  // history query is enough to flip Overview from the empty section to the full
+  // data layout; the hourly/insights/recommendations sub-queries fall back to
+  // their defaults.
   client.setQueryData(historyKeys.data('7d'), historyData);
   return client;
 }
 
+/**
+ * overview · OverviewView. The landing dashboard — the composition root that
+ * assembles the greeting hero, stat strip, top-this-week, listening clock, top
+ * albums, smart mixes, recommendations, and the recently-added rail, all gated
+ * by interface-store toggles (all on by default) and the data branches
+ * (loading / error / first-run / populated). The leaf sections are tested in
+ * their own stories, so here the populated story asserts the greeting hero plus
+ * the section headings, and the first-run story asserts the welcome empty state.
+ * The playback + weather stores are seeded to the baseline so the hero is
+ * deterministic.
+ */
 const meta: Meta<typeof OverviewView> = {
   title: 'overview/OverviewView',
   component: OverviewView,
+  // a11y stays at the global 'todo' default rather than ratcheting to 'error':
+  // this composition root mounts RecommendationsShelf, whose discover section
+  // async-swaps in the out-of-scope DependencyInstallCard under the Storybook
+  // IPC mock. The leaf overview components are individually ratcheted to 'error'
+  // in their own stories; here `play` asserts the composed structure.
+  parameters: {},
   decorators: [
-    Story => (
-      <QueryClientProvider client={seededClient()}>
-        <div className="flex h-[48rem] flex-col">
-          <Story />
-        </div>
-      </QueryClientProvider>
-    ),
+    Story => {
+      useWeatherStore.setState({ enabled: false, coords: null });
+      usePlaybackStore.setState({ currentTrack: null });
+      return (
+        <QueryClientProvider client={seededClient()}>
+          <div className="flex h-[48rem] flex-col">
+            <Story />
+          </div>
+        </QueryClientProvider>
+      );
+    },
   ],
 };
 
@@ -78,8 +105,27 @@ export default meta;
 
 type Story = StoryObj<typeof OverviewView>;
 
-export const Populated: Story = {};
+/** A library with listening history — the hero plus every data section heading. */
+export const Populated: Story = {
+  decorators: [
+    Story => {
+      useLibraryStore.setState({ library, libraryLoaded: true });
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Greeting hero (eyebrow + heading) anchors the top of the dashboard.
+    await expect(await canvas.findByText('Your sanctuary')).toBeInTheDocument();
+    // The stat strip + week sections render once history exists.
+    await expect(canvas.getByText('Listened this week')).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Top this week' })).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Listening clock' })).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Top albums this week' })).toBeInTheDocument();
+  },
+};
 
+/** No library at all — the single welcoming first-run empty state with its CTA. */
 export const FirstRun: Story = {
   decorators: [
     Story => {
@@ -87,4 +133,11 @@ export const FirstRun: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('Your sanctuary starts here')).toBeInTheDocument();
+    // The empty state offers a single create CTA; the data sections stay hidden.
+    await expect(canvas.getByRole('button', { name: 'Add a music folder' })).toBeInTheDocument();
+    await expect(canvas.queryByText('Listened this week')).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/overview/RecentlyAdded/RecentlyAdded.stories.tsx
+++ b/apps/web/src/components/overview/RecentlyAdded/RecentlyAdded.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, fn } from 'storybook/test';
 import type { Track } from '@/stores/types';
 
 import RecentlyAdded from './RecentlyAdded';
@@ -30,10 +31,24 @@ const tracks: Track[] = [
   }),
 ];
 
+/**
+ * overview · RecentlyAdded. A horizontally-scrolling rail of the most recently
+ * imported tracks. A real `<h2>` ("Recently added") sits beside a "{n} new
+ * tracks" count; each card is a `<button>` labelled "Play {title}" that fires
+ * `onPlay` with the track id. Subtitles carry a relative "added N ago" string
+ * (non-deterministic), so stories assert the stable heading, count, and card
+ * roles rather than the relative time. Cover art is a decorative `OverviewCover`
+ * fallback.
+ */
 const meta: Meta<typeof RecentlyAdded> = {
   title: 'overview/RecentlyAdded',
   component: RecentlyAdded,
-  args: { onPlay: () => {} },
+  parameters: {
+    // Real heading; each card is a labelled button in a list, covers are
+    // aria-hidden — axe passes clean.
+    a11y: { test: 'error' },
+  },
+  args: { onPlay: fn() },
   decorators: [
     Story => (
       <div className="w-[40rem]">
@@ -47,6 +62,17 @@ export default meta;
 
 type Story = StoryObj<typeof RecentlyAdded>;
 
+/** Three new tracks — the count label, a card per track, and play-on-click. */
 export const Default: Story = {
   args: { tracks },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Recently added' })).toBeInTheDocument();
+    await expect(canvas.getByText('3 new tracks')).toBeInTheDocument();
+    // One card button per track.
+    await expect(canvas.getAllByRole('button', { name: /^Play / })).toHaveLength(3);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Play Drift' }));
+    await expect(args.onPlay).toHaveBeenCalledWith('t1');
+  },
 };

--- a/apps/web/src/components/overview/RecommendationsShelf/RecommendationsShelf.stories.tsx
+++ b/apps/web/src/components/overview/RecommendationsShelf/RecommendationsShelf.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, userEvent, expect, fn } from 'storybook/test';
 import type { RecommendationShelves } from '@shiranami/contracts';
 import { recommendationKeys } from '@/hooks/queries/useRecommendations';
 
@@ -29,10 +30,27 @@ function seededClient(): QueryClient {
   return client;
 }
 
+/**
+ * overview · RecommendationsShelf. The "Recommended for you" shelf — a "From
+ * your library" section of play-on-click track cards plus a "Discover new music"
+ * section. The library rows read from the seeded recommendations cache; each is
+ * a `<button>` labelled "Play {title}" that fires `onPlay`. The discover section
+ * is gated on yt-dlp/ffmpeg being present (checked over IPC on mount); under the
+ * Storybook electronAPI mock that check resolves to "needs install", so the
+ * discover slot asynchronously swaps in the out-of-scope dependency-install
+ * card. Stories seed the cache and drive a library row.
+ */
 const meta: Meta<typeof RecommendationsShelf> = {
   title: 'overview/RecommendationsShelf',
   component: RecommendationsShelf,
-  args: { onPlay: () => {}, hasLibrary: true },
+  // a11y stays at the global 'todo' default rather than ratcheting to 'error':
+  // the discover section runs an on-mount dependency check that, under the
+  // Storybook IPC mock, resolves to "needs install" and async-mounts the
+  // out-of-scope DependencyInstallCard — so axe-cleanliness here depends on a
+  // component outside this file's audit scope. The deterministic library
+  // section (real <h2>, labelled play buttons) is asserted in `play`.
+  parameters: {},
+  args: { onPlay: fn(), hasLibrary: true },
   decorators: [
     Story => (
       <QueryClientProvider client={seededClient()}>
@@ -48,4 +66,19 @@ export default meta;
 
 type Story = StoryObj<typeof RecommendationsShelf>;
 
-export const Default: Story = {};
+/** Two library picks — the shelf heading, the section, and play-on-click. */
+export const Default: Story = {
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole('heading', { name: 'Recommended for you' })
+    ).toBeInTheDocument();
+    // The "From your library" section header is a real heading.
+    await expect(canvas.getByRole('heading', { name: 'From your library' })).toBeInTheDocument();
+
+    // Each seeded library pick is a labelled play button.
+    await userEvent.click(canvas.getByRole('button', { name: 'Play Drift' }));
+    await expect(args.onPlay).toHaveBeenCalledWith('lt1');
+    await expect(canvas.getByRole('button', { name: 'Play Afterglow' })).toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/overview/SmartMixesShelf/SmartMixesShelf.stories.tsx
+++ b/apps/web/src/components/overview/SmartMixesShelf/SmartMixesShelf.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, userEvent, expect } from 'storybook/test';
 import type { SmartMixResult } from '@shiranami/contracts';
 import type { Track } from '@/stores/types';
 import { useLibraryStore } from '@/stores/useLibraryStore';
+import { usePlaybackStore } from '@/stores/usePlaybackStore';
 
 import SmartMixesShelf from './SmartMixesShelf';
 
@@ -35,24 +37,41 @@ const library: Track[] = [
   },
 ];
 
-function seededClient(): QueryClient {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  useLibraryStore.setState({ library });
-  client.setQueryData(['smartMixes', new Date().getHours(), 'none'], mixes);
-  return client;
-}
-
+/**
+ * overview · SmartMixesShelf. A compact chip row of contextual mixes generated
+ * from the current hour + opted-in weather and the library's metadata. A real
+ * `<h2>` ("For you right now") sits over one `<button>` chip per mix; the chip
+ * label is the localized mix title and clicking it resolves the mix's track ids
+ * against the in-memory library and starts playback. The whole shelf is hidden
+ * when no mix qualifies. The mixes query is keyed on the current local hour, so
+ * the seeded client mirrors `useSmartMixes`' key. Stories seed the library +
+ * mixes cache and drive a chip into the playback store.
+ */
 const meta: Meta<typeof SmartMixesShelf> = {
   title: 'overview/SmartMixesShelf',
   component: SmartMixesShelf,
+  parameters: {
+    // Real heading; each chip is a text-labelled button with decorative icons —
+    // axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
-    Story => (
-      <QueryClientProvider client={seededClient()}>
-        <div className="w-[40rem]">
-          <Story />
-        </div>
-      </QueryClientProvider>
-    ),
+    Story => {
+      // useSmartMixes keys on (hour, weather). Weather is off here, so the
+      // condition segment is 'none'; the hour matches useCurrentHour's initial
+      // read taken at the same render.
+      useLibraryStore.setState({ library });
+      usePlaybackStore.setState({ queue: [], queueIndex: 0 });
+      const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      client.setQueryData(['smartMixes', new Date().getHours(), 'none'], mixes);
+      return (
+        <QueryClientProvider client={client}>
+          <div className="w-[40rem]">
+            <Story />
+          </div>
+        </QueryClientProvider>
+      );
+    },
   ],
 };
 
@@ -60,4 +79,18 @@ export default meta;
 
 type Story = StoryObj<typeof SmartMixesShelf>;
 
-export const Default: Story = {};
+/** Two mixes — the section heading + a chip each; clicking one queues its track. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'For you right now' })).toBeInTheDocument();
+    // One chip per seeded mix, labelled by its localized title.
+    const focusChip = canvas.getByRole('button', { name: 'Focus' });
+    await expect(focusChip).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Best of the 1990s' })).toBeInTheDocument();
+
+    // Clicking a chip resolves its track ids and starts the queue.
+    await userEvent.click(focusChip);
+    await expect(usePlaybackStore.getState().queue).toHaveLength(1);
+  },
+};

--- a/apps/web/src/components/overview/StatStrip/StatStrip.stories.tsx
+++ b/apps/web/src/components/overview/StatStrip/StatStrip.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { ListeningStatsSummary } from '@/types/electron';
 
 import StatStrip from './StatStrip';
@@ -13,9 +14,22 @@ const summary: ListeningStatsSummary = {
   topArtists: [{ artist: 'Idealism', playCount: 41, listenedSeconds: 9000 }],
 };
 
+/**
+ * overview · StatStrip. The four-up Overview stat grid: listened-this-week,
+ * tracks-played, top-artist, and new-in-library tiles. Labels and trend copy are
+ * localized from the `overview` namespace; the top artist and new-count come
+ * from the supplied summary. Each tile's kanji watermark is decorative
+ * (`aria-hidden`). Stories assert the four labels, the top artist, and the
+ * week-over-week trend hint (present vs. the "No comparison yet" fallback).
+ */
 const meta: Meta<typeof StatStrip> = {
   title: 'overview/StatStrip',
   component: StatStrip,
+  parameters: {
+    // All four tiles are plain text on glass with aria-hidden watermarks —
+    // axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="w-[56rem]">
@@ -29,6 +43,7 @@ export default meta;
 
 type Story = StoryObj<typeof StatStrip>;
 
+/** A full week with a positive trend — all four labels, the artist, and the delta hint. */
 export const Default: Story = {
   args: {
     summary,
@@ -36,13 +51,33 @@ export const Default: Story = {
     trendDeltaMinutes: 138,
     sessionCount: 5,
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Listened this week')).toBeInTheDocument();
+    await expect(canvas.getByText('Tracks played')).toBeInTheDocument();
+    await expect(canvas.getByText('Top artist this week')).toBeInTheDocument();
+    await expect(canvas.getByText('New in library')).toBeInTheDocument();
+    // Top artist + new-in-library values come from the summary / count.
+    await expect(canvas.getByText('Idealism')).toBeInTheDocument();
+    await expect(canvas.getByText('+3')).toBeInTheDocument();
+    // +138 min ⇒ "+2h 18m vs. last week".
+    await expect(canvas.getByText('+2h 18m vs. last week')).toBeInTheDocument();
+  },
 };
 
+/** No prior window + nothing new — the trend falls back to "No comparison yet". */
 export const NoComparison: Story = {
   args: {
     summary,
     newInLibraryCount: 0,
     trendDeltaMinutes: undefined,
     sessionCount: 0,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No comparison yet')).toBeInTheDocument();
+    // Nothing added ⇒ the new-in-library value reads "0".
+    await expect(canvas.getByText('0')).toBeInTheDocument();
+    await expect(canvas.queryByText(/vs\. last week/)).not.toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/overview/StatTile/StatTile.stories.tsx
+++ b/apps/web/src/components/overview/StatTile/StatTile.stories.tsx
@@ -1,10 +1,23 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import StatTile from './StatTile';
 
+/**
+ * overview · StatTile. One Overview stat tile: a faint decorative kanji
+ * watermark, an emphasized value, a two-line uppercase label, and an optional
+ * trend hint tinted by direction (`up` reads green, others muted). The watermark
+ * is `aria-hidden`, so the only readable content is the value, label, and hint.
+ * Stories assert the value + label text and that the hint shows only when given.
+ */
 const meta: Meta<typeof StatTile> = {
   title: 'overview/StatTile',
   component: StatTile,
+  parameters: {
+    // The kanji watermark is aria-hidden; value/label/hint are plain text with
+    // sufficient contrast on the glass surface — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="w-56">
@@ -18,14 +31,23 @@ export default meta;
 
 type Story = StoryObj<typeof StatTile>;
 
+/** Value + label only — no trend hint line. */
 export const Default: Story = {
   args: {
     kanji: '時',
     value: '14h 32m',
     label: 'Listened this week',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('14h 32m')).toBeInTheDocument();
+    await expect(canvas.getByText('Listened this week')).toBeInTheDocument();
+    // No hint was supplied, so the trend sub-line is absent.
+    await expect(canvas.queryByText(/vs\. last week/)).not.toBeInTheDocument();
+  },
 };
 
+/** Upward trend — the hint renders and is tinted positive (green). */
 export const TrendUp: Story = {
   args: {
     kanji: '時',
@@ -34,8 +56,15 @@ export const TrendUp: Story = {
     hint: '+2h 18m vs. last week',
     trend: 'up',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const hint = canvas.getByText('+2h 18m vs. last week');
+    await expect(hint).toBeInTheDocument();
+    await expect(hint).toHaveClass('text-emerald-400/90');
+  },
 };
 
+/** Downward trend — the hint renders but stays muted (not the positive tint). */
 export const TrendDown: Story = {
   args: {
     kanji: '時',
@@ -43,5 +72,11 @@ export const TrendDown: Story = {
     label: 'Listened this week',
     hint: '−45m vs. last week',
     trend: 'down',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const hint = canvas.getByText('−45m vs. last week');
+    await expect(hint).toBeInTheDocument();
+    await expect(hint).not.toHaveClass('text-emerald-400/90');
   },
 };

--- a/apps/web/src/components/overview/TopAlbums/TopAlbums.stories.tsx
+++ b/apps/web/src/components/overview/TopAlbums/TopAlbums.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { ListeningAlbumStat } from '@/types/electron';
 
 import TopAlbums from './TopAlbums';
@@ -9,9 +10,21 @@ const albums: ListeningAlbumStat[] = [
   { album: 'Slow Mornings', artist: 'Aso', albumArt: null, playCount: 9 },
 ];
 
+/**
+ * overview · TopAlbums. The "Top albums this week" card — a real `<h2>` over a
+ * list of albums, each with artist, a play-count bar, and a localized "{n}
+ * plays" label. A missing artist falls back to the common "Unknown Artist"
+ * string. With no albums the list is replaced by an empty-state line. Stories
+ * cover the populated list (heading + per-album labels) and the empty state.
+ */
 const meta: Meta<typeof TopAlbums> = {
   title: 'overview/TopAlbums',
   component: TopAlbums,
+  parameters: {
+    // Real heading; rows are plain text in a list, bar fills are decorative —
+    // axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="w-80">
@@ -25,10 +38,26 @@ export default meta;
 
 type Story = StoryObj<typeof TopAlbums>;
 
+/** Three albums — the heading plus each album's name and "{n} plays" label. */
 export const Default: Story = {
   args: { albums },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Top albums this week' })).toBeInTheDocument();
+    await expect(canvas.getByText('Midnight Tapes')).toBeInTheDocument();
+    await expect(canvas.getByText('24 plays')).toBeInTheDocument();
+    // Each album is its own list row.
+    await expect(canvas.getAllByRole('listitem')).toHaveLength(3);
+  },
 };
 
+/** No albums — the list is replaced by the empty-state copy. */
 export const Empty: Story = {
   args: { albums: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Top albums this week' })).toBeInTheDocument();
+    await expect(canvas.getByText(/most-spun albums/)).toBeInTheDocument();
+    await expect(canvas.queryByRole('listitem')).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/overview/TopThisWeek/TopThisWeek.stories.tsx
+++ b/apps/web/src/components/overview/TopThisWeek/TopThisWeek.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, fn } from 'storybook/test';
 import type { ListeningStatsTrack } from '@/types/electron';
 
 import TopThisWeek from './TopThisWeek';
@@ -23,10 +24,23 @@ const tracks: ListeningStatsTrack[] = [
   makeTrack({ trackId: 't3', title: 'Intro', playCount: 6 }),
 ];
 
+/**
+ * overview · TopThisWeek. The most-played-tracks leaderboard. A real `<h2>`
+ * ("Top this week") sits beside an "Open library" header action; each ranked row
+ * is a `<button>` labelled "Play {title}" that fires `onPlay` with the track id.
+ * Cover art is a decorative `OverviewCover` fallback. With no tracks the rows are
+ * replaced by an empty-state line. Stories drive a row + the header action with
+ * `fn()` spies and assert the empty branch.
+ */
 const meta: Meta<typeof TopThisWeek> = {
   title: 'overview/TopThisWeek',
   component: TopThisWeek,
-  args: { onPlay: () => {}, onOpenLibrary: () => {} },
+  parameters: {
+    // Real heading; every row + the header action is a labelled button, covers
+    // are aria-hidden — axe passes clean.
+    a11y: { test: 'error' },
+  },
+  args: { onPlay: fn(), onOpenLibrary: fn() },
   decorators: [
     Story => (
       <div className="w-[34rem]">
@@ -40,10 +54,29 @@ export default meta;
 
 type Story = StoryObj<typeof TopThisWeek>;
 
+/** Three ranked tracks — clicking a row plays it; the header opens the library. */
 export const Default: Story = {
   args: { tracks },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Top this week' })).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Play Drift' }));
+    await expect(args.onPlay).toHaveBeenCalledWith('t1');
+
+    await userEvent.click(canvas.getByRole('button', { name: /Open library/ }));
+    await expect(args.onOpenLibrary).toHaveBeenCalledTimes(1);
+  },
 };
 
+/** No tracks — the rows are replaced by the empty-state copy. */
 export const Empty: Story = {
   args: { tracks: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Top this week' })).toBeInTheDocument();
+    await expect(canvas.getByText(/your week will start to take shape/)).toBeInTheDocument();
+    // No play rows render in the empty state.
+    await expect(canvas.queryByRole('button', { name: /^Play / })).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/overview/WeatherRow/WeatherRow.stories.tsx
+++ b/apps/web/src/components/overview/WeatherRow/WeatherRow.stories.tsx
@@ -1,13 +1,27 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { WeatherCurrent } from '@shiranami/contracts';
 
 import WeatherRow from './WeatherRow';
 
 const rain: WeatherCurrent = { tempC: 12, condition: 'rain', label: 'Rain' };
 
+/**
+ * overview · WeatherRow. The clock card's weather line: the current condition +
+ * rounded temperature ("Rain · 12°C") over a localized, city-prefixed flavor
+ * line — or a single "Weather unavailable" line when weather is missing or the
+ * query errored. Condition labels arrive in English from Open-Meteo; only the
+ * chrome (flavor copy, "unavailable") is localized. This component takes the
+ * weather as props — the parent GreetingHero owns the fetch. Stories cover the
+ * available and unavailable branches.
+ */
 const meta: Meta<typeof WeatherRow> = {
   title: 'overview/WeatherRow',
   component: WeatherRow,
+  parameters: {
+    // Plain text lines, no controls or images — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="w-56">
@@ -21,17 +35,30 @@ export default meta;
 
 type Story = StoryObj<typeof WeatherRow>;
 
+/** Rain at 12°C in Kraków — the weather line plus a city-prefixed flavor line. */
 export const WithWeather: Story = {
   args: {
     weather: rain,
     isError: false,
     cityLabel: 'Kraków, PL',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Rain · 12°C')).toBeInTheDocument();
+    // The flavor line is prefixed with the city label.
+    await expect(canvas.getByText(/^Kraków, PL · /)).toBeInTheDocument();
+  },
 };
 
+/** Errored fetch — the single muted "unavailable" line replaces both rows. */
 export const Unavailable: Story = {
   args: {
     weather: undefined,
     isError: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Weather unavailable')).toBeInTheDocument();
+    await expect(canvas.queryByText(/°C/)).not.toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/player/AudioVisualizer/AudioVisualizer.stories.tsx
+++ b/apps/web/src/components/player/AudioVisualizer/AudioVisualizer.stories.tsx
@@ -2,31 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 
 import AudioVisualizer from './AudioVisualizer';
-import type { FrequencySource } from '../visualizer-source';
-
-/**
- * A deterministic, audio-free frequency source so a story can drive the real
- * per-frame draw path without the playback engine — two summed sine waves
- * tapered toward the high bins, mirroring the rough shape of real spectrum
- * data (same shape the settings preview uses).
- */
-function createSyntheticSource(): FrequencySource {
-  let t = 0;
-  return {
-    binCount: 256,
-    read(buf) {
-      t += 0.04;
-      for (let i = 0; i < buf.length; i++) {
-        const x = i / buf.length;
-        const a = Math.sin(t + x * 7) * (1 - x);
-        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
-        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
-      }
-      return true;
-    },
-  };
-}
-
+import { createSyntheticSource } from '../visualizerStorySource';
 /**
  * player · AudioVisualizer. Canvas frequency bars with a soft lofi aesthetic —
  * center-aligned rounded bars with edge fading. Renders a single decorative

--- a/apps/web/src/components/player/AudioVisualizer/AudioVisualizer.stories.tsx
+++ b/apps/web/src/components/player/AudioVisualizer/AudioVisualizer.stories.tsx
@@ -1,10 +1,47 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import AudioVisualizer from './AudioVisualizer';
+import type { FrequencySource } from '../visualizer-source';
 
+/**
+ * A deterministic, audio-free frequency source so a story can drive the real
+ * per-frame draw path without the playback engine — two summed sine waves
+ * tapered toward the high bins, mirroring the rough shape of real spectrum
+ * data (same shape the settings preview uses).
+ */
+function createSyntheticSource(): FrequencySource {
+  let t = 0;
+  return {
+    binCount: 256,
+    read(buf) {
+      t += 0.04;
+      for (let i = 0; i < buf.length; i++) {
+        const x = i / buf.length;
+        const a = Math.sin(t + x * 7) * (1 - x);
+        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
+        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * player · AudioVisualizer. Canvas frequency bars with a soft lofi aesthetic —
+ * center-aligned rounded bars with edge fading. Renders a single decorative
+ * `<canvas>` (no role, no text) that animates from a `FrequencySource` via a
+ * frame-rate-capped rAF loop. With no source and no playback analyser the loop
+ * idles before drawing but the canvas still mounts; a synthetic source drives
+ * the real draw path.
+ */
 const meta: Meta<typeof AudioVisualizer> = {
   title: 'player/AudioVisualizer',
   component: AudioVisualizer,
+  // a11y ratcheted to 'error': the component renders a lone <canvas> with no
+  // role and no accessible name (purely decorative, pointer-events-none), which
+  // is axe-clean — there is no text, contrast surface, or named-region to flag.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div style={{ width: 320, height: 96 }}>
@@ -18,6 +55,29 @@ export default meta;
 
 type Story = StoryObj<typeof AudioVisualizer>;
 
-export const Default: Story = {
+/**
+ * Idle — active with no source and no playback analyser, so the rAF prelude
+ * returns before drawing. The decorative canvas still mounts into the DOM.
+ */
+export const Idle: Story = {
   render: () => <AudioVisualizer active />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+  },
+};
+
+/**
+ * Active — fed a deterministic synthetic source so the real per-frame bar draw
+ * executes against a live 2D context. The canvas mounts and fills its wrapper.
+ */
+export const Active: Story = {
+  render: () => <AudioVisualizer active source={createSyntheticSource()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+    // Decorative canvas: no role/name to assert, so confirm it fills its wrapper
+    // (block display + w-full/h-full) by checking it is the rendered element.
+    await expect(canvas).toBeVisible();
+  },
 };

--- a/apps/web/src/components/player/CircleVisualizer/CircleVisualizer.stories.tsx
+++ b/apps/web/src/components/player/CircleVisualizer/CircleVisualizer.stories.tsx
@@ -1,10 +1,47 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import CircleVisualizer from './CircleVisualizer';
+import type { FrequencySource } from '../visualizer-source';
 
+/**
+ * A deterministic, audio-free frequency source so a story can drive the real
+ * per-frame draw path without the playback engine — two summed sine waves
+ * tapered toward the high bins, mirroring the rough shape of real spectrum
+ * data (same shape the settings preview uses).
+ */
+function createSyntheticSource(): FrequencySource {
+  let t = 0;
+  return {
+    binCount: 256,
+    read(buf) {
+      t += 0.04;
+      for (let i = 0; i < buf.length; i++) {
+        const x = i / buf.length;
+        const a = Math.sin(t + x * 7) * (1 - x);
+        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
+        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * player · CircleVisualizer. A compact circular spectrum — a centered ring with
+ * radial bars growing outward and a dotted inner ring. Renders a single
+ * decorative `<canvas>` (no role, no text) that animates from a
+ * `FrequencySource` via a frame-rate-capped rAF loop. With no source and no
+ * playback analyser the loop idles before drawing but the canvas still mounts;
+ * a synthetic source drives the real draw path.
+ */
 const meta: Meta<typeof CircleVisualizer> = {
   title: 'player/CircleVisualizer',
   component: CircleVisualizer,
+  // a11y ratcheted to 'error': the component renders a lone <canvas> with no
+  // role and no accessible name (purely decorative, pointer-events-none), which
+  // is axe-clean — there is no text, contrast surface, or named-region to flag.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div style={{ width: 320, height: 96 }}>
@@ -18,6 +55,28 @@ export default meta;
 
 type Story = StoryObj<typeof CircleVisualizer>;
 
-export const Default: Story = {
+/**
+ * Idle — active with no source and no playback analyser, so the rAF prelude
+ * returns before drawing. The decorative canvas still mounts into the DOM.
+ */
+export const Idle: Story = {
   render: () => <CircleVisualizer active />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+  },
+};
+
+/**
+ * Active — fed a deterministic synthetic source so the real per-frame radial
+ * draw executes against a live 2D context. The canvas mounts and fills its
+ * wrapper.
+ */
+export const Active: Story = {
+  render: () => <CircleVisualizer active source={createSyntheticSource()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+    await expect(canvas).toBeVisible();
+  },
 };

--- a/apps/web/src/components/player/CircleVisualizer/CircleVisualizer.stories.tsx
+++ b/apps/web/src/components/player/CircleVisualizer/CircleVisualizer.stories.tsx
@@ -2,31 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 
 import CircleVisualizer from './CircleVisualizer';
-import type { FrequencySource } from '../visualizer-source';
-
-/**
- * A deterministic, audio-free frequency source so a story can drive the real
- * per-frame draw path without the playback engine — two summed sine waves
- * tapered toward the high bins, mirroring the rough shape of real spectrum
- * data (same shape the settings preview uses).
- */
-function createSyntheticSource(): FrequencySource {
-  let t = 0;
-  return {
-    binCount: 256,
-    read(buf) {
-      t += 0.04;
-      for (let i = 0; i < buf.length; i++) {
-        const x = i / buf.length;
-        const a = Math.sin(t + x * 7) * (1 - x);
-        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
-        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
-      }
-      return true;
-    },
-  };
-}
-
+import { createSyntheticSource } from '../visualizerStorySource';
 /**
  * player · CircleVisualizer. A compact circular spectrum — a centered ring with
  * radial bars growing outward and a dotted inner ring. Renders a single

--- a/apps/web/src/components/player/CompactPlayer/CompactPlayer.stories.tsx
+++ b/apps/web/src/components/player/CompactPlayer/CompactPlayer.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useCompactStore } from '@/stores/useCompactStore';
@@ -33,10 +34,24 @@ function seedCompact(track: Track | null): void {
   });
 }
 
+/**
+ * player · CompactPlayer. The mini "Compact Mode" window — a title bar with
+ * favorite, lyrics (a pressed toggle), pin, expand, and minimize buttons, over a
+ * card holding the album art, track text, transport (PlayerControls), volume, and
+ * a seek row (SeekBar + TimeDisplay). It reads `usePlaybackStore` for the track
+ * and `useCompactStore` for which chrome to show. With no track it shows the
+ * "Nothing playing" idle state and the transport play button is disabled. Stories
+ * seed both stores and assert the chrome by role + name.
+ */
 const meta: Meta<typeof CompactPlayer> = {
   title: 'player/CompactPlayer',
   component: CompactPlayer,
-  parameters: { layout: 'centered' },
+  parameters: {
+    layout: 'centered',
+    // Every chrome button is icon-only but labelled, the favorite/lyrics toggles
+    // expose state, and the seek + volume sliders carry accessible names — clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <TooltipProvider>
@@ -52,6 +67,7 @@ export default meta;
 
 type Story = StoryObj<typeof CompactPlayer>;
 
+/** Playing — the mini-player with its full chrome and an active lyrics toggle. */
 export const Playing: Story = {
   decorators: [
     Story => {
@@ -59,8 +75,23 @@ export const Playing: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Midnight Tapes')).toBeInTheDocument();
+    // Transport is wired (playing → Pause); the seek + volume sliders are named.
+    await expect(canvas.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+    await expect(canvas.getByRole('slider', { name: 'Seek' })).toBeInTheDocument();
+    await expect(canvas.getByRole('slider', { name: 'Volume' })).toBeInTheDocument();
+
+    // The lyrics control is a toggle button reporting its (closed) pressed state.
+    const lyrics = canvas.getByRole('button', { name: 'Show lyrics' });
+    await expect(lyrics).toHaveAttribute('aria-pressed', 'false');
+    // The album art doubles as the expand-to-full-player control.
+    await expect(canvas.getByRole('button', { name: 'Expand to full player' })).toBeInTheDocument();
+  },
 };
 
+/** Idle — no track: the placeholder copy shows and transport is disabled. */
 export const Idle: Story = {
   decorators: [
     Story => {
@@ -68,4 +99,13 @@ export const Idle: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Nothing playing')).toBeInTheDocument();
+    // No track to control, so the transport play/pause button is disabled. Its
+    // label tracks the seeded `isPlaying` flag (here "Pause"), not the absence of
+    // a track — assert the disabled transport control rather than a "Play" label
+    // that this idle seed never renders.
+    await expect(canvas.getByRole('button', { name: 'Pause' })).toBeDisabled();
+  },
 };

--- a/apps/web/src/components/player/ConstellationVisualizer/ConstellationVisualizer.stories.tsx
+++ b/apps/web/src/components/player/ConstellationVisualizer/ConstellationVisualizer.stories.tsx
@@ -2,31 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 
 import ConstellationVisualizer from './ConstellationVisualizer';
-import type { FrequencySource } from '../visualizer-source';
-
-/**
- * A deterministic, audio-free frequency source so a story can drive the real
- * per-frame draw path without the playback engine — two summed sine waves
- * tapered toward the high bins, mirroring the rough shape of real spectrum
- * data (same shape the settings preview uses).
- */
-function createSyntheticSource(): FrequencySource {
-  let t = 0;
-  return {
-    binCount: 256,
-    read(buf) {
-      t += 0.04;
-      for (let i = 0; i < buf.length; i++) {
-        const x = i / buf.length;
-        const a = Math.sin(t + x * 7) * (1 - x);
-        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
-        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
-      }
-      return true;
-    },
-  };
-}
-
+import { createSyntheticSource } from '../visualizerStorySource';
 /**
  * player · ConstellationVisualizer. Drifting particles connected by lines that
  * brighten and reach further on bass — the "linked points" effect. Renders a

--- a/apps/web/src/components/player/ConstellationVisualizer/ConstellationVisualizer.stories.tsx
+++ b/apps/web/src/components/player/ConstellationVisualizer/ConstellationVisualizer.stories.tsx
@@ -1,10 +1,47 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import ConstellationVisualizer from './ConstellationVisualizer';
+import type { FrequencySource } from '../visualizer-source';
 
+/**
+ * A deterministic, audio-free frequency source so a story can drive the real
+ * per-frame draw path without the playback engine — two summed sine waves
+ * tapered toward the high bins, mirroring the rough shape of real spectrum
+ * data (same shape the settings preview uses).
+ */
+function createSyntheticSource(): FrequencySource {
+  let t = 0;
+  return {
+    binCount: 256,
+    read(buf) {
+      t += 0.04;
+      for (let i = 0; i < buf.length; i++) {
+        const x = i / buf.length;
+        const a = Math.sin(t + x * 7) * (1 - x);
+        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
+        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * player · ConstellationVisualizer. Drifting particles connected by lines that
+ * brighten and reach further on bass — the "linked points" effect. Renders a
+ * single decorative `<canvas>` (no role, no text) that animates from a
+ * `FrequencySource` via a frame-rate-capped rAF loop. With no source and no
+ * playback analyser the loop idles before drawing but the canvas still mounts;
+ * a synthetic source drives the real draw path.
+ */
 const meta: Meta<typeof ConstellationVisualizer> = {
   title: 'player/ConstellationVisualizer',
   component: ConstellationVisualizer,
+  // a11y ratcheted to 'error': the component renders a lone <canvas> with no
+  // role and no accessible name (purely decorative, pointer-events-none), which
+  // is axe-clean — there is no text, contrast surface, or named-region to flag.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div style={{ width: 320, height: 96 }}>
@@ -18,6 +55,28 @@ export default meta;
 
 type Story = StoryObj<typeof ConstellationVisualizer>;
 
-export const Default: Story = {
+/**
+ * Idle — active with no source and no playback analyser, so the rAF prelude
+ * returns before drawing. The decorative canvas still mounts into the DOM.
+ */
+export const Idle: Story = {
   render: () => <ConstellationVisualizer active />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+  },
+};
+
+/**
+ * Active — fed a deterministic synthetic source so the real per-frame particle
+ * + link draw executes against a live 2D context. The canvas mounts and fills
+ * its wrapper.
+ */
+export const Active: Story = {
+  render: () => <ConstellationVisualizer active source={createSyntheticSource()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+    await expect(canvas).toBeVisible();
+  },
 };

--- a/apps/web/src/components/player/EqualizerPanel/EqualizerPanel.stories.tsx
+++ b/apps/web/src/components/player/EqualizerPanel/EqualizerPanel.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, screen, userEvent, expect } from 'storybook/test';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { useEqStore } from '@/stores/useEqStore';
 
@@ -14,6 +15,22 @@ function seedEq(enabled: boolean): void {
   });
 }
 
+/**
+ * player · EqualizerPanel. The 10-band graphic EQ. By default it renders as an
+ * icon-only popover trigger ("Equalizer") in the player bar; with `inline` it
+ * renders the controls directly (used by the settings section). The surface
+ * holds an enable switch, a preset Select, the band strip (ten VerticalBand
+ * sliders), and a preamp slider, all reading `useEqStore`. The popover content
+ * portals to `document.body`, so stories query it via `screen`.
+ *
+ * a11y note: both variants ultimately expose the band sliders, which place their
+ * aria-label on the Radix Root (not the Thumb) — so those `role="slider"`
+ * elements are unnamed and axe's aria-input-field-name rule fails. The inline
+ * variant renders them immediately; the popover variant reveals them once its
+ * `play` opens the popover. Both are therefore deferred to `'todo'` until the
+ * band slider forwards its label to the Thumb (the shared ui/slider already does
+ * this) — a fix in VerticalBandSlider's own markup, out of scope for this pass.
+ */
 const meta: Meta<typeof EqualizerPanel> = {
   title: 'player/EqualizerPanel',
   component: EqualizerPanel,
@@ -32,16 +49,39 @@ export default meta;
 
 type Story = StoryObj<typeof EqualizerPanel>;
 
+/** Enabled trigger — the labelled EQ button opens its control popover on click. */
 export const TriggerEnabled: Story = {
+  // a11y stays at the global 'todo' default (NOT ratcheted): this story's `play`
+  // opens the popover, which mounts the ten band sliders. VerticalBandSlider puts
+  // its aria-label on the Radix Root rather than the Thumb, so each role="slider"
+  // thumb is unnamed and axe's aria-input-field-name rule fails. Same blocker as
+  // InlineSection — out of scope for this story-only pass.
   decorators: [
     Story => {
       seedEq(true);
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Equalizer' });
+    await userEvent.click(trigger);
+
+    // Popover content portals to body — the enable switch + preset select appear.
+    await expect(await screen.findByRole('switch')).toBeInTheDocument();
+    await expect(screen.getByRole('combobox')).toBeInTheDocument();
+    // The preamp uses the shared ui/slider, so its name lands on the thumb.
+    await expect(screen.getByRole('slider', { name: 'Preamp' })).toBeInTheDocument();
+  },
 };
 
+/** Inline section — the EQ controls rendered directly, as in the settings panel. */
 export const InlineSection: Story = {
+  // a11y stays at the global 'todo' default (NOT ratcheted): the inline variant
+  // renders the band-slider strip, and VerticalBandSlider puts its aria-label on
+  // the Radix Root rather than the Thumb — so each role="slider" thumb is unnamed
+  // and axe's aria-input-field-name rule fails. The fix lives in the band slider's
+  // own markup, which is out of scope for this story-only pass.
   args: { inline: true, layout: 'section' },
   decorators: [
     Story => {
@@ -53,4 +93,12 @@ export const InlineSection: Story = {
       );
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The enable switch + preset combobox render inline (no popover to open).
+    await expect(canvas.getByRole('switch')).toBeInTheDocument();
+    await expect(canvas.getByRole('combobox')).toBeInTheDocument();
+    // Ten band sliders plus the preamp slider make eleven role="slider" elements.
+    await expect(canvas.getAllByRole('slider')).toHaveLength(11);
+  },
 };

--- a/apps/web/src/components/player/KanjiVisualizer/KanjiVisualizer.stories.tsx
+++ b/apps/web/src/components/player/KanjiVisualizer/KanjiVisualizer.stories.tsx
@@ -1,10 +1,47 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import KanjiVisualizer from './KanjiVisualizer';
+import type { FrequencySource } from '../visualizer-source';
 
+/**
+ * A deterministic, audio-free frequency source so a story can drive the real
+ * per-frame draw path without the playback engine — two summed sine waves
+ * tapered toward the high bins, mirroring the rough shape of real spectrum
+ * data (same shape the settings preview uses).
+ */
+function createSyntheticSource(): FrequencySource {
+  let t = 0;
+  return {
+    binCount: 256,
+    read(buf) {
+      t += 0.04;
+      for (let i = 0; i < buf.length; i++) {
+        const x = i / buf.length;
+        const a = Math.sin(t + x * 7) * (1 - x);
+        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
+        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * player · KanjiVisualizer. Kanji-rain — columns of falling glyphs with a
+ * fading trail, each column's speed and brightness reacting to its frequency
+ * band. Renders a single decorative `<canvas>` (no role, no text) that animates
+ * from a `FrequencySource` via a frame-rate-capped rAF loop. With no source and
+ * no playback analyser the loop idles before drawing but the canvas still
+ * mounts; a synthetic source drives the real draw path.
+ */
 const meta: Meta<typeof KanjiVisualizer> = {
   title: 'player/KanjiVisualizer',
   component: KanjiVisualizer,
+  // a11y ratcheted to 'error': the component renders a lone <canvas> with no
+  // role and no accessible name (the glyphs are painted into the canvas bitmap,
+  // not real DOM text), which is axe-clean — nothing to flag in the a11y tree.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div style={{ width: 320, height: 96 }}>
@@ -18,6 +55,28 @@ export default meta;
 
 type Story = StoryObj<typeof KanjiVisualizer>;
 
-export const Default: Story = {
+/**
+ * Idle — active with no source and no playback analyser, so the rAF prelude
+ * returns before drawing. The decorative canvas still mounts into the DOM.
+ */
+export const Idle: Story = {
   render: () => <KanjiVisualizer active />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+  },
+};
+
+/**
+ * Active — fed a deterministic synthetic source so the real per-frame glyph
+ * column draw executes against a live 2D context. The canvas mounts and fills
+ * its wrapper.
+ */
+export const Active: Story = {
+  render: () => <KanjiVisualizer active source={createSyntheticSource()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+    await expect(canvas).toBeVisible();
+  },
 };

--- a/apps/web/src/components/player/KanjiVisualizer/KanjiVisualizer.stories.tsx
+++ b/apps/web/src/components/player/KanjiVisualizer/KanjiVisualizer.stories.tsx
@@ -2,31 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 
 import KanjiVisualizer from './KanjiVisualizer';
-import type { FrequencySource } from '../visualizer-source';
-
-/**
- * A deterministic, audio-free frequency source so a story can drive the real
- * per-frame draw path without the playback engine — two summed sine waves
- * tapered toward the high bins, mirroring the rough shape of real spectrum
- * data (same shape the settings preview uses).
- */
-function createSyntheticSource(): FrequencySource {
-  let t = 0;
-  return {
-    binCount: 256,
-    read(buf) {
-      t += 0.04;
-      for (let i = 0; i < buf.length; i++) {
-        const x = i / buf.length;
-        const a = Math.sin(t + x * 7) * (1 - x);
-        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
-        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
-      }
-      return true;
-    },
-  };
-}
-
+import { createSyntheticSource } from '../visualizerStorySource';
 /**
  * player · KanjiVisualizer. Kanji-rain — columns of falling glyphs with a
  * fading trail, each column's speed and brightness reacting to its frequency

--- a/apps/web/src/components/player/LiquidVisualizer/LiquidVisualizer.stories.tsx
+++ b/apps/web/src/components/player/LiquidVisualizer/LiquidVisualizer.stories.tsx
@@ -1,10 +1,47 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import LiquidVisualizer from './LiquidVisualizer';
+import type { FrequencySource } from '../visualizer-source';
 
+/**
+ * A deterministic, audio-free frequency source so a story can drive the real
+ * per-frame draw path without the playback engine — two summed sine waves
+ * tapered toward the high bins, mirroring the rough shape of real spectrum
+ * data (same shape the settings preview uses).
+ */
+function createSyntheticSource(): FrequencySource {
+  let t = 0;
+  return {
+    binCount: 256,
+    read(buf) {
+      t += 0.04;
+      for (let i = 0; i < buf.length; i++) {
+        const x = i / buf.length;
+        const a = Math.sin(t + x * 7) * (1 - x);
+        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
+        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * player · LiquidVisualizer. A soft metaball blob whose vertices wobble with
+ * audio and a slow morph, wrapped in a glowing halo. Renders a single
+ * decorative `<canvas>` (no role, no text) that animates from a
+ * `FrequencySource` via a frame-rate-capped rAF loop. With no source and no
+ * playback analyser the loop idles before drawing but the canvas still mounts;
+ * a synthetic source drives the real draw path.
+ */
 const meta: Meta<typeof LiquidVisualizer> = {
   title: 'player/LiquidVisualizer',
   component: LiquidVisualizer,
+  // a11y ratcheted to 'error': the component renders a lone <canvas> with no
+  // role and no accessible name (purely decorative, pointer-events-none), which
+  // is axe-clean — there is no text, contrast surface, or named-region to flag.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div style={{ width: 320, height: 96 }}>
@@ -18,6 +55,28 @@ export default meta;
 
 type Story = StoryObj<typeof LiquidVisualizer>;
 
-export const Default: Story = {
+/**
+ * Idle — active with no source and no playback analyser, so the rAF prelude
+ * returns before drawing. The decorative canvas still mounts into the DOM.
+ */
+export const Idle: Story = {
   render: () => <LiquidVisualizer active />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+  },
+};
+
+/**
+ * Active — fed a deterministic synthetic source so the real per-frame blob +
+ * halo draw executes against a live 2D context. The canvas mounts and fills its
+ * wrapper.
+ */
+export const Active: Story = {
+  render: () => <LiquidVisualizer active source={createSyntheticSource()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+    await expect(canvas).toBeVisible();
+  },
 };

--- a/apps/web/src/components/player/LiquidVisualizer/LiquidVisualizer.stories.tsx
+++ b/apps/web/src/components/player/LiquidVisualizer/LiquidVisualizer.stories.tsx
@@ -2,31 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 
 import LiquidVisualizer from './LiquidVisualizer';
-import type { FrequencySource } from '../visualizer-source';
-
-/**
- * A deterministic, audio-free frequency source so a story can drive the real
- * per-frame draw path without the playback engine — two summed sine waves
- * tapered toward the high bins, mirroring the rough shape of real spectrum
- * data (same shape the settings preview uses).
- */
-function createSyntheticSource(): FrequencySource {
-  let t = 0;
-  return {
-    binCount: 256,
-    read(buf) {
-      t += 0.04;
-      for (let i = 0; i < buf.length; i++) {
-        const x = i / buf.length;
-        const a = Math.sin(t + x * 7) * (1 - x);
-        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
-        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
-      }
-      return true;
-    },
-  };
-}
-
+import { createSyntheticSource } from '../visualizerStorySource';
 /**
  * player · LiquidVisualizer. A soft metaball blob whose vertices wobble with
  * audio and a slow morph, wrapped in a glowing halo. Renders a single

--- a/apps/web/src/components/player/MediaSessionSync/MediaSessionSync.stories.tsx
+++ b/apps/web/src/components/player/MediaSessionSync/MediaSessionSync.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 
@@ -27,9 +28,19 @@ function seedPlayback(): void {
   });
 }
 
+/**
+ * player · MediaSessionSync. A headless side-effect leaf: it subscribes to
+ * playback state and pushes position/playback-state to `navigator.mediaSession`
+ * (and, under Electron, to the main process via IPC), then renders nothing. It
+ * is isolated as its own component so the per-250ms currentTime updates re-render
+ * only this leaf, not the App tree. There is no visible UI and no accessible
+ * content — the story exists to prove the effects mount without throwing.
+ */
 const meta: Meta<typeof MediaSessionSync> = {
   title: 'player/MediaSessionSync',
   component: MediaSessionSync,
+  // a11y stays at the global 'todo' default: this component renders null, so
+  // there is no DOM for axe to audit.
   parameters: { layout: 'centered' },
 };
 
@@ -38,8 +49,8 @@ export default meta;
 type Story = StoryObj<typeof MediaSessionSync>;
 
 /**
- * The component renders nothing — this story exists to exercise its media-session
- * side-effects in isolation. The surface is intentionally blank.
+ * The component renders nothing — this story exercises its media-session
+ * side-effects in isolation and asserts the surface stays blank (no throw).
  */
 export const Default: Story = {
   decorators: [
@@ -48,4 +59,10 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    // Headless: it mounted (the canvas root exists) but contributes no DOM of
+    // its own — there is nothing visible to assert beyond a clean mount.
+    await expect(canvasElement).toBeTruthy();
+    await expect(canvasElement).toBeEmptyDOMElement();
+  },
 };

--- a/apps/web/src/components/player/MirrorVisualizer/MirrorVisualizer.stories.tsx
+++ b/apps/web/src/components/player/MirrorVisualizer/MirrorVisualizer.stories.tsx
@@ -1,10 +1,47 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import MirrorVisualizer from './MirrorVisualizer';
+import type { FrequencySource } from '../visualizer-source';
 
+/**
+ * A deterministic, audio-free frequency source so a story can drive the real
+ * per-frame draw path without the playback engine — two summed sine waves
+ * tapered toward the high bins, mirroring the rough shape of real spectrum
+ * data (same shape the settings preview uses).
+ */
+function createSyntheticSource(): FrequencySource {
+  let t = 0;
+  return {
+    binCount: 256,
+    read(buf) {
+      t += 0.04;
+      for (let i = 0; i < buf.length; i++) {
+        const x = i / buf.length;
+        const a = Math.sin(t + x * 7) * (1 - x);
+        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
+        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * player · MirrorVisualizer. Top bars anchored to the center line with a dimmer
+ * reflected copy below, like a reflection on still water. Renders a single
+ * decorative `<canvas>` (no role, no text) that animates from a
+ * `FrequencySource` via a frame-rate-capped rAF loop. With no source and no
+ * playback analyser the loop idles before drawing but the canvas still mounts;
+ * a synthetic source drives the real draw path.
+ */
 const meta: Meta<typeof MirrorVisualizer> = {
   title: 'player/MirrorVisualizer',
   component: MirrorVisualizer,
+  // a11y ratcheted to 'error': the component renders a lone <canvas> with no
+  // role and no accessible name (purely decorative, pointer-events-none), which
+  // is axe-clean — there is no text, contrast surface, or named-region to flag.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div style={{ width: 320, height: 96 }}>
@@ -18,6 +55,28 @@ export default meta;
 
 type Story = StoryObj<typeof MirrorVisualizer>;
 
-export const Default: Story = {
+/**
+ * Idle — active with no source and no playback analyser, so the rAF prelude
+ * returns before drawing. The decorative canvas still mounts into the DOM.
+ */
+export const Idle: Story = {
   render: () => <MirrorVisualizer active />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+  },
+};
+
+/**
+ * Active — fed a deterministic synthetic source so the real per-frame mirrored
+ * bar draw executes against a live 2D context. The canvas mounts and fills its
+ * wrapper.
+ */
+export const Active: Story = {
+  render: () => <MirrorVisualizer active source={createSyntheticSource()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+    await expect(canvas).toBeVisible();
+  },
 };

--- a/apps/web/src/components/player/MirrorVisualizer/MirrorVisualizer.stories.tsx
+++ b/apps/web/src/components/player/MirrorVisualizer/MirrorVisualizer.stories.tsx
@@ -2,31 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 
 import MirrorVisualizer from './MirrorVisualizer';
-import type { FrequencySource } from '../visualizer-source';
-
-/**
- * A deterministic, audio-free frequency source so a story can drive the real
- * per-frame draw path without the playback engine — two summed sine waves
- * tapered toward the high bins, mirroring the rough shape of real spectrum
- * data (same shape the settings preview uses).
- */
-function createSyntheticSource(): FrequencySource {
-  let t = 0;
-  return {
-    binCount: 256,
-    read(buf) {
-      t += 0.04;
-      for (let i = 0; i < buf.length; i++) {
-        const x = i / buf.length;
-        const a = Math.sin(t + x * 7) * (1 - x);
-        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
-        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
-      }
-      return true;
-    },
-  };
-}
-
+import { createSyntheticSource } from '../visualizerStorySource';
 /**
  * player · MirrorVisualizer. Top bars anchored to the center line with a dimmer
  * reflected copy below, like a reflection on still water. Renders a single

--- a/apps/web/src/components/player/MountainVisualizer/MountainVisualizer.stories.tsx
+++ b/apps/web/src/components/player/MountainVisualizer/MountainVisualizer.stories.tsx
@@ -2,31 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 
 import MountainVisualizer from './MountainVisualizer';
-import type { FrequencySource } from '../visualizer-source';
-
-/**
- * A deterministic, audio-free frequency source so a story can drive the real
- * per-frame draw path without the playback engine — two summed sine waves
- * tapered toward the high bins, mirroring the rough shape of real spectrum
- * data (same shape the settings preview uses).
- */
-function createSyntheticSource(): FrequencySource {
-  let t = 0;
-  return {
-    binCount: 256,
-    read(buf) {
-      t += 0.04;
-      for (let i = 0; i < buf.length; i++) {
-        const x = i / buf.length;
-        const a = Math.sin(t + x * 7) * (1 - x);
-        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
-        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
-      }
-      return true;
-    },
-  };
-}
-
+import { createSyntheticSource } from '../visualizerStorySource';
 /**
  * player · MountainVisualizer. Three layered, low-pass-smoothed silhouettes
  * drifting under a glowing moon and twinkling stars. Renders a single

--- a/apps/web/src/components/player/MountainVisualizer/MountainVisualizer.stories.tsx
+++ b/apps/web/src/components/player/MountainVisualizer/MountainVisualizer.stories.tsx
@@ -1,10 +1,47 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import MountainVisualizer from './MountainVisualizer';
+import type { FrequencySource } from '../visualizer-source';
 
+/**
+ * A deterministic, audio-free frequency source so a story can drive the real
+ * per-frame draw path without the playback engine — two summed sine waves
+ * tapered toward the high bins, mirroring the rough shape of real spectrum
+ * data (same shape the settings preview uses).
+ */
+function createSyntheticSource(): FrequencySource {
+  let t = 0;
+  return {
+    binCount: 256,
+    read(buf) {
+      t += 0.04;
+      for (let i = 0; i < buf.length; i++) {
+        const x = i / buf.length;
+        const a = Math.sin(t + x * 7) * (1 - x);
+        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
+        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * player · MountainVisualizer. Three layered, low-pass-smoothed silhouettes
+ * drifting under a glowing moon and twinkling stars. Renders a single
+ * decorative `<canvas>` (no role, no text) that animates from a
+ * `FrequencySource` via a frame-rate-capped rAF loop. With no source and no
+ * playback analyser the loop idles before drawing but the canvas still mounts;
+ * a synthetic source drives the real draw path.
+ */
 const meta: Meta<typeof MountainVisualizer> = {
   title: 'player/MountainVisualizer',
   component: MountainVisualizer,
+  // a11y ratcheted to 'error': the component renders a lone <canvas> with no
+  // role and no accessible name (purely decorative, pointer-events-none), which
+  // is axe-clean — there is no text, contrast surface, or named-region to flag.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div className="h-[20rem] w-[32rem] bg-background">
@@ -18,6 +55,28 @@ export default meta;
 
 type Story = StoryObj<typeof MountainVisualizer>;
 
-export const Default: Story = {
+/**
+ * Idle — active with no source and no playback analyser, so the rAF prelude
+ * returns before drawing. The decorative canvas still mounts into the DOM.
+ */
+export const Idle: Story = {
   render: () => <MountainVisualizer active />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+  },
+};
+
+/**
+ * Active — fed a deterministic synthetic source so the real per-frame layered
+ * silhouette draw executes against a live 2D context. The canvas mounts and
+ * fills its wrapper.
+ */
+export const Active: Story = {
+  render: () => <MountainVisualizer active source={createSyntheticSource()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+    await expect(canvas).toBeVisible();
+  },
 };

--- a/apps/web/src/components/player/ParticleVisualizer/ParticleVisualizer.stories.tsx
+++ b/apps/web/src/components/player/ParticleVisualizer/ParticleVisualizer.stories.tsx
@@ -2,31 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 
 import ParticleVisualizer from './ParticleVisualizer';
-import type { FrequencySource } from '../visualizer-source';
-
-/**
- * A deterministic, audio-free frequency source so a story can drive the real
- * per-frame draw path without the playback engine — two summed sine waves
- * tapered toward the high bins, mirroring the rough shape of real spectrum
- * data (same shape the settings preview uses).
- */
-function createSyntheticSource(): FrequencySource {
-  let t = 0;
-  return {
-    binCount: 256,
-    read(buf) {
-      t += 0.04;
-      for (let i = 0; i < buf.length; i++) {
-        const x = i / buf.length;
-        const a = Math.sin(t + x * 7) * (1 - x);
-        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
-        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
-      }
-      return true;
-    },
-  };
-}
-
+import { createSyntheticSource } from '../visualizerStorySource';
 /**
  * player · ParticleVisualizer. A flowing bezier-curved frequency line with a
  * soft gradient fill underneath — calm and organic. Renders a single decorative

--- a/apps/web/src/components/player/ParticleVisualizer/ParticleVisualizer.stories.tsx
+++ b/apps/web/src/components/player/ParticleVisualizer/ParticleVisualizer.stories.tsx
@@ -1,10 +1,47 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import ParticleVisualizer from './ParticleVisualizer';
+import type { FrequencySource } from '../visualizer-source';
 
+/**
+ * A deterministic, audio-free frequency source so a story can drive the real
+ * per-frame draw path without the playback engine — two summed sine waves
+ * tapered toward the high bins, mirroring the rough shape of real spectrum
+ * data (same shape the settings preview uses).
+ */
+function createSyntheticSource(): FrequencySource {
+  let t = 0;
+  return {
+    binCount: 256,
+    read(buf) {
+      t += 0.04;
+      for (let i = 0; i < buf.length; i++) {
+        const x = i / buf.length;
+        const a = Math.sin(t + x * 7) * (1 - x);
+        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
+        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * player · ParticleVisualizer. A flowing bezier-curved frequency line with a
+ * soft gradient fill underneath — calm and organic. Renders a single decorative
+ * `<canvas>` (no role, no text) that animates from a `FrequencySource` via a
+ * frame-rate-capped rAF loop. With no source and no playback analyser the loop
+ * idles before drawing but the canvas still mounts; a synthetic source drives
+ * the real draw path.
+ */
 const meta: Meta<typeof ParticleVisualizer> = {
   title: 'player/ParticleVisualizer',
   component: ParticleVisualizer,
+  // a11y ratcheted to 'error': the component renders a lone <canvas> with no
+  // role and no accessible name (purely decorative, pointer-events-none), which
+  // is axe-clean — there is no text, contrast surface, or named-region to flag.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div className="h-[20rem] w-[32rem] bg-background">
@@ -18,6 +55,28 @@ export default meta;
 
 type Story = StoryObj<typeof ParticleVisualizer>;
 
-export const Default: Story = {
+/**
+ * Idle — active with no source and no playback analyser, so the rAF prelude
+ * returns before drawing. The decorative canvas still mounts into the DOM.
+ */
+export const Idle: Story = {
   render: () => <ParticleVisualizer active />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+  },
+};
+
+/**
+ * Active — fed a deterministic synthetic source so the real per-frame bezier
+ * wave draw executes against a live 2D context. The canvas mounts and fills its
+ * wrapper.
+ */
+export const Active: Story = {
+  render: () => <ParticleVisualizer active source={createSyntheticSource()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+    await expect(canvas).toBeVisible();
+  },
 };

--- a/apps/web/src/components/player/PlayerBar/PlayerBar.stories.tsx
+++ b/apps/web/src/components/player/PlayerBar/PlayerBar.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useInterfaceStore } from '@/stores/useInterfaceStore';
@@ -37,10 +38,25 @@ function seedBar(track: Track | null): void {
   });
 }
 
+/**
+ * player · PlayerBar. The full bottom transport bar, assembled from the smaller
+ * player parts: track info + favorite on the left, PlayerControls + seek row in
+ * the center, and the volume + panel-toggle cluster (lyrics, queue, sleep timer,
+ * EQ, compact, visualizer) on the right. It is gated on `usePlaybackStore`'s
+ * current track (it renders nothing without one) and reads `useInterfaceStore`
+ * for which elements to show. Radio streams swap the seek row for a "Live"
+ * badge and hide the favorite control. Stories seed both stores and assert the
+ * assembled chrome by role + name.
+ */
 const meta: Meta<typeof PlayerBar> = {
   title: 'player/PlayerBar',
   component: PlayerBar,
-  parameters: { layout: 'fullscreen' },
+  parameters: {
+    layout: 'fullscreen',
+    // Transport + toggle buttons are all labelled, the seek + volume sliders
+    // carry accessible names, and the EQ/sleep popovers stay closed — clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <TooltipProvider>
@@ -56,6 +72,7 @@ export default meta;
 
 type Story = StoryObj<typeof PlayerBar>;
 
+/** Default — a local track with the full control cluster and the seek row. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -63,17 +80,44 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Midnight Tapes')).toBeInTheDocument();
+    // Transport + seek + volume are wired (playing → Pause).
+    await expect(canvas.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+    await expect(canvas.getByRole('slider', { name: 'Seek' })).toBeInTheDocument();
+    await expect(canvas.getByRole('slider', { name: 'Volume' })).toBeInTheDocument();
+    // Right-cluster toggles and the (closed) EQ popover trigger are present.
+    await expect(canvas.getByRole('button', { name: 'Toggle lyrics' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Toggle queue' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Equalizer' })).toBeInTheDocument();
+    // A local, non-radio track offers the add-to-favorites control.
+    await expect(canvas.getByRole('button', { name: 'Add to favorites' })).toBeInTheDocument();
+  },
 };
 
+/** Radio — a live stream: the "Live" badge replaces the seek row and favorite. */
 export const Radio: Story = {
   decorators: [
     Story => {
-      seedBar(makeTrack({ title: 'Lofi Radio', filePath: 'https://stream.example.com/lofi' }));
+      seedBar(makeTrack({ title: 'Lofi Radio', filePath: 'shiranami-radio://lofi-girl' }));
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Lofi Radio')).toBeInTheDocument();
+    // Live streams show the "Live" badge instead of a scrubber.
+    await expect(canvas.getByText('Live')).toBeInTheDocument();
+    await expect(canvas.queryByRole('slider', { name: 'Seek' })).not.toBeInTheDocument();
+    // Favorite is suppressed for radio.
+    await expect(
+      canvas.queryByRole('button', { name: 'Add to favorites' })
+    ).not.toBeInTheDocument();
+  },
 };
 
+/** Favorited — a hearted track: the favorite control offers to remove it. */
 export const Favorited: Story = {
   decorators: [
     Story => {
@@ -81,4 +125,9 @@ export const Favorited: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // A favorited track flips the control to "Remove from favorites".
+    await expect(canvas.getByRole('button', { name: 'Remove from favorites' })).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/player/PlayerControls/PlayerControls.stories.tsx
+++ b/apps/web/src/components/player/PlayerControls/PlayerControls.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 import type { RepeatMode } from '@/stores/types';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
@@ -38,10 +39,24 @@ function seedPlayback(opts: SeedOptions = {}): void {
   });
 }
 
+/**
+ * player · PlayerControls. The transport cluster — shuffle, previous, play/pause,
+ * next, repeat — backed by `usePlaybackStore`. Every glyph is icon-only, so each
+ * control carries an aria-label from the `player` i18n namespace (Shuffle,
+ * Previous, Play/Pause, Next, "Repeat: <mode>"). The play/pause button is
+ * disabled with no current track and swaps its label between Play and Pause as
+ * playback toggles. Stories seed the store, then click controls and assert the
+ * store actions fire (clicking play/pause calls `togglePlay`, etc.).
+ */
 const meta: Meta<typeof PlayerControls> = {
   title: 'player/PlayerControls',
   component: PlayerControls,
-  parameters: { layout: 'centered' },
+  parameters: {
+    layout: 'centered',
+    // Every transport button is icon-only but labelled via aria-label; nothing
+    // here trips axe, so the panel is held to the strict standard.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <TooltipProvider>
@@ -55,6 +70,7 @@ export default meta;
 
 type Story = StoryObj<typeof PlayerControls>;
 
+/** Paused with a track — the primary control reads "Play" and clicking it toggles playback. */
 export const Paused: Story = {
   decorators: [
     Story => {
@@ -62,8 +78,21 @@ export const Paused: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const play = canvas.getByRole('button', { name: 'Play' });
+    await expect(play).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: 'Previous' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Shuffle' })).toBeInTheDocument();
+
+    await userEvent.click(play);
+    // togglePlay flips isPlaying — the primary control relabels Play → Pause.
+    await expect(canvas.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+  },
 };
 
+/** Playing with shuffle on and repeat-all — the control reads "Pause"; clicking next advances. */
 export const Playing: Story = {
   decorators: [
     Story => {
@@ -71,8 +100,18 @@ export const Playing: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+    // Repeat label encodes the active mode for screen readers.
+    await expect(canvas.getByRole('button', { name: 'Repeat: all' })).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Pause' }));
+    await expect(canvas.getByRole('button', { name: 'Play' })).toBeInTheDocument();
+  },
 };
 
+/** Loading — while buffering (and not yet playing) the spinner replaces the glyph. */
 export const Loading: Story = {
   decorators: [
     Story => {
@@ -80,8 +119,15 @@ export const Loading: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The label still resolves to Play (isPlaying is false) even though the
+    // spinner glyph is shown — the accessible name tracks state, not the icon.
+    await expect(canvas.getByRole('button', { name: 'Play' })).toBeInTheDocument();
+  },
 };
 
+/** Repeat-one — the repeat control announces its single-track mode. */
 export const RepeatOne: Story = {
   decorators: [
     Story => {
@@ -89,4 +135,22 @@ export const RepeatOne: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Repeat: one' })).toBeInTheDocument();
+  },
+};
+
+/** No track — the play/pause control is disabled until something is queued. */
+export const Empty: Story = {
+  decorators: [
+    Story => {
+      seedPlayback({ hasTrack: false });
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Play' })).toBeDisabled();
+  },
 };

--- a/apps/web/src/components/player/PlayerOverflowMenu/PlayerOverflowMenu.stories.tsx
+++ b/apps/web/src/components/player/PlayerOverflowMenu/PlayerOverflowMenu.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, screen, userEvent, expect } from 'storybook/test';
 import { useInterfaceStore } from '@/stores/useInterfaceStore';
 import { useUIStore } from '@/stores/useUIStore';
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -16,10 +17,24 @@ function seedMenu(visualizerOn: boolean): void {
   useUIStore.setState({ showVisualizer: visualizerOn });
 }
 
+/**
+ * player · PlayerOverflowMenu. The narrow-width "More" popover that collapses the
+ * secondary player controls — sleep timer, equalizer, compact mode, and the
+ * visualizer toggle — behind a single icon button. It mirrors the PlayerBar
+ * element-visibility toggles (`useInterfaceStore`) so a hidden control stays
+ * hidden here too, and reflects the visualizer state from `useUIStore`. The
+ * popover content portals to `document.body`, so stories query it via `screen`.
+ * Stories seed the stores, open the popover, and assert the collapsed controls
+ * by role + name.
+ */
 const meta: Meta<typeof PlayerOverflowMenu> = {
   title: 'player/PlayerOverflowMenu',
   component: PlayerOverflowMenu,
-  parameters: { layout: 'centered' },
+  parameters: {
+    // The trigger plus every nested control is icon-only with an aria-label, and
+    // the nested sleep-timer/EQ popovers stay closed — axe passes for the menu.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <TooltipProvider>
@@ -35,6 +50,7 @@ export default meta;
 
 type Story = StoryObj<typeof PlayerOverflowMenu>;
 
+/** Default — opening "More" surfaces the collapsed secondary controls. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -42,8 +58,19 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'More' }));
+
+    // Popover content portals to body — query the collapsed controls via screen.
+    await expect(await screen.findByRole('button', { name: 'Sleep timer' })).toBeInTheDocument();
+    await expect(screen.getByRole('button', { name: 'Equalizer' })).toBeInTheDocument();
+    await expect(screen.getByRole('button', { name: 'Compact mode' })).toBeInTheDocument();
+    await expect(screen.getByRole('button', { name: 'Toggle visualizer' })).toBeInTheDocument();
+  },
 };
 
+/** VisualizerActive — the trigger shows an active dot; the toggle is still present. */
 export const VisualizerActive: Story = {
   decorators: [
     Story => {
@@ -51,4 +78,12 @@ export const VisualizerActive: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'More' }));
+    // With the visualizer on, the toggle still resolves by its stable name.
+    await expect(
+      await screen.findByRole('button', { name: 'Toggle visualizer' })
+    ).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/player/QueuePanel/QueuePanel.stories.tsx
+++ b/apps/web/src/components/player/QueuePanel/QueuePanel.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 
@@ -33,9 +34,23 @@ function seedQueue(tracks: Track[], index: number): void {
   });
 }
 
+/**
+ * player · QueuePanel. The play queue — a "Queue" heading with a Clear action, a
+ * "Now Playing" row, and a drag-reorderable "Up Next" list, all reading
+ * `usePlaybackStore`. Each row shows the track title/artist plus a remove button
+ * ("Remove from queue") and a drag handle ("Drag to reorder"); the active row
+ * carries an sr-only "Now Playing" label. With an empty queue it shows the
+ * "Queue is empty" placeholder. Stories seed the queue and assert the structure
+ * by role + name.
+ */
 const meta: Meta<typeof QueuePanel> = {
   title: 'player/QueuePanel',
   component: QueuePanel,
+  parameters: {
+    // The heading is semantic, the clear/remove/drag controls are all labelled,
+    // and the now-playing row has an sr-only name — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="flex h-[36rem] w-80 flex-col glass border border-border/30 rounded-2xl overflow-hidden">
@@ -49,6 +64,7 @@ export default meta;
 
 type Story = StoryObj<typeof QueuePanel>;
 
+/** With queue — the now-playing track plus three reorderable up-next rows. */
 export const WithQueue: Story = {
   decorators: [
     Story => {
@@ -56,8 +72,22 @@ export const WithQueue: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Queue' })).toBeInTheDocument();
+    // The now-playing track plus the three up-next titles all render.
+    await expect(canvas.getByText('Current track')).toBeInTheDocument();
+    await expect(canvas.getByText('Up next one')).toBeInTheDocument();
+
+    // Each interactive row exposes a labelled remove control; the three up-next
+    // rows plus the now-playing row give four.
+    await expect(canvas.getAllByRole('button', { name: 'Remove from queue' })).toHaveLength(4);
+    // The three sortable up-next rows each carry a drag handle.
+    await expect(canvas.getAllByRole('button', { name: 'Drag to reorder' })).toHaveLength(3);
+  },
 };
 
+/** Empty — the placeholder replaces the rows. */
 export const Empty: Story = {
   decorators: [
     Story => {
@@ -65,4 +95,10 @@ export const Empty: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Queue is empty')).toBeInTheDocument();
+    // No Clear action when there is nothing to clear.
+    await expect(canvas.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/player/QueueRow/QueueRow.stories.tsx
+++ b/apps/web/src/components/player/QueueRow/QueueRow.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, fn } from 'storybook/test';
 import { DndContext } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import type { Track } from '@/stores/types';
@@ -20,15 +21,29 @@ function makeTrack(overrides: Partial<Track> = {}): Track {
 
 const track = makeTrack();
 
+/**
+ * player · QueueRow. The queue list rows, in three forms: the draggable "Up Next"
+ * row (default export, wrapped in dnd-kit context), the non-draggable "Now
+ * Playing" `QueueItem`, and the `DragOverlayContent` shown while dragging. Each
+ * interactive row renders the track title/artist plus a remove button ("Remove
+ * from queue") and — for the sortable row — a drag handle ("Drag to reorder"),
+ * with labels pulled from the `queue` i18n namespace. Clicking the row plays it;
+ * clicking remove removes it. Stories drive the `onPlay`/`onRemove` spies.
+ */
 const meta: Meta<typeof SortableQueueRow> = {
   title: 'player/QueueRow',
   component: SortableQueueRow,
+  parameters: {
+    // The remove button and drag handle are icon-only but labelled from i18n —
+    // axe passes clean for every row form.
+    a11y: { test: 'error' },
+  },
   args: {
     track,
     sortableId: 'queue-1',
     queueIndex: 1,
-    onPlay: () => {},
-    onRemove: () => {},
+    onPlay: fn(),
+    onRemove: fn(),
   },
   decorators: [
     Story => (
@@ -47,20 +62,48 @@ export default meta;
 
 type Story = StoryObj<typeof SortableQueueRow>;
 
-export const Sortable: Story = {};
+/** Sortable up-next row — clicking it plays; the remove button fires its callback. */
+export const Sortable: Story = {
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Midnight study session')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Drag to reorder' })).toBeInTheDocument();
 
-export const NowPlaying: StoryObj<typeof QueueItem> = {
-  render: () => (
-    <div className="w-80 p-4">
-      <QueueItem track={track} index={0} isActive isPlaying onPlay={() => {}} onRemove={() => {}} />
-    </div>
-  ),
+    // Remove stops propagation and calls onRemove with the queue index (1).
+    await userEvent.click(canvas.getByRole('button', { name: 'Remove from queue' }));
+    await expect(args.onRemove).toHaveBeenCalled();
+  },
 };
 
+/** Now Playing — the active, non-draggable row with an sr-only status label. */
+export const NowPlaying: StoryObj<typeof QueueItem> = {
+  render: () => {
+    const onPlay = fn();
+    const onRemove = fn();
+    return (
+      <div className="w-80 p-4">
+        <QueueItem track={track} index={0} isActive isPlaying onPlay={onPlay} onRemove={onRemove} />
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The active+playing row announces "Now Playing" to screen readers.
+    await expect(canvas.getByText('Now Playing')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Remove from queue' })).toBeInTheDocument();
+  },
+};
+
+/** Overlay — the floating preview rendered under the cursor while dragging. */
 export const Overlay: StoryObj<typeof DragOverlayContent> = {
   render: () => (
     <div className="w-80 p-4">
       <DragOverlayContent track={track} />
     </div>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The overlay is a static, non-interactive preview of the row content.
+    await expect(canvas.getByText('Midnight study session')).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/player/RingsVisualizer/RingsVisualizer.stories.tsx
+++ b/apps/web/src/components/player/RingsVisualizer/RingsVisualizer.stories.tsx
@@ -2,31 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 
 import RingsVisualizer from './RingsVisualizer';
-import type { FrequencySource } from '../visualizer-source';
-
-/**
- * A deterministic, audio-free frequency source so a story can drive the real
- * per-frame draw path without the playback engine — two summed sine waves
- * tapered toward the high bins, mirroring the rough shape of real spectrum
- * data (same shape the settings preview uses).
- */
-function createSyntheticSource(): FrequencySource {
-  let t = 0;
-  return {
-    binCount: 256,
-    read(buf) {
-      t += 0.04;
-      for (let i = 0; i < buf.length; i++) {
-        const x = i / buf.length;
-        const a = Math.sin(t + x * 7) * (1 - x);
-        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
-        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
-      }
-      return true;
-    },
-  };
-}
-
+import { createSyntheticSource } from '../visualizerStorySource';
 /**
  * player · RingsVisualizer. Concentric pulse rings spawned on each bass kick
  * that expand and fade, with a bass-reactive glowing core dot. Renders a single

--- a/apps/web/src/components/player/RingsVisualizer/RingsVisualizer.stories.tsx
+++ b/apps/web/src/components/player/RingsVisualizer/RingsVisualizer.stories.tsx
@@ -1,10 +1,47 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import RingsVisualizer from './RingsVisualizer';
+import type { FrequencySource } from '../visualizer-source';
 
+/**
+ * A deterministic, audio-free frequency source so a story can drive the real
+ * per-frame draw path without the playback engine — two summed sine waves
+ * tapered toward the high bins, mirroring the rough shape of real spectrum
+ * data (same shape the settings preview uses).
+ */
+function createSyntheticSource(): FrequencySource {
+  let t = 0;
+  return {
+    binCount: 256,
+    read(buf) {
+      t += 0.04;
+      for (let i = 0; i < buf.length; i++) {
+        const x = i / buf.length;
+        const a = Math.sin(t + x * 7) * (1 - x);
+        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
+        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * player · RingsVisualizer. Concentric pulse rings spawned on each bass kick
+ * that expand and fade, with a bass-reactive glowing core dot. Renders a single
+ * decorative `<canvas>` (no role, no text) that animates from a
+ * `FrequencySource` via a frame-rate-capped rAF loop. With no source and no
+ * playback analyser the loop idles before drawing but the canvas still mounts;
+ * a synthetic source drives the real draw path.
+ */
 const meta: Meta<typeof RingsVisualizer> = {
   title: 'player/RingsVisualizer',
   component: RingsVisualizer,
+  // a11y ratcheted to 'error': the component renders a lone <canvas> with no
+  // role and no accessible name (purely decorative, pointer-events-none), which
+  // is axe-clean — there is no text, contrast surface, or named-region to flag.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div className="h-[20rem] w-[32rem] bg-background">
@@ -18,6 +55,28 @@ export default meta;
 
 type Story = StoryObj<typeof RingsVisualizer>;
 
-export const Default: Story = {
+/**
+ * Idle — active with no source and no playback analyser, so the rAF prelude
+ * returns before drawing. The decorative canvas still mounts into the DOM.
+ */
+export const Idle: Story = {
   render: () => <RingsVisualizer active />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+  },
+};
+
+/**
+ * Active — fed a deterministic synthetic source so the real per-frame ring
+ * spawn + core draw executes against a live 2D context. The canvas mounts and
+ * fills its wrapper.
+ */
+export const Active: Story = {
+  render: () => <RingsVisualizer active source={createSyntheticSource()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+    await expect(canvas).toBeVisible();
+  },
 };

--- a/apps/web/src/components/player/SeekBar/SeekBar.stories.tsx
+++ b/apps/web/src/components/player/SeekBar/SeekBar.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { usePlayerUIStore } from '@/stores/usePlayerUIStore';
 
@@ -10,9 +11,23 @@ function seedSeek(currentTime: number, duration: number, scrubTime: number | nul
   usePlayerUIStore.setState({ scrubTime });
 }
 
+/**
+ * player · SeekBar. The primary scrubber — a hand-rolled `role="slider"` element
+ * (not Radix) so the fill + thumb can be driven by compositor-only transforms in
+ * a rAF loop. It exposes aria-valuemin/max/now plus an aria-valuetext of
+ * "<position> of <duration>", and is keyboard-operable (Arrows/Page/Home/End).
+ * It reads `usePlaybackStore` for time/duration and `usePlayerUIStore` for the
+ * in-progress scrub value. Stories seed those, then assert the slider's
+ * accessible name + value.
+ */
 const meta: Meta<typeof SeekBar> = {
   title: 'player/SeekBar',
   component: SeekBar,
+  parameters: {
+    // The slider role lands directly on the labelled element ("Seek"), so the
+    // aria-input-field-name rule is satisfied without a Radix thumb.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="w-80 p-4">
@@ -26,6 +41,7 @@ export default meta;
 
 type Story = StoryObj<typeof SeekBar>;
 
+/** Midway — the slider reports the current position against the total duration. */
 export const Midway: Story = {
   decorators: [
     Story => {
@@ -33,8 +49,17 @@ export const Midway: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const slider = canvas.getByRole('slider', { name: 'Seek' });
+    await expect(slider).toHaveAttribute('aria-valuenow', '108');
+    await expect(slider).toHaveAttribute('aria-valuemax', '215');
+    // valuetext renders the human-readable position the OS/screen-reader announces.
+    await expect(slider).toHaveAttribute('aria-valuetext', '1:48 of 3:35');
+  },
 };
 
+/** Start — position pinned to zero. */
 export const Start: Story = {
   decorators: [
     Story => {
@@ -42,8 +67,16 @@ export const Start: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('slider', { name: 'Seek' })).toHaveAttribute(
+      'aria-valuenow',
+      '0'
+    );
+  },
 };
 
+/** Scrubbing — the active scrub time overrides the playback time on the readout. */
 export const Scrubbing: Story = {
   decorators: [
     Story => {
@@ -51,4 +84,12 @@ export const Scrubbing: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // scrubTime (60) wins over the stored currentTime (108) while dragging.
+    await expect(canvas.getByRole('slider', { name: 'Seek' })).toHaveAttribute(
+      'aria-valuenow',
+      '60'
+    );
+  },
 };

--- a/apps/web/src/components/player/SleepTimer/SleepTimer.stories.tsx
+++ b/apps/web/src/components/player/SleepTimer/SleepTimer.stories.tsx
@@ -75,7 +75,9 @@ export const Running: Story = {
     // The trigger keeps its "Sleep timer" accessible name even while active.
     await userEvent.click(canvas.getByRole('button', { name: 'Sleep timer' }));
     await expect(await screen.findByRole('button', { name: 'Cancel timer' })).toBeInTheDocument();
-    // 1800s remaining formats to "30:00" in the minutes-only display.
-    await expect(screen.getByText('30:00')).toBeInTheDocument();
+    // 1800s remaining formats to "30:00", but the timer ticks down via Date.now()
+    // so the exact second is flaky — match the mm:ss shape (29/30 minutes) instead
+    // of pinning the literal string.
+    await expect(screen.getByText(/^(29|30):\d{2}$/)).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/player/SleepTimer/SleepTimer.stories.tsx
+++ b/apps/web/src/components/player/SleepTimer/SleepTimer.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, screen, userEvent, expect } from 'storybook/test';
 import { useSleepTimerStore } from '@/stores/useSleepTimerStore';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
@@ -9,9 +10,23 @@ function seedTimer(endTime: number | null, remaining: number): void {
   useSleepTimerStore.setState({ endTime, remaining });
 }
 
+/**
+ * player · SleepTimer. An icon-only popover trigger ("Sleep timer") that opens a
+ * panel of duration presets plus a custom-minutes input, backed by
+ * `useSleepTimerStore`. When a timer is running the trigger swaps to a TimerOff
+ * glyph (the aria-label stays "Sleep timer"), and the panel shows the remaining
+ * time and a Cancel control. The popover content portals to `document.body`, so
+ * stories query it via `screen`. Stories seed the store, open the popover, and
+ * assert the preset/cancel controls by role + name.
+ */
 const meta: Meta<typeof SleepTimer> = {
   title: 'player/SleepTimer',
   component: SleepTimer,
+  parameters: {
+    // The trigger is labelled, the preset/cancel controls are text buttons, and
+    // the custom input carries an aria-label — axe passes for the open popover.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <TooltipProvider>
@@ -27,6 +42,7 @@ export default meta;
 
 type Story = StoryObj<typeof SleepTimer>;
 
+/** Idle — opening the trigger reveals the duration presets and the custom option. */
 export const Idle: Story = {
   decorators: [
     Story => {
@@ -34,8 +50,19 @@ export const Idle: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Sleep timer' });
+    await userEvent.click(trigger);
+
+    // Popover content portals to body — query it via screen. Preset buttons are
+    // labelled by their pluralized minutes text; "Custom" reveals the input mode.
+    await expect(await screen.findByRole('button', { name: 'Custom' })).toBeInTheDocument();
+    await expect(screen.getByRole('button', { name: '15 minutes' })).toBeInTheDocument();
+  },
 };
 
+/** Running — the panel shows the remaining time and a cancel control. */
 export const Running: Story = {
   decorators: [
     Story => {
@@ -43,4 +70,12 @@ export const Running: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The trigger keeps its "Sleep timer" accessible name even while active.
+    await userEvent.click(canvas.getByRole('button', { name: 'Sleep timer' }));
+    await expect(await screen.findByRole('button', { name: 'Cancel timer' })).toBeInTheDocument();
+    // 1800s remaining formats to "30:00" in the minutes-only display.
+    await expect(screen.getByText('30:00')).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/player/TimeDisplay/TimeDisplay.stories.tsx
+++ b/apps/web/src/components/player/TimeDisplay/TimeDisplay.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { usePlayerUIStore } from '@/stores/usePlayerUIStore';
 
@@ -10,9 +11,21 @@ function seedTime(currentTime: number, scrubTime: number | null): void {
   usePlayerUIStore.setState({ scrubTime });
 }
 
+/**
+ * player · TimeDisplay. A memoized text-only readout of the current playback
+ * position, isolated so per-second time ticks re-render it alone rather than the
+ * whole player. It renders `formatDuration(scrubTime ?? currentTime)` as bare
+ * text (no wrapping element of its own), subscribing to `usePlaybackStore` for
+ * currentTime and `usePlayerUIStore` for the active scrub value. Stories seed
+ * those and assert the formatted m:ss string it prints.
+ */
 const meta: Meta<typeof TimeDisplay> = {
   title: 'player/TimeDisplay',
   component: TimeDisplay,
+  parameters: {
+    // Plain text content with no interactive elements — nothing for axe to flag.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <span className="tabular-nums text-sm text-muted-foreground">
@@ -26,6 +39,7 @@ export default meta;
 
 type Story = StoryObj<typeof TimeDisplay>;
 
+/** Playing — the readout formats the current playback time as m:ss. */
 export const Playing: Story = {
   decorators: [
     Story => {
@@ -33,8 +47,14 @@ export const Playing: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // 83s → "1:23" via formatDuration.
+    await expect(canvas.getByText('1:23')).toBeInTheDocument();
+  },
 };
 
+/** Scrubbing — the active scrub time overrides the playback time on the readout. */
 export const Scrubbing: Story = {
   decorators: [
     Story => {
@@ -42,4 +62,9 @@ export const Scrubbing: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // scrubTime (12 → "0:12") wins over currentTime (83) while dragging.
+    await expect(canvas.getByText('0:12')).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/player/VerticalBandSlider/VerticalBandSlider.stories.tsx
+++ b/apps/web/src/components/player/VerticalBandSlider/VerticalBandSlider.stories.tsx
@@ -1,11 +1,26 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
 import VerticalBandSlider from './VerticalBandSlider';
 
+/**
+ * player · VerticalBandSlider. One band of the graphic EQ — a vertical Radix
+ * slider with a frequency label beneath and a tooltip showing the band name +
+ * gain. It is fully controlled via props (`value`/`onChange`), so stories drive
+ * it through args rather than a store. The slider's `aria-label` is placed on
+ * the Radix Root rather than the Thumb (unlike the shared ui/slider), so the
+ * `role="slider"` thumb element has no accessible name — see the a11y note.
+ */
 const meta: Meta<typeof VerticalBandSlider> = {
   title: 'player/VerticalBandSlider',
   component: VerticalBandSlider,
+  // a11y stays at 'todo' (NOT ratcheted to 'error'): this component puts its
+  // aria-label on the Radix Slider.Root, not the Thumb, so the role="slider"
+  // thumb element ends up unnamed and axe's aria-input-field-name rule fails.
+  // The fix belongs in this component's own markup (or by forwarding the label
+  // to the Thumb like the shared ui/slider does) — out of scope for the
+  // story-only pass, so the gap is documented here rather than papered over.
   args: {
     freq: 1000,
     value: 0,
@@ -29,8 +44,18 @@ export default meta;
 
 type Story = StoryObj<typeof VerticalBandSlider>;
 
-export const Default: Story = {};
+/** Flat — the 1 kHz band at 0 dB; the frequency label prints beneath the slider. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // freq 1000 renders as the "1k" frequency label under the band.
+    await expect(canvas.getByText('1k')).toBeInTheDocument();
+    // The slider role is present (aria-label sits on the Root, not the thumb).
+    await expect(canvas.getByRole('slider')).toBeInTheDocument();
+  },
+};
 
+/** Boosted — the 16 kHz "Air" band pushed to +6 dB, with the kHz frequency label. */
 export const Boosted: Story = {
   args: {
     freq: 16000,
@@ -39,11 +64,22 @@ export const Boosted: Story = {
     bandName: 'Air',
     gainLabel: '+6.0 dB',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // freq 16000 collapses to the "16k" label.
+    await expect(canvas.getByText('16k')).toBeInTheDocument();
+  },
 };
 
+/** Disabled — the band is non-interactive (EQ off). */
 export const Disabled: Story = {
   args: {
     disabled: true,
     gainLabel: '0.0 dB',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Radix reflects the disabled state on the slider via data-disabled.
+    await expect(canvas.getByRole('slider')).toHaveAttribute('data-disabled');
   },
 };

--- a/apps/web/src/components/player/VinylVisualizer/VinylVisualizer.stories.tsx
+++ b/apps/web/src/components/player/VinylVisualizer/VinylVisualizer.stories.tsx
@@ -1,10 +1,47 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import VinylVisualizer from './VinylVisualizer';
+import type { FrequencySource } from '../visualizer-source';
 
+/**
+ * A deterministic, audio-free frequency source so a story can drive the real
+ * per-frame draw path without the playback engine — two summed sine waves
+ * tapered toward the high bins, mirroring the rough shape of real spectrum
+ * data (same shape the settings preview uses).
+ */
+function createSyntheticSource(): FrequencySource {
+  let t = 0;
+  return {
+    binCount: 256,
+    read(buf) {
+      t += 0.04;
+      for (let i = 0; i < buf.length; i++) {
+        const x = i / buf.length;
+        const a = Math.sin(t + x * 7) * (1 - x);
+        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
+        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * player · VinylVisualizer. A spinning record with audio-reactive grooves, a
+ * tinted center label, and a mid-frequency outer glow ring. Renders a single
+ * decorative `<canvas>` (no role, no text) that animates from a
+ * `FrequencySource` via a frame-rate-capped rAF loop. With no source and no
+ * playback analyser the loop idles before drawing but the canvas still mounts;
+ * a synthetic source drives the real draw path.
+ */
 const meta: Meta<typeof VinylVisualizer> = {
   title: 'player/VinylVisualizer',
   component: VinylVisualizer,
+  // a11y ratcheted to 'error': the component renders a lone <canvas> with no
+  // role and no accessible name (purely decorative, pointer-events-none), which
+  // is axe-clean — there is no text, contrast surface, or named-region to flag.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div className="h-[20rem] w-[32rem] bg-background">
@@ -18,6 +55,28 @@ export default meta;
 
 type Story = StoryObj<typeof VinylVisualizer>;
 
-export const Default: Story = {
+/**
+ * Idle — active with no source and no playback analyser, so the rAF prelude
+ * returns before drawing. The decorative canvas still mounts into the DOM.
+ */
+export const Idle: Story = {
   render: () => <VinylVisualizer active />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+  },
+};
+
+/**
+ * Active — fed a deterministic synthetic source so the real per-frame disc +
+ * groove draw executes against a live 2D context. The canvas mounts and fills
+ * its wrapper.
+ */
+export const Active: Story = {
+  render: () => <VinylVisualizer active source={createSyntheticSource()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+    await expect(canvas).toBeVisible();
+  },
 };

--- a/apps/web/src/components/player/VinylVisualizer/VinylVisualizer.stories.tsx
+++ b/apps/web/src/components/player/VinylVisualizer/VinylVisualizer.stories.tsx
@@ -2,31 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 
 import VinylVisualizer from './VinylVisualizer';
-import type { FrequencySource } from '../visualizer-source';
-
-/**
- * A deterministic, audio-free frequency source so a story can drive the real
- * per-frame draw path without the playback engine — two summed sine waves
- * tapered toward the high bins, mirroring the rough shape of real spectrum
- * data (same shape the settings preview uses).
- */
-function createSyntheticSource(): FrequencySource {
-  let t = 0;
-  return {
-    binCount: 256,
-    read(buf) {
-      t += 0.04;
-      for (let i = 0; i < buf.length; i++) {
-        const x = i / buf.length;
-        const a = Math.sin(t + x * 7) * (1 - x);
-        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
-        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
-      }
-      return true;
-    },
-  };
-}
-
+import { createSyntheticSource } from '../visualizerStorySource';
 /**
  * player · VinylVisualizer. A spinning record with audio-reactive grooves, a
  * tinted center label, and a mid-frequency outer glow ring. Renders a single

--- a/apps/web/src/components/player/VolumeControl/VolumeControl.stories.tsx
+++ b/apps/web/src/components/player/VolumeControl/VolumeControl.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect } from 'storybook/test';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
@@ -9,9 +10,22 @@ function seedVolume(volume: number, isMuted: boolean): void {
   usePlaybackStore.setState({ volume, isMuted });
 }
 
+/**
+ * player · VolumeControl. A mute toggle plus a 0–1 Radix volume slider, both
+ * reading `usePlaybackStore`. The icon-only mute button carries an aria-label
+ * that flips between "Mute" and "Unmute"; the slider's "Volume" name is
+ * forwarded onto the Radix thumb (the `role="slider"` element) by the shared
+ * ui/slider, so it has an accessible name. Stories seed the store, assert the
+ * slider + button by role/name, and toggle mute to confirm the label swap.
+ */
 const meta: Meta<typeof VolumeControl> = {
   title: 'player/VolumeControl',
   component: VolumeControl,
+  parameters: {
+    // The mute button is labelled and the slider thumb carries the forwarded
+    // "Volume" name, so axe's aria-input-field-name rule is satisfied.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <TooltipProvider>
@@ -27,6 +41,7 @@ export default meta;
 
 type Story = StoryObj<typeof VolumeControl>;
 
+/** High volume — the slider sits near max and the button offers Mute. */
 export const High: Story = {
   decorators: [
     Story => {
@@ -34,8 +49,20 @@ export const High: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Radix puts role="slider" on the thumb; the shared ui/slider forwards the
+    // "Volume" aria-label onto it, so it resolves by accessible name.
+    await expect(canvas.getByRole('slider', { name: 'Volume' })).toBeInTheDocument();
+
+    const muteButton = canvas.getByRole('button', { name: 'Mute' });
+    await userEvent.click(muteButton);
+    // Muting flips the icon-only button's accessible name to Unmute.
+    await expect(canvas.getByRole('button', { name: 'Unmute' })).toBeInTheDocument();
+  },
 };
 
+/** Low volume — the slider reflects a quieter level; the button still reads Mute. */
 export const Low: Story = {
   decorators: [
     Story => {
@@ -43,8 +70,14 @@ export const Low: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('slider', { name: 'Volume' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Mute' })).toBeInTheDocument();
+  },
 };
 
+/** Muted — the button offers Unmute and the slider snaps to zero. */
 export const Muted: Story = {
   decorators: [
     Story => {
@@ -52,4 +85,13 @@ export const Muted: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Unmute' })).toBeInTheDocument();
+    // While muted the slider value reads 0 regardless of the stored volume.
+    await expect(canvas.getByRole('slider', { name: 'Volume' })).toHaveAttribute(
+      'aria-valuenow',
+      '0'
+    );
+  },
 };

--- a/apps/web/src/components/player/VuVisualizer/VuVisualizer.stories.tsx
+++ b/apps/web/src/components/player/VuVisualizer/VuVisualizer.stories.tsx
@@ -2,31 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 
 import VuVisualizer from './VuVisualizer';
-import type { FrequencySource } from '../visualizer-source';
-
-/**
- * A deterministic, audio-free frequency source so a story can drive the real
- * per-frame draw path without the playback engine — two summed sine waves
- * tapered toward the high bins, mirroring the rough shape of real spectrum
- * data (same shape the settings preview uses).
- */
-function createSyntheticSource(): FrequencySource {
-  let t = 0;
-  return {
-    binCount: 256,
-    read(buf) {
-      t += 0.04;
-      for (let i = 0; i < buf.length; i++) {
-        const x = i / buf.length;
-        const a = Math.sin(t + x * 7) * (1 - x);
-        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
-        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
-      }
-      return true;
-    },
-  };
-}
-
+import { createSyntheticSource } from '../visualizerStorySource';
 /**
  * player · VuVisualizer. Twin analog VU needles (L/R) sweeping over a ticked
  * arc. Renders a single decorative `<canvas>` (no role, no text) that animates

--- a/apps/web/src/components/player/VuVisualizer/VuVisualizer.stories.tsx
+++ b/apps/web/src/components/player/VuVisualizer/VuVisualizer.stories.tsx
@@ -1,10 +1,46 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import VuVisualizer from './VuVisualizer';
+import type { FrequencySource } from '../visualizer-source';
 
+/**
+ * A deterministic, audio-free frequency source so a story can drive the real
+ * per-frame draw path without the playback engine — two summed sine waves
+ * tapered toward the high bins, mirroring the rough shape of real spectrum
+ * data (same shape the settings preview uses).
+ */
+function createSyntheticSource(): FrequencySource {
+  let t = 0;
+  return {
+    binCount: 256,
+    read(buf) {
+      t += 0.04;
+      for (let i = 0; i < buf.length; i++) {
+        const x = i / buf.length;
+        const a = Math.sin(t + x * 7) * (1 - x);
+        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
+        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * player · VuVisualizer. Twin analog VU needles (L/R) sweeping over a ticked
+ * arc. Renders a single decorative `<canvas>` (no role, no text) that animates
+ * from a `FrequencySource` via a frame-rate-capped rAF loop. With no source and
+ * no playback analyser the loop idles before drawing but the canvas still
+ * mounts; a synthetic source drives the real draw path.
+ */
 const meta: Meta<typeof VuVisualizer> = {
   title: 'player/VuVisualizer',
   component: VuVisualizer,
+  // a11y ratcheted to 'error': the component renders a lone <canvas> with no
+  // role and no accessible name (the meter face + tick labels are painted into
+  // the canvas bitmap, not real DOM text), which is axe-clean — nothing to flag.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div className="h-[20rem] w-[32rem] bg-background">
@@ -18,6 +54,28 @@ export default meta;
 
 type Story = StoryObj<typeof VuVisualizer>;
 
-export const Default: Story = {
+/**
+ * Idle — active with no source and no playback analyser, so the rAF prelude
+ * returns before drawing. The decorative canvas still mounts into the DOM.
+ */
+export const Idle: Story = {
   render: () => <VuVisualizer active />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+  },
+};
+
+/**
+ * Active — fed a deterministic synthetic source so the real per-frame needle +
+ * bezel draw executes against a live 2D context. The canvas mounts and fills
+ * its wrapper.
+ */
+export const Active: Story = {
+  render: () => <VuVisualizer active source={createSyntheticSource()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+    await expect(canvas).toBeVisible();
+  },
 };

--- a/apps/web/src/components/player/WaveformSeekbar/WaveformSeekbar.stories.tsx
+++ b/apps/web/src/components/player/WaveformSeekbar/WaveformSeekbar.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { usePlayerUIStore } from '@/stores/usePlayerUIStore';
@@ -29,9 +30,23 @@ function seedWaveform(currentTime: number): void {
   usePlayerUIStore.setState({ scrubTime: null });
 }
 
+/**
+ * player · WaveformSeekbar. The native-peaks variant of the scrubber — same
+ * `role="slider"` contract as SeekBar (aria-valuemin/max/now + valuetext, full
+ * keyboard operability) but it paints per-track waveform peaks to a canvas. The
+ * peaks are decoded in the Electron main process; in the browser run there is no
+ * native bridge, so it draws a flat bar and stays a functional scrubber. Reads
+ * `usePlaybackStore` + `usePlayerUIStore`. Stories seed those and assert the
+ * slider's accessible name + reported position.
+ */
 const meta: Meta<typeof WaveformSeekbar> = {
   title: 'player/WaveformSeekbar',
   component: WaveformSeekbar,
+  parameters: {
+    // The slider role lands on the labelled wrapper ("Seek"); the canvas is
+    // decorative, so axe's aria-input-field-name rule passes.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="w-96 p-4">
@@ -45,6 +60,7 @@ export default meta;
 
 type Story = StoryObj<typeof WaveformSeekbar>;
 
+/** Compact — the default-height waveform reports its playhead position. */
 export const Compact: Story = {
   decorators: [
     Story => {
@@ -52,8 +68,16 @@ export const Compact: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const slider = canvas.getByRole('slider', { name: 'Seek' });
+    await expect(slider).toHaveAttribute('aria-valuenow', '90');
+    await expect(slider).toHaveAttribute('aria-valuemax', '215');
+    await expect(slider).toHaveAttribute('aria-valuetext', '1:30 of 3:35');
+  },
 };
 
+/** Tall — a larger canvas height; the same slider contract holds. */
 export const Tall: Story = {
   args: { canvasClassName: 'h-16' },
   decorators: [
@@ -62,4 +86,11 @@ export const Tall: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('slider', { name: 'Seek' })).toHaveAttribute(
+      'aria-valuenow',
+      '90'
+    );
+  },
 };

--- a/apps/web/src/components/player/WaveformVisualizer/WaveformVisualizer.stories.tsx
+++ b/apps/web/src/components/player/WaveformVisualizer/WaveformVisualizer.stories.tsx
@@ -1,10 +1,47 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import WaveformVisualizer from './WaveformVisualizer';
+import type { FrequencySource } from '../visualizer-source';
 
+/**
+ * A deterministic, audio-free frequency source so a story can drive the real
+ * per-frame draw path without the playback engine — two summed sine waves
+ * tapered toward the high bins, mirroring the rough shape of real spectrum
+ * data (same shape the settings preview uses).
+ */
+function createSyntheticSource(): FrequencySource {
+  let t = 0;
+  return {
+    binCount: 256,
+    read(buf) {
+      t += 0.04;
+      for (let i = 0; i < buf.length; i++) {
+        const x = i / buf.length;
+        const a = Math.sin(t + x * 7) * (1 - x);
+        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
+        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * player · WaveformVisualizer. Dense tightly-packed thin bars of varying height
+ * forming a barcode/waveform silhouette (ElevenLabs-style). Renders a single
+ * decorative `<canvas>` (no role, no text) that animates from a
+ * `FrequencySource` via a frame-rate-capped rAF loop. With no source and no
+ * playback analyser the loop idles before drawing but the canvas still mounts;
+ * a synthetic source drives the real draw path.
+ */
 const meta: Meta<typeof WaveformVisualizer> = {
   title: 'player/WaveformVisualizer',
   component: WaveformVisualizer,
+  // a11y ratcheted to 'error': the component renders a lone <canvas> with no
+  // role and no accessible name (purely decorative, pointer-events-none), which
+  // is axe-clean — there is no text, contrast surface, or named-region to flag.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div className="h-[20rem] w-[32rem] bg-background">
@@ -18,6 +55,28 @@ export default meta;
 
 type Story = StoryObj<typeof WaveformVisualizer>;
 
-export const Default: Story = {
+/**
+ * Idle — active with no source and no playback analyser, so the rAF prelude
+ * returns before drawing. The decorative canvas still mounts into the DOM.
+ */
+export const Idle: Story = {
   render: () => <WaveformVisualizer active />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+  },
+};
+
+/**
+ * Active — fed a deterministic synthetic source so the real per-frame dense-bar
+ * draw executes against a live 2D context. The canvas mounts and fills its
+ * wrapper.
+ */
+export const Active: Story = {
+  render: () => <WaveformVisualizer active source={createSyntheticSource()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = canvasElement.querySelector('canvas');
+    await expect(canvas).toBeInTheDocument();
+    await expect(canvas).toBeVisible();
+  },
 };

--- a/apps/web/src/components/player/WaveformVisualizer/WaveformVisualizer.stories.tsx
+++ b/apps/web/src/components/player/WaveformVisualizer/WaveformVisualizer.stories.tsx
@@ -2,31 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 
 import WaveformVisualizer from './WaveformVisualizer';
-import type { FrequencySource } from '../visualizer-source';
-
-/**
- * A deterministic, audio-free frequency source so a story can drive the real
- * per-frame draw path without the playback engine — two summed sine waves
- * tapered toward the high bins, mirroring the rough shape of real spectrum
- * data (same shape the settings preview uses).
- */
-function createSyntheticSource(): FrequencySource {
-  let t = 0;
-  return {
-    binCount: 256,
-    read(buf) {
-      t += 0.04;
-      for (let i = 0; i < buf.length; i++) {
-        const x = i / buf.length;
-        const a = Math.sin(t + x * 7) * (1 - x);
-        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
-        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
-      }
-      return true;
-    },
-  };
-}
-
+import { createSyntheticSource } from '../visualizerStorySource';
 /**
  * player · WaveformVisualizer. Dense tightly-packed thin bars of varying height
  * forming a barcode/waveform silhouette (ElevenLabs-style). Renders a single

--- a/apps/web/src/components/player/visualizerStorySource.ts
+++ b/apps/web/src/components/player/visualizerStorySource.ts
@@ -1,0 +1,25 @@
+import type { FrequencySource } from './visualizer-source';
+
+/**
+ * A deterministic, audio-free frequency source so a story can drive the real
+ * per-frame draw path without the playback engine — two summed sine waves
+ * tapered toward the high bins, mirroring the rough shape of real spectrum
+ * data (same shape the settings preview uses). Shared across every visualizer
+ * story so the synthetic spectrum stays identical and lives in one place.
+ */
+export function createSyntheticSource(): FrequencySource {
+  let t = 0;
+  return {
+    binCount: 256,
+    read(buf) {
+      t += 0.04;
+      for (let i = 0; i < buf.length; i++) {
+        const x = i / buf.length;
+        const a = Math.sin(t + x * 7) * (1 - x);
+        const b = Math.sin(t * 1.6 + x * 3.5 + 1.1) * (1 - x * 0.55);
+        buf[i] = Math.max(0, Math.min(255, ((a + b) * 0.5 + 0.5) * 255 * 0.65));
+      }
+      return true;
+    },
+  };
+}

--- a/apps/web/src/components/playlists/PlaylistDetailHeader/PlaylistDetailHeader.stories.tsx
+++ b/apps/web/src/components/playlists/PlaylistDetailHeader/PlaylistDetailHeader.stories.tsx
@@ -1,5 +1,6 @@
 import { createRef } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, fn } from 'storybook/test';
 import type { Playlist } from '@/types/electron';
 import type { usePlaylistCover } from '@/hooks/usePlaylistCover';
 
@@ -33,9 +34,23 @@ function makePlaylist(overrides: Partial<Playlist> = {}): Playlist {
   };
 }
 
+/**
+ * playlists · PlaylistDetailHeader. The header for a playlist detail page: a
+ * back action, the cover thumbnail (opens the cover menu), the editable name,
+ * the track-count / duration line, and play-all + delete actions. It's a pure
+ * props component (no store/query). Stories assert the labelled controls, the
+ * track-count line, the disabled play-all on an empty playlist, and that the
+ * name + delete actions fire their callbacks. The share action only renders
+ * under Electron, so it's absent in the browser.
+ */
 const meta: Meta<typeof PlaylistDetailHeader> = {
   title: 'playlists/PlaylistDetailHeader',
   component: PlaylistDetailHeader,
+  parameters: {
+    // Back / play-all / delete icon buttons carry aria-labels, the cover button
+    // is named via its title, and the name is a text button — axe passes clean.
+    a11y: { test: 'error' },
+  },
   args: {
     playlist: makePlaylist(),
     selectedPlaylistId: 'pl-1',
@@ -46,16 +61,16 @@ const meta: Meta<typeof PlaylistDetailHeader> = {
     cover: makeCover(),
     isEditing: false,
     editName: '',
-    setEditName: () => {},
+    setEditName: fn(),
     nameInputRef: createRef<HTMLInputElement>(),
     showDeleteConfirm: false,
-    setShowDeleteConfirm: () => {},
-    onBack: () => {},
-    onPlayAll: () => {},
-    onDelete: () => {},
-    onStartEdit: () => {},
-    onSaveName: () => {},
-    onNameKeyDown: () => {},
+    setShowDeleteConfirm: fn(),
+    onBack: fn(),
+    onPlayAll: fn(),
+    onDelete: fn(),
+    onStartEdit: fn(),
+    onSaveName: fn(),
+    onNameKeyDown: fn(),
   },
   decorators: [
     Story => (
@@ -70,13 +85,52 @@ export default meta;
 
 type Story = StoryObj<typeof PlaylistDetailHeader>;
 
-export const Default: Story = {};
+/** Populated playlist — labelled controls, track count, and callback wiring. */
+export const Default: Story = {
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Back to playlists' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Edit playlist cover' })).toBeInTheDocument();
+    await expect(canvas.getByText('12 tracks · 43:00')).toBeInTheDocument();
 
+    const playAll = canvas.getByRole('button', { name: 'Play All' });
+    await expect(playAll).toBeEnabled();
+
+    // The name button (when not editing) starts an inline rename.
+    await userEvent.click(canvas.getByRole('button', { name: 'Late-night focus' }));
+    await expect(args.onStartEdit).toHaveBeenCalled();
+
+    // The delete button opens the confirm popover via the setter.
+    await userEvent.click(canvas.getByRole('button', { name: 'Delete playlist' }));
+    await expect(args.setShowDeleteConfirm).toHaveBeenCalledWith(true);
+  },
+};
+
+/** Empty playlist — zero tracks and a disabled play-all action. */
 export const Empty: Story = {
   args: {
     playlist: makePlaylist({ name: 'Fresh start' }),
     trackCount: 0,
     totalDuration: 0,
     hasTracks: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Fresh start' })).toBeInTheDocument();
+    await expect(canvas.getByText('0 tracks')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Play All' })).toBeDisabled();
+  },
+};
+
+/** The delete-confirm popover is shown — its confirm + cancel actions render. */
+export const ConfirmingDelete: Story = {
+  args: {
+    showDeleteConfirm: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Delete this playlist?')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/playlists/PlaylistDetailView/PlaylistDetailView.stories.tsx
+++ b/apps/web/src/components/playlists/PlaylistDetailView/PlaylistDetailView.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, expect } from 'storybook/test';
 import type { Playlist } from '@/types/electron';
 import type { Track } from '@/stores/types';
 import { useViewStore } from '@/stores/useViewStore';
@@ -44,9 +45,22 @@ function seededClient(playlist: Playlist, tracks: Track[]): QueryClient {
   return client;
 }
 
+/**
+ * playlists · PlaylistDetailView. The full playlist detail page: it composes the
+ * detail header (back / play-all / rename / delete) with the reorderable track
+ * list. It reads the selected playlist id from the view store and fetches the
+ * playlist + tracks via React Query. Stories seed the query client + view store
+ * so the page renders without IPC, asserting the header chrome and the track
+ * list (or its empty state).
+ */
 const meta: Meta<typeof PlaylistDetailView> = {
   title: 'playlists/PlaylistDetailView',
   component: PlaylistDetailView,
+  parameters: {
+    // Back action is an aria-labelled icon button, play-all/name are labelled
+    // buttons, and each track row is a labelled button — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="flex h-[40rem] w-[48rem] flex-col">
@@ -60,6 +74,7 @@ export default meta;
 
 type Story = StoryObj<typeof PlaylistDetailView>;
 
+/** A playlist with three tracks — header chrome and a rendered track row. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -76,8 +91,22 @@ export const Default: Story = {
       );
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Back to playlists' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Late-night focus' })).toBeInTheDocument();
+    await expect(canvas.getByText('3 tracks · 10:45')).toBeInTheDocument();
+    // The virtualized track list mounts rows after measuring — wait for the first.
+    // Each row's dnd-kit sortable wrapper is also a `role="button"` echoing the
+    // row text, so two elements match the name; target the real play <button>.
+    const rowMatches = await canvas.findAllByRole('button', {
+      name: /Midnight study session\s+Lofi Girl/,
+    });
+    await expect(rowMatches.find(el => el.tagName === 'BUTTON')).toBeInTheDocument();
+  },
 };
 
+/** An empty playlist — the header still renders and the list shows its empty state. */
 export const Empty: Story = {
   decorators: [
     Story => {
@@ -90,4 +119,10 @@ export const Empty: Story = {
       );
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Fresh start' })).toBeInTheDocument();
+    await expect(canvas.getByText('0 tracks')).toBeInTheDocument();
+    await expect(canvas.getByText('No tracks yet')).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/playlists/PlaylistTrackList/PlaylistTrackList.stories.tsx
+++ b/apps/web/src/components/playlists/PlaylistTrackList/PlaylistTrackList.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect, fn } from 'storybook/test';
 import type { Track } from '@/stores/types';
 
 import PlaylistTrackList from './PlaylistTrackList';
@@ -22,9 +23,22 @@ const tracks = [
   makeTrack({ id: 'c', title: 'Slow morning coffee' }),
 ];
 
+/**
+ * playlists · PlaylistTrackList. The reorderable track list inside a playlist
+ * detail page: a `react-window` list of dnd-kit sortable rows, each a play
+ * `<button>` (named "title artist") with a drag handle, favorite, add-to-playlist,
+ * and remove action. Renders an empty state when there are no tracks. It's a pure
+ * props component; stories assert a representative rendered row and the empty
+ * state.
+ */
 const meta: Meta<typeof PlaylistTrackList> = {
   title: 'playlists/PlaylistTrackList',
   component: PlaylistTrackList,
+  parameters: {
+    // Each row's play button is named by its text, and the drag handle / favorite
+    // / add / remove icon buttons all carry aria-labels — axe passes clean.
+    a11y: { test: 'error' },
+  },
   args: {
     displayTracks: tracks,
     sortableIds: tracks.map(t => t.id),
@@ -32,12 +46,12 @@ const meta: Meta<typeof PlaylistTrackList> = {
     currentTrack: null,
     isPlaying: false,
     sensors: [],
-    onDragStart: () => {},
-    onDragEnd: () => {},
-    onDragCancel: () => {},
-    onPlayTrack: () => {},
-    onToggleFavorite: () => {},
-    onRemoveTrack: () => {},
+    onDragStart: fn(),
+    onDragEnd: fn(),
+    onDragCancel: fn(),
+    onPlayTrack: fn(),
+    onToggleFavorite: fn(),
+    onRemoveTrack: fn(),
   },
   decorators: [
     Story => (
@@ -52,11 +66,37 @@ export default meta;
 
 type Story = StoryObj<typeof PlaylistTrackList>;
 
-export const Default: Story = {};
+/** Three tracks — assert a representative row and its per-row actions. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The virtualized list mounts rows after measuring — wait for the first. Each
+    // row's dnd-kit sortable wrapper is also a `role="button"` echoing the row
+    // text, so two elements match the name; target the real play <button>.
+    const rowMatches = await canvas.findAllByRole('button', {
+      name: /Midnight study session\s+Lofi Girl/,
+    });
+    await expect(rowMatches.find(el => el.tagName === 'BUTTON')).toBeInTheDocument();
+    // Each row exposes a labelled drag handle and a remove action.
+    await expect(canvas.getAllByRole('button', { name: 'Drag to reorder' }).length).toBeGreaterThan(
+      0
+    );
+    await expect(
+      canvas.getAllByRole('button', { name: 'Remove from playlist' }).length
+    ).toBeGreaterThan(0);
+  },
+};
 
+/** No tracks — the empty state. */
 export const Empty: Story = {
   args: {
     displayTracks: [],
     sortableIds: [],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No tracks yet')).toBeInTheDocument();
+    await expect(canvas.getByText('Add tracks from your library')).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Drag to reorder' })).not.toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/playlists/PlaylistsView/PlaylistsView.stories.tsx
+++ b/apps/web/src/components/playlists/PlaylistsView/PlaylistsView.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, userEvent, expect } from 'storybook/test';
 import type { Playlist } from '@/types/electron';
 import { playlistKeys } from '@/hooks/queries/usePlaylists';
 
@@ -26,8 +27,21 @@ function seededClient(playlists: Playlist[]): QueryClient {
   return client;
 }
 
+/**
+ * playlists · PlaylistsView. The playlists overview: an `<h1>` title, a "New
+ * Playlist" button that reveals an inline create form, and one card `<button>`
+ * per playlist (opening it routes to the detail view). It reads the list via
+ * React Query; stories pre-seed the query client so the grid renders
+ * deterministically without IPC, and drive the create-form reveal.
+ */
 const meta: Meta<typeof PlaylistsView> = {
   title: 'playlists/PlaylistsView',
+  parameters: {
+    // Title is a real <h1>, each card + the create CTA are labelled buttons, the
+    // create form input is aria-labelled, and the card placeholder icon is a
+    // decorative SVG — axe passes clean.
+    a11y: { test: 'error' },
+  },
   component: PlaylistsView,
   decorators: [
     Story => (
@@ -42,6 +56,7 @@ export default meta;
 
 type Story = StoryObj<typeof PlaylistsView>;
 
+/** Three playlists — heading, the card grid, and the reveal of the create form. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -57,8 +72,22 @@ export const Default: Story = {
       );
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Your playlists' })).toBeInTheDocument();
+    // Each seeded playlist is its own card button (name starts with its title).
+    await expect(canvas.getByRole('button', { name: /Late-night focus/ })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: /Rainy day cafe/ })).toBeInTheDocument();
+
+    // The "New Playlist" button reveals the inline create form.
+    await userEvent.click(canvas.getByRole('button', { name: 'New Playlist' }));
+    await expect(
+      await canvas.findByRole('textbox', { name: 'Playlist name...' })
+    ).toBeInTheDocument();
+  },
 };
 
+/** No playlists — the empty state and onboarding hint. */
 export const Empty: Story = {
   decorators: [
     Story => {
@@ -70,4 +99,11 @@ export const Empty: Story = {
       );
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No playlists yet')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'New Playlist' })).toBeInTheDocument();
+    // No card buttons exist in the empty state.
+    await expect(canvas.queryByRole('button', { name: /focus/ })).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/playlists/VirtualSortableTrackRow/VirtualSortableTrackRow.stories.tsx
+++ b/apps/web/src/components/playlists/VirtualSortableTrackRow/VirtualSortableTrackRow.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect, fn } from 'storybook/test';
 import { DndContext } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import type { Track } from '@/stores/types';
@@ -20,18 +21,31 @@ function makeTrack(overrides: Partial<Track> = {}): Track {
 
 const track = makeTrack();
 
+/**
+ * playlists · VirtualSortableTrackRow. A single `react-window` row that is also a
+ * dnd-kit sortable: a labelled drag handle plus the shared track row (a play
+ * `<button>` named "title artist", with favorite / add / remove actions). The
+ * "now playing" variant adds a sr-only "Now Playing" prefix to the row's name.
+ * Stories wrap the row in a `SortableContext` and assert the row name + drag
+ * handle for the idle and playing states.
+ */
 const meta: Meta<typeof VirtualSortableTrackRow> = {
   title: 'playlists/VirtualSortableTrackRow',
   component: VirtualSortableTrackRow,
+  parameters: {
+    // The play button is named by its text, and the drag handle / favorite / add
+    // / remove icon buttons all carry aria-labels — axe passes clean.
+    a11y: { test: 'error' },
+  },
   args: {
     index: 0,
     style: { position: 'relative', height: 48 },
     tracks: [track],
     currentTrack: null,
     isPlaying: false,
-    onPlayTrack: () => {},
-    onToggleFavorite: () => {},
-    onRemoveTrack: () => {},
+    onPlayTrack: fn(),
+    onToggleFavorite: fn(),
+    onRemoveTrack: fn(),
   },
   decorators: [
     Story => (
@@ -50,11 +64,34 @@ export default meta;
 
 type Story = StoryObj<typeof VirtualSortableTrackRow>;
 
-export const Default: Story = {};
+/** Idle row — the play button and the labelled drag handle. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The dnd-kit sortable wrapper is itself a `role="button"` whose computed
+    // name echoes the row text, so two elements match the name — target the real
+    // play control, the only true <button> among them.
+    const playButton = canvas
+      .getAllByRole('button', { name: /Midnight study session\s+Lofi Girl/ })
+      .find(el => el.tagName === 'BUTTON');
+    await expect(playButton).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Drag to reorder' })).toBeInTheDocument();
+  },
+};
 
+/** Now-playing row — the accessible name gains a "Now Playing" prefix. */
 export const Playing: Story = {
   args: {
     currentTrack: track,
     isPlaying: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Same wrapper/button name collision as the idle story, now with the sr-only
+    // "Now Playing" prefix — assert the real play <button> carries it.
+    const playButton = canvas
+      .getAllByRole('button', { name: /Now Playing\s+Midnight study session/ })
+      .find(el => el.tagName === 'BUTTON');
+    await expect(playButton).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/settings/AboutSection/AboutSection.stories.tsx
+++ b/apps/web/src/components/settings/AboutSection/AboutSection.stories.tsx
@@ -1,13 +1,30 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, userEvent, expect, fn, waitFor } from 'storybook/test';
+import { useOnboardingStore } from '@/stores/useOnboardingStore';
 
 import AboutSection from './AboutSection';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
+/**
+ * settings · AboutSection. The About panel's stack of `SettingsCard`s — a hero
+ * with the wordmark + version chip and GitHub/Changelog links, an authored
+ * "story" card, an Electron-only "Application logs" card, and a "Replay
+ * onboarding" card whose button resets onboarding via the store.
+ *
+ * The "Application logs" card is gated on `IS_ELECTRON`, which `@/lib/platform`
+ * captures as a module-load constant. In the Storybook browser run that constant
+ * resolves to `false` (platform.ts is imported before the preview's electronAPI
+ * mock is installed), so the logs card is unreachable here and the story asserts
+ * only the three always-present cards.
+ */
 const meta: Meta<typeof AboutSection> = {
   title: 'settings/AboutSection',
   component: AboutSection,
+  // Headings are real <h3>s, links carry visible text + icons, and the mascot
+  // <img> has an alt — axe clean.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <QueryClientProvider client={queryClient}>
@@ -23,4 +40,37 @@ export default meta;
 
 type Story = StoryObj<typeof AboutSection>;
 
-export const Default: Story = {};
+/** Default — every card renders and "Replay setup" drives the onboarding reset. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The three always-present section headings render. The "Application logs"
+    // card is Electron-gated (IS_ELECTRON is a false module-constant in the
+    // Storybook browser run, see meta), so it is intentionally not asserted here.
+    await expect(canvas.getByRole('heading', { name: 'Shiranami' })).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'The story' })).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Replay onboarding' })).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('heading', { name: 'Application logs' })
+    ).not.toBeInTheDocument();
+
+    // Outbound links expose their destinations by accessible name.
+    await expect(canvas.getByRole('link', { name: 'GitHub' })).toHaveAttribute(
+      'href',
+      'https://github.com/Shironex/shiranami'
+    );
+
+    // Clicking "Replay setup" calls the store's resetOnboarding. Seed a spy so
+    // the assertion is on a known setter, then restore it afterwards.
+    const resetOnboarding = fn();
+    const previous = useOnboardingStore.getState().resetOnboarding;
+    useOnboardingStore.setState({ resetOnboarding });
+    try {
+      await userEvent.click(canvas.getByRole('button', { name: 'Replay setup' }));
+      await waitFor(() => expect(resetOnboarding).toHaveBeenCalled());
+    } finally {
+      useOnboardingStore.setState({ resetOnboarding: previous });
+    }
+  },
+};

--- a/apps/web/src/components/settings/AccentColorPicker/AccentColorPicker.stories.tsx
+++ b/apps/web/src/components/settings/AccentColorPicker/AccentColorPicker.stories.tsx
@@ -1,11 +1,23 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
 import { useAccentStore, ACCENT_PRESETS } from '@/stores/useAccentStore';
 
 import AccentColorPicker from './AccentColorPicker';
 
+/**
+ * settings · AccentColorPicker. A `role="radiogroup"` named "Accent color" whose
+ * radios are: "Auto (theme accent)", one swatch per preset (named "Use {name}
+ * accent"), and a "Custom color" tile that opens the native color input. Exactly
+ * one radio is `aria-checked` at a time; selecting drives `useAccentStore`. The
+ * native `<input type="color">` is `aria-hidden`, so it never appears in the
+ * accessibility tree.
+ */
 const meta: Meta<typeof AccentColorPicker> = {
   title: 'settings/AccentColorPicker',
   component: AccentColorPicker,
+  // radiogroup + radios all carry accessible names; the color input is
+  // aria-hidden — axe clean.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div className="max-w-[420px] p-4">
@@ -19,6 +31,7 @@ export default meta;
 
 type Story = StoryObj<typeof AccentColorPicker>;
 
+/** Auto is the default selection; clicking a preset swatch updates the store. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -26,8 +39,26 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('radiogroup', { name: 'Accent color' });
+
+    // Auto starts active; the first preset (Violet) starts inactive.
+    const auto = within(group).getByRole('radio', { name: 'Auto (theme accent)' });
+    const violet = within(group).getByRole('radio', { name: 'Use Violet accent' });
+    await expect(auto).toHaveAttribute('aria-checked', 'true');
+    await expect(violet).toHaveAttribute('aria-checked', 'false');
+
+    // Selecting the Violet swatch writes its hex to the store.
+    await userEvent.click(violet);
+    await waitFor(() => expect(useAccentStore.getState().accentColor).toBe(ACCENT_PRESETS[0].hex));
+
+    // Reset for the next story.
+    useAccentStore.setState({ accentColor: null });
+  },
 };
 
+/** Preset selected — the first preset swatch reads as the active radio. */
 export const PresetSelected: Story = {
   decorators: [
     Story => {
@@ -35,8 +66,20 @@ export const PresetSelected: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('radio', { name: 'Use Violet accent' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    await expect(canvas.getByRole('radio', { name: 'Auto (theme accent)' })).toHaveAttribute(
+      'aria-checked',
+      'false'
+    );
+  },
 };
 
+/** Custom color — a non-preset hex marks the "Custom color" tile as active. */
 export const CustomColor: Story = {
   decorators: [
     Story => {
@@ -44,4 +87,11 @@ export const CustomColor: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('radio', { name: 'Custom color' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+  },
 };

--- a/apps/web/src/components/settings/AccentPreview/AccentPreview.stories.tsx
+++ b/apps/web/src/components/settings/AccentPreview/AccentPreview.stories.tsx
@@ -1,10 +1,21 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import AccentPreview from './AccentPreview';
 
+/**
+ * settings · AccentPreview. A presentational sample chrome (track row, accent
+ * progress bar, play button, nav pill, "on" switch graphic) rendered entirely
+ * from accent tokens so it live-updates as a swatch is picked. The whole sample
+ * is exposed as a single `role="img"` labelled "Accent preview"; its inner
+ * pieces are purely decorative.
+ */
 const meta: Meta<typeof AccentPreview> = {
   title: 'settings/AccentPreview',
   component: AccentPreview,
+  // Single labelled role="img"; decorative inner graphics carry no roles —
+  // axe clean.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div className="max-w-[420px] p-4">
@@ -18,4 +29,10 @@ export default meta;
 
 type Story = StoryObj<typeof AccentPreview>;
 
-export const Default: Story = {};
+/** Default — the labelled preview image renders. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('img', { name: 'Accent preview' })).toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/settings/AppearanceSection/AppearanceSection.stories.tsx
+++ b/apps/web/src/components/settings/AppearanceSection/AppearanceSection.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
 import { useThemeStore } from '@/stores/useThemeStore';
 import { useThemeBgStore } from '@/stores/useThemeBgStore';
 import { useAccentStore } from '@/stores/useAccentStore';
@@ -6,9 +7,23 @@ import { useUIStore } from '@/stores/useUIStore';
 
 import AppearanceSection from './AppearanceSection';
 
+/**
+ * settings · AppearanceSection. The Appearance panel: a "Language & scale" card
+ * (language chips + an interface-scale slider with preset chips), a "Theme" card
+ * (theme tile grid + background opacity/blur/dim sliders when a photo theme is
+ * active), and an "Accent color" card embedding AccentColorPicker + AccentPreview.
+ * Scale and accent are seeded per story so chip/picker assertions start known.
+ */
 const meta: Meta<typeof AppearanceSection> = {
   title: 'settings/AppearanceSection',
   component: AppearanceSection,
+  // a11y stays at the global 'todo' default: the interface-scale and
+  // background opacity/blur/dim Sliders are rendered without an accessible name
+  // (no aria-label passed at the call site in AppearanceSection.tsx), so axe's
+  // aria-input-field-name rule fails on the slider thumbs. The shared
+  // ui/slider.tsx forwards a name when given one, but adding names is a
+  // component-file change out of this story's scope. The labelled siblings
+  // (LyricsSection) are ratcheted to 'error' instead.
   decorators: [
     Story => (
       <div className="max-w-[680px] p-4">
@@ -22,6 +37,7 @@ export default meta;
 
 type Story = StoryObj<typeof AppearanceSection>;
 
+/** Default — the three cards render and the 120% scale chip drives the store. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -31,8 +47,22 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Language & scale' })).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Theme' })).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Accent color' })).toBeInTheDocument();
+
+    // Clicking the 120% preset chip pushes that scale into the UI store.
+    await userEvent.click(canvas.getByRole('button', { name: '120%' }));
+    await waitFor(() => expect(useUIStore.getState().uiScale).toBe(120));
+
+    useUIStore.setState({ uiScale: 100 });
+  },
 };
 
+/** Themed with accent — a photo theme reveals the background-adjustment sliders. */
 export const ThemedWithAccent: Story = {
   decorators: [
     Story => {
@@ -43,4 +73,11 @@ export const ThemedWithAccent: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The background-adjustment block (only present for photo themes) renders
+    // its labels, and three sliders are exposed (opacity / blur / dim).
+    await expect(canvas.getByText('Background adjustments')).toBeInTheDocument();
+    await expect(canvas.getAllByRole('slider')).toHaveLength(4);
+  },
 };

--- a/apps/web/src/components/settings/CompactModePreview/CompactModePreview.stories.tsx
+++ b/apps/web/src/components/settings/CompactModePreview/CompactModePreview.stories.tsx
@@ -56,10 +56,15 @@ export const Default: Story = {
 export const LargeWithLyrics: Story = {
   decorators: [
     Story => {
+      // Seed every preview-relevant key so residual values from an earlier story
+      // can't leak in — the preview reads all eight of these.
       useCompactStore.setState({
         compactSize: 'lg',
         compactFontSize: 'lg',
+        compactShowAlbumArt: true,
         compactShowAlbum: true,
+        compactShowSeek: true,
+        compactShowVolume: true,
         compactShowFavorite: true,
         compactShowLyrics: true,
       });

--- a/apps/web/src/components/settings/CompactModePreview/CompactModePreview.stories.tsx
+++ b/apps/web/src/components/settings/CompactModePreview/CompactModePreview.stories.tsx
@@ -1,11 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import { useCompactStore } from '@/stores/useCompactStore';
 
 import CompactModePreview from './CompactModePreview';
 
+/**
+ * settings · CompactModePreview. A presentational mock of the mini-player whose
+ * size, typography, padding, and visible elements are read from `useCompactStore`.
+ * The whole sample is a single `role="img"` labelled "Preview"; the sample track
+ * title/artist/album text render inside it, plus a "Preview only…" disclaimer.
+ */
 const meta: Meta<typeof CompactModePreview> = {
   title: 'settings/CompactModePreview',
   component: CompactModePreview,
+  // Single labelled role="img"; inner mock graphics are decorative — axe clean.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div className="max-w-[420px] p-4">
@@ -19,18 +28,47 @@ export default meta;
 
 type Story = StoryObj<typeof CompactModePreview>;
 
-export const Default: Story = {};
+/** Default — the labelled preview image and its sample track text render. */
+export const Default: Story = {
+  decorators: [
+    Story => {
+      useCompactStore.setState({
+        compactSize: 'md',
+        compactFontSize: 'md',
+        compactShowAlbumArt: true,
+        compactShowAlbum: true,
+        compactShowSeek: true,
+        compactShowVolume: true,
+        compactShowFavorite: false,
+        compactShowLyrics: false,
+      });
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('img', { name: 'Preview' })).toBeInTheDocument();
+    await expect(canvas.getByText('Sample track title')).toBeInTheDocument();
+  },
+};
 
+/** Large with lyrics — the album line still renders at the larger size. */
 export const LargeWithLyrics: Story = {
   decorators: [
     Story => {
       useCompactStore.setState({
         compactSize: 'lg',
         compactFontSize: 'lg',
+        compactShowAlbum: true,
         compactShowFavorite: true,
         compactShowLyrics: true,
       });
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('img', { name: 'Preview' })).toBeInTheDocument();
+    await expect(canvas.getByText('Sample album')).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/CompactSection/CompactSection.stories.tsx
+++ b/apps/web/src/components/settings/CompactSection/CompactSection.stories.tsx
@@ -1,10 +1,37 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
+import { useCompactStore } from '@/stores/useCompactStore';
 
 import CompactSection from './CompactSection';
 
+function seedDefaults(): void {
+  useCompactStore.setState({
+    compactSize: 'md',
+    compactFontSize: 'md',
+    compactShowAlbumArt: true,
+    compactShowAlbum: true,
+    compactShowSeek: true,
+    compactShowVolume: true,
+    compactShowFavorite: false,
+    compactShowLyrics: false,
+    compactDefaultAlwaysOnTop: false,
+  });
+}
+
+/**
+ * settings · CompactSection. The mini-player settings card: an embedded
+ * CompactModePreview, "Window size" / "Text size" preset chip rows, an ambient
+ * intensity slider, a "Visible elements" group of toggle rows (Album art, Album
+ * name, Seek bar, Volume slider, Favorite button, Lyrics button), and a
+ * "Behavior" always-on-top toggle. All state lives in `useCompactStore`.
+ */
 const meta: Meta<typeof CompactSection> = {
   title: 'settings/CompactSection',
   component: CompactSection,
+  // a11y stays at the global 'todo' default: the ambient-intensity Slider is
+  // rendered without an accessible name (no aria-label at the call site in
+  // CompactSection.tsx), so axe's aria-input-field-name rule fails on the slider
+  // thumb. Naming it is a component-file change out of this story's scope.
   decorators: [
     Story => (
       <div className="max-w-[680px] p-4">
@@ -18,4 +45,30 @@ export default meta;
 
 type Story = StoryObj<typeof CompactSection>;
 
-export const Default: Story = {};
+/** Default — the card renders; "Medium" sets size and the Album-art switch toggles. */
+export const Default: Story = {
+  decorators: [
+    Story => {
+      seedDefaults();
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Compact mode' })).toBeInTheDocument();
+
+    // The "Medium" window-size chip writes 'md' to the store.
+    await userEvent.click(canvas.getByRole('button', { name: 'Medium' }));
+    await waitFor(() => expect(useCompactStore.getState().compactSize).toBe('md'));
+
+    // The "Album art" element toggle starts checked; clicking it flips the store
+    // flag off. Element switches are named via aria-labelledby on SettingsToggleRow.
+    const albumArt = canvas.getByRole('switch', { name: 'Album art' });
+    await expect(albumArt).toBeChecked();
+    await userEvent.click(albumArt);
+    await waitFor(() => expect(useCompactStore.getState().compactShowAlbumArt).toBe(false));
+
+    seedDefaults();
+  },
+};

--- a/apps/web/src/components/settings/DiscordPreview/DiscordPreview.stories.tsx
+++ b/apps/web/src/components/settings/DiscordPreview/DiscordPreview.stories.tsx
@@ -1,10 +1,21 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import DiscordPreview from './DiscordPreview';
 
+/**
+ * settings · DiscordPreview. A presentational Discord rich-presence card adapted
+ * for the now-playing context. Props drive what shows: the "Shiranami" app name
+ * is always present, `details`/`state` are conditional text lines, `showTimestamp`
+ * reveals the "03:42 left" elapsed line, `showLargeImage` the cover tile, and
+ * `showButton` the "Get Shiranami" CTA. The "Listening to music" header is fixed.
+ */
 const meta: Meta<typeof DiscordPreview> = {
   title: 'settings/DiscordPreview',
   component: DiscordPreview,
+  // Plain presentational text card — no interactive controls or unnamed widgets;
+  // axe clean.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div className="max-w-[360px] p-4">
@@ -18,6 +29,7 @@ export default meta;
 
 type Story = StoryObj<typeof DiscordPreview>;
 
+/** Full — details, state, elapsed time, and the landing button all render. */
 export const Default: Story = {
   args: {
     details: 'Midnight Tapes',
@@ -26,8 +38,18 @@ export const Default: Story = {
     showLargeImage: true,
     showButton: true,
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Listening to music')).toBeInTheDocument();
+    await expect(canvas.getByText('Shiranami')).toBeInTheDocument();
+    await expect(canvas.getByText('Midnight Tapes')).toBeInTheDocument();
+    await expect(canvas.getByText('Idealism')).toBeInTheDocument();
+    await expect(canvas.getByText('03:42 left')).toBeInTheDocument();
+    await expect(canvas.getByText('Get Shiranami')).toBeInTheDocument();
+  },
 };
 
+/** Minimal — empty state plus all flags off hides every optional line. */
 export const Minimal: Story = {
   args: {
     details: 'Midnight Tapes',
@@ -35,5 +57,13 @@ export const Minimal: Story = {
     showTimestamp: false,
     showLargeImage: false,
     showButton: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Midnight Tapes')).toBeInTheDocument();
+    // Empty state, hidden timestamp, and hidden button drop their text.
+    await expect(canvas.queryByText('Idealism')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('03:42 left')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Get Shiranami')).not.toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/settings/DiscordSection/DiscordSection.stories.tsx
+++ b/apps/web/src/components/settings/DiscordSection/DiscordSection.stories.tsx
@@ -1,16 +1,29 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { DEFAULT_DISCORD_TEMPLATES, type DiscordRpcSettings } from '@shiranami/shared';
+import { within, expect } from 'storybook/test';
 
 import DiscordSection from './DiscordSection';
 
-/** Point the story's IPC mock at a concrete settings object so the card renders. */
-function seedDiscord(settings: DiscordRpcSettings): void {
-  window.electronAPI.discord.getSettings = () => Promise.resolve(settings);
-}
-
+/**
+ * settings · DiscordSection. The Discord Rich Presence panel. Settings load from
+ * an on-mount IPC read (`discord.getSettings`) gated on `IS_ELECTRON`; until they
+ * arrive the component renders `if (!settings) return null`. With presence
+ * enabled it shows a header switch ("Enable Discord Rich Presence"), the "Show
+ * track details" / "Show elapsed time" / "Custom templates" toggles, a Save
+ * button, a live "Preview" card, and an info callout.
+ *
+ * In the Storybook browser run `IS_ELECTRON` resolves to `false` — `@/lib/platform`
+ * captures it as a module-constant before the preview installs the electronAPI
+ * mock — so the on-mount `discord.getSettings` read is skipped entirely, `settings`
+ * stays null, and the component renders nothing. The loaded card is unreachable
+ * in-browser (no IPC seed can flip the false module-constant), so the story
+ * asserts the render-null contract.
+ */
 const meta: Meta<typeof DiscordSection> = {
   title: 'settings/DiscordSection',
   component: DiscordSection,
+  // Outside Electron the section renders nothing, so there are no roles to
+  // audit — axe passes trivially clean.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div className="max-w-[680px] p-4">
@@ -24,32 +37,20 @@ export default meta;
 
 type Story = StoryObj<typeof DiscordSection>;
 
-export const Default: Story = {
-  decorators: [
-    Story => {
-      seedDiscord({
-        enabled: true,
-        showTrackDetails: true,
-        showElapsedTime: true,
-        useCustomTemplates: false,
-        templates: DEFAULT_DISCORD_TEMPLATES,
-      });
-      return <Story />;
-    },
-  ],
-};
+/**
+ * Gated outside Electron — settings never load (`IS_ELECTRON` is false), so
+ * `if (!settings) return null` keeps the whole panel off-screen.
+ */
+export const GatedOutsideElectron: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
 
-export const CustomTemplates: Story = {
-  decorators: [
-    Story => {
-      seedDiscord({
-        enabled: true,
-        showTrackDetails: true,
-        showElapsedTime: true,
-        useCustomTemplates: true,
-        templates: DEFAULT_DISCORD_TEMPLATES,
-      });
-      return <Story />;
-    },
-  ],
+    // None of the loaded-card surfaces are reachable without IPC-delivered
+    // settings, which the false IS_ELECTRON module-constant prevents.
+    await expect(canvas.queryByText('Discord Rich Presence')).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('switch', { name: 'Enable Discord Rich Presence' })
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('heading', { name: 'Preview' })).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/DiscordTemplateEditor/DiscordTemplateEditor.stories.tsx
+++ b/apps/web/src/components/settings/DiscordTemplateEditor/DiscordTemplateEditor.stories.tsx
@@ -1,11 +1,23 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, fn, waitFor } from 'storybook/test';
 import { DEFAULT_DISCORD_TEMPLATES } from '@shiranami/shared';
 
 import DiscordTemplateEditor from './DiscordTemplateEditor';
 
+/**
+ * settings · DiscordTemplateEditor. A controlled editor for one activity's
+ * Discord status template: an "Activity type" select (bound to its label), two
+ * text inputs ("Line 1 (description)" / "Line 2 (state)"), three named toggles
+ * (Track timer / App logo / Shiranami button), a variable-hint panel, and a
+ * "Restore defaults" button. All changes flow up through `onTemplateChange` /
+ * `onReset` callbacks, asserted here with `fn()` spies.
+ */
 const meta: Meta<typeof DiscordTemplateEditor> = {
   title: 'settings/DiscordTemplateEditor',
   component: DiscordTemplateEditor,
+  // Inputs are bound to <label htmlFor>, the select trigger is labelled, switches
+  // carry aria-label, and the heading is real — axe clean.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div className="max-w-[680px] p-4">
@@ -19,12 +31,33 @@ export default meta;
 
 type Story = StoryObj<typeof DiscordTemplateEditor>;
 
+/** Default — inputs seed from the playing template; edits + reset fire callbacks. */
 export const Default: Story = {
   args: {
     selectedActivity: 'playing',
-    onActivityChange: () => {},
+    onActivityChange: fn(),
     currentTemplate: DEFAULT_DISCORD_TEMPLATES.playing,
-    onTemplateChange: () => {},
-    onReset: () => {},
+    onTemplateChange: fn(),
+    onReset: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Status templates' })).toBeInTheDocument();
+
+    // The Line 1 input is bound to its label and seeded from the playing template.
+    const line1 = canvas.getByLabelText('Line 1 (description)');
+    await expect(line1).toHaveValue('Listening to music');
+
+    // Typing reports the change upward through onTemplateChange.
+    await userEvent.type(line1, '!');
+    await waitFor(() => expect(args.onTemplateChange).toHaveBeenCalled());
+
+    // The activity-type combobox is labelled and present.
+    await expect(canvas.getByRole('combobox', { name: 'Activity type' })).toBeInTheDocument();
+
+    // "Restore defaults" invokes the reset callback.
+    await userEvent.click(canvas.getByRole('button', { name: 'Restore defaults' }));
+    await waitFor(() => expect(args.onReset).toHaveBeenCalled());
   },
 };

--- a/apps/web/src/components/settings/DiskUsageBar/DiskUsageBar.stories.tsx
+++ b/apps/web/src/components/settings/DiskUsageBar/DiskUsageBar.stories.tsx
@@ -63,7 +63,9 @@ export const Default: Story = {
 /** Nearly full — a high music/low free split still renders the same chrome. */
 export const NearlyFull: Story = {
   args: {
-    volume: { ...volume, musicBytes: 380 * GB, freeBytes: 20 * GB },
+    // Keep the payload internally consistent: used = total - free, and music
+    // stays within used (free 20 + used 480 = total 500; music 380 ≤ used 480).
+    volume: { ...volume, musicBytes: 380 * GB, freeBytes: 20 * GB, usedBytes: 480 * GB },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/apps/web/src/components/settings/DiskUsageBar/DiskUsageBar.stories.tsx
+++ b/apps/web/src/components/settings/DiskUsageBar/DiskUsageBar.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { VolumeUsage } from '@shiranami/contracts';
 
 import DiskUsageBar from './DiskUsageBar';
@@ -16,9 +17,19 @@ const volume: VolumeUsage = {
   unavailable: false,
 };
 
+/**
+ * settings · DiskUsageBar. A single-volume segmented bar (music · other-used ·
+ * free) with a "X used of Y" caption and a three-entry legend. The bar itself is
+ * a `role="img"` whose accessible name spells out the full byte breakdown;
+ * segment widths and color swatches are decorative (`aria-hidden`). All figures
+ * are derived in the hook from the passed `volume` prop.
+ */
 const meta: Meta<typeof DiskUsageBar> = {
   title: 'settings/DiskUsageBar',
   component: DiskUsageBar,
+  // The bar is a labelled role="img"; decorative segments/swatches are
+  // aria-hidden, legend text is plain — axe clean.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div className="max-w-[480px] p-4">
@@ -32,12 +43,31 @@ export default meta;
 
 type Story = StoryObj<typeof DiskUsageBar>;
 
+/** Default — the labelled bar renders with a music/other/free legend. */
 export const Default: Story = {
   args: { volume },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The bar's accessible name carries the full breakdown.
+    const bar = canvas.getByRole('img');
+    await expect(bar).toHaveAccessibleName(/of .* total/);
+
+    // The three legend entries render.
+    await expect(canvas.getByText('Music')).toBeInTheDocument();
+    await expect(canvas.getByText('Other')).toBeInTheDocument();
+    await expect(canvas.getByText('Free')).toBeInTheDocument();
+  },
 };
 
+/** Nearly full — a high music/low free split still renders the same chrome. */
 export const NearlyFull: Story = {
   args: {
     volume: { ...volume, musicBytes: 380 * GB, freeBytes: 20 * GB },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('img')).toBeInTheDocument();
+    await expect(canvas.getByText('Free')).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/settings/DiskUsageSection/DiskUsageSection.stories.tsx
+++ b/apps/web/src/components/settings/DiskUsageSection/DiskUsageSection.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, expect } from 'storybook/test';
 import type { DiskUsageResult } from '@shiranami/contracts';
 import { folderKeys } from '@/hooks/queries/useFolders';
 import { diskUsageKeys } from '@/hooks/queries/useDiskUsage';
@@ -25,6 +26,12 @@ const usage: DiskUsageResult = {
   computedAt: new Date(0).toISOString(),
 };
 
+/**
+ * Seed a QueryClient with both the watched folders and the disk-usage result so
+ * the section renders its volume breakdown rather than the loading or empty
+ * state. The disk-usage query reads via IPC at runtime; pre-seeding the cache is
+ * the browser-safe way to put it in the loaded state.
+ */
 function seededClient(): QueryClient {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   client.setQueryData(
@@ -35,9 +42,20 @@ function seededClient(): QueryClient {
   return client;
 }
 
+/**
+ * settings · DiskUsageSection. Per-volume library disk usage, rendered inside
+ * Library settings (Electron-only at the real call site). The usage query is
+ * IPC-backed, so the story pre-seeds the QueryClient cache with the folder list
+ * and a `DiskUsageResult` to drive the loaded state. With data present it shows
+ * the "Disk Usage" card, a "Refresh disk usage" icon button, the volume mount
+ * label, and a DiskUsageBar (`role="img"`).
+ */
 const meta: Meta<typeof DiskUsageSection> = {
   title: 'settings/DiskUsageSection',
   component: DiskUsageSection,
+  // Real heading, the refresh icon button carries an aria-label, and the
+  // embedded bar is a labelled role="img" — axe clean.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <QueryClientProvider client={seededClient()}>
@@ -53,4 +71,14 @@ export default meta;
 
 type Story = StoryObj<typeof DiskUsageSection>;
 
-export const Default: Story = {};
+/** Loaded — the volume breakdown, refresh control, and bar all render. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Disk Usage' })).toBeInTheDocument();
+    await expect(canvas.getByText('Macintosh HD')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Refresh disk usage' })).toBeInTheDocument();
+    await expect(canvas.getByRole('img')).toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/settings/EnrichBeforeAfterPreview/EnrichBeforeAfterPreview.stories.tsx
+++ b/apps/web/src/components/settings/EnrichBeforeAfterPreview/EnrichBeforeAfterPreview.stories.tsx
@@ -1,10 +1,24 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import EnrichBeforeAfterPreview from './EnrichBeforeAfterPreview';
 
+/**
+ * settings · EnrichBeforeAfterPreview. A static before/after sample of what
+ * enrichment does to a track: raw filename-derived tags ("From filename" — no
+ * art, Unknown artist/album) on the left, and filled cover art, artist, and
+ * album with a confidence pill ("Enriched") on the right. Purely presentational
+ * — it makes the feature's value legible before the user commits to the
+ * irreversible file-write path. No store or IPC dependency.
+ */
 const meta: Meta<typeof EnrichBeforeAfterPreview> = {
   title: 'settings/EnrichBeforeAfterPreview',
   component: EnrichBeforeAfterPreview,
+  parameters: {
+    // Static text + decorative icons (the arrow is aria-hidden); no interactive
+    // controls — axe clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="max-w-[420px] p-4">
@@ -18,4 +32,20 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+/** Both sides render — the raw "before" tags and the enriched "after" tags. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Column captions.
+    await expect(canvas.getByText('From filename')).toBeInTheDocument();
+    await expect(canvas.getByText('Enriched')).toBeInTheDocument();
+    // "Before" shows the unknown placeholders the scanner wrote.
+    await expect(canvas.getByText('Unknown Artist')).toBeInTheDocument();
+    await expect(canvas.getByText('Unknown Album')).toBeInTheDocument();
+    // "After" shows the resolved artist + album.
+    await expect(canvas.getByText('Nujabes')).toBeInTheDocument();
+    await expect(canvas.getByText('Modal Soul')).toBeInTheDocument();
+    // The illustrative 0.92 sample resolves to the high "Strong match" tier.
+    await expect(canvas.getByText('Strong match')).toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/settings/EnrichConfidenceBadge/EnrichConfidenceBadge.stories.tsx
+++ b/apps/web/src/components/settings/EnrichConfidenceBadge/EnrichConfidenceBadge.stories.tsx
@@ -1,10 +1,22 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import EnrichConfidenceBadge from './EnrichConfidenceBadge';
 
+/**
+ * settings · EnrichConfidenceBadge. A tiny pill that surfaces how confident a
+ * metadata match is, mapping the raw 0–1 score to a coarse level (≥0.8 Strong,
+ * ≥0.5 Likely, else Low) and a localized label. Renders nothing when the score
+ * is null/undefined, so callers can drop the badge entirely for unscored matches.
+ */
 const meta: Meta<typeof EnrichConfidenceBadge> = {
   title: 'settings/EnrichConfidenceBadge',
   component: EnrichConfidenceBadge,
+  parameters: {
+    // The badge is a plain text pill with sufficient token-backed contrast and
+    // no interactive elements — axe clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="flex items-center gap-2 p-4">
@@ -18,18 +30,41 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+/** A high score (≥0.8) resolves to the "Strong match" tier. */
 export const Default: Story = {
   args: { confidence: 0.92 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Strong match')).toBeInTheDocument();
+  },
 };
 
+/** A mid score (0.5–0.8) resolves to the "Likely match" tier. */
 export const Medium: Story = {
   args: { confidence: 0.6 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Likely match')).toBeInTheDocument();
+  },
 };
 
+/** A low score (<0.5) resolves to the "Low match" tier. */
 export const Low: Story = {
   args: { confidence: 0.3 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Low match')).toBeInTheDocument();
+  },
 };
 
+/** No score — the badge renders nothing at all. */
 export const NoScore: Story = {
   args: { confidence: null },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // None of the tier labels appear when the score is absent.
+    await expect(canvas.queryByText('Strong match')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Likely match')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Low match')).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/EnrichLastRunPanel/EnrichLastRunPanel.stories.tsx
+++ b/apps/web/src/components/settings/EnrichLastRunPanel/EnrichLastRunPanel.stories.tsx
@@ -1,10 +1,17 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
 import { useMetadataEnrichStore, type EnrichLastRunEntry } from '@/stores/useMetadataEnrichStore';
 
 import EnrichLastRunPanel from './EnrichLastRunPanel';
 
+/** Seed the store with a finished run so the (otherwise hidden) panel renders. */
 function seed(results: EnrichLastRunEntry[]): void {
   useMetadataEnrichStore.setState({ isEnriching: false, lastRunResults: results });
+}
+
+/** Restore runtime-only fields so each story renders from a clean baseline. */
+function resetEnrichRuntime(): void {
+  useMetadataEnrichStore.setState({ isEnriching: false, lastRunResults: [] });
 }
 
 const SAMPLE: EnrichLastRunEntry[] = [
@@ -29,9 +36,23 @@ const SAMPLE: EnrichLastRunEntry[] = [
   },
 ];
 
+/**
+ * settings · EnrichLastRunPanel. The in-memory post-run report for the bulk
+ * enrichment feature — a collapsible summary of the last run's per-track
+ * results (what changed, what matched, what failed). Visible only when a
+ * finished run with results exists and none is in flight. The header button
+ * carries `aria-expanded`; the per-track diff rows mount only when expanded.
+ * Stories seed the `useMetadataEnrichStore` snapshot the run collected.
+ */
 const meta: Meta<typeof EnrichLastRunPanel> = {
   title: 'settings/EnrichLastRunPanel',
   component: EnrichLastRunPanel,
+  parameters: {
+    // The toggle is a real <button> with aria-expanded and visible text; diff
+    // images are decorative (alt=""); status icons are aria-hidden — axe clean.
+    a11y: { test: 'error' },
+  },
+  beforeEach: resetEnrichRuntime,
   decorators: [
     Story => (
       <div className="max-w-[480px] p-4">
@@ -45,6 +66,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+/** Collapsed by default; expanding reveals the per-track diff for the run. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -52,4 +74,22 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Header shows the title + the "changed of total" summary (1 of 2 changed).
+    await expect(canvas.getByText('View last run')).toBeInTheDocument();
+    await expect(canvas.getByText('1 of 2 tracks changed')).toBeInTheDocument();
+
+    // Starts collapsed — the body and its diff rows are not mounted.
+    const toggle = canvas.getByRole('button', { name: /View last run/ });
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(canvas.queryByText('Nujabes')).not.toBeInTheDocument();
+
+    // Expanding mounts the per-track entries and their field diffs.
+    await userEvent.click(toggle);
+    await waitFor(() => expect(toggle).toHaveAttribute('aria-expanded', 'true'));
+    await expect(canvas.getByText('Nujabes')).toBeInTheDocument();
+    // The failed entry surfaces its no-match copy.
+    await expect(canvas.getByText('No matching metadata found.')).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/EnrichProgressBar/EnrichProgressBar.stories.tsx
+++ b/apps/web/src/components/settings/EnrichProgressBar/EnrichProgressBar.stories.tsx
@@ -1,16 +1,37 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import type { EnrichProgress } from '@shiranami/contracts';
 import { useMetadataEnrichStore } from '@/stores/useMetadataEnrichStore';
 
 import EnrichProgressBar from './EnrichProgressBar';
 
+/** Seed the enrich store so the (otherwise hidden) progress panel renders. */
 function seed(progress: EnrichProgress, isCancelling = false): void {
   useMetadataEnrichStore.setState({ isEnriching: true, isCancelling, progress });
 }
 
+/** Restore the runtime-only fields so each story renders from a clean baseline. */
+function resetEnrichRuntime(): void {
+  useMetadataEnrichStore.setState({ isEnriching: false, isCancelling: false, progress: null });
+}
+
+/**
+ * settings · EnrichProgressBar. An isolated, high-frequency subscriber that
+ * shows live per-track progress during a bulk metadata run. It renders only
+ * while a run is active and progress exists — a `role="status"` polite live
+ * region with the "Processing N of M" line, a per-track status line that varies
+ * by phase (searching / downloading / writing / done / error / cancelled), and
+ * an aria-hidden visual bar. Stories seed the `useMetadataEnrichStore` mirror.
+ */
 const meta: Meta<typeof EnrichProgressBar> = {
   title: 'settings/EnrichProgressBar',
   component: EnrichProgressBar,
+  parameters: {
+    // The panel is a labelled status region with plain text; the bar fill is
+    // aria-hidden and icons are aria-hidden — axe clean.
+    a11y: { test: 'error' },
+  },
+  beforeEach: resetEnrichRuntime,
   decorators: [
     Story => (
       <div className="max-w-[420px] p-4">
@@ -24,6 +45,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+/** Searching phase — the status region shows the count and the searched track. */
 export const Searching: Story = {
   decorators: [
     Story => {
@@ -31,8 +53,15 @@ export const Searching: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const status = canvas.getByRole('status');
+    await expect(within(status).getByText('Processing 3 of 12...')).toBeInTheDocument();
+    await expect(within(status).getByText('Searching for "feels.mp3"...')).toBeInTheDocument();
+  },
 };
 
+/** Done phase — the matched track name plus a confidence badge are shown. */
 export const Done: Story = {
   decorators: [
     Story => {
@@ -47,4 +76,26 @@ export const Done: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const status = canvas.getByRole('status');
+    await expect(within(status).getByText('Processing 8 of 12...')).toBeInTheDocument();
+    await expect(within(status).getByText('Modal Soul')).toBeInTheDocument();
+    // The 0.92 score resolves to the high "Strong match" confidence tier.
+    await expect(within(status).getByText('Strong match')).toBeInTheDocument();
+  },
+};
+
+/** Cancelling — the in-flight cancellation note appears beneath the bar. */
+export const Cancelling: Story = {
+  decorators: [
+    Story => {
+      seed({ current: 5, total: 12, trackName: 'feels.mp3', status: 'searching' }, true);
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Cancelling...')).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/EqCurvePreview/EqCurvePreview.stories.tsx
+++ b/apps/web/src/components/settings/EqCurvePreview/EqCurvePreview.stories.tsx
@@ -1,10 +1,24 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import EqCurvePreview from './EqCurvePreview';
 
+/**
+ * settings · EqCurvePreview. The live frequency-response curve for the
+ * equalizer — a hand-rolled SVG line through the 10 band gains (plus preamp) so
+ * presets read as distinct shapes, not just different slider heights. The SVG
+ * carries `role="img"` with a localized aria-label, and the bass→treble
+ * frequency axis ticks (31 … 16k) render below it. Pure SVG, no charting
+ * dependency. Driven by the `gains` / `preampDb` props.
+ */
 const meta: Meta<typeof EqCurvePreview> = {
   title: 'settings/EqCurvePreview',
   component: EqCurvePreview,
+  parameters: {
+    // The curve is a single role="img" with an accessible name; tick labels are
+    // plain text — axe clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="max-w-[360px] p-4">
@@ -21,14 +35,38 @@ type Story = StoryObj<typeof EqCurvePreview>;
 const FLAT = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 const SMILE = [6, 4, 1, -2, -3, -2, 1, 3, 5, 6];
 
+/** A flat curve — the labelled SVG and its full frequency axis still render. */
 export const Flat: Story = {
   args: { gains: FLAT, preampDb: 0 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('img', { name: 'Equalizer frequency response curve' })
+    ).toBeInTheDocument();
+    // The bass and treble ends of the frequency axis are labelled.
+    await expect(canvas.getByText('31')).toBeInTheDocument();
+    await expect(canvas.getByText('16k')).toBeInTheDocument();
+  },
 };
 
+/** A shaped ("smile") curve — same accessible chrome, different line shape. */
 export const Shaped: Story = {
   args: { gains: SMILE, preampDb: 0 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('img', { name: 'Equalizer frequency response curve' })
+    ).toBeInTheDocument();
+  },
 };
 
+/** Disabled — the curve dims but stays present and accessible. */
 export const Disabled: Story = {
   args: { gains: SMILE, preampDb: 0, disabled: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('img', { name: 'Equalizer frequency response curve' })
+    ).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/EqualizerSection/EqualizerSection.stories.tsx
+++ b/apps/web/src/components/settings/EqualizerSection/EqualizerSection.stories.tsx
@@ -93,10 +93,14 @@ export const Disabled: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole('switch')).not.toBeChecked();
-    // The band sliders are disabled while the EQ is off — Radix marks the thumb
-    // (role="slider") with data-disabled and drops it from the tab order.
+    // The band sliders (and the preamp) are disabled while the EQ is off — Radix
+    // marks each thumb (role="slider") with data-disabled and drops it from the
+    // tab order. Assert every slider, not just the first.
     const sliders = canvas.getAllByRole('slider');
-    await expect(sliders[0]).toHaveAttribute('data-disabled');
-    await expect(sliders[0]).not.toHaveAttribute('tabindex');
+    await expect(sliders.length).toBeGreaterThan(0);
+    for (const slider of sliders) {
+      await expect(slider).toHaveAttribute('data-disabled');
+      await expect(slider).not.toHaveAttribute('tabindex');
+    }
   },
 };

--- a/apps/web/src/components/settings/EqualizerSection/EqualizerSection.stories.tsx
+++ b/apps/web/src/components/settings/EqualizerSection/EqualizerSection.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
 import { useEqStore } from '@/stores/useEqStore';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
@@ -7,9 +8,24 @@ import EqualizerSection from './EqualizerSection';
 const FLAT = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 const SMILE = [6, 4, 1, -2, -3, -2, 1, 3, 5, 6];
 
+/**
+ * settings · EqualizerSection. The 10-band graphic EQ panel: an enable switch,
+ * a grid of genre preset tiles, the live response-curve preview, ten vertical
+ * band sliders with a preamp slider, and a reset. Reads/writes `useEqStore`.
+ * Stories seed the store and assert the chrome + a real preset/switch
+ * interaction against the store.
+ */
 const meta: Meta<typeof EqualizerSection> = {
   title: 'settings/EqualizerSection',
   component: EqualizerSection,
+  // a11y stays at the global 'todo' default: the ten per-band sliders are a
+  // hand-rolled `SliderPrimitive.Root` that puts its `aria-label` on the Root,
+  // not the Thumb — so each band's `role="slider"` is unnamed (axe
+  // aria-input-field-name). The fix lives in EqualizerSection.tsx itself, which
+  // is out of scope for this story-strengthening pass, so axe is left
+  // non-blocking here. The preamp slider (shared ui/slider.tsx) is correctly
+  // named on the thumb; only the band strip is affected.
+  parameters: { a11y: { test: 'todo' } },
   decorators: [
     Story => (
       <TooltipProvider>
@@ -25,6 +41,7 @@ export default meta;
 
 type Story = StoryObj<typeof EqualizerSection>;
 
+/** Enabled on the Flat preset — switch on, presets selectable, curve present. */
 export const Enabled: Story = {
   decorators: [
     Story => {
@@ -32,8 +49,26 @@ export const Enabled: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Equalizer' })).toBeInTheDocument();
+
+    // The master switch reflects the enabled store state.
+    const enable = canvas.getByRole('switch');
+    await expect(enable).toBeChecked();
+
+    // The response-curve preview renders alongside the band strip.
+    await expect(
+      canvas.getByRole('img', { name: 'Equalizer frequency response curve' })
+    ).toBeInTheDocument();
+
+    // Picking a different preset updates the store.
+    await userEvent.click(canvas.getByRole('button', { name: 'Rock' }));
+    await waitFor(() => expect(useEqStore.getState().preset).toBe('rock'));
+  },
 };
 
+/** A custom curve — the "Custom" indicator tile appears next to the presets. */
 export const Custom: Story = {
   decorators: [
     Story => {
@@ -41,8 +76,13 @@ export const Custom: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Custom')).toBeInTheDocument();
+  },
 };
 
+/** Disabled — the master switch is off and the band controls dim. */
 export const Disabled: Story = {
   decorators: [
     Story => {
@@ -50,4 +90,13 @@ export const Disabled: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('switch')).not.toBeChecked();
+    // The band sliders are disabled while the EQ is off — Radix marks the thumb
+    // (role="slider") with data-disabled and drops it from the tab order.
+    const sliders = canvas.getAllByRole('slider');
+    await expect(sliders[0]).toHaveAttribute('data-disabled');
+    await expect(sliders[0]).not.toHaveAttribute('tabindex');
+  },
 };

--- a/apps/web/src/components/settings/InterfaceSection/InterfaceSection.stories.tsx
+++ b/apps/web/src/components/settings/InterfaceSection/InterfaceSection.stories.tsx
@@ -1,16 +1,32 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, screen, userEvent, expect, waitFor } from 'storybook/test';
+import { useInterfaceStore, INTERFACE_DEFAULTS } from '@/stores/useInterfaceStore';
 
 import InterfaceSection from './InterfaceSection';
 
+/**
+ * settings · InterfaceSection. Four cards that hide/show interface elements: a
+ * "Panel layout" card with a side-panel-position select, a "Top bar" card with
+ * the "Language switcher" toggle, an "Overview widgets" card, and a "Player bar"
+ * card — each toggle row driven by `useInterfaceStore`. Layout dock side lives in
+ * `useLayoutStore`. State is reset to `INTERFACE_DEFAULTS` per story.
+ */
 const meta: Meta<typeof InterfaceSection> = {
   title: 'settings/InterfaceSection',
   component: InterfaceSection,
+  // Every toggle row switch is named via aria-labelledby, the side-panel select
+  // is a labelled combobox, the preview mocks are labelled role="img"s, and the
+  // card titles are real headings — axe clean.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
-    Story => (
-      <div className="max-w-[680px] p-4">
-        <Story />
-      </div>
-    ),
+    Story => {
+      useInterfaceStore.setState({ ...INTERFACE_DEFAULTS });
+      return (
+        <div className="max-w-[680px] p-4">
+          <Story />
+        </div>
+      );
+    },
   ],
 };
 
@@ -18,4 +34,38 @@ export default meta;
 
 type Story = StoryObj<typeof InterfaceSection>;
 
-export const Default: Story = {};
+/** Default — the four cards render; the Language-switcher toggle drives the store. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Panel layout' })).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Overview widgets' })).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Player bar' })).toBeInTheDocument();
+
+    // The side-panel position is a labelled combobox.
+    await expect(canvas.getByRole('combobox', { name: 'Side panel position' })).toBeInTheDocument();
+
+    // The top-bar "Language switcher" toggle is uniquely named; clicking it
+    // updates the matching store flag.
+    const langSwitch = canvas.getByRole('switch', { name: 'Language switcher' });
+    const before = useInterfaceStore.getState().topBarLanguageSwitcher;
+    await userEvent.click(langSwitch);
+    await waitFor(() => expect(useInterfaceStore.getState().topBarLanguageSwitcher).toBe(!before));
+
+    useInterfaceStore.setState({ ...INTERFACE_DEFAULTS });
+  },
+};
+
+/** Open the side-panel select to confirm both dock options portal in. */
+export const SidePanelOptions: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('combobox', { name: 'Side panel position' }));
+    // The listbox + options portal to the document body, so query via `screen`.
+    const listbox = await screen.findByRole('listbox');
+    await expect(within(listbox).getByRole('option', { name: 'Left' })).toBeInTheDocument();
+    await expect(within(listbox).getByRole('option', { name: 'Right' })).toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/settings/LibrarySection/LibrarySection.stories.tsx
+++ b/apps/web/src/components/settings/LibrarySection/LibrarySection.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { folderKeys } from '@/hooks/queries/useFolders';
@@ -18,15 +19,36 @@ function makeTrack(id: string): Track {
   };
 }
 
+/**
+ * Each story owns a QueryClient seeded with an empty folder list so the embedded
+ * DiskUsageSection settles on its "no folders" empty state instead of an IPC
+ * loading spinner.
+ */
 function client(): QueryClient {
   const c = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   c.setQueryData(folderKeys.all, []);
   return c;
 }
 
+/**
+ * settings · LibrarySection. The Library panel: a track-count card with a Rescan
+ * button, and — under Electron — an embedded DiskUsageSection plus a Backup &
+ * Restore card. A destructive "Danger Zone" card appears only when the library
+ * has tracks. The track list lives in `useLibraryStore`.
+ *
+ * The DiskUsageSection + Backup card are gated on `isElectron` (= the
+ * `IS_ELECTRON` module-constant from `@/lib/platform`). In the Storybook browser
+ * run that constant resolves to `false` — platform.ts is imported before the
+ * preview installs the electronAPI mock — so those two cards are unreachable
+ * here. The stories assert the always-present Library card and the
+ * library-gated Danger Zone, which exercise the store-driven behavior.
+ */
 const meta: Meta<typeof LibrarySection> = {
   title: 'settings/LibrarySection',
   component: LibrarySection,
+  // Card titles are real headings, every action is a named button, and the
+  // disk-usage empty state is plain text — axe clean.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <QueryClientProvider client={client()}>
@@ -42,6 +64,7 @@ export default meta;
 
 type Story = StoryObj<typeof LibrarySection>;
 
+/** With tracks — the count, the Rescan action, and the Danger Zone all render. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -52,8 +75,26 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Library' })).toBeInTheDocument();
+    await expect(canvas.getByText('Total tracks')).toBeInTheDocument();
+    await expect(canvas.getByText('3')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Rescan Library' })).toBeInTheDocument();
+
+    // Danger zone is present because the library has tracks.
+    await expect(canvas.getByRole('button', { name: 'Clear Library' })).toBeInTheDocument();
+
+    // The Backup & Restore card is Electron-gated (IS_ELECTRON is a false
+    // module-constant in the Storybook browser run, see meta), so it is absent.
+    await expect(
+      canvas.queryByRole('heading', { name: 'Backup & Restore' })
+    ).not.toBeInTheDocument();
+  },
 };
 
+/** Empty — no tracks means the Danger Zone is hidden. */
 export const Empty: Story = {
   decorators: [
     Story => {
@@ -61,4 +102,10 @@ export const Empty: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Library' })).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Clear Library' })).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/LyricsSection/LyricsSection.stories.tsx
+++ b/apps/web/src/components/settings/LyricsSection/LyricsSection.stories.tsx
@@ -29,6 +29,13 @@ function seedDefaults(): void {
 const meta: Meta<typeof LyricsSection> = {
   title: 'settings/LyricsSection',
   component: LyricsSection,
+  // Reset the appearance store to defaults before every story so a thrown
+  // assertion (or a story that seeds custom values) can never leak state into a
+  // later story. Stories that need custom values override these via a decorator,
+  // which runs after this seed-on-entry reset.
+  beforeEach: () => {
+    seedDefaults();
+  },
   // a11y stays at the global 'todo' default: the live previews render lyric text
   // at an intentionally reduced opacity (dim/synced-past lines), which makes the
   // foreground/background contrast non-deterministic for axe's color-contrast
@@ -50,12 +57,6 @@ type Story = StoryObj<typeof LyricsSection>;
 
 /** Default — both subsections render; the plain-text size chip drives the store. */
 export const Default: Story = {
-  decorators: [
-    Story => {
-      seedDefaults();
-      return <Story />;
-    },
-  ],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -66,13 +67,11 @@ export const Default: Story = {
     // the first (plain text).
     await expect(canvas.getAllByRole('slider')).toHaveLength(2);
     const [plainSizeGroup] = canvas.getAllByRole('radiogroup', { name: 'Font size' });
-    const sizeChips = within(plainSizeGroup).getAllByRole('radio');
 
-    // Clicking the third chip ("Large") writes 'lg' to the plain-text font size.
-    await userEvent.click(sizeChips[2]);
+    // Clicking the "Large" chip writes 'lg' to the plain-text font size — query
+    // it by its accessible name rather than array position.
+    await userEvent.click(within(plainSizeGroup).getByRole('radio', { name: 'Large' }));
     await waitFor(() => expect(useLyricsAppearanceStore.getState().lyricsPlainFontSize).toBe('lg'));
-
-    seedDefaults();
   },
 };
 
@@ -97,7 +96,5 @@ export const Customized: Story = {
       'aria-checked',
       'true'
     );
-
-    seedDefaults();
   },
 };

--- a/apps/web/src/components/settings/LyricsSection/LyricsSection.stories.tsx
+++ b/apps/web/src/components/settings/LyricsSection/LyricsSection.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
 import {
   useLyricsAppearanceStore,
   LYRICS_PLAIN_OPACITY_DEFAULT,
@@ -9,9 +10,31 @@ import {
 
 import LyricsSection from './LyricsSection';
 
+function seedDefaults(): void {
+  useLyricsAppearanceStore.setState({
+    lyricsPlainOpacity: LYRICS_PLAIN_OPACITY_DEFAULT,
+    lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
+    lyricsSyncedDimOpacity: LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
+    lyricsSyncedFontSize: LYRICS_SYNCED_FONT_SIZE_DEFAULT,
+  });
+}
+
+/**
+ * settings · LyricsSection. Lyrics appearance: a "Plain text" subsection and a
+ * "Synced lyrics" subsection, each with an opacity slider (accessibly named via
+ * aria-label), a font-size `role="radiogroup"` of size chips (Small / Default /
+ * Large / Extra large), and a live text preview. All four prefs live in
+ * `useLyricsAppearanceStore`.
+ */
 const meta: Meta<typeof LyricsSection> = {
   title: 'settings/LyricsSection',
   component: LyricsSection,
+  // a11y stays at the global 'todo' default: the live previews render lyric text
+  // at an intentionally reduced opacity (dim/synced-past lines), which makes the
+  // foreground/background contrast non-deterministic for axe's color-contrast
+  // rule depending on the seeded opacity. The opacity sliders and size radios
+  // ARE properly named (aria-label / radiogroup), so the deferral is purely the
+  // dimmed preview text — mirrors the SplashScreen timed-fade deferral.
   decorators: [
     Story => (
       <div className="max-w-[680px] p-4">
@@ -25,20 +48,35 @@ export default meta;
 
 type Story = StoryObj<typeof LyricsSection>;
 
+/** Default — both subsections render; the plain-text size chip drives the store. */
 export const Default: Story = {
   decorators: [
     Story => {
-      useLyricsAppearanceStore.setState({
-        lyricsPlainOpacity: LYRICS_PLAIN_OPACITY_DEFAULT,
-        lyricsPlainFontSize: LYRICS_PLAIN_FONT_SIZE_DEFAULT,
-        lyricsSyncedDimOpacity: LYRICS_SYNCED_DIM_OPACITY_DEFAULT,
-        lyricsSyncedFontSize: LYRICS_SYNCED_FONT_SIZE_DEFAULT,
-      });
+      seedDefaults();
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Lyrics' })).toBeInTheDocument();
+
+    // Each subsection has its own opacity slider (named) and a font-size
+    // radiogroup; both subsections share the "Font size" group name, so index
+    // the first (plain text).
+    await expect(canvas.getAllByRole('slider')).toHaveLength(2);
+    const [plainSizeGroup] = canvas.getAllByRole('radiogroup', { name: 'Font size' });
+    const sizeChips = within(plainSizeGroup).getAllByRole('radio');
+
+    // Clicking the third chip ("Large") writes 'lg' to the plain-text font size.
+    await userEvent.click(sizeChips[2]);
+    await waitFor(() => expect(useLyricsAppearanceStore.getState().lyricsPlainFontSize).toBe('lg'));
+
+    seedDefaults();
+  },
 };
 
+/** Customized — non-default opacity + sizes mark the matching size chips active. */
 export const Customized: Story = {
   decorators: [
     Story => {
@@ -51,4 +89,15 @@ export const Customized: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const [plainSizeGroup] = canvas.getAllByRole('radiogroup', { name: 'Font size' });
+    await expect(within(plainSizeGroup).getByRole('radio', { name: 'Large' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+
+    seedDefaults();
+  },
 };

--- a/apps/web/src/components/settings/MetadataEnrichSection/MetadataEnrichSection.stories.tsx
+++ b/apps/web/src/components/settings/MetadataEnrichSection/MetadataEnrichSection.stories.tsx
@@ -1,26 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { Track } from '@/stores/types';
+import { within, expect } from 'storybook/test';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { useMetadataEnrichStore } from '@/stores/useMetadataEnrichStore';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
 import MetadataEnrichSection from './MetadataEnrichSection';
 
-function makeTrack(overrides: Partial<Track> = {}): Track {
-  return {
-    id: 'track-1',
-    title: 'Midnight Tapes',
-    artist: 'Unknown Artist',
-    album: 'Unknown Album',
-    duration: 215,
-    filePath: '/music/test.mp3',
-    isFavorite: false,
-    ...overrides,
-  };
-}
-
-function seed(library: Track[]): void {
-  useLibraryStore.setState({ library });
+/** Reset the library + enrich run state to a clean, idle baseline. */
+function seed(): void {
+  useLibraryStore.setState({ library: [] });
   useMetadataEnrichStore.setState({
     isEnriching: false,
     isCancelling: false,
@@ -31,9 +19,29 @@ function seed(library: Track[]): void {
   });
 }
 
+/**
+ * settings · MetadataEnrichSection. The bulk metadata-enrichment panel: a static
+ * before/after preview, a stats line counting tracks with missing tags, an
+ * "Only fill missing fields" toggle, the run button (gated behind an inline
+ * confirm when writing tags to disk), and a separate "Write tags to audio files"
+ * opt-in.
+ *
+ * The entire section is gated by `if (!isElectron) return null`, where
+ * `isElectron` is the `IS_ELECTRON` module-constant from `@/lib/platform`. In the
+ * Storybook browser run that constant resolves to `false` — platform.ts is
+ * imported before the preview installs the electronAPI mock — so the section
+ * renders nothing here. The loaded panel (heading, stats line, run button,
+ * toggles) is therefore unreachable in-browser, and the story asserts the
+ * render-null contract: none of the gated UI is present.
+ */
 const meta: Meta<typeof MetadataEnrichSection> = {
   title: 'settings/MetadataEnrichSection',
   component: MetadataEnrichSection,
+  parameters: {
+    // Outside Electron the section renders nothing, so there are no roles to
+    // audit — axe passes trivially clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <TooltipProvider>
@@ -49,20 +57,33 @@ export default meta;
 
 type Story = StoryObj<typeof MetadataEnrichSection>;
 
-export const Default: Story = {
+/**
+ * Gated outside Electron — the whole section returns null, so none of its
+ * heading, stats line, run button, or toggles render.
+ */
+export const GatedOutsideElectron: Story = {
   decorators: [
     Story => {
-      seed([makeTrack(), makeTrack({ id: 'track-2', title: 'feels.mp3' })]);
+      seed();
       return <Story />;
     },
   ],
-};
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
 
-export const EmptyLibrary: Story = {
-  decorators: [
-    Story => {
-      seed([]);
-      return <Story />;
-    },
-  ],
+    // `if (!isElectron) return null` — no card heading, stats text, run button,
+    // or option toggles are reachable in the browser run.
+    await expect(
+      canvas.queryByRole('heading', { name: /Find Missing Metadata/ })
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByText('No tracks with missing metadata found')
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Find Missing Metadata' })
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('switch', { name: 'Only fill missing fields' })
+    ).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/MusicFoldersSection/MusicFoldersSection.stories.tsx
+++ b/apps/web/src/components/settings/MusicFoldersSection/MusicFoldersSection.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, expect } from 'storybook/test';
 import { folderKeys } from '@/hooks/queries/useFolders';
 import type { WatchedFolder } from './MusicFoldersSection.types';
 
@@ -10,15 +11,34 @@ const folders: WatchedFolder[] = [
   { id: 'f-2', path: '/Users/me/Downloads/Lofi' },
 ];
 
+/**
+ * Seed a client whose folders query is pre-populated and never refetches, so the
+ * IPC-backed `useFoldersQuery` resolves to the seed instead of the Storybook
+ * electron mock's no-op (which would otherwise clobber it back to empty).
+ */
 function seededClient(seed: WatchedFolder[]): QueryClient {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
   client.setQueryData(folderKeys.all, seed);
   return client;
 }
 
+/**
+ * settings · MusicFoldersSection. The "Music Folders" panel: the list of watched
+ * library directories (each with a hover Remove button), an Add Folder button,
+ * and the subfolder-playlist dialog it can open. Folder data comes from the
+ * IPC-backed `useFoldersQuery`; in the browser run there is no real DB, so stories
+ * seed the react-query cache directly. Add/remove are IPC no-ops here.
+ */
 const meta: Meta<typeof MusicFoldersSection> = {
   title: 'settings/MusicFoldersSection',
   component: MusicFoldersSection,
+  parameters: {
+    // Card title is a real heading, the Add button is a real button, and each
+    // remove control is an icon-button with an aria-label — axe clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="max-w-[640px] p-4">
@@ -32,6 +52,7 @@ export default meta;
 
 type Story = StoryObj<typeof MusicFoldersSection>;
 
+/** Two watched folders — paths listed, each with a Remove control. */
 export const Default: Story = {
   decorators: [
     Story => (
@@ -40,8 +61,20 @@ export const Default: Story = {
       </QueryClientProvider>
     ),
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Music Folders' })).toBeInTheDocument();
+    // Both seeded folder paths render.
+    await expect(await canvas.findByText('/Users/me/Music')).toBeInTheDocument();
+    await expect(canvas.getByText('/Users/me/Downloads/Lofi')).toBeInTheDocument();
+    // Each folder row exposes a labelled remove control.
+    await expect(canvas.getAllByRole('button', { name: 'Remove folder' })).toHaveLength(2);
+    // The add-folder action is present.
+    await expect(canvas.getByRole('button', { name: /Add Folder/ })).toBeInTheDocument();
+  },
 };
 
+/** No folders — the empty state replaces the list, Add still available. */
 export const Empty: Story = {
   decorators: [
     Story => (
@@ -50,4 +83,10 @@ export const Empty: Story = {
       </QueryClientProvider>
     ),
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('No folders added yet')).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Remove folder' })).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: /Add Folder/ })).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/PlaybackSection/PlaybackSection.stories.tsx
+++ b/apps/web/src/components/settings/PlaybackSection/PlaybackSection.stories.tsx
@@ -1,14 +1,28 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 
 import PlaybackSection from './PlaybackSection';
 
 const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
+/**
+ * settings · PlaybackSection. Playback preferences as toggle rows with live
+ * previews: "Remember playback position", "Crossfade" (revealing a duration
+ * slider when on), "Loudness leveling" (revealing a target slider + analyze
+ * control when on), and an always-present sleep-timer fade-out slider. Toggles +
+ * sliders live in `usePlaybackStore`; the remember-position flag comes from the
+ * IPC-backed settings query (undefined → false in the browser).
+ */
 const meta: Meta<typeof PlaybackSection> = {
   title: 'settings/PlaybackSection',
   component: PlaybackSection,
+  // a11y stays at the global 'todo' default: the crossfade-duration, loudness-
+  // target, and sleep-fade Sliders are rendered without an accessible name (no
+  // aria-label at the call site in PlaybackSection.tsx). The sleep-fade slider is
+  // always mounted, so even the default story trips axe's aria-input-field-name
+  // rule on its thumb. Naming them is a component-file change out of scope here.
   decorators: [
     Story => (
       <QueryClientProvider client={client}>
@@ -24,6 +38,7 @@ export default meta;
 
 type Story = StoryObj<typeof PlaybackSection>;
 
+/** Default — the rows render; toggling Crossfade flips the store and reveals it. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -35,8 +50,22 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Playback' })).toBeInTheDocument();
+
+    // The Crossfade switch is named and off; clicking it turns crossfade on.
+    const crossfade = canvas.getByRole('switch', { name: 'Crossfade' });
+    await expect(crossfade).not.toBeChecked();
+    await userEvent.click(crossfade);
+    await waitFor(() => expect(usePlaybackStore.getState().crossfadeEnabled).toBe(true));
+
+    usePlaybackStore.setState({ crossfadeEnabled: false });
+  },
 };
 
+/** Crossfade & loudness on — the duration/target sliders are revealed. */
 export const CrossfadeAndLoudnessOn: Story = {
   decorators: [
     Story => {
@@ -50,4 +79,14 @@ export const CrossfadeAndLoudnessOn: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('switch', { name: 'Crossfade' })).toBeChecked();
+    await expect(canvas.getByRole('switch', { name: 'Loudness leveling' })).toBeChecked();
+    // Crossfade duration, loudness target, and sleep-fade sliders are all shown.
+    await expect(canvas.getAllByRole('slider')).toHaveLength(3);
+
+    usePlaybackStore.setState({ crossfadeEnabled: false, loudnessEnabled: false });
+  },
 };

--- a/apps/web/src/components/settings/PrivacySection/PrivacySection.stories.tsx
+++ b/apps/web/src/components/settings/PrivacySection/PrivacySection.stories.tsx
@@ -1,11 +1,23 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
 import { useTelemetryStore } from '@/stores/useTelemetryStore';
 
 import PrivacySection from './PrivacySection';
 
+/**
+ * settings · PrivacySection. The crash-reporting panel: a "Send crash reports"
+ * toggle that, when on, reveals a "Performance monitoring" toggle, plus
+ * "What's sent" / "What's never sent" lists and a privacy note. A dev-only
+ * "Verify setup" test-event card shows when reporting is on and no restart is
+ * pending (Storybook runs in dev, so it appears in the enabled story). State
+ * lives in `useTelemetryStore`.
+ */
 const meta: Meta<typeof PrivacySection> = {
   title: 'settings/PrivacySection',
   component: PrivacySection,
+  // Both toggles are named via aria-labelledby, the card titles are real
+  // headings, and the test-event control is a named button — axe clean.
+  parameters: { a11y: { test: 'error' } },
   decorators: [
     Story => (
       <div className="max-w-[640px] p-4">
@@ -19,6 +31,7 @@ export default meta;
 
 type Story = StoryObj<typeof PrivacySection>;
 
+/** Off — the card and toggle render; clicking it enables reporting in the store. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -31,8 +44,27 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Crash reporting' })).toBeInTheDocument();
+
+    // While off, the performance toggle is hidden.
+    await expect(
+      canvas.queryByRole('switch', { name: 'Performance monitoring' })
+    ).not.toBeInTheDocument();
+
+    // Enabling crash reporting writes through the store setter.
+    const reports = canvas.getByRole('switch', { name: 'Send crash reports' });
+    await expect(reports).not.toBeChecked();
+    await userEvent.click(reports);
+    await waitFor(() => expect(useTelemetryStore.getState().enabled).toBe(true));
+
+    useTelemetryStore.setState({ enabled: false });
+  },
 };
 
+/** Enabled — the performance toggle and the dev-only test card are revealed. */
 export const Enabled: Story = {
   decorators: [
     Story => {
@@ -45,4 +77,12 @@ export const Enabled: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('switch', { name: 'Performance monitoring' })).toBeChecked();
+    // Storybook runs in dev with reporting on and no pending restart, so the
+    // "Verify setup" test card renders.
+    await expect(canvas.getByRole('button', { name: 'Send test event' })).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/ScrobbleSection/ScrobbleSection.stories.tsx
+++ b/apps/web/src/components/settings/ScrobbleSection/ScrobbleSection.stories.tsx
@@ -1,16 +1,32 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { ScrobbleStatus } from '@shiranami/contracts';
+import { within, expect } from 'storybook/test';
 
 import ScrobbleSection from './ScrobbleSection';
 
-/** Point the story's IPC mock at a concrete status so the providers render. */
-function seedStatus(status: ScrobbleStatus): void {
-  window.electronAPI.scrobble.getStatus = () => Promise.resolve(status);
-}
-
+/**
+ * settings · ScrobbleSection. The opt-in scrobbling panel: a master enable
+ * switch, then Last.fm (browser-auth handshake) and ListenBrainz (user-token)
+ * provider rows, each with a Connected / Not connected status pill and a
+ * connect/disconnect action. The raw session key + token never leave the main
+ * process — this UI only sees the status booleans + display name.
+ *
+ * Status is read on mount via `scrobble.getStatus()`, but that read is gated on
+ * `IS_ELECTRON`. In the Storybook browser run `IS_ELECTRON` resolves to `false`
+ * — `@/lib/platform` captures it as a module-constant before the preview installs
+ * the electronAPI mock — so the read is skipped and `status` stays the hook's
+ * `EMPTY_STATUS` (everything disconnected, pendingCount 0). The connected state
+ * is therefore unreachable in-browser (no IPC seed can flip the false
+ * module-constant), so the stories assert the real not-connected chrome.
+ */
 const meta: Meta<typeof ScrobbleSection> = {
   title: 'settings/ScrobbleSection',
   component: ScrobbleSection,
+  parameters: {
+    // Card title is a real heading, the master switch is labelled by its row,
+    // the LB token input carries an aria-label, and external links have
+    // rel=noopener — axe clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="max-w-[680px] p-4">
@@ -24,32 +40,38 @@ export default meta;
 
 type Story = StoryObj<typeof ScrobbleSection>;
 
+/** Nothing connected — both providers show "Not connected" and a Connect path. */
 export const Default: Story = {
-  decorators: [
-    Story => {
-      seedStatus({
-        enabled: false,
-        lastfmConnected: false,
-        lastfmUsername: null,
-        listenBrainzConnected: false,
-        pendingCount: 0,
-      });
-      return <Story />;
-    },
-  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Scrobbling' })).toBeInTheDocument();
+    // Master switch reflects the empty (disabled) status from EMPTY_STATUS.
+    await expect(canvas.getByRole('switch', { name: 'Enable scrobbling' })).not.toBeChecked();
+    // Both providers report not-connected.
+    await expect(canvas.getAllByText('Not connected')).toHaveLength(2);
+    // The ListenBrainz token field (a password input, so no textbox role) is
+    // exposed by its aria-label.
+    await expect(canvas.getByLabelText('ListenBrainz user token')).toBeInTheDocument();
+  },
 };
 
-export const Connected: Story = {
-  decorators: [
-    Story => {
-      seedStatus({
-        enabled: true,
-        lastfmConnected: true,
-        lastfmUsername: 'idealism',
-        listenBrainzConnected: true,
-        pendingCount: 3,
-      });
-      return <Story />;
-    },
-  ],
+/**
+ * Not-connected provider rows — the Connect actions are present. The connected
+ * state (status pills flipped, Disconnect buttons, "Connected as <name>") is
+ * unreachable in-browser because the on-mount status read is IS_ELECTRON-gated
+ * (false here, see meta), so this story asserts the connect-path chrome instead.
+ */
+export const NotConnected: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Both providers expose a "Connect" action (Last.fm browser auth + the
+    // ListenBrainz token submit).
+    await expect(canvas.getAllByRole('button', { name: 'Connect' })).toHaveLength(2);
+
+    // The connected-only "Connected as ..." line and Disconnect actions never
+    // render in the disconnected EMPTY_STATUS state.
+    await expect(canvas.queryByText('Connected as idealism')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Disconnect' })).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/SettingsCard/SettingsCard.stories.tsx
+++ b/apps/web/src/components/settings/SettingsCard/SettingsCard.stories.tsx
@@ -1,36 +1,67 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect, fn } from 'storybook/test';
 import { SlidersHorizontal } from 'lucide-react';
 
 import SettingsCard, { SettingsToggleRow, SettingsSelectRow } from './SettingsCard';
 
-const meta = {
+/**
+ * settings · SettingsCard. The shared chrome for a settings panel — an icon
+ * tile, an `<h3>` title with optional subtitle, and a content slot. The file
+ * also exports the row primitives (`SettingsToggleRow`, `SettingsSelectRow`)
+ * that sections compose: a labelled Radix Switch and a label-bound Select, each
+ * wired so its control inherits the row's accessible name. Presentational —
+ * no store or IPC dependency.
+ */
+const meta: Meta<typeof SettingsCard> = {
   title: 'settings/SettingsCard',
   component: SettingsCard,
-} satisfies Meta<typeof SettingsCard>;
+  parameters: {
+    // Title is a real heading; the toggle/select rows wire aria-labelledby from
+    // the row label onto the control — axe clean.
+    a11y: { test: 'error' },
+  },
+};
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+/** Card header + a toggle row and a label-bound select row, fully interactive. */
 export const Default: Story = {
-  args: {
-    icon: SlidersHorizontal,
-    title: 'Equalizer',
-    subtitle: 'Shape playback with a 10-band graphic EQ.',
-    children: (
-      <>
-        <SettingsToggleRow label="Enable equalizer" checked onCheckedChange={() => {}} />
+  render: () => {
+    const onToggle = fn();
+    return (
+      <SettingsCard
+        icon={SlidersHorizontal}
+        title="Equalizer"
+        subtitle="Shape playback with a 10-band graphic EQ."
+      >
+        <SettingsToggleRow label="Enable equalizer" checked onCheckedChange={onToggle} />
         <SettingsSelectRow
           label="Preset"
           value="flat"
-          onValueChange={() => {}}
+          onValueChange={fn()}
           options={[
             { value: 'flat', label: 'Flat' },
             { value: 'bass', label: 'Bass boost' },
           ]}
           divider
         />
-      </>
-    ),
+      </SettingsCard>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Heading + subtitle render.
+    await expect(canvas.getByRole('heading', { name: 'Equalizer' })).toBeInTheDocument();
+    await expect(canvas.getByText('Shape playback with a 10-band graphic EQ.')).toBeInTheDocument();
+
+    // The toggle row exposes its switch by the row label and starts checked
+    // (it's controlled, so the prop holds it on).
+    const toggle = canvas.getByRole('switch', { name: 'Enable equalizer' });
+    await expect(toggle).toBeChecked();
+
+    // The select row exposes its trigger by the row label.
+    await expect(canvas.getByRole('combobox', { name: 'Preset' })).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/settings/SettingsHeader/SettingsHeader.stories.tsx
+++ b/apps/web/src/components/settings/SettingsHeader/SettingsHeader.stories.tsx
@@ -1,21 +1,39 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import { SlidersHorizontal } from 'lucide-react';
 
 import SettingsHeader from './SettingsHeader';
 
-const meta = {
+/**
+ * settings · SettingsHeader. The section header at the top of a settings panel —
+ * a thin wrapper over the shared `PageHeader` (section variant) that renders the
+ * section icon tile plus an `<h2>` title and an optional uppercase subtitle. The
+ * icon is decorative (`aria-hidden`), so the title carries the section's
+ * accessible heading. Presentational — props in, header out.
+ */
+const meta: Meta<typeof SettingsHeader> = {
   title: 'settings/SettingsHeader',
   component: SettingsHeader,
-} satisfies Meta<typeof SettingsHeader>;
+  parameters: {
+    // Title is a real <h2>; the icon is aria-hidden + focusable="false" — axe clean.
+    a11y: { test: 'error' },
+  },
+};
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+/** Icon + heading + subtitle. */
 export const Default: Story = {
   args: {
     icon: SlidersHorizontal,
     title: 'Equalizer',
     subtitle: 'Shape playback with a 10-band graphic EQ.',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { level: 2, name: 'Equalizer' })).toBeInTheDocument();
+    await expect(canvas.getByText('Shape playback with a 10-band graphic EQ.')).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/settings/SettingsPreview/SettingsPreview.stories.tsx
+++ b/apps/web/src/components/settings/SettingsPreview/SettingsPreview.stories.tsx
@@ -1,16 +1,29 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import SettingsPreview from './SettingsPreview';
 
-const meta = {
+/**
+ * settings · SettingsPreview. A tiny layout primitive that frames a preview
+ * surface: an uppercase caption above an arbitrary content slot. Used to label
+ * the live previews in settings sections (sidebar mock, EQ curve, scale sample).
+ * Purely presentational — caption + children in, framed block out.
+ */
+const meta: Meta<typeof SettingsPreview> = {
   title: 'settings/SettingsPreview',
   component: SettingsPreview,
-} satisfies Meta<typeof SettingsPreview>;
+  parameters: {
+    // Caption is plain text; content is caller-supplied — axe clean for this
+    // sample.
+    a11y: { test: 'error' },
+  },
+};
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+/** Caption above a sample content block. */
 export const Default: Story = {
   args: {
     title: 'Preview',
@@ -19,5 +32,10 @@ export const Default: Story = {
         Preview content
       </div>
     ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Preview')).toBeInTheDocument();
+    await expect(canvas.getByText('Preview content')).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/settings/SettingsView/SettingsView.stories.tsx
+++ b/apps/web/src/components/settings/SettingsView/SettingsView.stories.tsx
@@ -1,12 +1,29 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
 import SettingsView from './SettingsView';
 
+/**
+ * settings · SettingsView. The composed Settings page: a section header `<h2>`
+ * for the active section, a `<nav aria-label="Settings sections">` of grouped
+ * nav buttons (Library / Playback / Appearance / System), and the active
+ * section's panel rendered to the right. Opens on the "Music Folders" section.
+ * Selecting a nav item swaps the active panel and updates the header. Stories
+ * assert the nav landmark + heading and that switching sections works — not
+ * every control inside each panel (those have their own stories).
+ */
 const meta: Meta<typeof SettingsView> = {
   title: 'settings/SettingsView',
   component: SettingsView,
-  parameters: { layout: 'fullscreen' },
+  parameters: {
+    layout: 'fullscreen',
+    // The nav is a labelled landmark, the active section title is a real <h2>,
+    // and nav items are real buttons with aria-current — axe clean. The active
+    // panel on open is Music Folders (no unnamed sliders), so the page itself
+    // stays axe-clean on first paint.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <TooltipProvider>
@@ -22,4 +39,34 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+/** Opens on Music Folders; selecting another nav item swaps the active section. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The section navigation is a labelled landmark with grouped buttons.
+    const nav = canvas.getByRole('navigation', { name: 'Settings sections' });
+    await expect(within(nav).getByRole('button', { name: 'Music Folders' })).toBeInTheDocument();
+    await expect(within(nav).getByRole('button', { name: 'Playback' })).toBeInTheDocument();
+
+    // Opens on the Music Folders section — its header is the active <h2>, and
+    // that nav item is marked current.
+    await expect(
+      canvas.getByRole('heading', { level: 2, name: 'Music Folders' })
+    ).toBeInTheDocument();
+    await expect(within(nav).getByRole('button', { name: 'Music Folders' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+
+    // Selecting the Playback section swaps the active panel + header.
+    await userEvent.click(within(nav).getByRole('button', { name: 'Playback' }));
+    await waitFor(() =>
+      expect(canvas.getByRole('heading', { level: 2, name: 'Playback' })).toBeInTheDocument()
+    );
+    await expect(within(nav).getByRole('button', { name: 'Playback' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  },
+};

--- a/apps/web/src/components/settings/SidebarPreview/SidebarPreview.stories.tsx
+++ b/apps/web/src/components/settings/SidebarPreview/SidebarPreview.stories.tsx
@@ -1,10 +1,36 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
+import { useUIStore } from '@/stores/useUIStore';
+import { DEFAULT_SIDEBAR_ORDER } from '@/lib/sidebar-items';
 
 import SidebarPreview from './SidebarPreview';
 
+/** Reset the sidebar UI state so the mock renders the full default nav. */
+function resetSidebar(): void {
+  useUIStore.setState({
+    sidebarHiddenItems: [],
+    sidebarOrder: DEFAULT_SIDEBAR_ORDER,
+    sidebarPlaylistsVisible: true,
+  });
+}
+
+/**
+ * settings · SidebarPreview. A scaled-down mock of the real app sidebar shown in
+ * the Sidebar settings section. It reads the live `useUIStore` order / hidden /
+ * playlists state and renders the visible nav items into a labelled
+ * `role="img"` block (named by the "Preview" caption), spotlighting the hovered
+ * row. Presentational over store state — no IPC. Stories assert the labelled
+ * mock and its visible nav rows.
+ */
 const meta: Meta<typeof SidebarPreview> = {
   title: 'settings/SidebarPreview',
   component: SidebarPreview,
+  parameters: {
+    // The mock is a single role="img" with an accessible name from the caption;
+    // its decorative skeleton bars carry no roles — axe clean.
+    a11y: { test: 'error' },
+  },
+  beforeEach: resetSidebar,
   decorators: [
     Story => (
       <div className="max-w-[420px] p-4">
@@ -18,4 +44,13 @@ export default meta;
 
 type Story = StoryObj<typeof SidebarPreview>;
 
-export const Default: Story = {};
+/** The labelled mock renders the visible sidebar nav items (e.g. Overview). */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The preview surface is exposed as a labelled image.
+    await expect(canvas.getByRole('img', { name: 'Preview' })).toBeInTheDocument();
+    // The default sidebar order surfaces the Overview nav item in the mock.
+    await expect(canvas.getByText('Overview')).toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/settings/SidebarSection/SidebarSection.stories.tsx
+++ b/apps/web/src/components/settings/SidebarSection/SidebarSection.stories.tsx
@@ -1,10 +1,38 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
+import { useUIStore } from '@/stores/useUIStore';
+import { DEFAULT_SIDEBAR_ORDER } from '@/lib/sidebar-items';
 
 import SidebarSection from './SidebarSection';
 
+/** Reset the sidebar UI state so every row starts visible and ordered. */
+function resetSidebar(): void {
+  useUIStore.setState({
+    sidebarHiddenItems: [],
+    sidebarOrder: DEFAULT_SIDEBAR_ORDER,
+    sidebarPlaylistsVisible: true,
+    landingView: 'overview',
+  });
+}
+
+/**
+ * settings · SidebarSection. The Sidebar settings panel: a live preview, a
+ * landing-view select, a drag-sortable list of nav items (each row a drag-handle
+ * button + a show/hide Switch named by the item, with "Always shown" /
+ * "Experimental" annotations), a "Show playlists" toggle, and a reset. Reads and
+ * writes `useUIStore`. Stories reset that store, assert the rows, and toggle an
+ * item's visibility against the store.
+ */
 const meta: Meta<typeof SidebarSection> = {
   title: 'settings/SidebarSection',
   component: SidebarSection,
+  parameters: {
+    // Card title is a real heading; each row switch is aria-labelledby the item
+    // label, each drag handle has an aria-label, and the nested preview is a
+    // labelled image — axe clean.
+    a11y: { test: 'error' },
+  },
+  beforeEach: resetSidebar,
   decorators: [
     Story => (
       <div className="max-w-[680px] p-4">
@@ -18,4 +46,24 @@ export default meta;
 
 type Story = StoryObj<typeof SidebarSection>;
 
-export const Default: Story = {};
+/** The row list renders, and toggling an item's switch updates the store. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Sidebar' })).toBeInTheDocument();
+
+    // The landing-view select and the playlists toggle render.
+    await expect(canvas.getByRole('combobox', { name: 'Open Shiranami to' })).toBeInTheDocument();
+    await expect(canvas.getByRole('switch', { name: 'Show playlists' })).toBeInTheDocument();
+
+    // Each item exposes a reorder handle by its localized label.
+    await expect(canvas.getByRole('button', { name: 'Reorder History' })).toBeInTheDocument();
+
+    // The History row's switch starts on (item visible); toggling it hides the
+    // item in the store.
+    const historySwitch = canvas.getByRole('switch', { name: 'History' });
+    await expect(historySwitch).toBeChecked();
+    await userEvent.click(historySwitch);
+    await waitFor(() => expect(useUIStore.getState().sidebarHiddenItems).toContain('history'));
+  },
+};

--- a/apps/web/src/components/settings/SubfolderPlaylistDialog/SubfolderPlaylistDialog.stories.tsx
+++ b/apps/web/src/components/settings/SubfolderPlaylistDialog/SubfolderPlaylistDialog.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { screen, within, userEvent, expect, fn, waitFor } from 'storybook/test';
 
 import SubfolderPlaylistDialog from './SubfolderPlaylistDialog';
 import type { ISubfolderEntry } from './SubfolderPlaylistDialog.types';
@@ -12,9 +13,23 @@ const subfolders: ISubfolderEntry[] = [
   { name: 'Focus', path: '/music/Focus', tracks: [] },
 ];
 
+/**
+ * settings · SubfolderPlaylistDialog. The post-scan prompt offering to turn each
+ * detected subfolder into a playlist: a checkbox row per subfolder (track count
+ * shown, rows whose name already exists are disabled + flagged), a select-all /
+ * deselect-all toggle, and Skip / Create Playlists actions. Confirm is disabled
+ * when nothing is selected. Renders into a portal, so stories query it via
+ * `screen` rather than the canvas.
+ */
 const meta: Meta<typeof SubfolderPlaylistDialog> = {
   title: 'settings/SubfolderPlaylistDialog',
   component: SubfolderPlaylistDialog,
+  // a11y stays at the global 'todo' default: the per-row Radix Checkbox is a
+  // `<button role="checkbox">` wrapped in a `<label>`, but a <button> is not a
+  // labelable element, so each checkbox ends up without an accessible name (axe
+  // aria-input-field-name). The fix belongs in SubfolderPlaylistDialog.tsx,
+  // which is out of scope for this story pass, so axe is left non-blocking here.
+  parameters: { a11y: { test: 'todo' } },
   decorators: [
     Story => (
       <QueryClientProvider client={queryClient}>
@@ -28,22 +43,53 @@ export default meta;
 
 type Story = StoryObj<typeof SubfolderPlaylistDialog>;
 
+/** Three fresh subfolders — all selected by default, Create is enabled. */
 export const Default: Story = {
   args: {
     open: true,
     subfolders,
     existingPlaylistNames: new Set(),
-    onOpenChange: () => {},
-    onConfirm: () => {},
+    onOpenChange: fn(),
+    onConfirm: fn(),
+  },
+  play: async ({ args }) => {
+    // The dialog renders into a portal — query it from the document.
+    const dialog = await screen.findByRole('dialog');
+    await expect(within(dialog).getByText('Subfolders Detected')).toBeInTheDocument();
+
+    // Each subfolder is offered as a checkbox row, all selected on open.
+    const checkboxes = within(dialog).getAllByRole('checkbox');
+    await expect(checkboxes).toHaveLength(3);
+    for (const box of checkboxes) await expect(box).toBeChecked();
+
+    // Create is enabled with a selection; clicking confirms + closes.
+    const create = within(dialog).getByRole('button', { name: 'Create Playlists' });
+    await expect(create).toBeEnabled();
+    await userEvent.click(create);
+    await waitFor(() => expect(args.onConfirm).toHaveBeenCalledTimes(1));
+    // The confirmed selection carries all three fresh subfolders.
+    expect((args.onConfirm as ReturnType<typeof fn>).mock.calls[0][0]).toHaveLength(3);
   },
 };
 
+/** A colliding name — the existing-playlist row is disabled and flagged. */
 export const SomeAlreadyExist: Story = {
   args: {
     open: true,
     subfolders,
     existingPlaylistNames: new Set(['Focus']),
-    onOpenChange: () => {},
-    onConfirm: () => {},
+    onOpenChange: fn(),
+    onConfirm: fn(),
+  },
+  play: async () => {
+    const dialog = await screen.findByRole('dialog');
+    // The clashing subfolder surfaces the "already exists" flag...
+    await expect(within(dialog).getByText('Playlist already exists')).toBeInTheDocument();
+    // ...and its checkbox is disabled, so only the two fresh rows stay selectable.
+    const checkboxes = within(dialog).getAllByRole('checkbox');
+    const disabled = checkboxes.filter(
+      box => box.hasAttribute('disabled') || box.getAttribute('data-disabled') !== null
+    );
+    await expect(disabled).toHaveLength(1);
   },
 };

--- a/apps/web/src/components/settings/SupportSection/SupportSection.stories.tsx
+++ b/apps/web/src/components/settings/SupportSection/SupportSection.stories.tsx
@@ -1,10 +1,24 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import SupportSection from './SupportSection';
 
+/**
+ * settings · SupportSection. A static "support the project" card: a real `<h3>`
+ * heading ("Support"), three explanatory paragraphs, and two external CTA links
+ * — "Buy me a coffee" and "Sponsor on GitHub" — both opening in a new tab with
+ * `rel="noopener noreferrer"` and marking the support banner as seen on click.
+ * Lucide glyphs inside the links are decorative. No props or store seeding
+ * needed; the section reads only static constants.
+ */
 const meta: Meta<typeof SupportSection> = {
   title: 'settings/SupportSection',
   component: SupportSection,
+  parameters: {
+    // Real heading, named external links carrying rel=noopener noreferrer, and
+    // decorative lucide icons inside the links — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="max-w-[640px] p-4">
@@ -18,4 +32,21 @@ export default meta;
 
 type Story = StoryObj<typeof SupportSection>;
 
-export const Default: Story = {};
+/** Both CTA links render, named and pointing at external, safely-targeted URLs. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Support' })).toBeInTheDocument();
+
+    const coffee = canvas.getByRole('link', { name: /Buy me a coffee/ });
+    const sponsor = canvas.getByRole('link', { name: /Sponsor on GitHub/ });
+    await expect(coffee).toBeInTheDocument();
+    await expect(sponsor).toBeInTheDocument();
+
+    // External CTAs open in a new tab and must be reverse-tabnabbing safe.
+    await expect(coffee).toHaveAttribute('target', '_blank');
+    await expect(coffee).toHaveAttribute('rel', 'noopener noreferrer');
+    await expect(sponsor).toHaveAttribute('rel', 'noopener noreferrer');
+  },
+};

--- a/apps/web/src/components/settings/SupportSection/SupportSection.stories.tsx
+++ b/apps/web/src/components/settings/SupportSection/SupportSection.stories.tsx
@@ -47,6 +47,7 @@ export const Default: Story = {
     // External CTAs open in a new tab and must be reverse-tabnabbing safe.
     await expect(coffee).toHaveAttribute('target', '_blank');
     await expect(coffee).toHaveAttribute('rel', 'noopener noreferrer');
+    await expect(sponsor).toHaveAttribute('target', '_blank');
     await expect(sponsor).toHaveAttribute('rel', 'noopener noreferrer');
   },
 };

--- a/apps/web/src/components/settings/SystemSection/SystemSection.stories.tsx
+++ b/apps/web/src/components/settings/SystemSection/SystemSection.stories.tsx
@@ -1,26 +1,86 @@
+import type { ReactElement } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, expect } from 'storybook/test';
+import { systemPrefsKeys, type SystemPrefs } from '@/hooks/queries/useSystemPrefs';
 
 import SystemSection from './SystemSection';
 
-const queryClient = new QueryClient();
-
+/**
+ * settings · SystemSection. Startup/tray behavior card: a real `<h3>` heading
+ * ("System behavior") over three Radix switches — Launch at startup, Minimize
+ * to tray, Close to tray — each labelled via `aria-labelledby`. The toggles
+ * read their checked state from the seeded `system-prefs` query cache.
+ *
+ * Each switch is `disabled` when `!IS_ELECTRON || !prefs`. In the Storybook
+ * browser run `IS_ELECTRON` resolves to `false` — `@/lib/platform` captures it as
+ * a module-constant before the preview installs the electronAPI mock — so the
+ * switches still render their seeded checked state but stay disabled, and a click
+ * cannot flip them (the write mutation is itself IS_ELECTRON-gated). Stories seed
+ * the query cache directly so the switches start deterministic.
+ */
 const meta: Meta<typeof SystemSection> = {
   title: 'settings/SystemSection',
   component: SystemSection,
-  decorators: [
-    Story => (
-      <QueryClientProvider client={queryClient}>
-        <div className="max-w-[640px] p-4">
-          <Story />
-        </div>
-      </QueryClientProvider>
-    ),
-  ],
+  parameters: {
+    // Real heading, three switches each named via aria-labelledby, and an info
+    // callout with a decorative lucide icon — axe passes clean.
+    a11y: { test: 'error' },
+  },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof SystemSection>;
 
-export const Default: Story = {};
+/** Seed the `system-prefs` cache so the toggles render with a known state. */
+function withSeededPrefs(prefs: SystemPrefs) {
+  return function Decorator(Story: () => ReactElement) {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData<SystemPrefs>(systemPrefsKeys.all, prefs);
+    return (
+      <QueryClientProvider client={client}>
+        <div className="max-w-[640px] p-4">
+          <Story />
+        </div>
+      </QueryClientProvider>
+    );
+  };
+}
+
+/** Launch-at-startup on, the other two off — the switches mirror the cache. */
+export const Default: Story = {
+  decorators: [
+    withSeededPrefs({ launchAtStartup: true, minimizeToTray: false, closeToTray: false }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'System behavior' })).toBeInTheDocument();
+
+    const [launch, minimize, close] = canvas.getAllByRole('switch');
+    await expect(launch).toBeChecked();
+    await expect(minimize).not.toBeChecked();
+    await expect(close).not.toBeChecked();
+  },
+};
+
+/**
+ * Outside Electron the switches are disabled. With `IS_ELECTRON` false (see meta)
+ * the toggle is `disabled` and cannot be flipped — it keeps its seeded state — so
+ * this story asserts that gated, non-interactive contract rather than an
+ * optimistic flip that only happens under a live electron-store write.
+ */
+export const MinimizeToTrayDisabled: Story = {
+  decorators: [
+    withSeededPrefs({ launchAtStartup: false, minimizeToTray: false, closeToTray: false }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const minimize = canvas.getByRole('switch', { name: 'Minimize to tray' });
+    // Seeded as off, and disabled because IS_ELECTRON is false here.
+    await expect(minimize).not.toBeChecked();
+    await expect(minimize).toBeDisabled();
+  },
+};

--- a/apps/web/src/components/settings/SystemSection/SystemSection.stories.tsx
+++ b/apps/web/src/components/settings/SystemSection/SystemSection.stories.tsx
@@ -58,10 +58,11 @@ export const Default: Story = {
 
     await expect(canvas.getByRole('heading', { name: 'System behavior' })).toBeInTheDocument();
 
-    const [launch, minimize, close] = canvas.getAllByRole('switch');
-    await expect(launch).toBeChecked();
-    await expect(minimize).not.toBeChecked();
-    await expect(close).not.toBeChecked();
+    // Query each switch by its accessible name (from aria-labelledby) rather than
+    // array position, so the assertions don't depend on render order.
+    await expect(canvas.getByRole('switch', { name: 'Launch at startup' })).toBeChecked();
+    await expect(canvas.getByRole('switch', { name: 'Minimize to tray' })).not.toBeChecked();
+    await expect(canvas.getByRole('switch', { name: 'Close to tray' })).not.toBeChecked();
   },
 };
 

--- a/apps/web/src/components/settings/ThemeBackgroundPreview/ThemeBackgroundPreview.stories.tsx
+++ b/apps/web/src/components/settings/ThemeBackgroundPreview/ThemeBackgroundPreview.stories.tsx
@@ -1,9 +1,24 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import { useThemeStore } from '@/stores/useThemeStore';
 import { useThemeBgStore } from '@/stores/useThemeBgStore';
 
 import ThemeBackgroundPreview from './ThemeBackgroundPreview';
 
+/**
+ * settings · ThemeBackgroundPreview. A scaled-down sample of the live theme
+ * background — the same image + scrim + dim stack the app paints, with the
+ * background-adjust slider values applied as locally-scoped inline styles — so
+ * users can judge opacity/blur/dim without the settings glass obscuring it. The
+ * image, scrim, and dim layers are all `aria-hidden`; a faux glass "now playing"
+ * card sits on top showing a sample track + artist. Renders nothing when the
+ * active theme is `none`, so every story seeds a photo theme first.
+ *
+ * a11y stays at `'todo'`: this is a decorative preview whose foreground glass
+ * card sits over arbitrary (often dark) photo backgrounds, so the faux track
+ * text can't be guaranteed to clear axe's color-contrast threshold. Same
+ * deferral precedent as splash/SplashScreen and debug/DebugOverlay.
+ */
 const meta: Meta<typeof ThemeBackgroundPreview> = {
   title: 'settings/ThemeBackgroundPreview',
   component: ThemeBackgroundPreview,
@@ -20,6 +35,7 @@ export default meta;
 
 type Story = StoryObj<typeof ThemeBackgroundPreview>;
 
+/** Lofi Night theme at full opacity, no blur/dim — the sample chrome reads over it. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -28,8 +44,14 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Sample Track')).toBeInTheDocument();
+    await expect(canvas.getByText('Now playing over your background')).toBeInTheDocument();
+  },
 };
 
+/** Snow theme with the slider pushed to blurred + dimmed — still renders the chrome. */
 export const BlurredAndDimmed: Story = {
   decorators: [
     Story => {
@@ -38,4 +60,8 @@ export const BlurredAndDimmed: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Sample Track')).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/UiScalePreview/UiScalePreview.stories.tsx
+++ b/apps/web/src/components/settings/UiScalePreview/UiScalePreview.stories.tsx
@@ -1,11 +1,25 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import UiScalePreview from './UiScalePreview';
 
+/**
+ * settings · UiScalePreview. Side-by-side sample cards comparing the default UI
+ * scale against the chosen one, so the interface-scale slider's effect stays
+ * legible while the rest of the settings page is unaffected. The comparison
+ * tile is grouped under `role="img"` named "Scale preview"; each card shows a
+ * sample track title + artist sized by an inline px factor. Driven by the
+ * `scale` prop (a percentage).
+ */
 const meta: Meta<typeof UiScalePreview> = {
   title: 'settings/UiScalePreview',
   component: UiScalePreview,
   args: { scale: 120 },
+  parameters: {
+    // The preview groups its sample cards under a named role="img"; the sample
+    // text uses standard foreground/muted tokens on a surface — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="max-w-[420px] p-4">
@@ -19,8 +33,21 @@ export default meta;
 
 type Story = StoryObj<typeof UiScalePreview>;
 
-export const Default: Story = {};
+/** 120% scale — the named comparison image and a sample title both render. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('img', { name: 'Scale preview' })).toBeInTheDocument();
+    // Each card renders the sample title; the active card mirrors it at the factor.
+    await expect(canvas.getAllByText('Evening Rain').length).toBeGreaterThan(0);
+  },
+};
 
+/** A larger 150% scale still presents the same named comparison image. */
 export const Enlarged: Story = {
   args: { scale: 150 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('img', { name: 'Scale preview' })).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/UpdatesSection/UpdatesSection.stories.tsx
+++ b/apps/web/src/components/settings/UpdatesSection/UpdatesSection.stories.tsx
@@ -1,21 +1,43 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { within, expect } from 'storybook/test';
 
 import UpdatesSection from './UpdatesSection';
 
-const queryClient = new QueryClient();
-
+/**
+ * settings · UpdatesSection. The app-update card. Its layout forks on platform:
+ * macOS (unsigned, no auto-update) shows a notice plus an "Open GitHub Releases"
+ * link, while the non-macOS branch shows a "Check for updates" button,
+ * conditional download/install buttons, a status line, and a download progress
+ * bar.
+ *
+ * The fork is `isMac = IS_ELECTRON && platform === 'darwin'`. In the Storybook
+ * browser run `IS_ELECTRON` is a false module-constant (`@/lib/platform` is
+ * imported before the preview installs the electronAPI mock), so `isMac` is
+ * false and the NON-macOS branch renders: a "Check for updates" button and the
+ * idle "No updates available" status. The download/install buttons and progress
+ * bar stay unreachable here (they need live updater events), so the story
+ * asserts the idle default controls of that branch.
+ */
 const meta: Meta<typeof UpdatesSection> = {
   title: 'settings/UpdatesSection',
   component: UpdatesSection,
+  parameters: {
+    // Real heading, a named "Check for updates" button, and an idle status
+    // paragraph — every control carries an accessible name, axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
-    Story => (
-      <QueryClientProvider client={queryClient}>
-        <div className="max-w-[640px] p-4">
-          <Story />
-        </div>
-      </QueryClientProvider>
-    ),
+    Story => {
+      const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      return (
+        <QueryClientProvider client={client}>
+          <div className="max-w-[640px] p-4">
+            <Story />
+          </div>
+        </QueryClientProvider>
+      );
+    },
   ],
 };
 
@@ -23,4 +45,32 @@ export default meta;
 
 type Story = StoryObj<typeof UpdatesSection>;
 
-export const Default: Story = {};
+/**
+ * Non-macOS branch (IS_ELECTRON is a false module-constant here, so isMac is
+ * false): the "Check for updates" button and the idle "No updates available"
+ * status, with no download/install controls until live updater events arrive.
+ */
+export const CheckForUpdates: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Updates' })).toBeInTheDocument();
+
+    // The manual check control is a real, enabled button in the idle state.
+    await expect(canvas.getByRole('button', { name: 'Check for updates' })).toBeEnabled();
+
+    // Idle status line — nothing to download yet.
+    await expect(canvas.getByText('No updates available')).toBeInTheDocument();
+
+    // Download / install actions only appear once an update is available/ready,
+    // which needs live updater events that the no-op IPC mock never emits.
+    await expect(
+      canvas.queryByRole('button', { name: 'Install and restart' })
+    ).not.toBeInTheDocument();
+
+    // The macOS-only unsigned-build notice is not on this branch.
+    await expect(
+      canvas.queryByText(/Auto-updates are not available on macOS/)
+    ).not.toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.stories.tsx
+++ b/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.stories.tsx
@@ -1,8 +1,22 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
 import { useUIStore } from '@/stores/useUIStore';
 
 import VisualEffectsSection from './VisualEffectsSection';
 
+/**
+ * settings · VisualEffectsSection. Four immersive-effect switches — Now Playing
+ * view, Now playing banner, Low performance mode, Noise texture — each labelled
+ * via `aria-labelledby` and paired with a live preview tile beneath it. The
+ * switches read and write the UI store directly, so flipping one updates the
+ * store and re-renders the matching preview. Stories seed the store on entry.
+ *
+ * a11y stays at `'todo'`: the embedded effect-preview tiles render decorative
+ * mock chrome with low-opacity tinted text (e.g. amber "Reduced" badges on a
+ * faint wash) that can't be guaranteed to clear axe's color-contrast threshold,
+ * and those preview components are out of this story's scope to change. Same
+ * deferral precedent as splash/SplashScreen and debug/DebugOverlay.
+ */
 const meta: Meta<typeof VisualEffectsSection> = {
   title: 'settings/VisualEffectsSection',
   component: VisualEffectsSection,
@@ -19,6 +33,7 @@ export default meta;
 
 type Story = StoryObj<typeof VisualEffectsSection>;
 
+/** Now-playing effects on, perf/noise off — the four switches mirror the store. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -31,18 +46,38 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Visual effects' })).toBeInTheDocument();
+    await expect(canvas.getByRole('switch', { name: 'Now Playing view' })).toBeChecked();
+    await expect(canvas.getByRole('switch', { name: 'Low performance mode' })).not.toBeChecked();
+    await expect(canvas.getByRole('switch', { name: 'Noise texture' })).not.toBeChecked();
+  },
 };
 
-export const LowPerformance: Story = {
+/** Toggling low performance mode flips both the switch and the backing store. */
+export const TogglesLowPerformance: Story = {
   decorators: [
     Story => {
       useUIStore.setState({
-        nowPlayingViewEnabled: false,
-        libraryHeroCardEnabled: false,
-        lowPerformanceMode: true,
-        noiseOverlayEnabled: true,
+        nowPlayingViewEnabled: true,
+        libraryHeroCardEnabled: true,
+        lowPerformanceMode: false,
+        noiseOverlayEnabled: false,
       });
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const lowPerf = canvas.getByRole('switch', { name: 'Low performance mode' });
+    await expect(lowPerf).not.toBeChecked();
+
+    await userEvent.click(lowPerf);
+
+    await waitFor(() => expect(lowPerf).toBeChecked());
+    await expect(useUIStore.getState().lowPerformanceMode).toBe(true);
+  },
 };

--- a/apps/web/src/components/settings/VisualizerSection/VisualizerSection.stories.tsx
+++ b/apps/web/src/components/settings/VisualizerSection/VisualizerSection.stories.tsx
@@ -1,8 +1,22 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
 import { useUIStore } from '@/stores/useUIStore';
 
 import VisualizerSection from './VisualizerSection';
 
+/**
+ * settings · VisualizerSection. The audio-visualizer card. A "Show visualizer"
+ * switch gates the rest: when on, a position Select (`role="combobox"`), a live
+ * style preview tile, and a grid of selectable style buttons appear; when off,
+ * those controls are hidden. The switch toggles the UI store and the style grid
+ * writes the chosen style back to it. Stories seed the store on entry.
+ *
+ * a11y stays at `'todo'`: the embedded live preview renders a lazy `<canvas>`
+ * visualizer over a dark gradient tile (decorative, non-deterministic) that
+ * axe's color-contrast pass can't evaluate, and that preview is out of this
+ * story's scope. Same deferral precedent as splash/SplashScreen and
+ * debug/DebugOverlay.
+ */
 const meta: Meta<typeof VisualizerSection> = {
   title: 'settings/VisualizerSection',
   component: VisualizerSection,
@@ -19,6 +33,7 @@ export default meta;
 
 type Story = StoryObj<typeof VisualizerSection>;
 
+/** Visualizer on: the position select and the style grid both render. */
 export const Enabled: Story = {
   decorators: [
     Story => {
@@ -26,8 +41,24 @@ export const Enabled: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Visualizer' })).toBeInTheDocument();
+    await expect(canvas.getByRole('switch', { name: 'Show visualizer' })).toBeChecked();
+    // The position dropdown only renders while the visualizer is on.
+    await expect(canvas.getByRole('combobox')).toBeInTheDocument();
+
+    // The style grid marks the active tile pressed; picking another updates the store.
+    const bars = canvas.getByRole('button', { name: /Bars/ });
+    await expect(bars).toHaveAttribute('aria-pressed', 'true');
+
+    await userEvent.click(canvas.getByRole('button', { name: /Waveform/ }));
+    await waitFor(() => expect(useUIStore.getState().visualizerStyle).toBe('waveform'));
+  },
 };
 
+/** Visualizer off: only the gating switch shows, no position or style controls. */
 export const Disabled: Story = {
   decorators: [
     Story => {
@@ -35,4 +66,11 @@ export const Disabled: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('switch', { name: 'Show visualizer' })).not.toBeChecked();
+    await expect(canvas.queryByRole('combobox')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /Bars/ })).not.toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/VisualizerStyleGrid/VisualizerStyleGrid.stories.tsx
+++ b/apps/web/src/components/settings/VisualizerStyleGrid/VisualizerStyleGrid.stories.tsx
@@ -1,12 +1,26 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, fn, waitFor } from 'storybook/test';
 import type { VisualizerStyle } from '@/stores/useUIStore';
 
 import VisualizerStyleGrid from './VisualizerStyleGrid';
 
+/**
+ * settings · VisualizerStyleGrid. The shared visualizer-style picker used by
+ * both Settings · Visualizer and the onboarding wizard. Renders one toggle
+ * `<button>` per registered style, each carrying `aria-pressed` for the active
+ * selection and a text label (+ description, hidden in compact mode) as its
+ * accessible name. Selecting a tile fires `onSelect` with that style's id.
+ * Stories drive it through a controlled wrapper so the pressed state moves.
+ */
 const meta: Meta<typeof VisualizerStyleGrid> = {
   title: 'settings/VisualizerStyleGrid',
   component: VisualizerStyleGrid,
+  parameters: {
+    // Every tile is a real <button> with a text accessible name and aria-pressed;
+    // focus-visible rings are present — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="max-w-[480px] p-4">
@@ -20,19 +34,64 @@ export default meta;
 
 type Story = StoryObj<typeof VisualizerStyleGrid>;
 
-function Interactive(args: { columns?: 2 | 3; compact?: boolean }) {
+function Interactive(args: {
+  columns?: 2 | 3;
+  compact?: boolean;
+  onSelect?: (style: VisualizerStyle) => void;
+}) {
   const [value, setValue] = useState<VisualizerStyle>('bars');
-  return <VisualizerStyleGrid value={value} onSelect={setValue} {...args} />;
+  const { onSelect, ...rest } = args;
+  return (
+    <VisualizerStyleGrid
+      value={value}
+      onSelect={style => {
+        onSelect?.(style);
+        setValue(style);
+      }}
+      {...rest}
+    />
+  );
 }
 
+/** Active tile is pressed; clicking another moves the selection and fires onSelect. */
 export const Default: Story = {
-  render: () => <Interactive />,
+  args: { onSelect: fn() },
+  render: args => <Interactive onSelect={args.onSelect} />,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    const bars = canvas.getByRole('button', { name: /Bars/ });
+    await expect(bars).toHaveAttribute('aria-pressed', 'true');
+
+    const waveform = canvas.getByRole('button', { name: /Waveform/ });
+    await expect(waveform).toHaveAttribute('aria-pressed', 'false');
+
+    await userEvent.click(waveform);
+    await expect(args.onSelect).toHaveBeenCalledWith('waveform');
+    // The controlled wrapper moves the pressed state to the picked tile.
+    await waitFor(() => expect(waveform).toHaveAttribute('aria-pressed', 'true'));
+  },
 };
 
+/** Three-column layout still presents one named, pressable button per style. */
 export const ThreeColumns: Story = {
   render: () => <Interactive columns={3} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: /Bars/ })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  },
 };
 
+/** Compact mode drops per-style descriptions but keeps the named buttons. */
 export const Compact: Story = {
   render: () => <Interactive columns={3} compact />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Description text is hidden in compact mode.
+    await expect(canvas.queryByText('Soft frequency bars')).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Bars' })).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/VisualizerStylePreview/VisualizerStylePreview.stories.tsx
+++ b/apps/web/src/components/settings/VisualizerStylePreview/VisualizerStylePreview.stories.tsx
@@ -1,8 +1,21 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import { useUIStore } from '@/stores/useUIStore';
 
 import VisualizerStylePreview from './VisualizerStylePreview';
 
+/**
+ * settings · VisualizerStylePreview. A self-animating preview of the active
+ * visualizer style, fed by a deterministic synthetic frequency source so it
+ * renders without touching the playback engine. It frames a lazily-loaded
+ * `<canvas>` visualizer (suspends with a null fallback) beneath a "Preview"
+ * label and reads the chosen style from the UI store. Stories seed the style.
+ *
+ * a11y stays at `'todo'`: this is a decorative `<canvas>` preview on a dark
+ * gradient tile whose pixels axe can't evaluate for color-contrast, and whose
+ * lazy render is non-deterministic. Same deferral precedent as
+ * splash/SplashScreen and debug/DebugOverlay.
+ */
 const meta: Meta<typeof VisualizerStylePreview> = {
   title: 'settings/VisualizerStylePreview',
   component: VisualizerStylePreview,
@@ -19,6 +32,7 @@ export default meta;
 
 type Story = StoryObj<typeof VisualizerStylePreview>;
 
+/** Bars style: the preview frame and its "Preview" label render. */
 export const Bars: Story = {
   decorators: [
     Story => {
@@ -26,8 +40,14 @@ export const Bars: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The surrounding chrome renders synchronously; the lazy canvas may suspend.
+    await expect(canvas.getByText('Preview')).toBeInTheDocument();
+  },
 };
 
+/** Waveform style: the same labelled preview frame renders for a different style. */
 export const Waveform: Story = {
   decorators: [
     Story => {
@@ -35,4 +55,8 @@ export const Waveform: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Preview')).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/WeatherSection/WeatherSection.stories.tsx
+++ b/apps/web/src/components/settings/WeatherSection/WeatherSection.stories.tsx
@@ -1,11 +1,26 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
 import { useWeatherStore } from '@/stores/useWeatherStore';
 
 import WeatherSection from './WeatherSection';
 
+/**
+ * settings · WeatherSection. Opt-in weather card for the Overview clock. A real
+ * `<h3>` heading ("Weather on Overview") over an enable switch (labelled via
+ * `aria-labelledby`); turning it on reveals a city search form — a labelled
+ * `<input>` ("City") and a submit button — plus, once a city is chosen, a
+ * current-city chip with a "Clear city" button. The toggle and city live in the
+ * weather store, which stories seed on entry. Copy comes from the `overview`
+ * namespace.
+ */
 const meta: Meta<typeof WeatherSection> = {
   title: 'settings/WeatherSection',
   component: WeatherSection,
+  parameters: {
+    // Real heading, a named switch, a labelled city input, an icon button with
+    // an aria-label, and an info callout with a decorative icon — axe clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="max-w-[680px] p-4">
@@ -19,6 +34,7 @@ export default meta;
 
 type Story = StoryObj<typeof WeatherSection>;
 
+/** Disabled: just the heading and the gating switch — no city search yet. */
 export const Default: Story = {
   decorators: [
     Story => {
@@ -26,8 +42,22 @@ export const Default: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Weather on Overview' })).toBeInTheDocument();
+    const toggle = canvas.getByRole('switch', { name: 'Show weather on Overview' });
+    await expect(toggle).not.toBeChecked();
+    // The city search is gated behind the toggle.
+    await expect(canvas.queryByLabelText('City')).not.toBeInTheDocument();
+
+    // Enabling it reveals the city search input.
+    await userEvent.click(toggle);
+    await waitFor(() => expect(canvas.getByLabelText('City')).toBeInTheDocument());
+  },
 };
 
+/** Enabled with a chosen city: the current-city chip and clear button render. */
 export const WithCity: Story = {
   decorators: [
     Story => {
@@ -38,4 +68,11 @@ export const WithCity: Story = {
       return <Story />;
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('Showing weather for Tokyo, Japan')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Clear city' })).toBeInTheDocument();
+    await expect(canvas.getByLabelText('City')).toBeInTheDocument();
+  },
 };

--- a/apps/web/src/components/settings/downloads/DownloadLocationPanel/DownloadLocationPanel.stories.tsx
+++ b/apps/web/src/components/settings/downloads/DownloadLocationPanel/DownloadLocationPanel.stories.tsx
@@ -1,32 +1,83 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect, fn } from 'storybook/test';
 
 import DownloadLocationPanel from './DownloadLocationPanel';
 
-const meta = {
+/**
+ * settings/downloads · DownloadLocationPanel. Shows where search downloads are
+ * saved: a "Default"/"Custom" origin badge, the resolved path, a hint, a
+ * "Change location" button that opens the directory picker, and — only for a
+ * custom location — a "Reset to default" button. Both buttons disable while an
+ * update is in flight. Purely prop-driven (no IPC), so stories pass `fn()`
+ * spies for `onChange`/`onReset` and assert the rendered path + button wiring.
+ */
+const meta: Meta<typeof DownloadLocationPanel> = {
   title: 'settings/downloads/DownloadLocationPanel',
   component: DownloadLocationPanel,
-  args: {
-    onChange: () => {},
-    onReset: () => {},
+  parameters: {
+    // Plain text + two named buttons, no decorative-naming gaps — axe clean.
+    a11y: { test: 'error' },
   },
-} satisfies Meta<typeof DownloadLocationPanel>;
+  args: {
+    onChange: fn(),
+    onReset: fn(),
+  },
+};
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof DownloadLocationPanel>;
 
+/** Default location: the change button works, the reset button is hidden. */
 export const Default: Story = {
   args: {
     pathDisplay: '/Users/me/Music/Downloads',
     isDefault: true,
     updating: false,
   },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('/Users/me/Music/Downloads')).toBeInTheDocument();
+    // Reset is only offered for a custom location.
+    await expect(
+      canvas.queryByRole('button', { name: /Reset to default/ })
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: /Change location/ }));
+    await expect(args.onChange).toHaveBeenCalledTimes(1);
+  },
 };
 
+/** Custom location: both the change and reset affordances render. */
 export const Custom: Story = {
   args: {
     pathDisplay: '/Volumes/External/Lofi',
     isDefault: false,
     updating: false,
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('/Volumes/External/Lofi')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: /Change location/ })).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: /Reset to default/ }));
+    await expect(args.onReset).toHaveBeenCalledTimes(1);
+  },
+};
+
+/** Updating: both buttons are disabled while a location change is in flight. */
+export const Updating: Story = {
+  args: {
+    pathDisplay: '/Volumes/External/Lofi',
+    isDefault: false,
+    updating: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('button', { name: /Change location/ })).toBeDisabled();
+    await expect(canvas.getByRole('button', { name: /Reset to default/ })).toBeDisabled();
   },
 };

--- a/apps/web/src/components/settings/downloads/DownloadsSection/DownloadsSection.stories.tsx
+++ b/apps/web/src/components/settings/downloads/DownloadsSection/DownloadsSection.stories.tsx
@@ -1,10 +1,30 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import DownloadsSection from './DownloadsSection';
 
+/**
+ * settings/downloads · DownloadsSection. The yt-dlp / ffmpeg tool-management
+ * card: a real `<h3>` heading ("Downloads"), a labelled refresh icon button in
+ * the header, and — once tool status resolves — install/version/location rows.
+ *
+ * Tool status is read on mount from the main process via
+ * `electronAPI.downloader.getCachedToolStatus()` / `refreshToolStatus()`. Under
+ * Storybook the mock bridge resolves those to `undefined`, so installed-state
+ * stays `null` and the section renders its loading **skeleton** indefinitely
+ * (the binary path / version rows never appear). The story asserts the header
+ * chrome that always renders plus the checking state; the populated tool rows
+ * are covered by the leaf components' own stories (ToolStatusRow,
+ * ToolVersionBlock, DownloadLocationPanel, InstallProgressBar).
+ */
 const meta: Meta<typeof DownloadsSection> = {
   title: 'settings/downloads/DownloadsSection',
   component: DownloadsSection,
+  parameters: {
+    // Real heading + a refresh icon button carrying an aria-label, over a
+    // decorative skeleton (no semantic content) — axe passes clean.
+    a11y: { test: 'error' },
+  },
   decorators: [
     Story => (
       <div className="max-w-[680px] p-4">
@@ -18,4 +38,19 @@ export default meta;
 
 type Story = StoryObj<typeof DownloadsSection>;
 
-export const Default: Story = {};
+/** Browser/checking state: header chrome renders, the skeleton holds the body. */
+export const Checking: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Downloads' })).toBeInTheDocument();
+
+    // The refresh control is labelled; it's disabled while tool status is unknown.
+    const refresh = canvas.getByRole('button', { name: 'Refresh tool status' });
+    await expect(refresh).toBeInTheDocument();
+    await expect(refresh).toBeDisabled();
+
+    // While checking, the populated yt-dlp path / version rows are not yet shown.
+    await expect(canvas.queryByText('Binary path')).not.toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/settings/downloads/InstallProgressBar/InstallProgressBar.stories.tsx
+++ b/apps/web/src/components/settings/downloads/InstallProgressBar/InstallProgressBar.stories.tsx
@@ -1,26 +1,68 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import InstallProgressBar from './InstallProgressBar';
 
-const meta = {
+/**
+ * settings/downloads · InstallProgressBar. The determinate progress indicator
+ * shown while a download tool (yt-dlp / ffmpeg) installs: a `role="progressbar"`
+ * with `aria-valuenow` over a caption, wrapped in a `role="status"`
+ * `aria-live="polite"` region so the caption is announced as it updates. Purely
+ * presentational and prop-driven (`percent`, `caption`). Stories assert the
+ * reported value and the live-region caption.
+ *
+ * a11y stays at `'todo'`: the underlying `ProgressBar` primitive only sets an
+ * accessible name when given an `aria-label`, and this component doesn't pass
+ * one — so axe's `aria-progressbar-name` rule flags the unnamed progressbar.
+ * Adding the name lives in the shared ui ProgressBar / this component's source,
+ * both outside this story's scope, so the deferral is intentional.
+ */
+const meta: Meta<typeof InstallProgressBar> = {
   title: 'settings/downloads/InstallProgressBar',
   component: InstallProgressBar,
-} satisfies Meta<typeof InstallProgressBar>;
+  decorators: [
+    Story => (
+      <div className="w-[28rem] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof InstallProgressBar>;
 
+/** Mid-install: the progressbar reports 42% inside the polite live region. */
 export const Default: Story = {
   args: {
     percent: 42,
     caption: 'Downloading yt-dlp... 42%',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const status = canvas.getByRole('status');
+    await expect(status).toHaveAttribute('aria-live', 'polite');
+
+    const bar = canvas.getByRole('progressbar');
+    await expect(bar).toHaveAttribute('aria-valuenow', '42');
+    await expect(bar).toHaveAttribute('aria-valuemin', '0');
+    await expect(bar).toHaveAttribute('aria-valuemax', '100');
+
+    await expect(canvas.getByText('Downloading yt-dlp... 42%')).toBeInTheDocument();
+  },
 };
 
+/** Completed install: the progressbar pins to its max value. */
 export const Complete: Story = {
   args: {
     percent: 100,
     caption: 'Installing... 100%',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+    await expect(canvas.getByText('Installing... 100%')).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/settings/downloads/ToolStatusRow/ToolStatusRow.stories.tsx
+++ b/apps/web/src/components/settings/downloads/ToolStatusRow/ToolStatusRow.stories.tsx
@@ -1,16 +1,36 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import ToolStatusRow from './ToolStatusRow';
 
-const meta = {
+/**
+ * settings/downloads · ToolStatusRow. A single tool's install status line: a
+ * decorative state glyph (check when installed, download when missing), the
+ * matching title, and a trailing status word — "Up to date" or "Update
+ * available" when installed, or optional content (e.g. "recommended") when not.
+ * Purely prop-driven; stories assert the branch text that renders.
+ */
+const meta: Meta<typeof ToolStatusRow> = {
   title: 'settings/downloads/ToolStatusRow',
   component: ToolStatusRow,
-} satisfies Meta<typeof ToolStatusRow>;
+  parameters: {
+    // Plain status text with decorative lucide glyphs — axe passes clean.
+    a11y: { test: 'error' },
+  },
+  decorators: [
+    Story => (
+      <div className="w-[28rem] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof ToolStatusRow>;
 
+/** Installed and current: the installed title plus an "Up to date" status. */
 export const Default: Story = {
   args: {
     installed: true,
@@ -18,8 +38,14 @@ export const Default: Story = {
     notInstalledTitle: 'yt-dlp not installed',
     updateAvailable: false,
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('yt-dlp installed')).toBeInTheDocument();
+    await expect(canvas.getByText('Up to date')).toBeInTheDocument();
+  },
 };
 
+/** Installed with a newer release: the "Update available" status shows instead. */
 export const UpdateAvailable: Story = {
   args: {
     installed: true,
@@ -27,14 +53,26 @@ export const UpdateAvailable: Story = {
     notInstalledTitle: 'yt-dlp not installed',
     updateAvailable: true,
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('yt-dlp installed')).toBeInTheDocument();
+    await expect(canvas.getByText('Update available')).toBeInTheDocument();
+    await expect(canvas.queryByText('Up to date')).not.toBeInTheDocument();
+  },
 };
 
+/** Not installed: the missing title plus the trailing "recommended" hint. */
 export const NotInstalled: Story = {
   args: {
     installed: false,
     installedTitle: 'ffmpeg installed',
     notInstalledTitle: 'ffmpeg not installed',
     updateAvailable: false,
-    notInstalledRight: 'Recommended',
+    notInstalledRight: 'recommended',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('ffmpeg not installed')).toBeInTheDocument();
+    await expect(canvas.getByText('recommended')).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/settings/downloads/ToolVersionBlock/ToolVersionBlock.stories.tsx
+++ b/apps/web/src/components/settings/downloads/ToolVersionBlock/ToolVersionBlock.stories.tsx
@@ -1,26 +1,60 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 
 import ToolVersionBlock from './ToolVersionBlock';
 
-const meta = {
+/**
+ * settings/downloads · ToolVersionBlock. A two-row version readout for a
+ * download tool: an "Installed version" row always renders, and a "Latest
+ * release" row appears only when a latest version is known. Purely
+ * presentational and prop-driven (`installedVersion`, `latestVersion`). Stories
+ * assert which rows render for each input.
+ */
+const meta: Meta<typeof ToolVersionBlock> = {
   title: 'settings/downloads/ToolVersionBlock',
   component: ToolVersionBlock,
-} satisfies Meta<typeof ToolVersionBlock>;
+  parameters: {
+    // Two labelled text rows, no interactive or media content — axe clean.
+    a11y: { test: 'error' },
+  },
+  decorators: [
+    Story => (
+      <div className="w-[28rem] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof ToolVersionBlock>;
 
+/** Both versions known: installed and latest-release rows render. */
 export const Default: Story = {
   args: {
     installedVersion: 'v2024.03.10',
     latestVersion: 'v2024.04.01',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Installed version')).toBeInTheDocument();
+    await expect(canvas.getByText('v2024.03.10')).toBeInTheDocument();
+    await expect(canvas.getByText('Latest release')).toBeInTheDocument();
+    await expect(canvas.getByText('v2024.04.01')).toBeInTheDocument();
+  },
 };
 
+/** Latest unknown: only the installed-version row renders. */
 export const NoLatest: Story = {
   args: {
     installedVersion: 'v2024.03.10',
     latestVersion: null,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Installed version')).toBeInTheDocument();
+    await expect(canvas.getByText('v2024.03.10')).toBeInTheDocument();
+    await expect(canvas.queryByText('Latest release')).not.toBeInTheDocument();
   },
 };


### PR DESCRIPTION
## Summary
- Completes the per-feature Storybook strengthening rollout (after #291/#296/#299/#300) by converting the **remaining ~104 render-only stories into real-browser tests** across `library`, `playlists`, `history`, `overview`, `player` (controls + 12 canvas visualizers), and `settings` (47 components incl. `settings/downloads`). Test-only — **no production/`ui` source changed**.
- Every story now follows the house shape: `play` functions asserting accessible **roles + names** (not test-ids), real `userEvent` + `fn()` spies, portalled UI queried via `screen`, async `findBy*` for timer/async content, and stores/query-clients seeded on entry.
- **a11y ratcheted to `error`** wherever axe is clean; deferred to the global `todo` default **with an explanatory meta comment** for the genuinely-unauditable surfaces — decorative/timer-gated brand layers, low-contrast dev previews, unnamed-thumb Radix sliders whose fix lives in component source (out of scope), and `IS_ELECTRON`-gated sections whose loaded state is unreachable in the browser run (the mock installs `window.electronAPI` *after* `platform.ts` freezes `IS_ELECTRON = false`, so those stories assert the real gated-out contract).

## Test plan
- [ ] CI **Storybook Tests** job is green
- [ ] `pnpm --filter @shiranami/web test:storybook` passes locally — **139 files / 290 tests** (verified)
- [ ] `pnpm --filter @shiranami/web typecheck` clean (verified)
- [ ] Spot-check autodocs render for a few of the new components in Storybook