### PR TITLE
feat(web): brand Storybook + Docs Overview + static deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Keep the Docker build context lean — these are reinstalled/regenerated inside
+# the image and only bloat the build context (and bust layer caching) if shipped.
+**/node_modules
+**/dist
+**/storybook-static

--- a/Dockerfile.storybook
+++ b/Dockerfile.storybook
@@ -15,13 +15,14 @@ RUN pnpm install --frozen-lockfile --filter @shiranami/web...
 FROM base AS build
 # Storybook builds a large bundle (every story + the docs pages); give Node room.
 ENV NODE_OPTIONS=--max-old-space-size=4096
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
-COPY --from=deps /app/packages/contracts/node_modules ./packages/contracts/node_modules
-COPY --from=deps /app/packages/shared/node_modules ./packages/shared/node_modules
+# Bring the whole installed workspace from deps — the root package.json,
+# pnpm-lock.yaml and pnpm-workspace.yaml included — so `pnpm --filter` can
+# resolve the workspace; node_modules (incl. the package symlinks) come along.
+COPY --from=deps /app ./
 # vite.config resolves @shiranami/contracts and @shiranami/shared to their `src`
 # (see apps/web/vite.config.ts aliases), so the source is enough — no package
-# build step. Copy the rarely-changing packages first for better layer caching.
+# build step. Overlay the real source over the package.json stubs from deps;
+# copy the rarely-changing packages first for better layer caching.
 COPY tsconfig.base.json ./
 COPY packages/contracts/ packages/contracts/
 COPY packages/shared/ packages/shared/
@@ -37,4 +38,9 @@ COPY --from=build /app/apps/web/storybook-static /app
 # serve drops its index fallback, so the root would otherwise show a dir listing.
 COPY apps/web/.storybook/serve.json /app/serve.json
 EXPOSE 3000
+# Drop to the image's built-in unprivileged user — the static server needs no root.
+USER node
+# Let Coolify/Traefik (and any orchestrator) detect a wedged server.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -q -O- http://localhost:3000/index.html || exit 1
 CMD ["serve", "/app", "-l", "3000"]

--- a/Dockerfile.storybook
+++ b/Dockerfile.storybook
@@ -1,0 +1,40 @@
+FROM node:22-alpine AS base
+RUN corepack enable && corepack prepare pnpm@10.9.0 --activate
+WORKDIR /app
+
+# Install dependencies — only @shiranami/web and the workspace packages it
+# depends on (`...` pulls in @shiranami/contracts + @shiranami/shared).
+FROM base AS deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/web/package.json apps/web/
+COPY packages/contracts/package.json packages/contracts/
+COPY packages/shared/package.json packages/shared/
+RUN pnpm install --frozen-lockfile --filter @shiranami/web...
+
+# Build the static Storybook
+FROM base AS build
+# Storybook builds a large bundle (every story + the docs pages); give Node room.
+ENV NODE_OPTIONS=--max-old-space-size=4096
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
+COPY --from=deps /app/packages/contracts/node_modules ./packages/contracts/node_modules
+COPY --from=deps /app/packages/shared/node_modules ./packages/shared/node_modules
+# vite.config resolves @shiranami/contracts and @shiranami/shared to their `src`
+# (see apps/web/vite.config.ts aliases), so the source is enough — no package
+# build step. Copy the rarely-changing packages first for better layer caching.
+COPY tsconfig.base.json ./
+COPY packages/contracts/ packages/contracts/
+COPY packages/shared/ packages/shared/
+COPY apps/web/ apps/web/
+RUN pnpm --filter @shiranami/web run build-storybook
+
+# Serve the static output — Coolify/Traefik handles TLS + routing
+FROM node:22-alpine AS production
+RUN npm install -g serve@14
+COPY --from=build /app/apps/web/storybook-static /app
+# serve reads /app/serve.json: long-cache hashed assets, serve iframe.html
+# directly (cleanUrls off), and rewrite / -> /index.html — with cleanUrls off,
+# serve drops its index fallback, so the root would otherwise show a dir listing.
+COPY apps/web/.storybook/serve.json /app/serve.json
+EXPOSE 3000
+CMD ["serve", "/app", "-l", "3000"]

