### PR TITLE
feat(lyrics): support local files and embedded tags before LRCLIB

### DIFF
--- a/apps/desktop/src/main/app/store.ts
+++ b/apps/desktop/src/main/app/store.ts
@@ -60,6 +60,11 @@ export interface StoreSchema {
   'system.minimizeToTray': boolean;
   'system.closeToTray': boolean;
 
+  // Renderer-writable (settings UI); read by lyrics-service.ts when resolving
+  // lyric sources. When true, LRCLIB synced lyrics outrank local plain-text
+  // files. Default implicit `undefined` → false (local-first).
+  'lyrics.preferSyncedFromLrclib': boolean;
+
   // Main-only (downloader.ts).
   'downloads.location': string;
   'downloads.toolStatusCache': ToolStatusCache;

--- a/apps/desktop/src/main/ipc/lyrics.ts
+++ b/apps/desktop/src/main/ipc/lyrics.ts
@@ -14,9 +14,10 @@ export function registerLyricsHandlers(): void {
       title: string,
       artist: string,
       album?: string,
-      duration?: number
+      duration?: number,
+      filePath?: string
     ): Promise<LyricsResult> => {
-      return fetchLyrics(title, artist, album, duration);
+      return fetchLyrics(title, artist, album, duration, filePath);
     },
     { schema: lyricsFetchArgs }
   );

--- a/apps/desktop/src/main/ipc/schemas/lyrics.ts
+++ b/apps/desktop/src/main/ipc/schemas/lyrics.ts
@@ -5,4 +5,5 @@ export const lyricsFetchArgs = z.tuple([
   z.string().min(1),
   z.string().optional(),
   z.number().optional(),
+  z.string().min(1).optional(),
 ]);

--- a/apps/desktop/src/main/ipc/schemas/store.ts
+++ b/apps/desktop/src/main/ipc/schemas/store.ts
@@ -27,6 +27,7 @@ const RENDERER_STORE_KEYS = [
   'system.launchAtStartup',
   'system.minimizeToTray',
   'system.closeToTray',
+  'lyrics.preferSyncedFromLrclib',
 ] as const;
 
 // Compile-time guarantee: every entry is a StoreSchema key.

--- a/apps/desktop/src/main/ipc/waveform.ts
+++ b/apps/desktop/src/main/ipc/waveform.ts
@@ -6,6 +6,7 @@ import { IPC_CHANNELS, WAVEFORM_PEAK_COUNT } from '@shiranami/contracts';
 import { handle } from './with-ipc-handler';
 import { logger } from '../app/logger';
 import { hashTrackKey, readCachedPeaks, writeCachedPeaks } from '../shared/waveform-cache';
+import { coalesce } from '../utils/coalesce';
 import { decodeWaveformPeaks, shutdownWaveformWorker } from '../workers/waveform-host';
 import { waveformGetPeaksArgs } from './schemas/waveform';
 
@@ -57,20 +58,14 @@ export function registerWaveformHandlers(): void {
       const cached = await readCachedPeaks(getPeaksDir(), hash);
       if (cached) return { peaks: cached };
 
-      const existing = inFlight.get(hash);
-      if (existing) return existing;
-
-      const job = (async (): Promise<WaveformPeaksResult | null> => {
+      return coalesce(inFlight, hash, async (): Promise<WaveformPeaksResult | null> => {
         const peaks = await decodeWaveformPeaks(filePath, WAVEFORM_PEAK_COUNT);
         if (!peaks) return null; // unsupported format or decode failure
         await writeCachedPeaks(getPeaksDir(), hash, peaks).catch(err =>
           logger.warn('[waveform] cache write failed:', err)
         );
         return { peaks };
-      })().finally(() => inFlight.delete(hash));
-
-      inFlight.set(hash, job);
-      return job;
+      });
     },
     { schema: waveformGetPeaksArgs }
   );

--- a/apps/desktop/src/main/preload/api/lyrics.ts
+++ b/apps/desktop/src/main/preload/api/lyrics.ts
@@ -1,5 +1,5 @@
 import { invoke } from '../context-bridge';
-import { IPC_CHANNELS } from '@shiranami/contracts';
+import { IPC_CHANNELS, type LyricsResult } from '@shiranami/contracts';
 
 const C = IPC_CHANNELS.lyrics;
 
@@ -8,14 +8,12 @@ export interface LyricsApi {
     title: string,
     artist: string,
     album?: string,
-    duration?: number
-  ) => Promise<{
-    synced: Array<{ time: number; text: string }> | null;
-    plain: string | null;
-    source: 'lrclib' | 'cache' | null;
-  }>;
+    duration?: number,
+    filePath?: string
+  ) => Promise<LyricsResult>;
 }
 
 export const lyricsApi: LyricsApi = {
-  fetch: (title, artist, album, duration) => invoke(C.fetch, title, artist, album, duration),
+  fetch: (title, artist, album, duration, filePath) =>
+    invoke(C.fetch, title, artist, album, duration, filePath),
 };

