### PR TITLE
feat(desktop): surface a native dialog when bootstrap fails

### DIFF
--- a/apps/desktop/src/main/app/boot-failure.test.ts
+++ b/apps/desktop/src/main/app/boot-failure.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const mockExit = vi.fn();
+const mockShowMessageBox = vi.fn();
+const mockOpenPath = vi.fn();
+
+vi.mock('electron', () => ({
+  app: {
+    exit: (...args: unknown[]) => mockExit(...args),
+  },
+  dialog: {
+    showMessageBox: (...args: unknown[]) => mockShowMessageBox(...args),
+  },
+  shell: {
+    openPath: (...args: unknown[]) => mockOpenPath(...args),
+  },
+}));
+
+const mockFlushLogs = vi.fn();
+const mockGetLogsDir = vi.fn(() => 'C:\\logs');
+vi.mock('./logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  flushLogs: (...args: unknown[]) => mockFlushLogs(...args),
+  getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
+}));
+
+const mockCaptureException = vi.fn();
+const mockSentryFlush = vi.fn();
+vi.mock('@sentry/electron/main', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  flush: (...args: unknown[]) => mockSentryFlush(...args),
+}));
+
+const { reportBootFailure } = await import('./boot-failure');
+
+describe('reportBootFailure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFlushLogs.mockResolvedValue(undefined);
+    mockSentryFlush.mockResolvedValue(true);
+    mockOpenPath.mockResolvedValue('');
+    mockShowMessageBox.mockResolvedValue({ response: 1 }); // default: Quit
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('captures the error to Sentry and exits with code 1', async () => {
+    const err = new Error('Database schema version 8 is newer than this app supports (7).');
+    await reportBootFailure(err);
+
+    expect(mockCaptureException).toHaveBeenCalledWith(err);
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('flushes logs AND Sentry before exiting so nothing is lost on a fast crash', async () => {
+    const order: string[] = [];
+    mockFlushLogs.mockImplementation(() => {
+      order.push('flushLogs');
+      return Promise.resolve();
+    });
+    mockSentryFlush.mockImplementation(() => {
+      order.push('sentryFlush');
+      return Promise.resolve(true);
+    });
+    mockExit.mockImplementation(() => {
+      order.push('exit');
+    });
+
+    await reportBootFailure(new Error('boom'));
+
+    expect(order.indexOf('flushLogs')).toBeLessThan(order.indexOf('exit'));
+    expect(order.indexOf('sentryFlush')).toBeLessThan(order.indexOf('exit'));
+  });
+
+  it('surfaces a native dialog with an Open Logs Folder affordance', async () => {
+    await reportBootFailure(new Error('boom'));
+
+    expect(mockShowMessageBox).toHaveBeenCalledTimes(1);
+    const opts = mockShowMessageBox.mock.calls[0][0] as Electron.MessageBoxOptions;
+    expect(opts.type).toBe('error');
+    expect(opts.buttons).toEqual(['Open Logs Folder', 'Quit']);
+    expect(opts.detail).toContain('boom');
+  });
+
+  it('opens the logs folder when the user picks that button', async () => {
+    mockShowMessageBox.mockResolvedValue({ response: 0 }); // Open Logs Folder
+    await reportBootFailure(new Error('boom'));
+
+    expect(mockOpenPath).toHaveBeenCalledWith('C:\\logs');
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('does NOT open the logs folder when the user picks Quit', async () => {
+    mockShowMessageBox.mockResolvedValue({ response: 1 });
+    await reportBootFailure(new Error('boom'));
+
+    expect(mockOpenPath).not.toHaveBeenCalled();
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('still exits when the dialog itself throws', async () => {
+    mockShowMessageBox.mockRejectedValue(new Error('no display'));
+    await reportBootFailure(new Error('boom'));
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('coerces non-Error throwables into the dialog detail', async () => {
+    await reportBootFailure('plain string failure');
+
+    const opts = mockShowMessageBox.mock.calls[0][0] as Electron.MessageBoxOptions;
+    expect(opts.detail).toContain('plain string failure');
+  });
+});
+
+describe('reportBootFailure under E2E', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFlushLogs.mockResolvedValue(undefined);
+    mockSentryFlush.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('skips the modal and fails fast when SHIRANAMI_E2E=1', async () => {
+    vi.stubEnv('SHIRANAMI_E2E', '1');
+    vi.resetModules();
+    const { reportBootFailure: e2eReport } = await import('./boot-failure');
+
+    await e2eReport(new Error('boom'));
+
+    expect(mockShowMessageBox).not.toHaveBeenCalled();
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/desktop/src/main/app/boot-failure.ts
+++ b/apps/desktop/src/main/app/boot-failure.ts
@@ -1,0 +1,70 @@
+import { app, dialog, shell } from 'electron';
+import * as Sentry from '@sentry/electron/main';
+import { logger, flushLogs, getLogsDir } from './logger';
+
+// Mirrors the E2E hatch in index.ts: under @playwright/test we must never raise
+// a modal dialog (it would block the test harness with no way to dismiss it).
+// We fail fast with a non-zero exit instead so the spec observes the dead app.
+const isE2E = process.env.SHIRANAMI_E2E === '1';
+
+/** Index of the "Open Logs Folder" button in the failure dialog. */
+const OPEN_LOGS_BUTTON = 0;
+
+/**
+ * Last-resort handler for a bootstrap failure that happens BEFORE the main
+ * window exists (e.g. the schema-downgrade guard in runMigrations throwing).
+ *
+ * Without this the process is a zombie: bootstrap rejected, no window was ever
+ * created, and on Windows there is no `window-all-closed` event to quit on, so
+ * the app stays alive, invisible, and the only trace is a log file the user has
+ * to hunt for manually. This surfaces a native error dialog (which, unlike a
+ * BrowserWindow, works with no renderer) with an affordance to open the logs
+ * folder, then exits with a non-zero code.
+ *
+ * Ordering is deliberate: the logger buffers entries and only flushes on an
+ * interval, so we `flushLogs()` (and `Sentry.flush()`) BEFORE exit — otherwise
+ * the error line could still be in-buffer and the "Open Logs Folder" button
+ * would open an empty folder.
+ */
+export async function reportBootFailure(error: unknown): Promise<void> {
+  logger.error('Failed to bootstrap application:', error);
+  Sentry.captureException(error);
+
+  // Persist the error to disk and best-effort flush it to Sentry before we
+  // exit — both are buffered and would otherwise be lost on a fast exit.
+  await flushLogs().catch(() => {});
+  await Sentry.flush(2000).catch(() => {});
+
+  const detail =
+    `Shiranami ran into a problem while opening your library and had to stop.\n\n` +
+    `${error instanceof Error ? error.message : String(error)}\n\n` +
+    `Technical details have been saved to the logs folder.`;
+
+  // E2E: skip the modal (it would hang the harness) and fail fast.
+  if (isE2E) {
+    app.exit(1);
+    return;
+  }
+
+  try {
+    const { response } = await dialog.showMessageBox({
+      type: 'error',
+      title: 'Shiranami could not start',
+      message: 'Shiranami could not start',
+      detail,
+      buttons: ['Open Logs Folder', 'Quit'],
+      defaultId: OPEN_LOGS_BUTTON,
+      cancelId: 1,
+      noLink: true,
+    });
+
+    if (response === OPEN_LOGS_BUTTON) {
+      await shell.openPath(getLogsDir()).catch(() => {});
+    }
+  } catch (dialogError) {
+    // A dialog failure must not strand the zombie process — fall through to exit.
+    logger.error('Failed to show boot-failure dialog:', dialogError);
+  }
+
+  app.exit(1);
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import { app, BrowserWindow, protocol } from 'electron';
 import * as Sentry from '@sentry/electron/main';
 import { initSentryMain, watchTelemetryConsent } from './app/sentry';
+import { reportBootFailure } from './app/boot-failure';
 import { createMainWindow } from './app/window';
 import { cleanupIpcHandlers } from './ipc/register';
 import { initializeAutoUpdater } from './app/updater';
@@ -232,13 +233,7 @@ for (const signal of ['SIGINT', 'SIGTERM'] as const) {
   });
 }
 
-app
-  .whenReady()
-  .then(bootstrap)
-  .catch(error => {
-    logger.error('Failed to bootstrap application:', error);
-    Sentry.captureException(error);
-  });
+app.whenReady().then(bootstrap).catch(reportBootFailure);
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {


### PR DESCRIPTION
## Summary
- Add `reportBootFailure` (`apps/desktop/src/main/app/boot-failure.ts`) so a pre-window bootstrap failure — e.g. the schema-downgrade guard in `runMigrations` throwing "Database schema version N is newer than this app supports" — shows a native error dialog with an "Open Logs Folder" button, instead of dying silently with only a log file and leaving an invisible zombie process (on Windows there is no `window-all-closed` event to quit on when no window was ever created).
- Flush the log buffer and Sentry to disk/network *before* exiting (the error line could otherwise be lost in the buffer, making "Open Logs Folder" useless), then exit with code 1. E2E runs skip the modal and fail fast so they don't hang on a dialog.
- Reduce the bootstrap catch in `index.ts` to delegate to the helper; add 8 unit tests covering flush-before-exit ordering, the Open Logs Folder affordance, the dialog-throw fallback, non-Error coercion, and the E2E path.

## Test plan
- [ ] Stamp a throwaway `shiranami.db` with `PRAGMA user_version = 9`, launch with `--user-data-dir=<that dir>`, and confirm the "Shiranami could not start" dialog appears with the schema-version detail.
- [ ] Click "Open Logs Folder" → the logs folder opens and contains the bootstrap error line.
- [ ] Click Quit (or Esc) → the app exits cleanly (code 1), no window, no lingering process.
- [ ] `pnpm --filter @shiranami/desktop test` passes (864 tests, incl. 8 new boot-failure specs).