--- a/apps/web/.storybook/decorators.tsx
+++ b/apps/web/.storybook/decorators.tsx
@@ -1,0 +1,72 @@
+import type { Decorator } from '@storybook/react-vite';
+
+/*
+ * NOTE — portal-to-body components (dialogs, alert-dialogs, modals, sheets) must
+ * render their Docs preview in an iframe so the `position: fixed` overlay (and an
+ * open Radix dialog's scroll-lock) stays inside the preview block instead of
+ * covering the whole Docs page. Set this DIRECTLY in the component's meta:
+ *
+ *   parameters: { docs: { story: { inline: false, iframeHeight: 620 } } }
+ *
+ * It must be an inline object literal, NOT a spread helper (`...fn()` / `...const`):
+ * Storybook statically parses the CSF `parameters` for docs render config and can't
+ * see through a spread, so `inline: false` is silently dropped (verified). Canvas
+ * rendering and play-function tests run in `story` viewMode, unaffected by this.
+ */
+
+/**
+ * Bounded height for the host in a Docs page vs. the standalone Canvas.
+ *
+ * In the Canvas view each story runs in its own iframe, so `100vh` resolves to
+ * the iframe's height — a real bound the view's inner `overflow-y-auto` can
+ * scroll against. On a Docs page the story renders *inline* (no iframe), so
+ * `100vh` would resolve to the whole browser viewport: the inner scroll viewport
+ * never gets a bounded parent and the docs preview just clips it (can't scroll).
+ * Inline docs therefore get a fixed, scrollable preview height instead.
+ */
+const hostHeight = (viewMode: string | undefined) =>
+  viewMode === 'docs' ? 'min(100vh, 600px)' : '100vh';
+
+/**
+ * Full-viewport-height flex host for `*View` stories. In the app these views
+ * render inside a height-constrained `flex-1` <main>; their own root is
+ * `flex-1 … overflow-hidden` with an inner `overflow-y-auto`, which only forms a
+ * scroll viewport when an ancestor bounds the height. Storybook's canvas does
+ * not, so the content clips and can't scroll — pair this decorator with
+ * `parameters.layout: 'fullscreen'` to restore the app's height context.
+ */
+export const withFullHeight: Decorator = (Story, context) => (
+  <div style={{ height: hostHeight(context.viewMode), display: 'flex', flexDirection: 'column' }}>
+    <Story />
+  </div>
+);
+
+/**
+ * Opaque app-shell surface host (full-height, like `withFullHeight`, plus the
+ * shell's themed surface). In the app, views render inside the shell's
+ * `bg-background text-foreground` <main>; isolated in Storybook a story has no
+ * such ancestor, so the app's translucent surfaces (`bg-card/40`, accent-tinted
+ * pills at `oklch .../0.10`, the Tiptap editor layer) and any color-inheriting
+ * text resolve against the bare canvas. axe's color-contrast resolver then walks
+ * past the translucent stack to the page root, assumes `#ffffff`, and reports
+ * false low-contrast failures. Restoring the opaque themed surface makes axe stop
+ * at the first opaque ancestor and measure contrast as it is in-app. Theme-aware
+ * via the `--background` / `--foreground` tokens (correct for dark and light).
+ *
+ * Inline styles, not Tailwind classes: this file lives in `.storybook/`, outside
+ * the `@source '../src/**'` scan, so `bg-background`/`text-foreground` utilities
+ * would never be generated for it (same reason `withFullHeight` is inline).
+ */
+export const withAppSurface: Decorator = (Story, context) => (
+  <div
+    style={{
+      height: hostHeight(context.viewMode),
+      display: 'flex',
+      flexDirection: 'column',
+      background: 'var(--background)',
+      color: 'var(--foreground)',
+    }}
+  >
+    <Story />
+  </div>
+);

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -5,8 +5,19 @@ import type { StorybookConfig } from '@storybook/react-vite';
 // plugin resolve without any explicit viteFinal merging here.
 const config: StorybookConfig = {
   framework: '@storybook/react-vite',
-  stories: ['../src/**/*.stories.@(ts|tsx)'],
-  addons: ['@storybook/addon-themes', '@storybook/addon-a11y', '@storybook/addon-vitest'],
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
+  addons: [
+    '@storybook/addon-docs',
+    '@storybook/addon-themes',
+    '@storybook/addon-a11y',
+    '@storybook/addon-vitest',
+  ],
+  core: { disableTelemetry: true },
+  // The brand logo is the square mascot; Storybook otherwise renders brandImage
+  // up to ~100px tall, which dominates the sidebar. Cap it to a
+  // sidebar-appropriate height (inline brand styles need !important to beat).
+  managerHead: head =>
+    `${head}<style>.sidebar-header img, img[alt='Shiranami'] { max-height: 40px !important; width: auto !important; }</style>`,
 };
 
 export default config;