--- a/apps/desktop/src/main/services/embedded-lyrics.test.ts
+++ b/apps/desktop/src/main/services/embedded-lyrics.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readEmbeddedLyrics } from './embedded-lyrics';
+
+// music-metadata is lazily imported inside embedded-lyrics; mock at the
+// import specifier to return controlled fixtures (metadata-service pattern).
+const parseFileMock = vi.fn();
+vi.mock('music-metadata', () => ({
+  parseFile: (...args: unknown[]) => parseFileMock(...args),
+}));
+
+const warnMock = vi.fn();
+vi.mock('../app/logger', () => ({
+  logger: {
+    warn: (...args: unknown[]) => warnMock(...args),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('readEmbeddedLyrics', () => {
+  beforeEach(() => {
+    parseFileMock.mockReset();
+    warnMock.mockReset();
+  });
+
+  it('returns synced lyrics from syncText (ms → s conversion)', async () => {
+    parseFileMock.mockResolvedValueOnce({
+      common: {
+        lyrics: [
+          {
+            syncText: [
+              { timestamp: 1000, text: 'first' },
+              { timestamp: 2500, text: 'second' },
+              { timestamp: 5000, text: 'third' },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = await readEmbeddedLyrics('/fake/track.mp3');
+    expect(result).toEqual({
+      synced: [
+        { time: 1, text: 'first' },
+        { time: 2.5, text: 'second' },
+        { time: 5, text: 'third' },
+      ],
+      plain: null,
+      source: 'embedded',
+    });
+  });
+
+  it('sorts syncText entries by time', async () => {
+    parseFileMock.mockResolvedValueOnce({
+      common: {
+        lyrics: [
+          {
+            syncText: [
+              { timestamp: 5000, text: 'c' },
+              { timestamp: 1000, text: 'a' },
+              { timestamp: 3000, text: 'b' },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = await readEmbeddedLyrics('/fake/track.mp3');
+    expect(result?.synced?.map(l => l.text)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('parses a raw LRC string in the text field into synced lines', async () => {
+    const lrc = '[00:01.00]line one\n[00:02.50]line two\n[00:05.00]line three';
+    parseFileMock.mockResolvedValueOnce({
+      common: { lyrics: [{ text: lrc }] },
+    });
+
+    const result = await readEmbeddedLyrics('/fake/track.mp3');
+    expect(result?.source).toBe('embedded');
+    expect(result?.plain).toBeNull();
+    expect(result?.synced).toEqual([
+      { time: 1, text: 'line one' },
+      { time: 2.5, text: 'line two' },
+      { time: 5, text: 'line three' },
+    ]);
+  });
+
+  it('returns plain for text without timestamps', async () => {
+    parseFileMock.mockResolvedValueOnce({
+      common: { lyrics: [{ text: 'just some lyrics\nanother line' }] },
+    });
+
+    const result = await readEmbeddedLyrics('/fake/track.mp3');
+    expect(result).toEqual({
+      synced: null,
+      plain: 'just some lyrics\nanother line',
+      source: 'embedded',
+    });
+  });
+
+  it('falls back to plain when LRC-looking text has no parseable lines', async () => {
+    // Has a timestamp-shaped prefix but no text after any timestamp.
+    const text = '[00:01.  broken markup that never parses';
+    parseFileMock.mockResolvedValueOnce({
+      common: { lyrics: [{ text }] },
+    });
+
+    const result = await readEmbeddedLyrics('/fake/track.mp3');
+    expect(result).toEqual({ synced: null, plain: text, source: 'embedded' });
+  });
+
+  it('prefers a syncText entry over a plain text entry when both exist', async () => {
+    parseFileMock.mockResolvedValueOnce({
+      common: {
+        lyrics: [
+          { text: 'some plain lyrics with lots of text that would otherwise win' },
+          { syncText: [{ timestamp: 1000, text: 'synced line' }] },
+        ],
+      },
+    });
+
+    const result = await readEmbeddedLyrics('/fake/track.mp3');
+    expect(result?.synced).toEqual([{ time: 1, text: 'synced line' }]);
+    expect(result?.plain).toBeNull();
+  });
+
+  it('picks the longest text entry when several exist', async () => {
+    parseFileMock.mockResolvedValueOnce({
+      common: { lyrics: [{ text: 'short' }, { text: 'a much longer set of lyrics' }] },
+    });
+
+    const result = await readEmbeddedLyrics('/fake/track.mp3');
+    expect(result?.plain).toBe('a much longer set of lyrics');
+  });
+
+  it('returns null when common.lyrics is undefined', async () => {
+    parseFileMock.mockResolvedValueOnce({ common: {} });
+    expect(await readEmbeddedLyrics('/fake/track.mp3')).toBeNull();
+  });
+
+  it('returns null when common.lyrics is an empty array', async () => {
+    parseFileMock.mockResolvedValueOnce({ common: { lyrics: [] } });
+    expect(await readEmbeddedLyrics('/fake/track.mp3')).toBeNull();
+  });
+
+  it('logs a warning and returns null when parseFile throws', async () => {
+    parseFileMock.mockRejectedValueOnce(new Error('boom'));
+    expect(await readEmbeddedLyrics('/fake/bad.mp3')).toBeNull();
+    expect(warnMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/main/services/embedded-lyrics.ts
+++ b/apps/desktop/src/main/services/embedded-lyrics.ts
@@ -1,0 +1,93 @@
+import { logger } from '../app/logger';
+import { getMusicMetadata } from '../shared/music-metadata';
+import { parseLrc, type LyricLine, type LyricsResult } from './lyrics-parse';
+
+export type EmbeddedLyricsResult = Omit<LyricsResult, 'source'> & {
+  source: 'embedded';
+};
+
+// Minimal local shape for a lyrics tag entry. music-metadata's runtime shape
+// varies by format/version, so we only type what we read and treat fields as
+// optional.
+interface SyncTextEntry {
+  timestamp?: number;
+  text?: string;
+}
+
+interface LyricsTagEntry {
+  syncText?: SyncTextEntry[];
+  text?: string;
+  descriptor?: string;
+  language?: string;
+}
+
+const LRC_TIMESTAMP_RE = /\[\d{2}:\d{2}[.:]/;
+
+function looksLikeLrc(text: string): boolean {
+  return LRC_TIMESTAMP_RE.test(text);
+}
+
+/**
+ * Read lyrics embedded in an audio file's metadata tags (ID3 USLT/SYLT,
+ * Vorbis LYRICS, MP4 ©lyr). Returns null when the file has no embedded
+ * lyrics or when parsing fails.
+ */
+export async function readEmbeddedLyrics(
+  audioFilePath: string
+): Promise<EmbeddedLyricsResult | null> {
+  const mm = await getMusicMetadata();
+
+  let metadata: Awaited<ReturnType<typeof mm.parseFile>>;
+  try {
+    metadata = await mm.parseFile(audioFilePath, { skipCovers: true, duration: false });
+  } catch (error) {
+    logger.warn(`[embedded-lyrics] Failed to parse file: ${audioFilePath}`, error);
+    return null;
+  }
+
+  const raw = (metadata.common as { lyrics?: unknown }).lyrics;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    logger.debug(`[embedded-lyrics] No lyrics tag in: ${audioFilePath}`);
+    return null;
+  }
+
+  const entries = raw as LyricsTagEntry[];
+
+  // Prefer an entry with a non-empty syncText array (SYLT frames).
+  const syncEntry = entries.find(e => Array.isArray(e?.syncText) && e.syncText.length > 0);
+
+  if (syncEntry?.syncText) {
+    const lines: LyricLine[] = [];
+    for (const s of syncEntry.syncText) {
+      if (typeof s?.timestamp === 'number' && typeof s?.text === 'string') {
+        lines.push({ time: s.timestamp / 1000, text: s.text });
+      }
+    }
+    if (lines.length > 0) {
+      lines.sort((a, b) => a.time - b.time);
+      return { synced: lines, plain: null, source: 'embedded' };
+    }
+  }
+
+  // Otherwise, fall back to text entries (USLT / Vorbis LYRICS / ©lyr).
+  // If multiple, pick the longest.
+  const textEntry = entries
+    .filter(e => typeof e?.text === 'string' && e.text.length > 0)
+    .sort((a, b) => (b.text?.length ?? 0) - (a.text?.length ?? 0))[0];
+
+  if (!textEntry?.text) {
+    return null;
+  }
+
+  const text = textEntry.text;
+
+  // Some taggers store raw LRC inside the unsynchronized-lyrics frame.
+  if (looksLikeLrc(text)) {
+    const lines = parseLrc(text);
+    if (lines.length > 0) {
+      return { synced: lines, plain: null, source: 'embedded' };
+    }
+  }
+
+  return { synced: null, plain: text, source: 'embedded' };
+}

--- a/apps/desktop/src/main/services/embedded-lyrics.ts
+++ b/apps/desktop/src/main/services/embedded-lyrics.ts
@@ -21,7 +21,7 @@ interface LyricsTagEntry {
   language?: string;
 }
 
-const LRC_TIMESTAMP_RE = /\[\d{2}:\d{2}[.:]/;
+const LRC_TIMESTAMP_RE = /\[\d{1,2}:\d{2}[.:]/;
 
 function looksLikeLrc(text: string): boolean {
   return LRC_TIMESTAMP_RE.test(text);

--- a/apps/desktop/src/main/services/local-lyrics.test.ts
+++ b/apps/desktop/src/main/services/local-lyrics.test.ts
@@ -80,6 +80,18 @@ describe('loadLocalLyrics', () => {
     expect(result).toEqual({ synced: null, plain: content, source: 'local-lrc' });
   });
 
+  it('prefers a .txt over a timestampless .lrc', async () => {
+    writeFileSync(path.join(dir, 'Song.lrc'), 'Just plain text\nNo timestamps here');
+    writeFileSync(path.join(dir, 'Song.txt'), 'Proper plain lyrics');
+
+    const result = await loadLocalLyrics(audioPath);
+    expect(result).toEqual({
+      synced: null,
+      plain: 'Proper plain lyrics',
+      source: 'local-txt',
+    });
+  });
+
   it('finds lyrics in a Lyrics/ subfolder', async () => {
     mkdirSync(path.join(dir, 'Lyrics'));
     writeFileSync(path.join(dir, 'Lyrics', 'Song.lrc'), '[00:05.00]From subfolder');

--- a/apps/desktop/src/main/services/local-lyrics.test.ts
+++ b/apps/desktop/src/main/services/local-lyrics.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync } from 'fs';
+import * as path from 'path';
+import { makeTempDir, cleanupTempDir } from '../../../test/setup';
+import { loadLocalLyrics, stripLyricsHeader } from './local-lyrics';
+
+describe('stripLyricsHeader', () => {
+  it('strips a simple key/value header with blank separator', () => {
+    const input = 'Artist: Gary Moore\nTitle: Still Got The Blues\n\nWoke up this morning';
+    expect(stripLyricsHeader(input)).toBe('Woke up this morning');
+  });
+
+  it('returns original when nothing looks like a header', () => {
+    const input = 'Just some lyrics\nSecond line';
+    expect(stripLyricsHeader(input)).toBe(input);
+  });
+
+  it('returns original if the whole file is header-shaped', () => {
+    const input = 'Title: X\nArtist: Y';
+    expect(stripLyricsHeader(input)).toBe(input);
+  });
+
+  it('does not strip [Chorus] section markers', () => {
+    const input = '[Chorus]\nSing a song';
+    expect(stripLyricsHeader(input)).toBe(input);
+  });
+
+  it('does not strip duet-style "He:"/"She:" dialogue lines', () => {
+    const input = 'He: Hello there\nShe: Hi\nTogether now';
+    expect(stripLyricsHeader(input)).toBe(input);
+  });
+});
+
+describe('loadLocalLyrics', () => {
+  let dir: string;
+  let audioPath: string;
+
+  beforeEach(() => {
+    dir = makeTempDir();
+    audioPath = path.join(dir, 'Song.mp3');
+  });
+
+  afterEach(() => {
+    cleanupTempDir(dir);
+  });
+
+  it('loads a sibling .lrc as synced lyrics', async () => {
+    writeFileSync(path.join(dir, 'Song.lrc'), '[00:01.00]One\n[00:02.00]Two\n[00:03.00]Three');
+
+    const result = await loadLocalLyrics(audioPath);
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('local-lrc');
+    expect(result!.plain).toBeNull();
+    expect(result!.synced).toEqual([
+      { time: 1, text: 'One' },
+      { time: 2, text: 'Two' },
+      { time: 3, text: 'Three' },
+    ]);
+  });
+
+  it('loads a sibling .txt with BOM, CRLF, and header stripped', async () => {
+    writeFileSync(
+      path.join(dir, 'Song.txt'),
+      '﻿Artist: Test Artist\r\n\r\nFirst line\r\nSecond line'
+    );
+
+    const result = await loadLocalLyrics(audioPath);
+    expect(result).toEqual({
+      synced: null,
+      plain: 'First line\nSecond line',
+      source: 'local-txt',
+    });
+  });
+
+  it('falls back to plain when a .lrc has no timestamps', async () => {
+    const content = 'Just plain text\nNo timestamps here';
+    writeFileSync(path.join(dir, 'Song.lrc'), content);
+
+    const result = await loadLocalLyrics(audioPath);
+    expect(result).toEqual({ synced: null, plain: content, source: 'local-lrc' });
+  });
+
+  it('finds lyrics in a Lyrics/ subfolder', async () => {
+    mkdirSync(path.join(dir, 'Lyrics'));
+    writeFileSync(path.join(dir, 'Lyrics', 'Song.lrc'), '[00:05.00]From subfolder');
+
+    const result = await loadLocalLyrics(audioPath);
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('local-lrc');
+    expect(result!.synced).toEqual([{ time: 5, text: 'From subfolder' }]);
+  });
+
+  it('finds a .txt in a lowercase lyrics/ subfolder', async () => {
+    mkdirSync(path.join(dir, 'lyrics'));
+    writeFileSync(path.join(dir, 'lyrics', 'Song.txt'), 'Plain from subfolder');
+
+    const result = await loadLocalLyrics(audioPath);
+    expect(result).toEqual({
+      synced: null,
+      plain: 'Plain from subfolder',
+      source: 'local-txt',
+    });
+  });
+
+  it('prefers a sibling .lrc over a sibling .txt', async () => {
+    writeFileSync(path.join(dir, 'Song.lrc'), '[00:01.00]From lrc');
+    writeFileSync(path.join(dir, 'Song.txt'), 'From txt');
+
+    const result = await loadLocalLyrics(audioPath);
+    expect(result!.source).toBe('local-lrc');
+    expect(result!.synced).toEqual([{ time: 1, text: 'From lrc' }]);
+  });
+
+  it('ignores lyric files whose basename does not match the track', async () => {
+    writeFileSync(path.join(dir, 'Other.lrc'), '[00:01.00]Wrong song');
+
+    expect(await loadLocalLyrics(audioPath)).toBeNull();
+  });
+
+  it('returns null when no lyrics file exists', async () => {
+    expect(await loadLocalLyrics(audioPath)).toBeNull();
+  });
+
+  it('returns a header-only .txt unchanged rather than empty', async () => {
+    const content = 'Title: X\nArtist: Y';
+    writeFileSync(path.join(dir, 'Song.txt'), content);
+
+    const result = await loadLocalLyrics(audioPath);
+    expect(result).toEqual({ synced: null, plain: content, source: 'local-txt' });
+  });
+});

--- a/apps/desktop/src/main/services/local-lyrics.ts
+++ b/apps/desktop/src/main/services/local-lyrics.ts
@@ -71,6 +71,10 @@ function buildCandidatePaths(audioFilePath: string): string[] {
  */
 export async function loadLocalLyrics(audioFilePath: string): Promise<LocalLyricsResult | null> {
   const candidates = buildCandidatePaths(audioFilePath);
+  // Raw content of the first timestampless .lrc we hit, kept as a last resort
+  // so a later candidate (a synced .lrc or a .txt) can still win.
+  let lrcPlainFallback: string | null = null;
+
   for (const candidate of candidates) {
     let raw: string;
     try {
@@ -94,14 +98,24 @@ export async function loadLocalLyrics(audioFilePath: string): Promise<LocalLyric
         logger.debug(`[local-lyrics] Loaded synced lyrics: ${candidate}`);
         return { synced, plain: null, source: 'local-lrc' };
       }
-      // Fallback: show raw text so something is visible
-      logger.debug(`[local-lyrics] .lrc had no timestamps, using plain fallback: ${candidate}`);
-      return { synced: null, plain: content, source: 'local-lrc' };
+      // No timestamps: remember the raw text as a last resort, but keep
+      // looking — another candidate may have proper timestamps or be a .txt.
+      if (lrcPlainFallback === null) {
+        logger.debug(`[local-lyrics] .lrc had no timestamps, keeping as fallback: ${candidate}`);
+        lrcPlainFallback = content;
+      }
+      continue;
     }
 
     const stripped = stripLyricsHeader(content);
     logger.debug(`[local-lyrics] Loaded plain lyrics: ${candidate}`);
     return { synced: null, plain: stripped, source: 'local-txt' };
+  }
+
+  if (lrcPlainFallback !== null) {
+    // Nothing better turned up; show the timestampless .lrc as plain text.
+    logger.debug('[local-lyrics] Using timestampless .lrc as plain fallback');
+    return { synced: null, plain: lrcPlainFallback, source: 'local-lrc' };
   }
 
   logger.debug('[local-lyrics] No lyric file found, checked:', candidates);

--- a/apps/desktop/src/main/services/local-lyrics.ts
+++ b/apps/desktop/src/main/services/local-lyrics.ts
@@ -1,0 +1,109 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { logger } from '../app/logger';
+import { parseLrc, stripBom, normalizeNewlines, type LyricsResult } from './lyrics-parse';
+
+export type LocalLyricsResult = Omit<LyricsResult, 'source'> & {
+  source: 'local-lrc' | 'local-txt';
+};
+
+// Whitelist of known metadata keys so we don't strip dialogue/duet lines
+// like "He: Hello" or "She: Hi" that often appear at the top of lyrics.
+const HEADER_LINE_RE =
+  /^(Artist|Title|Album|Author|Lyrics|By|Offset|Composer|Year|Writer|Track):\s*(.+)$/i;
+
+// A "Key: value" line longer than this is body content, not metadata.
+const MAX_HEADER_LINE_LENGTH = 120;
+
+/**
+ * Strip a leading "Key: Value" header block from plain text lyrics.
+ * Stops at the first blank line or first non-Key:Value line.
+ * If the whole file looks like header, returns the original content.
+ */
+export function stripLyricsHeader(content: string): string {
+  const lines = content.split('\n');
+  let i = 0;
+  let consumed = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.length >= MAX_HEADER_LINE_LENGTH) break;
+    if (!HEADER_LINE_RE.test(line)) break;
+    consumed++;
+    i++;
+  }
+
+  if (consumed === 0) return content;
+
+  // If we consumed everything (no body), return original
+  const hasBodyAhead = lines.slice(i).some(l => l.trim().length > 0);
+  if (!hasBodyAhead) return content;
+
+  // Skip one blank separator line after the header block
+  if (i < lines.length && lines[i].trim() === '') {
+    i++;
+  }
+
+  return lines.slice(i).join('\n').replace(/\s+$/, '');
+}
+
+/**
+ * Candidate lyric-file locations for an audio file, in precedence order:
+ * sibling .lrc, .lrc inside a Lyrics/ (or lyrics/) subfolder, then the same
+ * three locations for .txt. Filenames must match the audio file's basename.
+ */
+function buildCandidatePaths(audioFilePath: string): string[] {
+  const dir = path.dirname(audioFilePath);
+  const base = path.parse(audioFilePath).name;
+  return [
+    path.join(dir, `${base}.lrc`),
+    path.join(dir, 'Lyrics', `${base}.lrc`),
+    path.join(dir, 'lyrics', `${base}.lrc`),
+    path.join(dir, `${base}.txt`),
+    path.join(dir, 'Lyrics', `${base}.txt`),
+    path.join(dir, 'lyrics', `${base}.txt`),
+  ];
+}
+
+/**
+ * Look for a .lrc or .txt lyrics file next to the given audio file (or in a
+ * Lyrics/ subfolder). Returns null if none of the candidate paths exist.
+ */
+export async function loadLocalLyrics(audioFilePath: string): Promise<LocalLyricsResult | null> {
+  const candidates = buildCandidatePaths(audioFilePath);
+  for (const candidate of candidates) {
+    let raw: string;
+    try {
+      raw = await fs.readFile(candidate, 'utf-8');
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+        // The file exists but couldn't be read (EACCES, EISDIR, …) — exactly
+        // the "my lyrics file isn't detected" support case, so log loudly.
+        logger.warn(`[local-lyrics] Failed to read ${candidate}`, error);
+      }
+      continue;
+    }
+
+    const content = normalizeNewlines(stripBom(raw));
+    const ext = path.extname(candidate).toLowerCase();
+
+    if (ext === '.lrc') {
+      const synced = parseLrc(content);
+      if (synced.length >= 1) {
+        logger.debug(`[local-lyrics] Loaded synced lyrics: ${candidate}`);
+        return { synced, plain: null, source: 'local-lrc' };
+      }
+      // Fallback: show raw text so something is visible
+      logger.debug(`[local-lyrics] .lrc had no timestamps, using plain fallback: ${candidate}`);
+      return { synced: null, plain: content, source: 'local-lrc' };
+    }
+
+    const stripped = stripLyricsHeader(content);
+    logger.debug(`[local-lyrics] Loaded plain lyrics: ${candidate}`);
+    return { synced: null, plain: stripped, source: 'local-txt' };
+  }
+
+  logger.debug('[local-lyrics] No lyric file found, checked:', candidates);
+  return null;
+}

--- a/apps/desktop/src/main/services/lyrics-parse.ts
+++ b/apps/desktop/src/main/services/lyrics-parse.ts
@@ -1,0 +1,48 @@
+import type { LyricLine, LyricsResult } from '@shiranami/contracts';
+
+export type { LyricLine, LyricsResult, LyricsSource } from '@shiranami/contracts';
+
+/**
+ * Parse LRC format string into array of timed lyric lines.
+ * Format: [mm:ss.xx]Lyric text
+ */
+export function parseLrc(lrc: string): LyricLine[] {
+  const lines: LyricLine[] = [];
+  const regex = /\[(\d{2}):(\d{2})\.(\d{2,3})\]\s*(.*)/;
+
+  for (const rawLine of lrc.split('\n')) {
+    const match = rawLine.match(regex);
+    if (match) {
+      const minutes = parseInt(match[1], 10);
+      const seconds = parseInt(match[2], 10);
+      const ms = match[3].length === 2 ? parseInt(match[3], 10) * 10 : parseInt(match[3], 10);
+      const time = minutes * 60 + seconds + ms / 1000;
+      const text = match[4].trim();
+      if (text) {
+        lines.push({ time, text });
+      }
+    }
+  }
+
+  return lines.sort((a, b) => a.time - b.time);
+}
+
+export function stripBom(content: string): string {
+  return content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
+}
+
+export function normalizeNewlines(content: string): string {
+  return content.replace(/\r\n?/g, '\n');
+}
+
+export function hasSyncedLyrics(
+  result: LyricsResult | null
+): result is LyricsResult & { synced: LyricLine[] } {
+  return !!result && Array.isArray(result.synced) && result.synced.length > 0;
+}
+
+export function hasPlainLyrics(
+  result: LyricsResult | null
+): result is LyricsResult & { plain: string } {
+  return !!result && typeof result.plain === 'string' && result.plain.length > 0;
+}

--- a/apps/desktop/src/main/services/lyrics-parse.ts
+++ b/apps/desktop/src/main/services/lyrics-parse.ts
@@ -10,8 +10,8 @@ export type { LyricLine, LyricsResult, LyricsSource } from '@shiranami/contracts
  */
 export function parseLrc(lrc: string): LyricLine[] {
   const lines: LyricLine[] = [];
-  const lineRegex = /^\s*((?:\[\d{2}:\d{2}[.:]\d{2,3}\])+)\s*(.*)/;
-  const timestampRegex = /\[(\d{2}):(\d{2})[.:](\d{2,3})\]/g;
+  const lineRegex = /^\s*((?:\[\d{1,2}:\d{2}[.:]\d{2,3}\])+)\s*(.*)/;
+  const timestampRegex = /\[(\d{1,2}):(\d{2})[.:](\d{2,3})\]/g;
 
   for (const rawLine of lrc.split('\n')) {
     const match = rawLine.match(lineRegex);

--- a/apps/desktop/src/main/services/lyrics-parse.ts
+++ b/apps/desktop/src/main/services/lyrics-parse.ts
@@ -5,22 +5,25 @@ export type { LyricLine, LyricsResult, LyricsSource } from '@shiranami/contracts
 /**
  * Parse LRC format string into array of timed lyric lines.
  * Format: [mm:ss.xx]Lyric text
+ * A line may carry multiple timestamps ([mm:ss.xx][mm:ss.xx]Text) for
+ * repeated lyrics, and the millisecond separator may be `.` or `:`.
  */
 export function parseLrc(lrc: string): LyricLine[] {
   const lines: LyricLine[] = [];
-  const regex = /\[(\d{2}):(\d{2})\.(\d{2,3})\]\s*(.*)/;
+  const lineRegex = /^\s*((?:\[\d{2}:\d{2}[.:]\d{2,3}\])+)\s*(.*)/;
+  const timestampRegex = /\[(\d{2}):(\d{2})[.:](\d{2,3})\]/g;
 
   for (const rawLine of lrc.split('\n')) {
-    const match = rawLine.match(regex);
-    if (match) {
-      const minutes = parseInt(match[1], 10);
-      const seconds = parseInt(match[2], 10);
-      const ms = match[3].length === 2 ? parseInt(match[3], 10) * 10 : parseInt(match[3], 10);
+    const match = rawLine.match(lineRegex);
+    if (!match) continue;
+    const text = match[2].trim();
+    if (!text) continue;
+    for (const stamp of match[1].matchAll(timestampRegex)) {
+      const minutes = parseInt(stamp[1], 10);
+      const seconds = parseInt(stamp[2], 10);
+      const ms = stamp[3].length === 2 ? parseInt(stamp[3], 10) * 10 : parseInt(stamp[3], 10);
       const time = minutes * 60 + seconds + ms / 1000;
-      const text = match[4].trim();
-      if (text) {
-        lines.push({ time, text });
-      }
+      lines.push({ time, text });
     }
   }
 

--- a/apps/desktop/src/main/services/lyrics-service.test.ts
+++ b/apps/desktop/src/main/services/lyrics-service.test.ts
@@ -75,6 +75,21 @@ describe('parseLrc', () => {
     const result = parseLrc(lrc);
     expect(result).toEqual([{ time: 120, text: 'Has text' }]);
   });
+
+  it('emits one entry per timestamp on multi-timestamp lines, sorted by time', () => {
+    const lrc = '[02:03.04][01:02.03]Repeated line';
+    const result = parseLrc(lrc);
+    expect(result).toEqual([
+      { time: 62.03, text: 'Repeated line' },
+      { time: 123.04, text: 'Repeated line' },
+    ]);
+  });
+
+  it('accepts a colon as the millisecond separator', () => {
+    const lrc = '[00:05:12]Colon separator';
+    const result = parseLrc(lrc);
+    expect(result).toEqual([{ time: 5.12, text: 'Colon separator' }]);
+  });
 });
 
 describe('buildSearchQueries', () => {

--- a/apps/desktop/src/main/services/lyrics-service.test.ts
+++ b/apps/desktop/src/main/services/lyrics-service.test.ts
@@ -90,6 +90,12 @@ describe('parseLrc', () => {
     const result = parseLrc(lrc);
     expect(result).toEqual([{ time: 5.12, text: 'Colon separator' }]);
   });
+
+  it('accepts single-digit minutes', () => {
+    const lrc = '[1:30.00]Single digit';
+    const result = parseLrc(lrc);
+    expect(result).toEqual([{ time: 90, text: 'Single digit' }]);
+  });
 });
 
 describe('buildSearchQueries', () => {

--- a/apps/desktop/src/main/services/lyrics-service.test.ts
+++ b/apps/desktop/src/main/services/lyrics-service.test.ts
@@ -1,5 +1,42 @@
-import { describe, it, expect } from 'vitest';
-import { parseLrc, buildSearchQueries } from './lyrics-service';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { parseLrc, buildSearchQueries, fetchLyrics, type LyricsResult } from './lyrics-service';
+
+const loadLocalLyricsMock = vi.fn();
+vi.mock('./local-lyrics', () => ({
+  loadLocalLyrics: (...args: unknown[]) => loadLocalLyricsMock(...args),
+}));
+
+const readEmbeddedLyricsMock = vi.fn();
+vi.mock('./embedded-lyrics', () => ({
+  readEmbeddedLyrics: (...args: unknown[]) => readEmbeddedLyricsMock(...args),
+}));
+
+const storeGetMock = vi.fn();
+vi.mock('../app/store', () => ({
+  store: { get: (...args: unknown[]) => storeGetMock(...args) },
+}));
+
+const isPathAllowedMock = vi.fn();
+vi.mock('../shared/folders-cache', () => ({
+  isPathAllowed: (...args: unknown[]) => isPathAllowedMock(...args),
+}));
+
+const findLyricsMock = vi.fn();
+const searchLyricsMock = vi.fn();
+vi.mock('lrclib-api', () => ({
+  Client: class {
+    findLyrics = (...args: unknown[]) => findLyricsMock(...args);
+    searchLyrics = (...args: unknown[]) => searchLyricsMock(...args);
+  },
+}));
+
+vi.mock('../app/http', () => ({
+  getLrclibGate: () => ({ run: <T>(fn: () => Promise<T>) => fn() }),
+}));
+
+vi.mock('../app/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
 
 describe('parseLrc', () => {
   it('parses standard [mm:ss.xx] lines', () => {
@@ -68,5 +105,229 @@ describe('buildSearchQueries', () => {
     const queries = buildSearchQueries('Artist \u2013 Song', 'Other');
     expect(queries).toContain('Artist Song');
     expect(queries).toContain('Song Artist');
+  });
+});
+
+describe('fetchLyrics precedence', () => {
+  const LOCAL_SYNCED: LyricsResult = {
+    synced: [{ time: 1, text: 'local synced' }],
+    plain: null,
+    source: 'local-lrc',
+  };
+  const LOCAL_PLAIN: LyricsResult = { synced: null, plain: 'local plain', source: 'local-txt' };
+  const EMBEDDED_SYNCED: LyricsResult = {
+    synced: [{ time: 2, text: 'embedded synced' }],
+    plain: null,
+    source: 'embedded',
+  };
+  const EMBEDDED_PLAIN: LyricsResult = {
+    synced: null,
+    plain: 'embedded plain',
+    source: 'embedded',
+  };
+
+  // Module-level LRU persists across tests \u2014 every test uses a unique
+  // title/artist pair so no test reads another's cached network result.
+  let n = 0;
+  function track(): { title: string; artist: string; filePath: string } {
+    n += 1;
+    return { title: `Song ${n}`, artist: `Artist ${n}`, filePath: `/music/song-${n}.mp3` };
+  }
+
+  beforeEach(() => {
+    loadLocalLyricsMock.mockReset().mockResolvedValue(null);
+    readEmbeddedLyricsMock.mockReset().mockResolvedValue(null);
+    findLyricsMock.mockReset().mockResolvedValue(null);
+    searchLyricsMock.mockReset().mockResolvedValue([]);
+    storeGetMock.mockReset().mockReturnValue(undefined); // preferSynced OFF (default)
+    isPathAllowedMock.mockReset().mockResolvedValue(true); // path inside the library
+  });
+
+  it('local synced wins and skips embedded parse + network entirely', async () => {
+    const { title, artist, filePath } = track();
+    loadLocalLyricsMock.mockResolvedValue(LOCAL_SYNCED);
+
+    const result = await fetchLyrics(title, artist, undefined, undefined, filePath);
+
+    expect(result).toEqual(LOCAL_SYNCED);
+    expect(readEmbeddedLyricsMock).not.toHaveBeenCalled();
+    expect(findLyricsMock).not.toHaveBeenCalled();
+    expect(searchLyricsMock).not.toHaveBeenCalled();
+  });
+
+  it('embedded synced beats everything but a local synced file, without network', async () => {
+    const { title, artist, filePath } = track();
+    loadLocalLyricsMock.mockResolvedValue(LOCAL_PLAIN);
+    readEmbeddedLyricsMock.mockResolvedValue(EMBEDDED_SYNCED);
+
+    const result = await fetchLyrics(title, artist, undefined, undefined, filePath);
+
+    expect(result).toEqual(EMBEDDED_SYNCED);
+    expect(findLyricsMock).not.toHaveBeenCalled();
+  });
+
+  it('default OFF: local plain suppresses the network call', async () => {
+    const { title, artist, filePath } = track();
+    loadLocalLyricsMock.mockResolvedValue(LOCAL_PLAIN);
+
+    const result = await fetchLyrics(title, artist, undefined, undefined, filePath);
+
+    expect(result).toEqual(LOCAL_PLAIN);
+    expect(findLyricsMock).not.toHaveBeenCalled();
+    expect(searchLyricsMock).not.toHaveBeenCalled();
+  });
+
+  it('default OFF: embedded plain suppresses the network call when no local file', async () => {
+    const { title, artist, filePath } = track();
+    readEmbeddedLyricsMock.mockResolvedValue(EMBEDDED_PLAIN);
+
+    const result = await fetchLyrics(title, artist, undefined, undefined, filePath);
+
+    expect(result).toEqual(EMBEDDED_PLAIN);
+    expect(findLyricsMock).not.toHaveBeenCalled();
+  });
+
+  it('default OFF: local plain beats embedded plain', async () => {
+    const { title, artist, filePath } = track();
+    loadLocalLyricsMock.mockResolvedValue(LOCAL_PLAIN);
+    readEmbeddedLyricsMock.mockResolvedValue(EMBEDDED_PLAIN);
+
+    const result = await fetchLyrics(title, artist, undefined, undefined, filePath);
+
+    expect(result).toEqual(LOCAL_PLAIN);
+  });
+
+  it('falls through to LRCLIB when nothing local exists', async () => {
+    const { title, artist, filePath } = track();
+    findLyricsMock.mockResolvedValue({ syncedLyrics: '[00:01.00]net line', plainLyrics: null });
+
+    const result = await fetchLyrics(title, artist, undefined, undefined, filePath);
+
+    expect(result.source).toBe('lrclib');
+    expect(result.synced).toEqual([{ time: 1, text: 'net line' }]);
+  });
+
+  it('preferSynced ON: LRCLIB synced outranks local plain', async () => {
+    const { title, artist, filePath } = track();
+    storeGetMock.mockReturnValue(true);
+    loadLocalLyricsMock.mockResolvedValue(LOCAL_PLAIN);
+    findLyricsMock.mockResolvedValue({ syncedLyrics: '[00:01.00]net line', plainLyrics: null });
+
+    const result = await fetchLyrics(title, artist, undefined, undefined, filePath);
+
+    expect(result.source).toBe('lrclib');
+  });
+
+  it('preferSynced ON: local plain wins when LRCLIB has nothing', async () => {
+    const { title, artist, filePath } = track();
+    storeGetMock.mockReturnValue(true);
+    loadLocalLyricsMock.mockResolvedValue(LOCAL_PLAIN);
+
+    const result = await fetchLyrics(title, artist, undefined, undefined, filePath);
+
+    expect(result).toEqual(LOCAL_PLAIN);
+    expect(findLyricsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preferSynced ON: local plain wins over LRCLIB plain-only', async () => {
+    const { title, artist, filePath } = track();
+    storeGetMock.mockReturnValue(true);
+    loadLocalLyricsMock.mockResolvedValue(LOCAL_PLAIN);
+    findLyricsMock.mockResolvedValue({ syncedLyrics: null, plainLyrics: 'net plain' });
+
+    const result = await fetchLyrics(title, artist, undefined, undefined, filePath);
+
+    expect(result).toEqual(LOCAL_PLAIN);
+  });
+
+  it('without filePath, resolves via LRCLIB only (legacy behavior)', async () => {
+    const { title, artist } = track();
+    findLyricsMock.mockResolvedValue({ syncedLyrics: null, plainLyrics: 'net plain' });
+
+    const result = await fetchLyrics(title, artist);
+
+    expect(result.source).toBe('lrclib');
+    expect(loadLocalLyricsMock).not.toHaveBeenCalled();
+    expect(readEmbeddedLyricsMock).not.toHaveBeenCalled();
+  });
+
+  it('caches LRCLIB results but re-checks local sources on every call', async () => {
+    const { title, artist, filePath } = track();
+    findLyricsMock.mockResolvedValue({ syncedLyrics: null, plainLyrics: 'net plain' });
+
+    await fetchLyrics(title, artist, undefined, undefined, filePath);
+    expect(findLyricsMock).toHaveBeenCalledTimes(1);
+    expect(loadLocalLyricsMock).toHaveBeenCalledTimes(1);
+
+    // Second call: network served from cache, disk re-checked.
+    const second = await fetchLyrics(title, artist, undefined, undefined, filePath);
+    expect(second.source).toBe('lrclib');
+    expect(findLyricsMock).toHaveBeenCalledTimes(1);
+    expect(loadLocalLyricsMock).toHaveBeenCalledTimes(2);
+
+    // A lyric file added mid-session wins immediately despite the cache.
+    loadLocalLyricsMock.mockResolvedValue(LOCAL_SYNCED);
+    const third = await fetchLyrics(title, artist, undefined, undefined, filePath);
+    expect(third).toEqual(LOCAL_SYNCED);
+  });
+
+  it('returns the empty result when no source has lyrics', async () => {
+    const { title, artist, filePath } = track();
+
+    const result = await fetchLyrics(title, artist, undefined, undefined, filePath);
+
+    expect(result).toEqual({ synced: null, plain: null, source: null });
+  });
+
+  it('a local resolver crash degrades to the network path instead of failing', async () => {
+    const { title, artist, filePath } = track();
+    loadLocalLyricsMock.mockRejectedValue(new Error('disk error'));
+    readEmbeddedLyricsMock.mockRejectedValue(new Error('parse error'));
+    findLyricsMock.mockResolvedValue({ syncedLyrics: null, plainLyrics: 'net plain' });
+
+    const result = await fetchLyrics(title, artist, undefined, undefined, filePath);
+
+    expect(result.source).toBe('lrclib');
+  });
+
+  it('denies local resolution for paths outside the library (containment gate)', async () => {
+    const { title, artist } = track();
+    isPathAllowedMock.mockResolvedValue(false);
+    loadLocalLyricsMock.mockResolvedValue(LOCAL_SYNCED); // would win if reachable
+    findLyricsMock.mockResolvedValue({ syncedLyrics: null, plainLyrics: 'net plain' });
+
+    const result = await fetchLyrics(title, artist, undefined, undefined, '/etc/anything.mp3');
+
+    expect(loadLocalLyricsMock).not.toHaveBeenCalled();
+    expect(readEmbeddedLyricsMock).not.toHaveBeenCalled();
+    expect(result.source).toBe('lrclib');
+  });
+
+  it('an isPathAllowed crash fails closed and degrades to the network path', async () => {
+    const { title, artist, filePath } = track();
+    isPathAllowedMock.mockRejectedValue(new Error('db down'));
+    findLyricsMock.mockResolvedValue({ syncedLyrics: null, plainLyrics: 'net plain' });
+
+    const result = await fetchLyrics(title, artist, undefined, undefined, filePath);
+
+    expect(loadLocalLyricsMock).not.toHaveBeenCalled();
+    expect(result.source).toBe('lrclib');
+  });
+
+  it('concurrent fetches for the same track share one in-flight LRCLIB request', async () => {
+    const { title, artist, filePath } = track();
+    let resolveFind: (value: unknown) => void = () => {};
+    findLyricsMock.mockReturnValue(new Promise(resolve => (resolveFind = resolve)));
+
+    const first = fetchLyrics(title, artist, undefined, undefined, filePath);
+    const second = fetchLyrics(title, artist, undefined, undefined, filePath);
+    // Let both calls reach the network step before the fetch resolves.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    resolveFind({ syncedLyrics: null, plainLyrics: 'net plain' });
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(findLyricsMock).toHaveBeenCalledTimes(1);
+    expect(a.source).toBe('lrclib');
+    expect(b.source).toBe('lrclib');
   });
 });

--- a/apps/desktop/src/main/services/lyrics-service.ts
+++ b/apps/desktop/src/main/services/lyrics-service.ts
@@ -1,19 +1,25 @@
 import { UNKNOWN_ALBUM } from '@shiranami/shared';
 import { getLrclibGate } from '../app/http';
 import { logger } from '../app/logger';
+import { store } from '../app/store';
+import { isPathAllowed } from '../shared/folders-cache';
+import { coalesce } from '../utils/coalesce';
+import { readEmbeddedLyrics } from './embedded-lyrics';
+import { loadLocalLyrics } from './local-lyrics';
+import {
+  hasPlainLyrics,
+  hasSyncedLyrics,
+  parseLrc,
+  type LyricLine,
+  type LyricsResult,
+} from './lyrics-parse';
 
-export interface LyricLine {
-  time: number; // seconds
-  text: string;
-}
+export { parseLrc };
+export type { LyricLine, LyricsResult };
 
-export interface LyricsResult {
-  synced: LyricLine[] | null; // Timestamped lyrics
-  plain: string | null; // Plain text lyrics
-  source: 'lrclib' | 'cache' | null;
-}
-
-// In-memory cache for current session
+// In-memory cache for current session. Only network (LRCLIB) results are
+// cached — local/embedded sources are re-read from disk on every fetch so
+// newly added or edited lyric files show up without a restart.
 const lyricsCache = new Map<string, LyricsResult>();
 const LYRICS_CACHE_MAX = 200;
 
@@ -39,31 +45,6 @@ function cacheSet(key: string, value: LyricsResult): void {
     if (oldest !== undefined) lyricsCache.delete(oldest);
   }
   lyricsCache.set(key, value);
-}
-
-/**
- * Parse LRC format string into array of timed lyric lines.
- * Format: [mm:ss.xx]Lyric text
- */
-export function parseLrc(lrc: string): LyricLine[] {
-  const lines: LyricLine[] = [];
-  const regex = /\[(\d{2}):(\d{2})\.(\d{2,3})\]\s*(.*)/;
-
-  for (const rawLine of lrc.split('\n')) {
-    const match = rawLine.match(regex);
-    if (match) {
-      const minutes = parseInt(match[1], 10);
-      const seconds = parseInt(match[2], 10);
-      const ms = match[3].length === 2 ? parseInt(match[3], 10) * 10 : parseInt(match[3], 10);
-      const time = minutes * 60 + seconds + ms / 1000;
-      const text = match[4].trim();
-      if (text) {
-        lines.push({ time, text });
-      }
-    }
-  }
-
-  return lines.sort((a, b) => a.time - b.time);
 }
 
 /**
@@ -117,26 +98,22 @@ export function buildSearchQueries(title: string, artist: string): string[] {
   return queries;
 }
 
+const EMPTY_RESULT: LyricsResult = { synced: null, plain: null, source: null };
+
 /**
- * Fetch lyrics for a track from LRCLIB.
- * Returns synced (timestamped) lyrics if available, otherwise plain text.
+ * Fetch lyrics from LRCLIB. Returns the result on a hit, EMPTY_RESULT when
+ * LRCLIB definitively has nothing (cacheable), or null on failure (not
+ * cacheable, so a transient network error doesn't stick for the session).
  */
-export async function fetchLyrics(
+async function fetchFromLrclib(
   title: string,
   artist: string,
   album?: string,
   duration?: number
-): Promise<LyricsResult> {
-  const key = getCacheKey(title, artist);
-
-  // Check memory cache
-  const cached = cacheGet(key);
-  if (cached) {
-    return { ...cached, source: 'cache' };
-  }
-
+): Promise<LyricsResult | null> {
   try {
-    const { Client } = require('lrclib-api');
+    // Lazy import — keeps the dependency off the startup path (and mockable).
+    const { Client } = await import('lrclib-api');
     const client = new Client();
 
     const query = {
@@ -170,14 +147,12 @@ export async function fetchLyrics(
           );
           if (searchResults && searchResults.length > 0) {
             const best = searchResults[0];
-            const lyricsResult: LyricsResult = {
+            logger.info(`[lyrics] Found lyrics via search "${sq}" for: ${title} - ${artist}`);
+            return {
               synced: best.syncedLyrics ? parseLrc(best.syncedLyrics) : null,
               plain: best.plainLyrics || null,
               source: 'lrclib',
             };
-            cacheSet(key, lyricsResult);
-            logger.info(`[lyrics] Found lyrics via search "${sq}" for: ${title} - ${artist}`);
-            return lyricsResult;
           }
         } catch (err) {
           // This search variant failed, try next
@@ -186,9 +161,7 @@ export async function fetchLyrics(
       }
 
       logger.debug(`[lyrics] No lyrics found for: ${title} - ${artist}`);
-      const empty: LyricsResult = { synced: null, plain: null, source: null };
-      cacheSet(key, empty);
-      return empty;
+      return EMPTY_RESULT;
     }
 
     const lyricsResult: LyricsResult = {
@@ -196,14 +169,145 @@ export async function fetchLyrics(
       plain: result.plainLyrics || null,
       source: 'lrclib',
     };
-
-    cacheSet(key, lyricsResult);
     logger.info(
-      `[lyrics] Found ${lyricsResult.synced ? 'synced' : 'plain'} lyrics for: ${title} - ${artist}`
+      `[lyrics] Found ${lyricsResult.synced ? 'synced' : 'plain'} lyrics via lrclib for: ${title} - ${artist}`
     );
     return lyricsResult;
   } catch (error) {
     logger.warn(`[lyrics] Failed to fetch lyrics for: ${title} - ${artist}`, error);
-    return { synced: null, plain: null, source: null };
+    return null;
   }
+}
+
+function getPreferSyncedFromLrclib(): boolean {
+  return store.get('lyrics.preferSyncedFromLrclib') === true;
+}
+
+/**
+ * Containment gate shared with the audio-protocol and shell handlers: only
+ * paths inside the library roots / userData / the tracks table may be probed,
+ * so a compromised renderer can't use this channel to read arbitrary
+ * .lrc/.txt files. Non-file inputs (radio-stream pseudo-paths) are denied
+ * here too and fall through to the LRCLIB path.
+ */
+async function isLocalResolutionAllowed(filePath: string): Promise<boolean> {
+  try {
+    if (await isPathAllowed(filePath)) return true;
+    logger.debug(`[lyrics] Local lyric resolution skipped (path not allowed): ${filePath}`);
+  } catch (error) {
+    logger.warn('[lyrics] isPathAllowed threw for:', filePath, error);
+  }
+  return false;
+}
+
+// In-flight network fetches keyed like the cache, so concurrent requests for
+// the same track (e.g. a settings invalidation racing a panel mount) share
+// one LRCLIB chain instead of double-occupying the rate-limit gate.
+const inflightLrclib = new Map<string, Promise<LyricsResult | null>>();
+
+/** LRCLIB with session memoization: LRU for results, in-flight dedup for concurrent calls. */
+async function getCachedLrclib(
+  title: string,
+  artist: string,
+  album?: string,
+  duration?: number
+): Promise<LyricsResult | null> {
+  const key = getCacheKey(title, artist);
+  const cached = cacheGet(key);
+  if (cached) return cached;
+
+  const result = await coalesce(inflightLrclib, key, () =>
+    fetchFromLrclib(title, artist, album, duration)
+  );
+  if (result) cacheSet(key, result);
+  return result;
+}
+
+/**
+ * Fetch lyrics for a track. When `filePath` is provided, local sources are
+ * checked first — sidecar .lrc/.txt, a Lyrics/ subfolder, then embedded tags.
+ *
+ * Precedence with `lyrics.preferSyncedFromLrclib` OFF (default):
+ *   local(synced) → embedded(synced) → local(plain) → embedded(plain) →
+ *   lrclib(synced) → lrclib(plain)
+ *   — any local/embedded hit skips the network call entirely.
+ *
+ * Precedence with the setting ON:
+ *   local(synced) → embedded(synced) → lrclib(synced) →
+ *   local(plain) → embedded(plain) → lrclib(plain)
+ *
+ * Without `filePath`, behaves as before: LRCLIB only.
+ */
+export async function fetchLyrics(
+  title: string,
+  artist: string,
+  album?: string,
+  duration?: number,
+  filePath?: string
+): Promise<LyricsResult> {
+  let local: LyricsResult | null = null;
+  let embedded: LyricsResult | null = null;
+
+  if (filePath && (await isLocalResolutionAllowed(filePath))) {
+    try {
+      local = await loadLocalLyrics(filePath);
+    } catch (error) {
+      // The resolver handles its own expected failures — reaching here is a
+      // bug, and it silently degrades the track to network-only lyrics.
+      logger.warn('[lyrics] loadLocalLyrics threw for:', filePath, error);
+    }
+
+    // A synced local file always wins — skip the (relatively expensive)
+    // embedded tag parse and the network entirely.
+    if (hasSyncedLyrics(local)) {
+      logger.info(`[lyrics] Using local synced lyrics for: ${title} - ${artist}`);
+      return local;
+    }
+
+    try {
+      embedded = await readEmbeddedLyrics(filePath);
+    } catch (error) {
+      logger.warn('[lyrics] readEmbeddedLyrics threw for:', filePath, error);
+    }
+
+    // Embedded synced lyrics outrank LRCLIB in both toggle states.
+    if (hasSyncedLyrics(embedded)) {
+      logger.info(`[lyrics] Using embedded synced lyrics for: ${title} - ${artist}`);
+      return embedded;
+    }
+  }
+
+  const preferSyncedFromLrclib = getPreferSyncedFromLrclib();
+
+  // Default (setting OFF): any local/embedded content beats LRCLIB, so a
+  // plain local hit also skips the network call.
+  if (!preferSyncedFromLrclib) {
+    const winner = hasPlainLyrics(local) ? local : hasPlainLyrics(embedded) ? embedded : null;
+    if (winner) {
+      logger.info(`[lyrics] Using ${winner.source} lyrics for: ${title} - ${artist}`);
+      return winner;
+    }
+  }
+
+  // LRCLIB is needed to complete the decision (memory-cached per session).
+  const lrclib = await getCachedLrclib(title, artist, album, duration);
+
+  const orderedCandidates: Array<LyricsResult | null> = preferSyncedFromLrclib
+    ? [
+        hasSyncedLyrics(lrclib) ? lrclib : null,
+        hasPlainLyrics(local) ? local : null,
+        hasPlainLyrics(embedded) ? embedded : null,
+        hasPlainLyrics(lrclib) ? lrclib : null,
+      ]
+    : [hasSyncedLyrics(lrclib) ? lrclib : null, hasPlainLyrics(lrclib) ? lrclib : null];
+
+  const winner = orderedCandidates.find((c): c is LyricsResult => c !== null);
+  if (winner) {
+    logger.info(
+      `[lyrics] Using ${winner.source} ${winner.synced ? 'synced' : 'plain'} lyrics for: ${title} - ${artist}`
+    );
+    return winner;
+  }
+
+  return EMPTY_RESULT;
 }

--- a/apps/desktop/src/main/services/metadata-service.ts
+++ b/apps/desktop/src/main/services/metadata-service.ts
@@ -4,25 +4,16 @@ import { UNKNOWN_ARTIST, UNKNOWN_ALBUM } from '@shiranami/shared';
 import { logger } from '../app/logger';
 import { saveAlbumArt } from '../protocols/art-protocol';
 import { isAudioExtension } from '../shared/media-types';
+import { getMusicMetadata } from '../shared/music-metadata';
 
 export type { TrackMetadata };
-
-// Cache the dynamic import
-let mmModule: typeof import('music-metadata') | null = null;
-
-async function getModule() {
-  if (!mmModule) {
-    mmModule = await import('music-metadata');
-  }
-  return mmModule;
-}
 
 /**
  * Parse metadata from an audio file.
  * Returns structured metadata with album art saved to disk (shiranami-art:// URL).
  */
 export async function parseAudioMetadata(filePath: string): Promise<TrackMetadata> {
-  const mm = await getModule();
+  const mm = await getMusicMetadata();
 
   try {
     const metadata = await mm.parseFile(filePath, { skipCovers: false });

--- a/apps/desktop/src/main/shared/music-metadata.ts
+++ b/apps/desktop/src/main/shared/music-metadata.ts
@@ -1,11 +1,11 @@
 // music-metadata is ESM-only and heavy, so it's loaded lazily once and the
-// module promise result is shared by every consumer (metadata parsing,
-// embedded lyrics).
-let mmModule: typeof import('music-metadata') | null = null;
+// import promise is shared by every consumer (metadata parsing, embedded
+// lyrics), which also avoids redundant imports on concurrent first calls.
+let mmPromise: Promise<typeof import('music-metadata')> | null = null;
 
-export async function getMusicMetadata(): Promise<typeof import('music-metadata')> {
-  if (!mmModule) {
-    mmModule = await import('music-metadata');
+export function getMusicMetadata(): Promise<typeof import('music-metadata')> {
+  if (!mmPromise) {
+    mmPromise = import('music-metadata');
   }
-  return mmModule;
+  return mmPromise;
 }

--- a/apps/desktop/src/main/shared/music-metadata.ts
+++ b/apps/desktop/src/main/shared/music-metadata.ts
@@ -1,0 +1,11 @@
+// music-metadata is ESM-only and heavy, so it's loaded lazily once and the
+// module promise result is shared by every consumer (metadata parsing,
+// embedded lyrics).
+let mmModule: typeof import('music-metadata') | null = null;
+
+export async function getMusicMetadata(): Promise<typeof import('music-metadata')> {
+  if (!mmModule) {
+    mmModule = await import('music-metadata');
+  }
+  return mmModule;
+}

--- a/apps/desktop/src/main/utils/coalesce.ts
+++ b/apps/desktop/src/main/utils/coalesce.ts
@@ -1,0 +1,18 @@
+/**
+ * Coalesce concurrent async calls by key: while a call for `key` is in
+ * flight, later callers await the same promise instead of starting another.
+ * The entry is removed when the promise settles (resolve or reject), so a
+ * failure never sticks — the next caller retries fresh.
+ */
+export function coalesce<T>(
+  inflight: Map<string, Promise<T>>,
+  key: string,
+  factory: () => Promise<T>
+): Promise<T> {
+  let pending = inflight.get(key);
+  if (!pending) {
+    pending = factory().finally(() => inflight.delete(key));
+    inflight.set(key, pending);
+  }
+  return pending;
+}

--- a/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.hooks.ts
+++ b/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.hooks.ts
@@ -7,7 +7,8 @@ import {
 import { useLyricsView } from '@/hooks/useLyricsView';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { cn } from '@/lib/utils';
-import type { ILyricsPanelView } from './LyricsPanel.types';
+import type { LyricsSource } from '@/hooks/queries/useLyrics';
+import type { ILyricsPanelView, TranslateFn } from './LyricsPanel.types';
 
 // Common per-line affordances. Size + opacity come from user prefs and are
 // composed below via LYR_SIZE_CLASS + CSS custom properties.
@@ -21,6 +22,21 @@ const PANEL_IDLE = 'text-foreground opacity-[var(--lyrics-idle-opacity)] hover:o
 const PANEL_PAST = 'text-foreground opacity-[var(--lyrics-past-opacity)]';
 const PANEL_ACTIVE_AFFORDANCES = 'text-foreground font-semibold';
 
+/** Human label for where the lyrics came from, or null when unresolved. */
+function sourceToLabel(source: LyricsSource, t: TranslateFn): string | null {
+  switch (source) {
+    case 'local-lrc':
+    case 'local-txt':
+      return t('sourceLocal');
+    case 'embedded':
+      return t('sourceEmbedded');
+    case 'lrclib':
+      return t('sourceLrclib');
+    default:
+      return null;
+  }
+}
+
 export function useLyricsPanel(): ILyricsPanelView {
   const { t } = useTranslation('lyrics');
   const currentTrack = usePlaybackStore(s => s.currentTrack);
@@ -29,7 +45,7 @@ export function useLyricsPanel(): ILyricsPanelView {
   const lyricsSyncedDimOpacity = useLyricsAppearanceStore(s => s.lyricsSyncedDimOpacity);
   const lyricsSyncedFontSize = useLyricsAppearanceStore(s => s.lyricsSyncedFontSize);
 
-  const { synced, plain, activeLine, isLoading, handleLineClick } = useLyricsView();
+  const { synced, plain, source, activeLine, isLoading, handleLineClick } = useLyricsView();
 
   const baseSizeClass = LYR_SIZE_CLASS[lyricsSyncedFontSize];
   const activeSizeClass = LYR_SIZE_CLASS[nextLyricsFontSize(lyricsSyncedFontSize)];
@@ -41,6 +57,7 @@ export function useLyricsPanel(): ILyricsPanelView {
     plain,
     activeLine,
     isLoading,
+    sourceLabel: sourceToLabel(source, t),
     onLineClick: handleLineClick,
     syncedDimOpacity: lyricsSyncedDimOpacity,
     plainOpacity: lyricsPlainOpacity,

--- a/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.stories.tsx
+++ b/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { within, expect } from 'storybook/test';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import type { Track } from '@/stores/types';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
-import { lyricsKeys, type LyricLine } from '@/hooks/queries/useLyrics';
+import { lyricsKeys, type LyricLine, type LyricsSource } from '@/hooks/queries/useLyrics';
 
 import LyricsPanel from './LyricsPanel';
 
@@ -29,11 +30,25 @@ const SYNCED: LyricLine[] = [
 /**
  * Pre-seed a client with the current track's lyrics so the panel renders its
  * synced lines without IPC (and the query never resolves to `undefined`).
- * Mirrors how SmartPlaylistsView seeds its query client.
+ * Mirrors how SmartPlaylistsView seeds its query client. Refetching is
+ * disabled at the client level — the lyrics query is stale-on-mount in the
+ * app (fresh local-file checks), which would overwrite the seed here.
  */
-function seededClient(synced: LyricLine[] | null, plain: string | null): QueryClient {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  client.setQueryData(lyricsKeys.track('track-1'), { synced, plain, source: 'test' });
+function seededClient(
+  synced: LyricLine[] | null,
+  plain: string | null,
+  source: LyricsSource = 'lrclib'
+): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnMount: false, refetchOnWindowFocus: false },
+    },
+  });
+  client.setQueryData(lyricsKeys.track('track-1', '/music/midnight.mp3'), {
+    synced,
+    plain,
+    source,
+  });
   return client;
 }
 
@@ -54,9 +69,11 @@ const meta: Meta<typeof LyricsPanel> = {
   },
   decorators: [
     Story => (
-      <div className="flex h-[32rem] w-[22rem] flex-col">
-        <Story />
-      </div>
+      <TooltipProvider>
+        <div className="flex h-[32rem] w-[22rem] flex-col">
+          <Story />
+        </div>
+      </TooltipProvider>
     ),
   ],
   beforeEach: () => {
@@ -68,7 +85,7 @@ export default meta;
 
 type Story = StoryObj<typeof LyricsPanel>;
 
-/** Default — the "Lyrics" header over the seeded synced lines. */
+/** Default — the "Lyrics" header (with LRCLIB source badge) over the seeded synced lines. */
 export const Default: Story = {
   decorators: [
     Story => (
@@ -80,6 +97,25 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole('heading', { name: 'Lyrics' })).toBeInTheDocument();
+    await expect(canvas.getByText('LRCLIB')).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Soft rain against the glass' })
+    ).toBeInTheDocument();
+  },
+};
+
+/** Lyrics resolved from a local .lrc file — the header badge reads "Local". */
+export const LocalSource: Story = {
+  decorators: [
+    Story => (
+      <QueryClientProvider client={seededClient(SYNCED, null, 'local-lrc')}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Local')).toBeInTheDocument();
     await expect(
       canvas.getByRole('button', { name: 'Soft rain against the glass' })
     ).toBeInTheDocument();

--- a/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.test.tsx
+++ b/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactElement } from 'react';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import type { Track } from '@/stores/types';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import type { useLyricsView } from '@/hooks/useLyricsView';
@@ -7,6 +9,7 @@ import type { useLyricsView } from '@/hooks/useLyricsView';
 const EMPTY_LYRICS_VIEW: ReturnType<typeof useLyricsView> = {
   synced: null,
   plain: null,
+  source: null,
   activeLine: -1,
   isLoading: false,
   isError: false,
@@ -36,6 +39,11 @@ function makeTrack(overrides: Partial<Track> = {}): Track {
 
 function setLyricsView(overrides: Partial<typeof EMPTY_LYRICS_VIEW> = {}): void {
   useLyricsViewMock.mockReturnValue({ ...EMPTY_LYRICS_VIEW, ...overrides });
+}
+
+/** The source badge's Radix tooltip needs a provider in the tree. */
+function renderPanel(ui: ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
 }
 
 beforeEach(() => {
@@ -95,5 +103,34 @@ describe('LyricsPanel', () => {
 
     expect(screen.getByRole('button', { name: 'Panel synced one' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Panel synced two' })).toBeInTheDocument();
+  });
+
+  it('shows a Local source badge for local lyric files', () => {
+    setLyricsView({ synced: [{ time: 0, text: 'From disk' }], source: 'local-lrc' });
+    renderPanel(<LyricsPanel />);
+
+    expect(screen.getByText('Local')).toBeInTheDocument();
+  });
+
+  it('shows an Embedded source badge for tag-embedded lyrics', () => {
+    setLyricsView({ plain: 'From the tag', source: 'embedded' });
+    renderPanel(<LyricsPanel />);
+
+    expect(screen.getByText('Embedded')).toBeInTheDocument();
+  });
+
+  it('shows an LRCLIB source badge for network lyrics', () => {
+    setLyricsView({ plain: 'From the network', source: 'lrclib' });
+    renderPanel(<LyricsPanel />);
+
+    expect(screen.getByText('LRCLIB')).toBeInTheDocument();
+  });
+
+  it('renders no source badge when lyrics are unresolved', () => {
+    renderPanel(<LyricsPanel />);
+
+    expect(screen.queryByText('Local')).not.toBeInTheDocument();
+    expect(screen.queryByText('Embedded')).not.toBeInTheDocument();
+    expect(screen.queryByText('LRCLIB')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.tsx
+++ b/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.tsx
@@ -1,3 +1,4 @@
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { LyricsBody } from '../LyricsBody';
 import { useLyricsPanel } from './LyricsPanel.hooks';
 import type { ILyricsPanelProps } from './LyricsPanel.types';
@@ -10,6 +11,7 @@ export default function LyricsPanel({ headerAction }: ILyricsPanelProps) {
     plain,
     activeLine,
     isLoading,
+    sourceLabel,
     onLineClick,
     syncedDimOpacity,
     plainOpacity,
@@ -25,9 +27,22 @@ export default function LyricsPanel({ headerAction }: ILyricsPanelProps) {
   return (
     <div className="flex flex-col h-full">
       <div className="px-5 py-3.5 border-b border-border/20 shrink-0 flex items-center justify-between">
-        <h2 className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-          {t('title')}
-        </h2>
+        <div className="flex items-center gap-2">
+          <h2 className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+            {t('title')}
+          </h2>
+          {sourceLabel && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded-full border border-border/30 bg-muted/20 text-[9px] font-semibold uppercase tracking-[0.1em] leading-none text-muted-foreground/70">
+                  <span className="sr-only">{t('sourceTooltip')}: </span>
+                  <span>{sourceLabel}</span>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{t('sourceTooltip')}</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
         {headerAction}
       </div>
       <LyricsBody

--- a/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.types.ts
+++ b/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.types.ts
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import type { useTranslation } from 'react-i18next';
 import type { LyricLine } from '@/hooks/queries/useLyrics';
 
-type TranslateFn = ReturnType<typeof useTranslation>['t'];
+export type TranslateFn = ReturnType<typeof useTranslation>['t'];
 
 export interface ILyricsPanelProps {
   /** Optional control rendered at the right edge of the panel header. */
@@ -22,6 +22,8 @@ export interface ILyricsPanelView {
   readonly activeLine: number;
   /** Lyrics fetch in flight. */
   readonly isLoading: boolean;
+  /** Translated source-badge label (Local / Embedded / LRCLIB), or null when unresolved. */
+  readonly sourceLabel: string | null;
   /** Seek to a line's timestamp. */
   readonly onLineClick: (time: number) => void;
   /** Idle/past synced-line dim opacity from user prefs. */

--- a/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.test.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.test.tsx
@@ -34,6 +34,7 @@ vi.mock('@/hooks/useLyricsView', () => ({
   useLyricsView: () => ({
     synced: null,
     plain: null,
+    source: null,
     activeLine: -1,
     isLoading: false,
     isError: false,

--- a/apps/web/src/components/settings/LyricsSection/LyricsSection.hooks.ts
+++ b/apps/web/src/components/settings/LyricsSection/LyricsSection.hooks.ts
@@ -1,5 +1,10 @@
 import { useTranslation } from 'react-i18next';
 import {
+  usePreferSyncedFromLrclibQuery,
+  useUpdatePreferSyncedFromLrclibMutation,
+} from '@/hooks/queries/useLyrics';
+import { IS_ELECTRON } from '@/lib/platform';
+import {
   useLyricsAppearanceStore,
   LYRICS_PLAIN_OPACITY_MIN,
   LYRICS_PLAIN_OPACITY_MAX,
@@ -16,6 +21,12 @@ import type { ILyricsSectionView } from './LyricsSection.types';
 
 export function useLyricsSection(): ILyricsSectionView {
   const { t: tc } = useTranslation('common');
+
+  // Persisted as an electron-store key (main reads it during lyric
+  // resolution). Query-seeded + optimistic mutation with rollback, matching
+  // the useSystemPrefs pattern for main-consumed settings.
+  const { data: preferSynced } = usePreferSyncedFromLrclibQuery();
+  const updatePreferSynced = useUpdatePreferSyncedFromLrclibMutation();
 
   const lyricsPlainOpacity = useLyricsAppearanceStore(s => s.lyricsPlainOpacity);
   const lyricsPlainFontSize = useLyricsAppearanceStore(s => s.lyricsPlainFontSize);
@@ -40,6 +51,11 @@ export function useLyricsSection(): ILyricsSectionView {
   return {
     t,
     resetLabel: tc('reset'),
+
+    preferSyncedFromLrclib: preferSynced === true,
+    // Inert until the persisted value has seeded (and outside Electron).
+    preferSyncedDisabled: !IS_ELECTRON || preferSynced === undefined,
+    onSetPreferSyncedFromLrclib: value => updatePreferSynced.mutate(value),
 
     lyricsPlainOpacity,
     lyricsPlainFontSize,

--- a/apps/web/src/components/settings/LyricsSection/LyricsSection.stories.tsx
+++ b/apps/web/src/components/settings/LyricsSection/LyricsSection.stories.tsx
@@ -75,6 +75,21 @@ export const Default: Story = {
   },
 };
 
+/** Sources — the LRCLIB source-preference toggle flips and persists. */
+export const Sources: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const toggle = canvas.getByRole('switch', { name: 'Prefer synced lyrics from LRCLIB' });
+    // Disabled until the persisted value has seeded from electron-store.
+    await waitFor(() => expect(toggle).toBeEnabled());
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    await userEvent.click(toggle);
+    await waitFor(() => expect(toggle).toHaveAttribute('aria-checked', 'true'));
+  },
+};
+
 /** Customized — non-default opacity + sizes mark the matching size chips active. */
 export const Customized: Story = {
   decorators: [

--- a/apps/web/src/components/settings/LyricsSection/LyricsSection.stories.tsx
+++ b/apps/web/src/components/settings/LyricsSection/LyricsSection.stories.tsx
@@ -1,5 +1,8 @@
+import type { ReactElement } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { within, userEvent, expect, waitFor } from 'storybook/test';
+import { lyricsPrefKeys } from '@/hooks/queries/useLyrics';
 import {
   useLyricsAppearanceStore,
   LYRICS_PLAIN_OPACITY_DEFAULT,
@@ -9,6 +12,19 @@ import {
 } from '@/stores/useLyricsAppearanceStore';
 
 import LyricsSection from './LyricsSection';
+
+/** Seed the source-preference query cache so the toggle renders a known state. */
+function withSeededPreferSynced(value: boolean) {
+  return function Decorator(Story: () => ReactElement) {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData<boolean>(lyricsPrefKeys.preferSynced, value);
+    return (
+      <QueryClientProvider client={client}>
+        <Story />
+      </QueryClientProvider>
+    );
+  };
+}
 
 function seedDefaults(): void {
   useLyricsAppearanceStore.setState({
@@ -75,18 +91,33 @@ export const Default: Story = {
   },
 };
 
-/** Sources — the LRCLIB source-preference toggle flips and persists. */
+/**
+ * Sources — the LRCLIB source-preference toggle renders its seeded state. As in
+ * SystemSection: in the Storybook browser run `IS_ELECTRON` is false (module
+ * constant captured before the preview installs the electronAPI mock), so the
+ * toggle stays `disabled` and this story asserts that gated contract; the
+ * interactive optimistic flip is covered by LyricsSection.test.tsx under jsdom.
+ */
 export const Sources: Story = {
+  decorators: [withSeededPreferSynced(false)],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
     const toggle = canvas.getByRole('switch', { name: 'Prefer synced lyrics from LRCLIB' });
-    // Disabled until the persisted value has seeded from electron-store.
-    await waitFor(() => expect(toggle).toBeEnabled());
-    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+    await expect(toggle).not.toBeChecked();
+    await expect(toggle).toBeDisabled();
+  },
+};
 
-    await userEvent.click(toggle);
-    await waitFor(() => expect(toggle).toHaveAttribute('aria-checked', 'true'));
+/** Sources with the preference on — the seeded checked state renders. */
+export const SourcesPreferSynced: Story = {
+  decorators: [withSeededPreferSynced(true)],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByRole('switch', { name: 'Prefer synced lyrics from LRCLIB' })
+    ).toBeChecked();
   },
 };
 

--- a/apps/web/src/components/settings/LyricsSection/LyricsSection.test.tsx
+++ b/apps/web/src/components/settings/LyricsSection/LyricsSection.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   useLyricsAppearanceStore,
   LYRICS_PLAIN_OPACITY_DEFAULT,
@@ -10,6 +11,16 @@ import {
 } from '@/stores/useLyricsAppearanceStore';
 
 import LyricsSection from './LyricsSection';
+
+/** The section hook invalidates lyrics queries, so it needs a query client. */
+function renderSection() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <LyricsSection />
+    </QueryClientProvider>
+  );
+}
 
 function reset(): void {
   useLyricsAppearanceStore.setState({
@@ -26,16 +37,35 @@ afterEach(reset);
 
 describe('LyricsSection', () => {
   it('renders the lyrics card with both subsections', () => {
-    render(<LyricsSection />);
+    renderSection();
 
     expect(screen.getByRole('heading', { name: 'Lyrics' })).toBeInTheDocument();
+  });
+
+  it('persists the LRCLIB source-preference toggle', async () => {
+    const user = userEvent.setup();
+    renderSection();
+
+    const toggle = screen.getByRole('switch', { name: 'Prefer synced lyrics from LRCLIB' });
+    // Disabled until the persisted value has seeded from electron-store.
+    await waitFor(() => expect(toggle).toBeEnabled());
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    await user.click(toggle);
+
+    // Optimistic flip + persist through the store IPC.
+    await waitFor(() => expect(toggle).toHaveAttribute('aria-checked', 'true'));
+    expect(window.electronAPI.store.set).toHaveBeenCalledWith(
+      'lyrics.preferSyncedFromLrclib',
+      true
+    );
   });
 
   it('sets the plain-lyrics font size when a size chip is clicked', async () => {
     const user = userEvent.setup();
     const setLyricsPlainFontSize = vi.fn();
     useLyricsAppearanceStore.setState({ setLyricsPlainFontSize });
-    render(<LyricsSection />);
+    renderSection();
 
     const radiogroups = screen.getAllByRole('radiogroup');
     const plainSizeButtons = within(radiogroups[0]).getAllByRole('radio');

--- a/apps/web/src/components/settings/LyricsSection/LyricsSection.tsx
+++ b/apps/web/src/components/settings/LyricsSection/LyricsSection.tsx
@@ -1,6 +1,6 @@
 import { Captions } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { SettingsCard } from '@/components/settings/SettingsCard';
+import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsCard';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { Slider } from '@/components/ui/slider';
 import {
@@ -18,6 +18,9 @@ export default function LyricsSection() {
   const {
     t,
     resetLabel,
+    preferSyncedFromLrclib,
+    preferSyncedDisabled,
+    onSetPreferSyncedFromLrclib,
     lyricsPlainOpacity,
     lyricsPlainFontSize,
     onSetPlainOpacity,
@@ -39,6 +42,17 @@ export default function LyricsSection() {
   return (
     <SettingsCard icon={Captions} title={t('lyr.title')} subtitle={t('lyr.subtitle')}>
       <div className="space-y-8">
+        {/* Sources subsection */}
+        <Subsection title={t('lyr.sources.title')} subtitle={t('lyr.sources.subtitle')}>
+          <SettingsToggleRow
+            label={t('lyr.sources.preferSyncedTitle')}
+            description={t('lyr.sources.preferSyncedDesc')}
+            checked={preferSyncedFromLrclib}
+            onCheckedChange={onSetPreferSyncedFromLrclib}
+            disabled={preferSyncedDisabled}
+          />
+        </Subsection>
+
         {/* Plain text subsection */}
         <Subsection title={t('lyr.plain.title')} subtitle={t('lyr.plain.subtitle')}>
           <OpacityControl

--- a/apps/web/src/components/settings/LyricsSection/LyricsSection.types.ts
+++ b/apps/web/src/components/settings/LyricsSection/LyricsSection.types.ts
@@ -9,6 +9,14 @@ export interface ILyricsSectionView {
   /** Localized "reset" label (from the `common` namespace). */
   readonly resetLabel: string;
 
+  // --- Sources ---
+  /** When true, LRCLIB synced lyrics outrank local plain-text files. */
+  readonly preferSyncedFromLrclib: boolean;
+  /** True until the persisted value has seeded (or outside Electron). */
+  readonly preferSyncedDisabled: boolean;
+  /** Persist the source-precedence toggle and re-resolve current lyrics. */
+  readonly onSetPreferSyncedFromLrclib: (value: boolean) => void;
+
   // --- Plain lyrics ---
   /** Plain-lyrics text opacity (0–1). */
   readonly lyricsPlainOpacity: number;

--- a/apps/web/src/hooks/queries/useLyrics.ts
+++ b/apps/web/src/hooks/queries/useLyrics.ts
@@ -69,13 +69,19 @@ export function useUpdatePreferSyncedFromLrclibMutation() {
       if (!IS_ELECTRON) return;
       await window.electronAPI.store.set(PREFER_SYNCED_STORE_KEY, value);
     },
-    // Optimistic flip so the switch tracks the click; rolled back by the
-    // invalidate below if the write fails.
+    // Optimistic flip so the switch tracks the click; on failure the previous
+    // value is restored synchronously from the onMutate context, then the
+    // invalidate re-syncs with the store as the source of truth.
     onMutate: async value => {
       await queryClient.cancelQueries({ queryKey: lyricsPrefKeys.preferSynced });
+      const previous = queryClient.getQueryData<boolean>(lyricsPrefKeys.preferSynced);
       queryClient.setQueryData<boolean>(lyricsPrefKeys.preferSynced, value);
+      return { previous };
     },
-    onError: () => {
+    onError: (_err, _value, context) => {
+      if (context) {
+        queryClient.setQueryData(lyricsPrefKeys.preferSynced, context.previous);
+      }
       toast.error(i18n.t('failedSaveSettings', { ns: 'toast' }));
       queryClient.invalidateQueries({ queryKey: lyricsPrefKeys.preferSynced });
     },

--- a/apps/web/src/hooks/queries/useLyrics.ts
+++ b/apps/web/src/hooks/queries/useLyrics.ts
@@ -1,18 +1,14 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import type { LyricsResult } from '@shiranami/contracts';
+import { IS_ELECTRON } from '@/lib/platform';
+import i18n from '@/lib/i18n';
 
-export interface LyricLine {
-  time: number;
-  text: string;
-}
-
-interface LyricsResult {
-  synced: LyricLine[] | null;
-  plain: string | null;
-  source: string | null;
-}
+export type { LyricLine, LyricsResult, LyricsSource } from '@shiranami/contracts';
 
 export const lyricsKeys = {
-  track: (trackId: string) => ['lyrics', trackId] as const,
+  all: ['lyrics'] as const,
+  track: (trackId: string, filePath?: string) => ['lyrics', trackId, filePath ?? ''] as const,
 };
 
 export function useLyricsQuery(
@@ -21,17 +17,71 @@ export function useLyricsQuery(
   artist: string,
   album?: string,
   duration?: number,
+  filePath?: string
 ) {
   return useQuery({
-    queryKey: lyricsKeys.track(trackId!),
+    queryKey: lyricsKeys.track(trackId!, filePath),
     queryFn: async (): Promise<LyricsResult> => {
       if (!window.electronAPI?.lyrics) {
         return { synced: null, plain: null, source: null };
       }
-      return await window.electronAPI.lyrics.fetch(title, artist, album, duration);
+      return await window.electronAPI.lyrics.fetch(title, artist, album, duration, filePath);
     },
     enabled: !!trackId,
-    staleTime: Infinity, // lyrics don't change
+    // Refetch on mount/track change so newly added local lyric files are
+    // picked up without a restart. Cheap: the main process re-checks disk and
+    // serves network results from its session cache. Previous data is kept
+    // while refetching, so there's no visible flicker.
+    staleTime: 0,
     retry: false,
+  });
+}
+
+/**
+ * `lyrics.preferSyncedFromLrclib` lives as an electron-store key (not the
+ * renderer settings blob) because the MAIN process consumes it during lyric
+ * resolution. Query + optimistic mutation mirror the useSystemPrefs pattern.
+ */
+
+const PREFER_SYNCED_STORE_KEY = 'lyrics.preferSyncedFromLrclib';
+
+export const lyricsPrefKeys = {
+  preferSynced: ['lyrics-prefs', 'prefer-synced-from-lrclib'] as const,
+};
+
+export function usePreferSyncedFromLrclibQuery() {
+  return useQuery({
+    queryKey: lyricsPrefKeys.preferSynced,
+    queryFn: async (): Promise<boolean> => {
+      const value = await window.electronAPI.store.get<boolean>(PREFER_SYNCED_STORE_KEY);
+      return value === true;
+    },
+    enabled: IS_ELECTRON,
+    staleTime: Infinity,
+  });
+}
+
+export function useUpdatePreferSyncedFromLrclibMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (value: boolean) => {
+      if (!IS_ELECTRON) return;
+      await window.electronAPI.store.set(PREFER_SYNCED_STORE_KEY, value);
+    },
+    // Optimistic flip so the switch tracks the click; rolled back by the
+    // invalidate below if the write fails.
+    onMutate: async value => {
+      await queryClient.cancelQueries({ queryKey: lyricsPrefKeys.preferSynced });
+      queryClient.setQueryData<boolean>(lyricsPrefKeys.preferSynced, value);
+    },
+    onError: () => {
+      toast.error(i18n.t('failedSaveSettings', { ns: 'toast' }));
+      queryClient.invalidateQueries({ queryKey: lyricsPrefKeys.preferSynced });
+    },
+    // Re-resolve the current track's lyrics under the new precedence.
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: lyricsKeys.all });
+    },
   });
 }

--- a/apps/web/src/hooks/useLyricsView.ts
+++ b/apps/web/src/hooks/useLyricsView.ts
@@ -2,12 +2,14 @@ import { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
-import { useLyricsQuery, type LyricLine } from '@/hooks/queries/useLyrics';
+import { useLyricsQuery, type LyricLine, type LyricsSource } from '@/hooks/queries/useLyrics';
 import { useActiveLineIndex } from '@/lib/lyrics';
 
 interface UseLyricsViewResult {
   synced: LyricLine[] | null;
   plain: string | null;
+  /** Where the lyrics were resolved from (local file, embedded tag, LRCLIB). */
+  source: LyricsSource;
   /** Index of the active synced line, or -1. */
   activeLine: number;
   isLoading: boolean;
@@ -35,7 +37,8 @@ export function useLyricsView(): UseLyricsViewResult {
     currentTrack?.title ?? '',
     currentTrack?.artist ?? '',
     currentTrack?.album,
-    currentTrack?.duration
+    currentTrack?.duration,
+    currentTrack?.filePath
   );
 
   useEffect(() => {
@@ -46,9 +49,10 @@ export function useLyricsView(): UseLyricsViewResult {
 
   const synced = data?.synced ?? null;
   const plain = data?.plain ?? null;
+  const source = data?.source ?? null;
   const activeLine = useActiveLineIndex(synced);
 
   const handleLineClick = useCallback((time: number) => seek(time), [seek]);
 
-  return { synced, plain, activeLine, isLoading, isError, handleLineClick };
+  return { synced, plain, source, activeLine, isLoading, isError, handleLineClick };
 }

--- a/apps/web/src/locales/en/lyrics.json
+++ b/apps/web/src/locales/en/lyrics.json
@@ -1,5 +1,9 @@
 {
   "title": "Lyrics",
   "finding": "Finding lyrics...",
-  "notFound": "No lyrics found"
+  "notFound": "No lyrics found",
+  "sourceLocal": "Local",
+  "sourceEmbedded": "Embedded",
+  "sourceLrclib": "LRCLIB",
+  "sourceTooltip": "Lyrics source"
 }

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -287,7 +287,13 @@
   },
   "lyr": {
     "title": "Lyrics",
-    "subtitle": "Appearance of lyrics in the lyrics panel",
+    "subtitle": "Sources and appearance of lyrics in the lyrics panel",
+    "sources": {
+      "title": "Sources",
+      "subtitle": "Where lyrics are looked up for your tracks",
+      "preferSyncedTitle": "Prefer synced lyrics from LRCLIB",
+      "preferSyncedDesc": "When a track only has a plain-text lyrics file, fetch synced lyrics from LRCLIB instead. Local and embedded synced lyrics always win."
+    },
     "plain": {
       "title": "Plain text",
       "subtitle": "Lyrics shown when no synced timing is available",

--- a/apps/web/src/locales/pl/lyrics.json
+++ b/apps/web/src/locales/pl/lyrics.json
@@ -1,5 +1,9 @@
 {
   "title": "Tekst piosenki",
   "finding": "Szukam tekstu...",
-  "notFound": "Nie znaleziono tekstu"
+  "notFound": "Nie znaleziono tekstu",
+  "sourceLocal": "Lokalny",
+  "sourceEmbedded": "Osadzony",
+  "sourceLrclib": "LRCLIB",
+  "sourceTooltip": "Źródło tekstu"
 }

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -303,7 +303,13 @@
   },
   "lyr": {
     "title": "Tekst piosenki",
-    "subtitle": "Wygląd tekstu piosenki w panelu",
+    "subtitle": "Źródła i wygląd tekstu piosenki w panelu",
+    "sources": {
+      "title": "Źródła",
+      "subtitle": "Skąd pobierany jest tekst dla Twoich utworów",
+      "preferSyncedTitle": "Preferuj zsynchronizowany tekst z LRCLIB",
+      "preferSyncedDesc": "Gdy utwór ma tylko zwykły plik tekstowy, pobierz zsynchronizowany tekst z LRCLIB. Lokalny i osadzony zsynchronizowany tekst zawsze ma pierwszeństwo."
+    },
     "plain": {
       "title": "Tekst zwykły",
       "subtitle": "Tekst pokazywany, gdy brak zsynchronizowanych znaczników czasu",

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -33,6 +33,7 @@ import type {
   RadioStationInput,
   RadioFavorite,
   WaveformPeaksResult,
+  LyricsResult,
 } from '@shiranami/contracts';
 import type {
   SHARE_ERROR_CODES,
@@ -156,12 +157,9 @@ export interface ElectronAPI {
       title: string,
       artist: string,
       album?: string,
-      duration?: number
-    ) => Promise<{
-      synced: Array<{ time: number; text: string }> | null;
-      plain: string | null;
-      source: 'lrclib' | 'cache' | null;
-    }>;
+      duration?: number,
+      filePath?: string
+    ) => Promise<LyricsResult>;
   };
   weather: {
     geocode: (query: string) => Promise<GeocodeResult | null>;

--- a/packages/contracts/src/domain/lyrics.ts
+++ b/packages/contracts/src/domain/lyrics.ts
@@ -1,0 +1,22 @@
+/**
+ * Lyrics wire types — the single definition of the `lyrics:fetch` result
+ * shape shared by the main-process resolver, the preload bridge, and the
+ * renderer. Adding a source or reshaping the result starts here.
+ */
+
+/** Where resolved lyrics came from; null when nothing was found. */
+export type LyricsSource = 'lrclib' | 'local-lrc' | 'local-txt' | 'embedded' | null;
+
+export interface LyricLine {
+  /** Seconds from track start. */
+  time: number;
+  text: string;
+}
+
+export interface LyricsResult {
+  /** Timestamped lyrics, or null when only plain text (or nothing) is available. */
+  synced: LyricLine[] | null;
+  /** Plain (untimed) lyrics. */
+  plain: string | null;
+  source: LyricsSource;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,6 +1,7 @@
 // Typed contracts for Shiranami: domain types, IPC channel manifest, and
 // shared API DTOs.
 export * from './domain/track';
+export * from './domain/lyrics';
 export * from './domain/media';
 export * from './domain/weather';
 export * from './domain/recommendation';


### PR DESCRIPTION
Closes #42. Supersedes #84 (same feature, pre-dated the main-process and web restructures — worth closing with a pointer here).

## Summary
- Resolve lyrics local-first in the Electron main process: sidecar `.lrc`/`.txt`, a `Lyrics/`/`lyrics/` subfolder, then embedded tags (USLT/SYLT, raw LRC in text) before any LRCLIB call — a local hit keeps the app fully offline. Local sources are re-read on every fetch so a newly added file shows up without a restart, while LRCLIB results stay session-cached and coalesced.
- Thread `track.filePath` through `lyrics:fetch` as an optional 5th arg (zod schema → handler → preload → renderer, wire types now defined once in `@shiranami/contracts`), contained by the same `isPathAllowed` gate the audio protocol uses so the channel can't read arbitrary files.
- New Settings → Lyrics → Sources toggle ("Prefer synced lyrics from LRCLIB", default off) following the `useSystemPrefs` optimistic-mutation pattern, plus a Local/Embedded/LRCLIB source badge in the lyrics panel header (EN+PL).

## Test plan
- [ ] Drop a `Song.lrc` next to a playing `Song.mp3` → reopen the panel: synced lyrics render with a "Local" badge and no lrclib.net request fires
- [ ] `.txt`-only track (BOM/CRLF/`Artist:` header sample from #42) → plain lyrics render with header stripped; toggle "Prefer synced from LRCLIB" on → LRCLIB synced version replaces it live
- [ ] Track with embedded USLT lyrics (sample from #42) and no sidecar → "Embedded" badge, synced highlight follows playback
- [ ] Radio stream / track without lyric files → LRCLIB fallback unchanged, no errors in the main log