--- a/apps/web/.storybook/manager.ts
+++ b/apps/web/.storybook/manager.ts
@@ -1,0 +1,5 @@
+import { addons } from 'storybook/manager-api';
+import { shiranamiTheme } from './shiranami-theme';
+
+// Brand the Storybook manager UI (sidebar, toolbar, logo) to match Shiranami.
+addons.setConfig({ theme: shiranamiTheme });

--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { I18nextProvider } from 'react-i18next';
@@ -9,10 +9,11 @@ import {
   PLAYLIST_ERROR_CODES,
   VALIDATION_ERROR_CODES,
 } from '@shiranami/contracts';
-import i18n, { initI18n } from '@/lib/i18n';
+import i18n, { initI18n, SUPPORTED_LANGUAGES } from '@/lib/i18n';
 import { useThemeStore, DEFAULT_THEME } from '@/stores/useThemeStore';
 import { useThemeBgStore } from '@/stores/useThemeBgStore';
 import type { ElectronAPI } from '@/types/electron';
+import { shiranamiTheme } from './shiranami-theme';
 import '@/styles/globals.css';
 
 // ---------------------------------------------------------------------------
@@ -81,11 +82,17 @@ void initI18n();
 
 // Each story render owns a fresh, throwaway QueryClient so cache and query state
 // never leak between stories. Queries never retry and never hit a backend, so
-// component stories render without the app's IPC-backed data layer.
-function StoryProviders({ children }: { children: ReactNode }) {
+// component stories render without the app's IPC-backed data layer. The active
+// locale is driven by the toolbar global so stories render the shipped
+// English/Polski copy rather than raw i18n keys.
+function StoryProviders({ locale, children }: { locale: string; children: ReactNode }) {
   const [queryClient] = useState(
     () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
   );
+
+  useEffect(() => {
+    void i18n.changeLanguage(locale);
+  }, [locale]);
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -94,8 +101,8 @@ function StoryProviders({ children }: { children: ReactNode }) {
   );
 }
 
-const withProviders: Decorator = Story => (
-  <StoryProviders>
+const withProviders: Decorator = (Story, context) => (
+  <StoryProviders locale={(context.globals.locale as string) ?? 'en'}>
     <Story />
   </StoryProviders>
 );
@@ -104,6 +111,17 @@ const preview: Preview = {
   // Generate a Docs page for every component from its args/argTypes + JSDoc.
   // Opt a component out with `tags: ['!autodocs']` on its meta.
   tags: ['autodocs'],
+  initialGlobals: { locale: 'en' },
+  globalTypes: {
+    locale: {
+      description: 'Language',
+      toolbar: {
+        icon: 'globe',
+        dynamicTitle: true,
+        items: SUPPORTED_LANGUAGES.map(l => ({ value: l.code, title: l.label })),
+      },
+    },
+  },
   // Storybook reuses ONE document across stories, and switching the app theme
   // writes `data-theme` onto <html> plus theme-background CSS vars — so a story
   // that picks a (dark photo) theme bleeds into later stories' axe runs, where
@@ -123,6 +141,19 @@ const preview: Preview = {
     }),
   ],
   parameters: {
+    // Brand the Docs pages with the same "Midnight Lofi Cafe" violet theme as the
+    // manager chrome (see .storybook/manager.ts) so autodocs match the dark app
+    // surface.
+    docs: {
+      theme: shiranamiTheme,
+    },
+    // Float the standalone MDX "Docs Overview" section to the top of the sidebar
+    // (so its Intro is the landing page); everything else stays alphabetical.
+    options: {
+      storySort: {
+        order: ['Docs Overview', ['Intro', 'Theming', 'Accessibility', 'Testing'], '*'],
+      },
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { I18nextProvider } from 'react-i18next';
@@ -83,16 +83,12 @@ void initI18n();
 // Each story render owns a fresh, throwaway QueryClient so cache and query state
 // never leak between stories. Queries never retry and never hit a backend, so
 // component stories render without the app's IPC-backed data layer. The active
-// locale is driven by the toolbar global so stories render the shipped
-// English/Polski copy rather than raw i18n keys.
-function StoryProviders({ locale, children }: { locale: string; children: ReactNode }) {
+// language is applied by the `locale` loader below (before the story mounts), so
+// stories render the shipped English/Polski copy from the first frame.
+function StoryProviders({ children }: { children: ReactNode }) {
   const [queryClient] = useState(
     () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
   );
-
-  useEffect(() => {
-    void i18n.changeLanguage(locale);
-  }, [locale]);
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -101,8 +97,8 @@ function StoryProviders({ locale, children }: { locale: string; children: ReactN
   );
 }
 
-const withProviders: Decorator = (Story, context) => (
-  <StoryProviders locale={(context.globals.locale as string) ?? 'en'}>
+const withProviders: Decorator = Story => (
+  <StoryProviders>
     <Story />
   </StoryProviders>
 );
@@ -111,6 +107,14 @@ const preview: Preview = {
   // Generate a Docs page for every component from its args/argTypes + JSDoc.
   // Opt a component out with `tags: ['!autodocs']` on its meta.
   tags: ['autodocs'],
+  // Apply the toolbar's language BEFORE the story renders (not in a useEffect),
+  // so the first frame is already localized — avoids a flash of the previous
+  // language and keeps the browser-mode story tests deterministic.
+  loaders: [
+    async context => {
+      await i18n.changeLanguage((context.globals.locale as string) ?? 'en');
+    },
+  ],
   initialGlobals: { locale: 'en' },
   globalTypes: {
     locale: {

--- a/apps/web/.storybook/serve.json
+++ b/apps/web/.storybook/serve.json
@@ -1,0 +1,16 @@
+{
+  "trailingSlash": false,
+  "cleanUrls": false,
+  "rewrites": [{ "source": "/", "destination": "/index.html" }],
+  "headers": [
+    {
+      "source": "assets/**",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/web/.storybook/shiranami-theme.ts
+++ b/apps/web/.storybook/shiranami-theme.ts
@@ -1,0 +1,62 @@
+import { create } from 'storybook/theming/create';
+
+/*
+ * Shiranami-branded Storybook theme — mirrors the app's default "Midnight Lofi
+ * Cafe" dark palette (src/styles/globals.css :root). The app's tokens are oklch;
+ * Storybook's theme API (emotion) takes plain color strings, so each value below
+ * is the sRGB-hex equivalent of its oklch source (noted inline). Shared by the
+ * manager chrome (manager.ts) and the Docs pages (preview.tsx →
+ * parameters.docs.theme) so the whole tool reads as Shiranami.
+ */
+
+// Brand accent — the app's canonical violet primary. The app ships it as the
+// sRGB triplet rgb(155,125,235) (--primary-rgb, ≈ oklch(0.72 0.12 280)); the
+// hover is a slightly deeper violet (≈ --brand-600 oklch(0.65 0.15 285)).
+const violet = '#9b7deb';
+const violetDeep = '#7e5bd6';
+
+// Midnight-violet surfaces / ink (oklch hue 280). The app's :root is very dark
+// (oklch L 0.06–0.12); these sRGB equivalents are lifted a touch so the
+// Storybook chrome reads as deep violet rather than pure black.
+const bg = '#0b0912'; // window background ≈ oklch(0.08 0.02 280)
+const surface = '#14121d'; // cards & chrome bars ≈ oklch(0.12 0.02 280)
+const ink = '#e6e7ef'; // primary text ≈ oklch(0.93 0.01 280)
+const inkMuted = '#9c9dab'; // secondary text ≈ oklch(0.70 0.02 280)
+const line = '#262130'; // borders — white/~12% over bg
+
+export const shiranamiTheme = create({
+  base: 'dark',
+
+  brandTitle: 'Shiranami',
+  // The mascot, served at the Storybook root from apps/web/public — by Vite's
+  // publicDir middleware in `storybook dev` and copied into the bundle by
+  // `storybook build`, so it resolves in both dev and the deployed static build.
+  brandImage: '/mascot.png',
+  brandTarget: '_self',
+
+  colorPrimary: violet,
+  colorSecondary: violet,
+
+  appBg: surface,
+  appContentBg: bg,
+  appPreviewBg: bg,
+  appBorderColor: line,
+  appBorderRadius: 12,
+
+  textColor: ink,
+  textInverseColor: bg,
+  textMutedColor: inkMuted,
+
+  barBg: surface,
+  barTextColor: inkMuted,
+  barSelectedColor: violet,
+  barHoverColor: violetDeep,
+
+  inputBg: bg,
+  inputBorder: line,
+  inputTextColor: ink,
+  inputBorderRadius: 8,
+
+  fontBase: "'DM Sans', system-ui, sans-serif",
+  fontCode: "'JetBrains Mono', ui-monospace, monospace",
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -57,6 +57,7 @@
     "@sentry/vite-plugin": "5.3.0",
     "@size-limit/file": "^12.1.0",
     "@storybook/addon-a11y": "^10.4.5",
+    "@storybook/addon-docs": "^10.4.5",
     "@storybook/addon-themes": "^10.4.5",
     "@storybook/addon-vitest": "^10.4.5",
     "@storybook/react-vite": "^10.4.5",

--- a/apps/web/src/stories/Accessibility.mdx
+++ b/apps/web/src/stories/Accessibility.mdx
@@ -1,0 +1,52 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs Overview/Accessibility" />
+
+# Accessibility
+
+Accessibility is checked automatically on every story. The
+`@storybook/addon-a11y` addon runs [axe](https://github.com/dequelabs/axe-core)
+against the rendered story — visible per story in the **Accessibility** tab — and
+the same scan runs headless as part of the Storybook test suite (see **Testing**).
+
+## The ratchet
+
+Enforcement is rolled out feature-by-feature rather than flipped on all at once:
+
+- **Default — `a11y.test: 'todo'`.** Violations surface as non-blocking warnings.
+  This keeps the suite green repo-wide while features are brought up to standard
+  one at a time. It's the global default set in `.storybook/preview.tsx`.
+- **Audited — `a11y.test: 'error'`.** Once a feature is clean, its stories set
+  `parameters.a11y.test = 'error'` at the meta level, which makes any new
+  violation **fail** the story test. This locks in the win — a regression can't
+  slip back.
+
+So the bar only ever moves forward: a component that's been audited stays
+audited, and unaudited ones still get a visible report without blocking everyone.
+
+## Decorative elements
+
+Shiranami keeps purely decorative art out of the accessibility tree at the
+element level rather than excluding it with a global axe selector. Two patterns
+are used:
+
+- **`aria-hidden` glyphs and icons** — Lucide status glyphs, the arrow in the
+  enrich before/after preview, and similar decoration are marked `aria-hidden`
+  (or rendered as `alt=""` images), so assistive tech skips them and they carry
+  no role for axe to flag.
+- **CSS generated content** — the faint onboarding kanji watermark
+  (`OnboardingKanji`) is painted as `::before` generated content
+  (`content: attr(data-kanji)`) and additionally `aria-hidden`, so the glyph
+  never enters the accessibility tree at all. axe's color-contrast rule still
+  measures `aria-hidden` *text nodes*, so rendering the wash as CSS content
+  (not a text node) is what stops it from flagging the intentional 5%-alpha
+  wash as a contrast failure.
+
+For view stories whose translucent surfaces would otherwise resolve against the
+bare Storybook canvas, the `withAppSurface` decorator restores the opaque themed
+surface so axe measures contrast as it is in-app (see **Theming**).
+
+## Checking a component
+
+Open any story and select the **Accessibility** tab to see violations, passes,
+and incomplete checks, with the offending node highlighted in the canvas.

--- a/apps/web/src/stories/Intro.mdx
+++ b/apps/web/src/stories/Intro.mdx
@@ -1,0 +1,42 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs Overview/Intro" />
+
+# Shiranami Component Library
+
+This is the living component library for **Shiranami** — the lofi music player
+(desktop app + web renderer). Every UI piece the app ships is documented here in
+isolation: rendered, interactive, themeable, and tested. Use it to explore what
+exists before building something new, to check a component's props and states,
+and to verify behavior without booting the whole Electron app.
+
+## How to navigate
+
+- **Sidebar** — components are grouped by feature area (`player`, `library`,
+  `playlists`, `radio`, `search`, `history`, `now-playing`, `lyrics`, `mixes`,
+  `overview`, `settings`, `downloads`, `onboarding`, `smart-playlists`, `splash`,
+  `ui`, …). This **Docs Overview** section collects the cross-cutting guides.
+- **Docs page** — each component has an auto-generated Docs page: a description,
+  a live preview of every story, and a props table (derived from its TypeScript
+  types + JSDoc).
+- **Stories** — the named variants under each component (`Default`, `Empty`,
+  `Loading`, `Playing`, …). Each opens in the Canvas.
+- **Addon tabs** — under a story you get **Controls** (tweak props live),
+  **Actions** (logged callbacks), **Interactions** (the play-function steps),
+  and **Accessibility** (the axe report).
+
+## Toolbar
+
+- **Theme** — toggle the preview between **light** and **dark** mode. The app's
+  default surface is the **Midnight Lofi Cafe** dark palette (a violet hue-280
+  midnight), so dark is the realistic baseline for most stories.
+- **Language** — switch the UI copy between **English** and **Polski**; stories
+  render the real shipped translations, not raw i18n keys.
+
+## Quality bar
+
+There are **353 stories** across **177 story files** (covering 200+ components),
+and every story is a real in-browser test — it must render without error, its
+play-function interactions must pass, and axe runs an accessibility scan on it.
+See **Testing** and **Accessibility** for how that works, and **Theming** for the
+token system.

--- a/apps/web/src/stories/Testing.mdx
+++ b/apps/web/src/stories/Testing.mdx
@@ -1,0 +1,64 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs Overview/Testing" />
+
+# Testing & stories
+
+Stories aren't just documentation here — they're a test suite. The same story
+that documents a component also verifies it.
+
+## Two separate suites
+
+Shiranami runs two Vitest suites from two dedicated config files, kept apart so
+the fast unit run stays jsdom-only:
+
+- **Unit** (`vitest.config.ts`, the `web` project) — the fast jsdom + Testing
+  Library suite for behavior-level tests. Run with
+  `pnpm --filter @shiranami/web test`.
+- **Storybook** (`vitest.storybook.config.ts`) — every story executed as a
+  real-browser test through `@storybook/addon-vitest` + Playwright Chromium. Run
+  with `pnpm --filter @shiranami/web test:storybook`.
+
+The storybook suite is intentionally a **standalone config**, not a second
+project bolted onto `vitest.config.ts`, so the everyday `pnpm test` aggregate
+stays jsdom-fast and the slow browser run is opt-in.
+
+## What a story test covers
+
+For each of the **353 stories** across **177 story files**, the storybook suite:
+
+1. **Render smoke test** — mounts the story in a real browser; any render error
+   fails it.
+2. **Play function** — if the story defines a `play`, its interaction steps run
+   (`userEvent` clicks/typing + `expect` assertions), exactly as in the
+   **Interactions** tab.
+3. **Accessibility** — axe scans the rendered story; whether a violation blocks
+   depends on the feature's `a11y.test` level (see **Accessibility**).
+
+## Keeping the canvas and the test runner in sync
+
+`.storybook/vitest.setup.ts` calls `setProjectAnnotations([preview])`, so the
+browser run applies the preview's decorators, parameters, theme, i18n, and —
+crucially — its global `beforeEach` theme/background reset. Without that explicit
+wiring, addon-vitest does not reliably run the preview-level `beforeEach` in the
+browser, and a story that switches the app theme would bleed `data-theme` into
+later stories' axe runs (dark background under light-mode foreground tokens →
+intermittent color-contrast flakes depending on file order).
+
+The storybook config also pre-bundles the story-test runtime deps
+(`optimizeDeps.include: ['@storybook/react-vite', 'storybook/test']`) so a cold
+CI run never discovers them mid-suite and loses the Vitest runner, and it widens
+`server.fs.allow` to the monorepo root so browser mode can fetch the hoisted,
+pnpm-virtual-store deps and the addon's injected setup file.
+
+## Writing a good story
+
+- Seed state directly (props, or a `beforeEach` that sets a Zustand store) —
+  stories never reach the backend (a recursive `window.electronAPI` mock answers
+  every IPC call with a resolved no-op, and each story gets a throwaway
+  `QueryClient`).
+- Add a `play` for anything interactive; assert the user-visible outcome.
+- Give the component meta a clear JSDoc description — it becomes the Docs page
+  intro and the props-table context.
+- Once the component passes axe cleanly, set `parameters.a11y.test = 'error'` to
+  lock it in.

--- a/apps/web/src/stories/Theming.mdx
+++ b/apps/web/src/stories/Theming.mdx
@@ -1,0 +1,64 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs Overview/Theming" />
+
+# Theming & tokens
+
+Shiranami is fully themeable, and Storybook renders every story under the real
+token system so what you see here matches the app.
+
+## The token system
+
+The palette is expressed as **oklch** CSS custom properties on `:root` in
+`src/styles/globals.css`. A component never hard-codes a color — it references a
+token (`bg-background`, `text-foreground`, `border-border`, `bg-primary`, …) that
+resolves against the active palette.
+
+The default **Midnight Lofi Cafe** palette (the app's `:root`) is a violet-tinted
+midnight at hue 280:
+
+- `--background: oklch(0.08 0.02 280)` — the deep midnight window surface
+- `--foreground: oklch(0.93 0.01 280)` — near-white text
+- `--primary: oklch(0.72 0.12 280)` — the signature violet accent
+  (also exposed as the sRGB triplet `--primary-rgb: 155, 125, 235` for the
+  `<canvas>` visualizers and inline glows that read a raw triplet)
+
+Working in oklch means lightness, chroma, and hue are independent, so derived
+tokens (hover states, glows) are computed with `oklch(from …)` rather than
+hand-picked.
+
+## Image themes
+
+On top of the default palette, the app ships four **image themes** selected via a
+`[data-theme=…]` attribute on `<html>` — each pairs a backdrop photo with its own
+accent, redefining only the tokens that change and inheriting everything else
+from `:root`:
+
+- **snow** — cool blue twilight
+- **summer** — bright lake daytime, cyan-blue accent
+- **sunset** — warm orange
+- **wisteria** — purple/pink spring dusk
+
+The default state is **"none"** (rendered from `:root` only, byte-identical to the
+base Midnight Lofi Cafe palette); "Lofi Night" is that same palette presented as a
+backdrop photo, accent unchanged. The backdrop image is applied at runtime by
+`ThemeBackground` (an inline document-relative `url()`), not as a CSS token.
+
+## How the Storybook theme toolbar works
+
+The **Theme** toolbar uses `withThemeByClassName` (from `@storybook/addon-themes`)
+and toggles only **light** ↔ **dark** — `dark` adds the bare `dark` class that
+Tailwind's `dark:` variant keys off; `light` clears it. The toolbar does **not**
+switch image themes; to exercise an image theme, a story seeds the app's theme
+store directly. The preview's global `beforeEach` resets the theme + background to
+their defaults before every story so each renders on a clean, deterministic
+baseline (preventing cross-story theme bleed into axe's color-contrast scan).
+
+## A note on story surfaces
+
+View-level stories can wrap in a `withAppSurface` decorator (from
+`.storybook/decorators.tsx`) that paints the opaque `--background` /
+`--foreground` surface. In the app these views sit inside the themed shell;
+isolated in Storybook they'd resolve translucent surfaces (`bg-card/40`,
+accent-tinted pills) against a bare canvas, which makes axe report false
+low-contrast failures. The decorator restores the in-app contrast context.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
       '@storybook/addon-a11y':
         specifier: ^10.4.5
         version: 10.4.5(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-docs':
+        specifier: ^10.4.5
+        version: 10.4.5(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.0)(rollup@4.60.2)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))(webpack@5.106.0(esbuild@0.28.0))
       '@storybook/addon-themes':
         specifier: ^10.4.5
         version: 10.4.5(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
@@ -3718,6 +3721,15 @@ packages:
       }
     engines: { node: '>= 10.0.0' }
 
+  '@mdx-js/react@3.1.1':
+    resolution:
+      {
+        integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==,
+      }
+    peerDependencies:
+      '@types/react': '>=16'
+      react: ^19.2.6
+
   '@microsoft/tsdoc@0.16.0':
     resolution:
       {
@@ -6199,6 +6211,18 @@ packages:
     peerDependencies:
       storybook: ^10.4.5
 
+  '@storybook/addon-docs@10.4.5':
+    resolution:
+      {
+        integrity: sha512-9mIV0maIxixfuvdpNhr3QMeU/gbJKeaBcWhPYuf176cqDZAG9EUhZ50TIinxeFRbyEGRJqaLPoiYwIu4GJu3jA==,
+      }
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.5
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@storybook/addon-themes@10.4.5':
     resolution:
       {
@@ -6855,6 +6879,12 @@ packages:
     resolution:
       {
         integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==,
+      }
+
+  '@types/mdx@2.0.14':
+    resolution:
+      {
+        integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==,
       }
 
   '@types/micromatch@4.0.10':
@@ -20465,6 +20495,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@mdx-js/react@3.1.1(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@types/mdx': 2.0.14
+      '@types/react': 19.2.15
+      react: 19.2.6
+
   '@microsoft/tsdoc@0.16.0': {}
 
   '@napi-rs/nice-android-arm-eabi@1.1.1':
@@ -22125,6 +22161,25 @@ snapshots:
       axe-core: 4.12.1
       storybook: 10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
+  '@storybook/addon-docs@10.4.5(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.0)(rollup@4.60.2)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))(webpack@5.106.0(esbuild@0.28.0))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@storybook/csf-plugin': 10.4.5(esbuild@0.28.0)(rollup@4.60.2)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))(webpack@5.106.0(esbuild@0.28.0))
+      '@storybook/icons': 2.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@storybook/react-dom-shim': 10.4.5(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      storybook: 10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      ts-dedent: 2.3.0
+    optionalDependencies:
+      '@types/react': 19.2.15
+    transitivePeerDependencies:
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+
   '@storybook/addon-themes@10.4.5(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       storybook: 10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -22544,6 +22599,8 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdx@2.0.14': {}
 
   '@types/micromatch@4.0.10':
     dependencies:


### PR DESCRIPTION
## Summary

Brings shiranami's Storybook up to parity with shiroani's — the testing pipeline already matched, so this adds the **branding**, **docs**, and **deployment** pieces that were never in scope of the original testing initiative.

- **Branded chrome** — a dark `shiranami-theme.ts` mirroring the Midnight Lofi Cafe violet palette (accent `#9b7deb`), shared by the manager UI (`manager.ts`) and the autodocs pages (`parameters.docs.theme`). The app mascot (`public/mascot.png`) is the brand logo, capped to a sidebar-appropriate height via `managerHead`.
- **Autodocs** — adds `@storybook/addon-docs` + the `*.mdx` glob, plus four standalone **Docs Overview** guides (Intro / Theming / Accessibility / Testing) grounded in shiranami's real setup. `storySort` floats them to the top so Intro is the landing page.
- **EN/PL language toolbar** — a globe toolbar global drives `i18n.changeLanguage`, so stories render the shipped English/Polski copy instead of raw keys.
- **Decorators** — `withFullHeight` / `withAppSurface` for full-screen `*View` stories (opaque themed surface so axe measures real contrast), with the portal-dialog `inline: false` gotcha documented.
- **Static deploy** — `Dockerfile.storybook` (multi-stage `build-storybook` → `serve@14` on :3000) + `serve.json`, matching how the landing/server images deploy via Coolify/Traefik. `.dockerignore` keeps the build context lean.

Mirrors shiroani commits `9e36c97f`, `e1f041c9`, `3836a6a4`, `dcb29dfe`, `0044e9dd`, `4a6e710e`, `4691a5ea`. Skipped on purpose: a `preview.css` (globals are already imported and there's no body-overflow lock to fight), a CI `build-storybook` job (shiroani builds only in Docker too), and a `.gitignore` entry (already present).

## Test plan

- [x] `pnpm install` — picks up `@storybook/addon-docs@^10.4.5`
- [x] `pnpm --filter @shiranami/web typecheck` — clean
- [x] `pnpm --filter @shiranami/web build-storybook` — succeeds; `storybook-static/` contains `mascot.png`, `index.html`, and the four `docs-overview-*--docs` pages
- [x] `pnpm --filter @shiranami/web lint` — clean
- [ ] Docker image build (`docker build -f Dockerfile.storybook .`) — not run locally (no daemon); validate on the Coolify side before wiring the subdomain