### PR TITLE
feat(desktop): add a dormant v2 handover bridge to the updater

### DIFF
--- a/apps/desktop/src/main/app/store.ts
+++ b/apps/desktop/src/main/app/store.ts
@@ -75,6 +75,11 @@ export interface StoreSchema {
   // Main-only migration flags.
   'migrations.albumArtV1': boolean;
 
+  // Main-only (v2-bridge): the one-time v2 crossover ping already fired. Set
+  // only when telemetry consent is on, so an opted-out install never records
+  // anything here. Default undefined → not yet pinged.
+  'v2.crossoverPinged': boolean;
+
   // Main-only (scrobbler.ts): opt-in scrobbling settings + secrets. The raw
   // Last.fm session key / ListenBrainz token NEVER round-trip to the renderer
   // (it reads only a {connected} status via the scrobble IPC), mirroring how

--- a/apps/desktop/src/main/app/updater.ts
+++ b/apps/desktop/src/main/app/updater.ts
@@ -7,6 +7,12 @@ import { sendToRenderer } from '../utils/window';
 
 const U = IPC_CHANNELS.updater;
 
+/** Delay before the first update check, so it never competes with first paint. */
+export const INITIAL_UPDATE_CHECK_DELAY_MS = 5_000;
+
+/** Cadence of the periodic update check. Shared with the v2 handover bridge. */
+export const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+
 let updaterEnabled = false;
 let updaterInitialized = false;
 
@@ -91,18 +97,13 @@ export function initializeAutoUpdater(_mainWindow: BrowserWindow, isDev: boolean
     }
   });
 
-  // Initial check after 5 seconds
   setTimeout(() => {
     checkForUpdates();
-  }, 5000);
+  }, INITIAL_UPDATE_CHECK_DELAY_MS);
 
-  // Periodic checks every hour
-  setInterval(
-    () => {
-      checkForUpdates();
-    },
-    60 * 60 * 1000
-  );
+  setInterval(() => {
+    checkForUpdates();
+  }, UPDATE_CHECK_INTERVAL_MS);
 }
 
 export async function checkForUpdates(): Promise<{ enabled: boolean }> {

--- a/apps/desktop/src/main/app/v2-bridge/constants.ts
+++ b/apps/desktop/src/main/app/v2-bridge/constants.ts
@@ -1,0 +1,66 @@
+/**
+ * Tunables for the dormant v2 handover bridge.
+ *
+ * Every value here is sized for the dormant case — the manifest does not exist
+ * yet, so the poll must stay cheap enough that a 404 an hour is free.
+ */
+
+/** Default manifest location. Deliberately NOT `latest.yml`: electron-updater
+ * must never see this file, and this file must never be parsed as an
+ * electron-builder feed. */
+const DEFAULT_MANIFEST_URL = 'https://shiranami.app/v2.json';
+
+/**
+ * Manifest URL, overridable for the Spike B rehearsal (a clean Windows VM
+ * running a real published v1.x against a test manifest). Read per call rather
+ * than at module load so tests can flip it without re-importing.
+ */
+export function getManifestUrl(): string {
+  const override = process.env.SHIRANAMI_V2_MANIFEST_URL;
+  return override && override.length > 0 ? override : DEFAULT_MANIFEST_URL;
+}
+
+/** True when a manifest URL override is set (the Spike B / local-test hatch). */
+export function hasManifestUrlOverride(): boolean {
+  const override = process.env.SHIRANAMI_V2_MANIFEST_URL;
+  return typeof override === 'string' && override.length > 0;
+}
+
+/** Manifest poll timeout. Short — a hanging poll must never pile up per tick. */
+export const MANIFEST_TIMEOUT_MS = 5_000;
+
+/** Hard cap on the manifest body. The real file is well under 2 KB. */
+export const MANIFEST_MAX_BYTES = 64 * 1024;
+
+/** Installer download timeout (Windows automatic path only). */
+export const INSTALLER_TIMEOUT_MS = 10 * 60_000;
+
+/** Refuse to buffer an installer larger than this, whatever the manifest says. */
+export const INSTALLER_MAX_BYTES = 300 * 1024 * 1024;
+
+/** Subdirectory of `userData` holding the downloaded Tauri installer. */
+export const INSTALLER_DIR_NAME = 'v2-update';
+
+/**
+ * NSIS passive-mode flag. Shows a progress bar, takes no input. Matches the
+ * `installMode: "passive"` the v2 bundle is configured with.
+ */
+export const NSIS_PASSIVE_FLAG = '/P';
+
+/** Handoff descriptor consumed by v2's first-run continuity step. */
+export const HANDOFF_FILE_NAME = 'v2-handoff.json';
+
+/** Renderer `localStorage` dump consumed by v2 before the zustand stores hydrate. */
+export const RENDERER_STATE_FILE_NAME = 'renderer-state.json';
+
+/** Only keys under this prefix are dumped — everything shiranami persists is namespaced. */
+export const RENDERER_STATE_KEY_PREFIX = 'shiranami.';
+
+/**
+ * Envelope version for both handoff files. Bump only on a breaking shape
+ * change; new fields are additive and optional so an older v2 reader survives.
+ */
+export const HANDOFF_SCHEMA_VERSION = 1;
+
+/** Store key recording that the one-time crossover ping already fired. */
+export const CROSSOVER_PINGED_KEY = 'v2.crossoverPinged' as const;

--- a/apps/desktop/src/main/app/v2-bridge/handoff.test.ts
+++ b/apps/desktop/src/main/app/v2-bridge/handoff.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { BrowserWindow } from 'electron';
+import { makeTempDir, cleanupTempDir } from '../../../../test/setup';
+
+const { mockLogger, mockApp, mockStore } = vi.hoisted(() => ({
+  mockLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  mockApp: { userData: '', version: '1.0.0' },
+  mockStore: { get: vi.fn(), set: vi.fn() },
+}));
+
+vi.mock('../logger', () => ({ logger: mockLogger }));
+vi.mock('../store', () => ({ store: mockStore }));
+vi.mock('electron', () => ({
+  app: {
+    getPath: (key: string) => (key === 'userData' ? mockApp.userData : '/mock/unknown'),
+    getVersion: () => mockApp.version,
+  },
+}));
+
+import { captureRendererState, writeHandoffFiles } from './handoff';
+import { HANDOFF_FILE_NAME, RENDERER_STATE_FILE_NAME } from './constants';
+
+let dir: string;
+
+/** A window whose `executeJavaScript` returns `result` (or rejects with it). */
+function windowMock(result: unknown, { reject = false, destroyed = false } = {}) {
+  return {
+    isDestroyed: () => destroyed,
+    webContents: {
+      executeJavaScript: vi.fn(() => (reject ? Promise.reject(result) : Promise.resolve(result))),
+    },
+  } as unknown as BrowserWindow;
+}
+
+function readJson(fileName: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(path.join(dir, fileName), 'utf8')) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dir = makeTempDir();
+  mockApp.userData = dir;
+  mockApp.version = '1.0.0';
+  mockStore.get.mockReturnValue(undefined);
+});
+
+afterEach(() => {
+  cleanupTempDir(dir);
+});
+
+describe('captureRendererState', () => {
+  it('returns the string-valued keys the page reported', async () => {
+    const win = windowMock({ 'shiranami.theme': '"dark"', 'shiranami.accent-store': '{"a":1}' });
+
+    await expect(captureRendererState(win)).resolves.toEqual({
+      'shiranami.theme': '"dark"',
+      'shiranami.accent-store': '{"a":1}',
+    });
+  });
+
+  it('scopes the evaluated script to the shiranami key prefix', async () => {
+    const win = windowMock({});
+
+    await captureRendererState(win);
+
+    const script = vi.mocked(win.webContents.executeJavaScript).mock.calls[0]?.[0] as string;
+    expect(script).toContain('"shiranami."');
+    expect(script).toContain('localStorage');
+  });
+
+  it('drops non-string values rather than trusting the page', async () => {
+    const win = windowMock({ 'shiranami.theme': '"dark"', 'shiranami.bogus': { nested: true } });
+
+    await expect(captureRendererState(win)).resolves.toEqual({ 'shiranami.theme': '"dark"' });
+  });
+
+  it('returns an empty dump when there is no window', async () => {
+    await expect(captureRendererState(null)).resolves.toEqual({});
+  });
+
+  it('returns an empty dump when the window is destroyed', async () => {
+    await expect(captureRendererState(windowMock({}, { destroyed: true }))).resolves.toEqual({});
+  });
+
+  it('returns an empty dump when evaluation fails', async () => {
+    const win = windowMock(new Error('page gone'), { reject: true });
+
+    await expect(captureRendererState(win)).resolves.toEqual({});
+    expect(mockLogger.warn).toHaveBeenCalled();
+  });
+});
+
+describe('writeHandoffFiles', () => {
+  it('writes the descriptor v2 needs to find the v1 data', async () => {
+    mockStore.get.mockReturnValue('/Users/someone/Music/Shiranami');
+
+    await expect(writeHandoffFiles(windowMock({}))).resolves.toBe(true);
+
+    expect(readJson(HANDOFF_FILE_NAME)).toMatchObject({
+      schemaVersion: 1,
+      v1Version: '1.0.0',
+      platform: process.platform,
+      userDataPath: dir,
+      databasePath: path.join(dir, 'shiranami.db'),
+      downloadsLocation: '/Users/someone/Music/Shiranami',
+    });
+  });
+
+  it('records a null downloads location when the user never set one', async () => {
+    await writeHandoffFiles(windowMock({}));
+
+    expect(readJson(HANDOFF_FILE_NAME).downloadsLocation).toBeNull();
+  });
+
+  it('writes the renderer localStorage dump alongside it', async () => {
+    const win = windowMock({ 'shiranami.onboarding': '{"completed":true}' });
+
+    await writeHandoffFiles(win);
+
+    expect(readJson(RENDERER_STATE_FILE_NAME)).toMatchObject({
+      schemaVersion: 1,
+      keys: { 'shiranami.onboarding': '{"completed":true}' },
+    });
+  });
+
+  it('still writes the descriptor when the renderer state cannot be captured', async () => {
+    const win = windowMock(new Error('detached'), { reject: true });
+
+    await expect(writeHandoffFiles(win)).resolves.toBe(true);
+    expect(readJson(RENDERER_STATE_FILE_NAME).keys).toEqual({});
+    expect(readJson(HANDOFF_FILE_NAME).v1Version).toBe('1.0.0');
+  });
+
+  it('leaves no temp file behind', async () => {
+    await writeHandoffFiles(windowMock({}));
+
+    expect(fs.readdirSync(dir).filter(name => name.endsWith('.tmp'))).toEqual([]);
+  });
+
+  it('reports failure without throwing when the directory is unwritable', async () => {
+    mockApp.userData = path.join(dir, 'does', 'not', 'exist');
+
+    await expect(writeHandoffFiles(windowMock({}))).resolves.toBe(false);
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it('overwrites a previous handoff rather than appending to it', async () => {
+    await writeHandoffFiles(windowMock({ 'shiranami.theme': '"light"' }));
+    await writeHandoffFiles(windowMock({ 'shiranami.theme': '"dark"' }));
+
+    expect(readJson(RENDERER_STATE_FILE_NAME).keys).toEqual({ 'shiranami.theme': '"dark"' });
+  });
+});

--- a/apps/desktop/src/main/app/v2-bridge/handoff.ts
+++ b/apps/desktop/src/main/app/v2-bridge/handoff.ts
@@ -1,0 +1,157 @@
+/**
+ * The two files v1 leaves behind for v2's first-run continuity step.
+ *
+ * Both land next to the library database in `userData`, because that is the
+ * directory v2 already has to locate in order to copy the library at all —
+ * v1 resolves these paths natively, v2 would otherwise have to guess them.
+ *
+ * - `v2-handoff.json`     — where v1 kept everything (userData, DB, downloads).
+ * - `renderer-state.json` — every `shiranami.*` localStorage key.
+ *
+ * The localStorage dump exists because Chromium's partition, WKWebView's store
+ * and WebView2's store are three separate origins: without it a returning user
+ * loses theme, accent, layout, grid size and the onboarding-complete flag, and
+ * gets re-onboarded on top of a migration.
+ *
+ * Neither writer throws. A failure to capture UI preferences must never block
+ * the handover — the library is what matters, and v2 re-derives what it can.
+ */
+
+import { app, type BrowserWindow } from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
+import { logger } from '../logger';
+import { store } from '../store';
+import {
+  HANDOFF_FILE_NAME,
+  HANDOFF_SCHEMA_VERSION,
+  RENDERER_STATE_FILE_NAME,
+  RENDERER_STATE_KEY_PREFIX,
+} from './constants';
+
+/** Contents of `v2-handoff.json`. New fields must be optional. */
+export interface V2HandoffDescriptor {
+  schemaVersion: number;
+  capturedAt: string;
+  v1Version: string;
+  platform: string;
+  userDataPath: string;
+  databasePath: string;
+  /** Resolved download folder, or null when the user never set one. */
+  downloadsLocation: string | null;
+}
+
+/** Contents of `renderer-state.json`. New fields must be optional. */
+export interface V2RendererStateDump {
+  schemaVersion: number;
+  capturedAt: string;
+  /** Raw `shiranami.*` localStorage entries, values left as stored strings. */
+  keys: Record<string, string>;
+}
+
+/**
+ * Serialize `value` to `filePath` via a temp file + rename, so a crash mid-write
+ * can never leave v2 reading a truncated descriptor. Mirrors the temp+rename
+ * pattern in `services/db-backup.ts` and `downloads/ytdlp-manager.ts`.
+ */
+function writeJsonAtomic(filePath: string, value: unknown): void {
+  const tempPath = `${filePath}.tmp`;
+  try {
+    fs.writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+    fs.renameSync(tempPath, filePath);
+  } catch (error) {
+    try {
+      fs.rmSync(tempPath, { force: true });
+    } catch {
+      // Best-effort cleanup; the stale temp file is harmless.
+    }
+    throw error;
+  }
+}
+
+/** Absolute path of the live library database. */
+function getDatabasePath(): string {
+  return path.join(app.getPath('userData'), 'shiranami.db');
+}
+
+/**
+ * Read every `shiranami.*` key out of the renderer's localStorage.
+ *
+ * Evaluated in the page rather than pushed over IPC so the bridge needs no
+ * renderer-side participation at all — a v1.x release that ships this hook
+ * carries zero renderer diff and therefore zero renderer regression risk.
+ *
+ * Returns `{}` when the window is gone or evaluation fails.
+ */
+export async function captureRendererState(
+  mainWindow: BrowserWindow | null
+): Promise<Record<string, string>> {
+  if (!mainWindow || mainWindow.isDestroyed()) return {};
+
+  const script = `(() => {
+    const out = {};
+    try {
+      for (let i = 0; i < localStorage.length; i += 1) {
+        const key = localStorage.key(i);
+        if (!key || !key.startsWith(${JSON.stringify(RENDERER_STATE_KEY_PREFIX)})) continue;
+        const value = localStorage.getItem(key);
+        if (typeof value === 'string') out[key] = value;
+      }
+    } catch {}
+    return out;
+  })()`;
+
+  try {
+    const result: unknown = await mainWindow.webContents.executeJavaScript(script, true);
+    if (!result || typeof result !== 'object') return {};
+
+    const dump: Record<string, string> = {};
+    for (const [key, value] of Object.entries(result as Record<string, unknown>)) {
+      if (typeof value === 'string') dump[key] = value;
+    }
+    return dump;
+  } catch (error) {
+    logger.warn('[v2-bridge] Could not read renderer state:', error);
+    return {};
+  }
+}
+
+/**
+ * Write both handoff files. Best-effort and never throws: returns true only
+ * when the descriptor (the file v2 actually needs) landed on disk.
+ */
+export async function writeHandoffFiles(mainWindow: BrowserWindow | null): Promise<boolean> {
+  const userDataPath = app.getPath('userData');
+  const capturedAt = new Date().toISOString();
+
+  const rendererKeys = await captureRendererState(mainWindow);
+  try {
+    const dump: V2RendererStateDump = {
+      schemaVersion: HANDOFF_SCHEMA_VERSION,
+      capturedAt,
+      keys: rendererKeys,
+    };
+    writeJsonAtomic(path.join(userDataPath, RENDERER_STATE_FILE_NAME), dump);
+  } catch (error) {
+    // UI preferences are recoverable-by-hand; the library is not. Keep going.
+    logger.warn('[v2-bridge] Failed to write renderer state:', error);
+  }
+
+  try {
+    const descriptor: V2HandoffDescriptor = {
+      schemaVersion: HANDOFF_SCHEMA_VERSION,
+      capturedAt,
+      v1Version: app.getVersion(),
+      platform: process.platform,
+      userDataPath,
+      databasePath: getDatabasePath(),
+      downloadsLocation: store.get('downloads.location') ?? null,
+    };
+    writeJsonAtomic(path.join(userDataPath, HANDOFF_FILE_NAME), descriptor);
+    logger.info(`[v2-bridge] Wrote handoff descriptor (${Object.keys(rendererKeys).length} keys)`);
+    return true;
+  } catch (error) {
+    logger.error('[v2-bridge] Failed to write handoff descriptor:', error);
+    return false;
+  }
+}

--- a/apps/desktop/src/main/app/v2-bridge/handover.test.ts
+++ b/apps/desktop/src/main/app/v2-bridge/handover.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { BrowserWindow } from 'electron';
+import { makeTempDir, cleanupTempDir } from '../../../../test/setup';
+
+const { mockLogger, mockApp, mockDialog, mockShell, mockSpawn } = vi.hoisted(() => ({
+  mockLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  mockApp: { userData: '', quit: vi.fn() },
+  mockDialog: { showMessageBox: vi.fn() },
+  mockShell: { openExternal: vi.fn() },
+  mockSpawn: vi.fn(),
+}));
+
+vi.mock('../logger', () => ({ logger: mockLogger }));
+vi.mock('child_process', () => ({ spawn: mockSpawn }));
+vi.mock('electron', () => ({
+  app: {
+    getPath: (key: string) => (key === 'userData' ? mockApp.userData : '/mock/unknown'),
+    quit: mockApp.quit,
+  },
+  dialog: mockDialog,
+  shell: mockShell,
+}));
+
+import {
+  installerFileName,
+  manualDownloadUrl,
+  runWindowsHandover,
+  showHandoverNotice,
+} from './handover';
+import { INSTALLER_DIR_NAME, INSTALLER_MAX_BYTES, NSIS_PASSIVE_FLAG } from './constants';
+import type { V2Artifact, V2Manifest } from './manifest';
+
+const INSTALLER_BYTES = Buffer.from('MZ-this-is-a-tauri-nsis-installer');
+const INSTALLER_SHA = createHash('sha256').update(INSTALLER_BYTES).digest('hex');
+const INSTALLER_URL = 'https://shiranami.app/releases/Shiranami_2.0.0_x64-setup.exe';
+
+const fetchMock = vi.fn();
+let dir: string;
+
+function artifact(overrides: Partial<V2Artifact> = {}): V2Artifact {
+  return {
+    url: INSTALLER_URL,
+    sha256: INSTALLER_SHA,
+    size: INSTALLER_BYTES.length,
+    ...overrides,
+  };
+}
+
+function manifest(overrides: Partial<V2Manifest> = {}): V2Manifest {
+  return {
+    enabled: true,
+    version: '2.0.0',
+    min_v1_version: '1.0.0',
+    platforms: { 'win32-x64': artifact() },
+    ...overrides,
+  };
+}
+
+function respondWith(bytes: Buffer, init: { ok?: boolean; status?: number } = {}): void {
+  fetchMock.mockResolvedValue({
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.length),
+  });
+}
+
+function installerPath(): string {
+  return path.join(dir, INSTALLER_DIR_NAME, 'Shiranami_2.0.0_x64-setup.exe');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dir = makeTempDir();
+  mockApp.userData = dir;
+  mockSpawn.mockReturnValue({ unref: vi.fn() });
+  mockDialog.showMessageBox.mockResolvedValue({ response: 1 });
+  mockShell.openExternal.mockResolvedValue(undefined);
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanupTempDir(dir);
+});
+
+describe('installerFileName', () => {
+  it('accepts a plain .exe basename', () => {
+    expect(installerFileName(INSTALLER_URL)).toBe('Shiranami_2.0.0_x64-setup.exe');
+  });
+
+  it.each([
+    ['https://shiranami.app/releases/', 'a bare directory'],
+    ['https://shiranami.app/releases/setup.exe.sh', 'a non-exe extension'],
+    ['https://shiranami.app/releases/..%2F..%2Fevil.exe', 'an escaped traversal'],
+    ['not a url at all', 'an unparseable URL'],
+  ])('rejects %s (%s)', url => {
+    expect(installerFileName(url)).toBeNull();
+  });
+});
+
+describe('runWindowsHandover', () => {
+  it('downloads, verifies, spawns the installer in passive mode, and quits', async () => {
+    respondWith(INSTALLER_BYTES);
+
+    await expect(runWindowsHandover(artifact())).resolves.toBe(true);
+
+    expect(fs.readFileSync(installerPath())).toEqual(INSTALLER_BYTES);
+    expect(mockSpawn).toHaveBeenCalledWith(installerPath(), [NSIS_PASSIVE_FLAG], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    expect(mockApp.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses to run an installer whose digest does not match the manifest', async () => {
+    respondWith(Buffer.from('a completely different payload'));
+
+    await expect(runWindowsHandover(artifact({ size: 30 }))).resolves.toBe(false);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(mockApp.quit).not.toHaveBeenCalled();
+  });
+
+  it('refuses to run an installer whose length does not match the manifest', async () => {
+    respondWith(INSTALLER_BYTES);
+
+    await expect(runWindowsHandover(artifact({ size: 999 }))).resolves.toBe(false);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('gives up when the download fails', async () => {
+    fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+
+    await expect(runWindowsHandover(artifact())).resolves.toBe(false);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(mockApp.quit).not.toHaveBeenCalled();
+  });
+
+  it('gives up on a non-2xx download', async () => {
+    respondWith(INSTALLER_BYTES, { ok: false, status: 403 });
+
+    await expect(runWindowsHandover(artifact())).resolves.toBe(false);
+  });
+
+  it('never fetches an artifact that claims to exceed the size ceiling', async () => {
+    await expect(runWindowsHandover(artifact({ size: INSTALLER_MAX_BYTES + 1 }))).resolves.toBe(
+      false
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('never fetches an artifact whose URL is not a plain installer file', async () => {
+    await expect(
+      runWindowsHandover(artifact({ url: 'https://shiranami.app/releases/' }))
+    ).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not quit when the installer cannot be spawned', async () => {
+    respondWith(INSTALLER_BYTES);
+    mockSpawn.mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+
+    await expect(runWindowsHandover(artifact())).resolves.toBe(false);
+    expect(mockApp.quit).not.toHaveBeenCalled();
+  });
+});
+
+describe('manualDownloadUrl', () => {
+  it('prefers the landing page when the manifest names one', () => {
+    const withPage = manifest({ download_page: 'https://shiranami.app/download' });
+    expect(manualDownloadUrl(withPage, artifact())).toBe('https://shiranami.app/download');
+  });
+
+  it('falls back to the artifact URL', () => {
+    expect(manualDownloadUrl(manifest(), artifact())).toBe(INSTALLER_URL);
+  });
+});
+
+describe('showHandoverNotice', () => {
+  const win = { isDestroyed: () => false } as unknown as BrowserWindow;
+
+  it('presents a modal against the main window and opens the download when accepted', async () => {
+    mockDialog.showMessageBox.mockResolvedValue({ response: 0 });
+
+    await showHandoverNotice(
+      win,
+      manifest({ download_page: 'https://shiranami.app/download' }),
+      artifact()
+    );
+
+    expect(mockDialog.showMessageBox).toHaveBeenCalledWith(win, expect.anything());
+    expect(mockShell.openExternal).toHaveBeenCalledWith('https://shiranami.app/download');
+  });
+
+  it('opens nothing when the user picks Later', async () => {
+    mockDialog.showMessageBox.mockResolvedValue({ response: 1 });
+
+    await showHandoverNotice(win, manifest(), artifact());
+
+    expect(mockShell.openExternal).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a windowless dialog when there is no live window', async () => {
+    await showHandoverNotice(null, manifest(), artifact());
+
+    expect(mockDialog.showMessageBox).toHaveBeenCalledWith(expect.anything());
+  });
+
+  it('never throws when the dialog cannot be shown', async () => {
+    mockDialog.showMessageBox.mockRejectedValue(new Error('no display'));
+
+    await expect(showHandoverNotice(win, manifest(), artifact())).resolves.toBeUndefined();
+    expect(mockLogger.warn).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/app/v2-bridge/handover.ts
+++ b/apps/desktop/src/main/app/v2-bridge/handover.ts
@@ -1,0 +1,179 @@
+/**
+ * The two ways v1 hands a user over to v2.
+ *
+ * **Windows — automatic.** Download the Tauri NSIS installer, verify its sha256
+ * against the manifest, spawn it detached in passive mode, quit. The installer
+ * carries an `NSIS_HOOK_PREINSTALL` that removes the Electron entry, so the
+ * user never sees two Shiranamis in Add/Remove Programs.
+ *
+ * **Everywhere else — a modal.** v1 has no auto-updater on macOS at all (the
+ * app is unsigned), so there is no updater to hand over *from*; an unsigned app
+ * rewriting `/Applications` and relaunching is exactly the Gatekeeper-quarantined
+ * path that fails silently on user machines. A blocking dialog linking to the
+ * download is the honest version of what those users already do by hand.
+ */
+
+import { app, dialog, shell, type BrowserWindow } from 'electron';
+import { spawn } from 'child_process';
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { logger } from '../logger';
+import type { V2Artifact, V2Manifest } from './manifest';
+import {
+  INSTALLER_DIR_NAME,
+  INSTALLER_MAX_BYTES,
+  INSTALLER_TIMEOUT_MS,
+  NSIS_PASSIVE_FLAG,
+} from './constants';
+
+/** Installer file names we are willing to write and execute. */
+const SAFE_INSTALLER_NAME = /^[A-Za-z0-9._-]+\.exe$/;
+
+/**
+ * Derive a safe local file name from the artifact URL. Returns null when the
+ * URL is unparseable or its basename is anything other than a plain `.exe` —
+ * the manifest is remote input, so it never gets to choose a path.
+ */
+export function installerFileName(artifactUrl: string): string | null {
+  let base: string;
+  try {
+    base = path.posix.basename(new URL(artifactUrl).pathname);
+  } catch {
+    return null;
+  }
+  return SAFE_INSTALLER_NAME.test(base) ? base : null;
+}
+
+/** Lowercase hex sha256 of a buffer. */
+function sha256(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+/**
+ * Download the artifact and verify it byte-for-byte against the manifest.
+ * Returns the path of the verified installer, or null on any failure (network,
+ * size mismatch, digest mismatch, disk).
+ */
+async function downloadVerifiedInstaller(artifact: V2Artifact): Promise<string | null> {
+  const fileName = installerFileName(artifact.url);
+  if (!fileName) {
+    logger.error('[v2-bridge] Manifest artifact URL is not a plain installer file');
+    return null;
+  }
+
+  if (artifact.size > INSTALLER_MAX_BYTES) {
+    logger.error(`[v2-bridge] Manifest artifact exceeds the size ceiling (${artifact.size} bytes)`);
+    return null;
+  }
+
+  const targetDir = path.join(app.getPath('userData'), INSTALLER_DIR_NAME);
+  const targetPath = path.join(targetDir, fileName);
+
+  let bytes: Buffer;
+  try {
+    const response = await fetch(artifact.url, {
+      signal: AbortSignal.timeout(INSTALLER_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      logger.error(`[v2-bridge] Installer download failed: HTTP ${response.status}`);
+      return null;
+    }
+    bytes = Buffer.from(await response.arrayBuffer());
+  } catch (error) {
+    logger.error('[v2-bridge] Installer download failed:', error);
+    return null;
+  }
+
+  if (bytes.length !== artifact.size) {
+    logger.error(
+      `[v2-bridge] Installer size mismatch: expected ${artifact.size}, got ${bytes.length}`
+    );
+    return null;
+  }
+
+  const digest = sha256(bytes);
+  if (digest.toLowerCase() !== artifact.sha256.toLowerCase()) {
+    logger.error('[v2-bridge] Installer sha256 mismatch — refusing to run it');
+    return null;
+  }
+
+  try {
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.writeFileSync(targetPath, bytes);
+  } catch (error) {
+    logger.error('[v2-bridge] Could not write the installer to disk:', error);
+    return null;
+  }
+
+  return targetPath;
+}
+
+/**
+ * Windows automatic handover. Returns true only once the installer is spawned
+ * and the quit is requested; every failure returns false so the caller can fall
+ * back to the manual notice.
+ */
+export async function runWindowsHandover(artifact: V2Artifact): Promise<boolean> {
+  const installerPath = await downloadVerifiedInstaller(artifact);
+  if (!installerPath) return false;
+
+  try {
+    const child = spawn(installerPath, [NSIS_PASSIVE_FLAG], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+  } catch (error) {
+    logger.error('[v2-bridge] Could not launch the v2 installer:', error);
+    return false;
+  }
+
+  logger.info('[v2-bridge] v2 installer launched — quitting v1');
+  app.quit();
+  return true;
+}
+
+/** Where the manual path sends the user: the landing page when the manifest
+ * names one, otherwise the artifact itself. */
+export function manualDownloadUrl(manifest: V2Manifest, artifact: V2Artifact): string {
+  return manifest.download_page ?? artifact.url;
+}
+
+/**
+ * Manual handover notice. Modal against the main window so it is unmissable,
+ * and opens the download in the user's browser rather than touching the
+ * installed app. Never throws.
+ */
+export async function showHandoverNotice(
+  mainWindow: BrowserWindow | null,
+  manifest: V2Manifest,
+  artifact: V2Artifact
+): Promise<void> {
+  const options = {
+    type: 'info' as const,
+    buttons: [`Download Shiranami ${manifest.version}`, 'Later'],
+    defaultId: 0,
+    cancelId: 1,
+    title: `Shiranami ${manifest.version} is here`,
+    message: `Shiranami ${manifest.version} is here`,
+    detail:
+      'This version of Shiranami will not update itself to the new one. ' +
+      'Download it from the site and install it over this copy — your library, ' +
+      'playlists and settings are carried across on first launch, and nothing ' +
+      'in this version is removed.',
+  };
+
+  try {
+    const result =
+      mainWindow && !mainWindow.isDestroyed()
+        ? await dialog.showMessageBox(mainWindow, options)
+        : await dialog.showMessageBox(options);
+
+    if (result.response === 0) {
+      await shell.openExternal(manualDownloadUrl(manifest, artifact));
+    }
+  } catch (error) {
+    logger.warn('[v2-bridge] Could not present the handover notice:', error);
+  }
+}

--- a/apps/desktop/src/main/app/v2-bridge/index.test.ts
+++ b/apps/desktop/src/main/app/v2-bridge/index.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { BrowserWindow } from 'electron';
+import { makeTempDir, cleanupTempDir } from '../../../../test/setup';
+
+const { mockLogger, mockApp, mockStore, mockSentry, mockHandover } = vi.hoisted(() => ({
+  mockLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  mockApp: { userData: '', version: '1.0.0', isPackaged: true },
+  mockStore: { get: vi.fn(), set: vi.fn() },
+  mockSentry: { captureMessage: vi.fn(), captureException: vi.fn() },
+  mockHandover: { runWindowsHandover: vi.fn(), showHandoverNotice: vi.fn() },
+}));
+
+vi.mock('../logger', () => ({ logger: mockLogger }));
+vi.mock('../store', () => ({ store: mockStore }));
+vi.mock('@sentry/electron/main', () => mockSentry);
+vi.mock('./handover', () => mockHandover);
+vi.mock('../updater', () => ({
+  INITIAL_UPDATE_CHECK_DELAY_MS: 5_000,
+  UPDATE_CHECK_INTERVAL_MS: 60 * 60 * 1000,
+}));
+vi.mock('electron', () => ({
+  app: {
+    getPath: (key: string) => (key === 'userData' ? mockApp.userData : '/mock/unknown'),
+    getVersion: () => mockApp.version,
+    get isPackaged() {
+      return mockApp.isPackaged;
+    },
+  },
+}));
+
+import { checkForV2Handover, initializeV2Bridge, stopV2Bridge } from './index';
+import { __resetManifestLogGate, currentPlatformKey, type V2Manifest } from './manifest';
+import { CROSSOVER_PINGED_KEY, HANDOFF_FILE_NAME, RENDERER_STATE_FILE_NAME } from './constants';
+
+const fetchMock = vi.fn();
+let dir: string;
+let realPlatform: PropertyDescriptor | undefined;
+
+function manifestFixture(overrides: Partial<V2Manifest> = {}): V2Manifest {
+  return {
+    enabled: true,
+    version: '2.0.0',
+    min_v1_version: '1.0.0',
+    platforms: {
+      [currentPlatformKey()]: {
+        url: 'https://shiranami.app/releases/Shiranami_2.0.0_x64-setup.exe',
+        sha256: 'a'.repeat(64),
+        size: 1024,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function serveManifest(manifest: V2Manifest | null, status = 404): void {
+  const body = manifest ? JSON.stringify(manifest) : 'Not Found';
+  fetchMock.mockResolvedValue({
+    ok: manifest !== null,
+    status: manifest ? 200 : status,
+    headers: { get: () => String(body.length) },
+    text: async () => body,
+  });
+}
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+const win = {
+  isDestroyed: () => false,
+  webContents: { executeJavaScript: vi.fn().mockResolvedValue({ 'shiranami.theme': '"dark"' }) },
+} as unknown as BrowserWindow;
+
+/** Files the bridge is allowed to leave in `userData` once it has acted. */
+function handoffArtifacts(): string[] {
+  return fs.readdirSync(dir).sort();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  stopV2Bridge();
+  __resetManifestLogGate();
+  dir = makeTempDir();
+  mockApp.userData = dir;
+  mockApp.version = '1.0.0';
+  mockApp.isPackaged = true;
+  mockStore.get.mockReturnValue(undefined);
+  mockHandover.runWindowsHandover.mockResolvedValue(true);
+  mockHandover.showHandoverNotice.mockResolvedValue(undefined);
+  realPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  if (realPlatform) Object.defineProperty(process, 'platform', realPlatform);
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  stopV2Bridge();
+  cleanupTempDir(dir);
+});
+
+describe('checkForV2Handover — dormant', () => {
+  it.each([
+    ['the manifest 404s', () => serveManifest(null)],
+    ['the network is down', () => fetchMock.mockRejectedValue(new TypeError('fetch failed'))],
+    ['the body is not JSON', () => serveManifest(null, 200)],
+  ])('does nothing at all when %s', async (_label, arrange) => {
+    arrange();
+
+    await expect(checkForV2Handover(win)).resolves.toBe('dormant');
+
+    expect(handoffArtifacts()).toEqual([]);
+    expect(mockHandover.runWindowsHandover).not.toHaveBeenCalled();
+    expect(mockHandover.showHandoverNotice).not.toHaveBeenCalled();
+    expect(mockSentry.captureMessage).not.toHaveBeenCalled();
+    expect(mockStore.set).not.toHaveBeenCalled();
+  });
+
+  it('never touches the renderer while dormant', async () => {
+    serveManifest(null);
+
+    await checkForV2Handover(win);
+
+    expect(win.webContents.executeJavaScript).not.toHaveBeenCalled();
+  });
+
+  it('does not surface a manifest whose kill switch is off', async () => {
+    serveManifest(manifestFixture({ enabled: false }));
+
+    await expect(checkForV2Handover(win)).resolves.toBe('not-applicable');
+    expect(handoffArtifacts()).toEqual([]);
+    expect(mockHandover.showHandoverNotice).not.toHaveBeenCalled();
+  });
+
+  it('does not surface to an install below the minimum v1 version', async () => {
+    mockApp.version = '0.20.0';
+    serveManifest(manifestFixture({ min_v1_version: '1.0.0' }));
+
+    await expect(checkForV2Handover(win)).resolves.toBe('not-applicable');
+    expect(handoffArtifacts()).toEqual([]);
+  });
+
+  it('does not surface when the manifest has no artifact for this platform', async () => {
+    serveManifest(manifestFixture({ platforms: {} }));
+
+    await expect(checkForV2Handover(win)).resolves.toBe('not-applicable');
+    expect(handoffArtifacts()).toEqual([]);
+  });
+});
+
+describe('checkForV2Handover — active', () => {
+  it('writes both handoff files before surfacing anything', async () => {
+    setPlatform('darwin');
+    serveManifest(manifestFixture());
+
+    await expect(checkForV2Handover(win)).resolves.toBe('notified');
+
+    expect(handoffArtifacts()).toEqual([HANDOFF_FILE_NAME, RENDERER_STATE_FILE_NAME].sort());
+    const dump = JSON.parse(
+      fs.readFileSync(path.join(dir, RENDERER_STATE_FILE_NAME), 'utf8')
+    ) as Record<string, unknown>;
+    expect(dump.keys).toEqual({ 'shiranami.theme': '"dark"' });
+  });
+
+  it('shows the manual notice off Windows and never spawns an installer', async () => {
+    setPlatform('darwin');
+    serveManifest(manifestFixture());
+
+    await checkForV2Handover(win);
+
+    expect(mockHandover.showHandoverNotice).toHaveBeenCalledTimes(1);
+    expect(mockHandover.runWindowsHandover).not.toHaveBeenCalled();
+  });
+
+  it('runs the automatic handover on a packaged Windows build', async () => {
+    setPlatform('win32');
+    serveManifest(manifestFixture());
+
+    await expect(checkForV2Handover(win)).resolves.toBe('handed-off');
+
+    expect(mockHandover.runWindowsHandover).toHaveBeenCalledTimes(1);
+    expect(mockHandover.showHandoverNotice).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the manual notice when the automatic handover fails', async () => {
+    setPlatform('win32');
+    mockHandover.runWindowsHandover.mockResolvedValue(false);
+    serveManifest(manifestFixture());
+
+    await expect(checkForV2Handover(win)).resolves.toBe('notified');
+    expect(mockHandover.showHandoverNotice).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the manual notice on an unpackaged Windows run', async () => {
+    setPlatform('win32');
+    mockApp.isPackaged = false;
+    serveManifest(manifestFixture());
+
+    await checkForV2Handover(win);
+
+    expect(mockHandover.runWindowsHandover).not.toHaveBeenCalled();
+    expect(mockHandover.showHandoverNotice).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces at most once per session', async () => {
+    setPlatform('darwin');
+    serveManifest(manifestFixture());
+
+    await checkForV2Handover(win);
+    await expect(checkForV2Handover(win)).resolves.toBe('already-surfaced');
+
+    expect(mockHandover.showHandoverNotice).toHaveBeenCalledTimes(1);
+  });
+
+  it('still surfaces the handover when the settings store is unreadable', async () => {
+    setPlatform('darwin');
+    mockStore.get.mockImplementation(() => {
+      throw new Error('store is corrupt');
+    });
+    serveManifest(manifestFixture());
+
+    await expect(checkForV2Handover(win)).resolves.toBe('notified');
+    expect(mockHandover.showHandoverNotice).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('crossover ping', () => {
+  beforeEach(() => {
+    setPlatform('darwin');
+    serveManifest(manifestFixture());
+  });
+
+  it('stays silent when telemetry consent is off', async () => {
+    mockStore.get.mockReturnValue(undefined);
+
+    await checkForV2Handover(win);
+
+    expect(mockSentry.captureMessage).not.toHaveBeenCalled();
+    expect(mockStore.set).not.toHaveBeenCalled();
+  });
+
+  it('fires once and records the flag when consent is on', async () => {
+    mockStore.get.mockImplementation((key: string) =>
+      key === 'app.telemetryEnabled' ? true : undefined
+    );
+
+    await checkForV2Handover(win);
+
+    expect(mockSentry.captureMessage).toHaveBeenCalledWith(
+      'v2-crossover',
+      expect.objectContaining({ level: 'info' })
+    );
+    expect(mockStore.set).toHaveBeenCalledWith(CROSSOVER_PINGED_KEY, true);
+  });
+
+  it('does not fire again once the flag is set', async () => {
+    mockStore.get.mockReturnValue(true);
+
+    await checkForV2Handover(win);
+
+    expect(mockSentry.captureMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('initializeV2Bridge', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    delete process.env.SHIRANAMI_V2_MANIFEST_URL;
+  });
+
+  afterEach(() => {
+    delete process.env.SHIRANAMI_V2_MANIFEST_URL;
+  });
+
+  it('does not poll at all in development', () => {
+    serveManifest(null);
+
+    initializeV2Bridge(win, true);
+    vi.advanceTimersByTime(10 * 60 * 60 * 1000);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('polls in development when a test manifest URL is pointed at it', async () => {
+    process.env.SHIRANAMI_V2_MANIFEST_URL = 'https://example.test/v2.json';
+    serveManifest(null);
+
+    initializeV2Bridge(win, true);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never polls before the app has settled, then polls hourly', async () => {
+    serveManifest(null);
+
+    initializeV2Bridge(win, false);
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('is idempotent — a second init does not double the polling', async () => {
+    serveManifest(null);
+
+    initializeV2Bridge(win, false);
+    initializeV2Bridge(win, false);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops polling once the bridge is torn down', async () => {
+    serveManifest(null);
+
+    initializeV2Bridge(win, false);
+    stopV2Bridge();
+    await vi.advanceTimersByTimeAsync(10 * 60 * 60 * 1000);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/app/v2-bridge/index.ts
+++ b/apps/desktop/src/main/app/v2-bridge/index.ts
@@ -1,0 +1,151 @@
+/**
+ * The dormant v2 handover bridge.
+ *
+ * Shiranami v2 is a Tauri app. `electron-updater` expects electron-builder
+ * metadata (`latest.yml`, `.blockmap`, its own NSIS) and cannot install a Tauri
+ * artifact — there is no supported hand-off mode. The documented failure here
+ * is shipping v1.x releases *without* a bridge and then discovering, months
+ * later, that the tail never crossed over because it never opened the app
+ * during the transition window. So the hook ships first and sleeps.
+ *
+ * **The dormant guarantee.** Everything below hangs off exactly one condition:
+ *
+ *     const artifact = manifest && resolveHandover(manifest);
+ *     if (!artifact) return;   // ← nothing else in this module runs
+ *
+ * `fetchV2Manifest()` returns `null` for every failure mode (404, offline, DNS,
+ * timeout, oversized, non-JSON, schema-invalid) and never throws;
+ * `resolveHandover()` returns `null` when the kill switch is off, the
+ * `min_v1_version` floor is not met, or this platform has no artifact. Until a
+ * manifest is published, the entire cost of this feature is one 5-second-capped
+ * GET per hour, off the startup path, and one log line per process.
+ */
+
+import * as Sentry from '@sentry/electron/main';
+import { app, type BrowserWindow } from 'electron';
+import { logger } from '../logger';
+import { store } from '../store';
+import { INITIAL_UPDATE_CHECK_DELAY_MS, UPDATE_CHECK_INTERVAL_MS } from '../updater';
+import { CROSSOVER_PINGED_KEY, hasManifestUrlOverride } from './constants';
+import { writeHandoffFiles } from './handoff';
+import { runWindowsHandover, showHandoverNotice } from './handover';
+import { fetchV2Manifest, resolveHandover, type V2Manifest } from './manifest';
+
+/** What a single bridge tick decided. Returned for tests and logging only. */
+export type V2BridgeOutcome =
+  | 'dormant'
+  | 'not-applicable'
+  | 'already-surfaced'
+  | 'handed-off'
+  | 'notified';
+
+let initialized = false;
+let surfacedThisSession = false;
+let checkInFlight = false;
+const timers: NodeJS.Timeout[] = [];
+
+/**
+ * One-time crossover ping so the v1 tail is measured rather than guessed.
+ * Gated on the same explicit opt-in as every other Sentry event — when consent
+ * is off this is a no-op and the flag stays unset.
+ */
+function pingCrossover(manifest: V2Manifest): void {
+  try {
+    if (store.get(CROSSOVER_PINGED_KEY) === true) return;
+    if (store.get('app.telemetryEnabled') !== true) return;
+
+    Sentry.captureMessage('v2-crossover', {
+      level: 'info',
+      tags: {
+        v1_version: app.getVersion(),
+        v2_version: manifest.version,
+        platform: process.platform,
+      },
+    });
+    store.set(CROSSOVER_PINGED_KEY, true);
+  } catch (error) {
+    logger.warn('[v2-bridge] Crossover ping failed:', error);
+  }
+}
+
+/**
+ * One bridge tick. Never throws — a handover failure degrades to the manual
+ * notice, and a manifest failure degrades to doing nothing at all.
+ */
+export async function checkForV2Handover(
+  mainWindow: BrowserWindow | null
+): Promise<V2BridgeOutcome> {
+  if (surfacedThisSession || checkInFlight) return 'already-surfaced';
+  checkInFlight = true;
+
+  try {
+    const manifest = await fetchV2Manifest();
+    if (!manifest) return 'dormant';
+
+    const artifact = resolveHandover(manifest);
+    if (!artifact) return 'not-applicable';
+
+    logger.info(`[v2-bridge] Handover manifest is live for v${manifest.version}`);
+    pingCrossover(manifest);
+    await writeHandoffFiles(mainWindow);
+
+    // Only a packaged Windows build can install over itself; anything else
+    // (macOS, Linux, an unpackaged run) gets the manual notice.
+    if (process.platform === 'win32' && app.isPackaged) {
+      surfacedThisSession = true;
+      if (await runWindowsHandover(artifact)) return 'handed-off';
+      logger.warn('[v2-bridge] Automatic handover failed — falling back to the manual notice');
+      await showHandoverNotice(mainWindow, manifest, artifact);
+      return 'notified';
+    }
+
+    surfacedThisSession = true;
+    await showHandoverNotice(mainWindow, manifest, artifact);
+    return 'notified';
+  } catch (error) {
+    // Defence in depth: every callee already swallows its own failures.
+    logger.warn('[v2-bridge] Handover check failed:', error);
+    return 'dormant';
+  } finally {
+    checkInFlight = false;
+  }
+}
+
+/**
+ * Schedule the bridge poll on the same cadence as the updater's own check.
+ *
+ * It does NOT ride inside `initializeAutoUpdater`, because that function
+ * returns early on macOS (unsigned, no updater) — and macOS users are exactly
+ * the ones who need the manual notice. Timers are `unref`'d so the poll never
+ * holds the event loop open.
+ */
+export function initializeV2Bridge(mainWindow: BrowserWindow | null, isDev: boolean): void {
+  if (initialized) return;
+
+  // Dev builds stay quiet unless a test manifest URL is pointed at them.
+  if (isDev && !hasManifestUrlOverride()) {
+    logger.info('[v2-bridge] Skipping handover bridge in development mode');
+    return;
+  }
+
+  initialized = true;
+
+  const tick = (): void => {
+    void checkForV2Handover(mainWindow);
+  };
+
+  timers.push(setTimeout(tick, INITIAL_UPDATE_CHECK_DELAY_MS).unref());
+  timers.push(setInterval(tick, UPDATE_CHECK_INTERVAL_MS).unref());
+}
+
+/** Cancel the bridge timers (app teardown, and between tests). */
+export function stopV2Bridge(): void {
+  for (const timer of timers) {
+    clearTimeout(timer);
+    clearInterval(timer);
+  }
+  timers.length = 0;
+  initialized = false;
+  surfacedThisSession = false;
+  checkInFlight = false;
+}

--- a/apps/desktop/src/main/app/v2-bridge/manifest.test.ts
+++ b/apps/desktop/src/main/app/v2-bridge/manifest.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { mockLogger, mockApp } = vi.hoisted(() => ({
+  mockLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  mockApp: { version: '1.0.0' },
+}));
+
+vi.mock('../logger', () => ({ logger: mockLogger }));
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => mockApp.version },
+}));
+
+import {
+  __resetManifestLogGate,
+  currentPlatformKey,
+  fetchV2Manifest,
+  meetsMinimumV1Version,
+  resolveHandover,
+  selectArtifact,
+  v2ManifestSchema,
+  type V2Manifest,
+} from './manifest';
+import { MANIFEST_MAX_BYTES } from './constants';
+
+const SHA = 'a'.repeat(64);
+
+function manifestFixture(overrides: Partial<V2Manifest> = {}): V2Manifest {
+  return {
+    enabled: true,
+    version: '2.0.0',
+    min_v1_version: '1.0.0',
+    platforms: {
+      [currentPlatformKey()]: {
+        url: 'https://shiranami.app/releases/Shiranami_2.0.0_x64-setup.exe',
+        sha256: SHA,
+        size: 12_345_678,
+      },
+    },
+    ...overrides,
+  };
+}
+
+/** Minimal `Response` stand-in — only the fields `fetchV2Manifest` reads. */
+function jsonResponse(body: string, init: { ok?: boolean; status?: number } = {}) {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    headers: { get: () => String(body.length) },
+    text: async () => body,
+  };
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  mockApp.version = '1.0.0';
+  vi.clearAllMocks();
+  __resetManifestLogGate();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchV2Manifest — the dormant path', () => {
+  it('returns null when the manifest does not exist (404)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse('Not Found', { ok: false, status: 404 }));
+
+    await expect(fetchV2Manifest()).resolves.toBeNull();
+  });
+
+  it('returns null on any other non-2xx status', async () => {
+    fetchMock.mockResolvedValue(jsonResponse('nope', { ok: false, status: 503 }));
+
+    await expect(fetchV2Manifest()).resolves.toBeNull();
+  });
+
+  it('returns null on a network failure instead of throwing', async () => {
+    fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+
+    await expect(fetchV2Manifest()).resolves.toBeNull();
+  });
+
+  it('returns null when the request times out', async () => {
+    const abortError = new Error('This operation was aborted');
+    abortError.name = 'AbortError';
+    fetchMock.mockRejectedValue(abortError);
+
+    await expect(fetchV2Manifest()).resolves.toBeNull();
+  });
+
+  it('returns null when the body is not JSON', async () => {
+    fetchMock.mockResolvedValue(jsonResponse('<!doctype html><title>404</title>'));
+
+    await expect(fetchV2Manifest()).resolves.toBeNull();
+  });
+
+  it('returns null when the JSON fails schema validation', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(JSON.stringify({ enabled: true })));
+
+    await expect(fetchV2Manifest()).resolves.toBeNull();
+  });
+
+  it('returns null when a platform entry carries a malformed digest', async () => {
+    const bad = manifestFixture();
+    bad.platforms[currentPlatformKey()]!.sha256 = 'not-a-digest';
+    fetchMock.mockResolvedValue(jsonResponse(JSON.stringify(bad)));
+
+    await expect(fetchV2Manifest()).resolves.toBeNull();
+  });
+
+  it('returns null when the body exceeds the size cap', async () => {
+    const oversized = ' '.repeat(MANIFEST_MAX_BYTES + 1);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      text: async () => oversized,
+    });
+
+    await expect(fetchV2Manifest()).resolves.toBeNull();
+  });
+
+  it('returns null without reading the body when content-length exceeds the cap', async () => {
+    const text = vi.fn();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => String(MANIFEST_MAX_BYTES + 1) },
+      text,
+    });
+
+    await expect(fetchV2Manifest()).resolves.toBeNull();
+    expect(text).not.toHaveBeenCalled();
+  });
+
+  it('never logs the dormant outcome more than once per process', async () => {
+    fetchMock.mockResolvedValue(jsonResponse('Not Found', { ok: false, status: 404 }));
+
+    await fetchV2Manifest();
+    await fetchV2Manifest();
+    await fetchV2Manifest();
+
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it('requests the manifest with a cache-bypassing GET so the kill switch is prompt', async () => {
+    fetchMock.mockResolvedValue(jsonResponse('Not Found', { ok: false, status: 404 }));
+
+    await fetchV2Manifest();
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/v2\.json$/);
+    expect(url).not.toMatch(/latest\.yml/);
+    expect(init.cache).toBe('no-store');
+    expect(init.signal).toBeDefined();
+  });
+});
+
+describe('fetchV2Manifest — the active path', () => {
+  it('returns the parsed manifest for a well-formed body', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(JSON.stringify(manifestFixture())));
+
+    const manifest = await fetchV2Manifest();
+
+    expect(manifest).not.toBeNull();
+    expect(manifest?.version).toBe('2.0.0');
+    expect(manifest?.enabled).toBe(true);
+  });
+
+  it('keeps an optional download_page and tolerates unknown platform keys', async () => {
+    const fixture = manifestFixture({ download_page: 'https://shiranami.app/download' });
+    fixture.platforms['sunos-sparc'] = {
+      url: 'https://shiranami.app/nope.exe',
+      sha256: 'b'.repeat(64),
+      size: 1,
+    };
+    fetchMock.mockResolvedValue(jsonResponse(JSON.stringify(fixture)));
+
+    const manifest = await fetchV2Manifest();
+
+    expect(manifest?.download_page).toBe('https://shiranami.app/download');
+    expect(Object.keys(manifest?.platforms ?? {})).toContain('sunos-sparc');
+  });
+
+  it('accepts a prerelease v2 version', () => {
+    const parsed = v2ManifestSchema.safeParse(manifestFixture({ version: '2.0.0-rc.1' }));
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe('resolveHandover', () => {
+  it('returns the artifact for this platform when everything lines up', () => {
+    expect(resolveHandover(manifestFixture())).not.toBeNull();
+  });
+
+  it('returns null when the kill switch is off', () => {
+    expect(resolveHandover(manifestFixture({ enabled: false }))).toBeNull();
+  });
+
+  it('returns null when this install is below the minimum v1 version', () => {
+    mockApp.version = '0.19.0';
+    expect(resolveHandover(manifestFixture({ min_v1_version: '1.0.0' }))).toBeNull();
+  });
+
+  it('returns null when the manifest has no artifact for this platform', () => {
+    expect(resolveHandover(manifestFixture({ platforms: {} }))).toBeNull();
+  });
+});
+
+describe('meetsMinimumV1Version', () => {
+  it.each([
+    ['1.0.0', '1.0.0', true],
+    ['1.0.1', '1.0.0', true],
+    ['1.2.0', '1.0.0', true],
+    ['2.0.0', '1.0.0', true],
+    ['0.20.3', '1.0.0', false],
+    ['1.0.0', '1.0.1', false],
+  ])('current %s against floor %s → %s', (current, floor, expected) => {
+    expect(meetsMinimumV1Version(manifestFixture({ min_v1_version: floor }), current)).toBe(
+      expected
+    );
+  });
+});
+
+describe('selectArtifact', () => {
+  it('keys off platform and arch', () => {
+    expect(currentPlatformKey()).toBe(`${process.platform}-${process.arch}`);
+    expect(selectArtifact(manifestFixture())?.size).toBe(12_345_678);
+  });
+
+  it('returns null when the key is absent', () => {
+    expect(selectArtifact(manifestFixture({ platforms: {} }))).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/app/v2-bridge/manifest.ts
+++ b/apps/desktop/src/main/app/v2-bridge/manifest.ts
@@ -1,0 +1,143 @@
+/**
+ * The `v2.json` handover manifest: fetch, validate, and answer "does this
+ * install cross over?".
+ *
+ * The whole module is written around one invariant: **`fetchV2Manifest` never
+ * throws and never reports.** While no manifest is published (today, and for
+ * every v1.x release until v2 ships) the poll gets a 404 and must be
+ * indistinguishable from the app doing nothing at all — no renderer event, no
+ * Sentry breadcrumb, and at most one log line per process.
+ */
+
+import { app } from 'electron';
+import { z } from 'zod';
+import { logger } from '../logger';
+import { hasUpdate } from '../../utils/version';
+import { getManifestUrl, MANIFEST_MAX_BYTES, MANIFEST_TIMEOUT_MS } from './constants';
+
+/** A dotted numeric version, optionally with a suffix (`2.0.0`, `2.0.0-rc.1`). */
+const versionString = z.string().regex(/^\d+(\.\d+)*(-.+)?$/, 'expected a dotted numeric version');
+
+const artifactSchema = z.object({
+  url: z.url(),
+  /** Lowercase hex sha256 of the artifact bytes. */
+  sha256: z.string().regex(/^[a-fA-F0-9]{64}$/, 'expected a hex sha256 digest'),
+  size: z.number().int().positive(),
+});
+
+/**
+ * Manifest shape. `platforms` is keyed `<process.platform>-<process.arch>`
+ * (e.g. `win32-x64`, `darwin-arm64`) so a v1 install can resolve its own
+ * artifact without the manifest encoding any Electron-specific naming.
+ */
+export const v2ManifestSchema = z.object({
+  /** Kill switch. `false` halts the rollout without shipping a release. */
+  enabled: z.boolean(),
+  version: versionString,
+  /** v1 installs older than this are not offered the handover. */
+  min_v1_version: versionString,
+  platforms: z.record(z.string(), artifactSchema),
+  /**
+   * Landing-page download URL used by the manual (macOS) path. Optional and
+   * additive: absent means fall back to the platform artifact URL.
+   */
+  download_page: z.url().optional(),
+});
+
+export type V2Manifest = z.infer<typeof v2ManifestSchema>;
+export type V2Artifact = z.infer<typeof artifactSchema>;
+
+/** One log line per process for the dormant failure path — never per tick. */
+let dormantFailureLogged = false;
+
+/** Test seam: forget that the dormant failure was already logged. */
+export function __resetManifestLogGate(): void {
+  dormantFailureLogged = false;
+}
+
+function noteDormant(reason: string): null {
+  if (!dormantFailureLogged) {
+    dormantFailureLogged = true;
+    logger.info(`[v2-bridge] No handover manifest (${reason}) — staying dormant`);
+  }
+  return null;
+}
+
+/** The `platforms` key this install resolves to. */
+export function currentPlatformKey(): string {
+  return `${process.platform}-${process.arch}`;
+}
+
+/** The artifact for this platform/arch, or null when the manifest omits it. */
+export function selectArtifact(manifest: V2Manifest): V2Artifact | null {
+  return manifest.platforms[currentPlatformKey()] ?? null;
+}
+
+/**
+ * True when this install is new enough to cross over. `hasUpdate(a, b)` is true
+ * when `b` is strictly newer than `a`, so the floor is met exactly when
+ * `min_v1_version` is not newer than the running version.
+ */
+export function meetsMinimumV1Version(manifest: V2Manifest, currentVersion: string): boolean {
+  return !hasUpdate(currentVersion, manifest.min_v1_version);
+}
+
+/**
+ * Fetch and validate the manifest. Returns null for every dormant outcome —
+ * 404, DNS failure, offline, timeout, oversized body, non-JSON body, or a body
+ * that fails schema validation. Callers only ever branch on `null` vs manifest.
+ */
+export async function fetchV2Manifest(): Promise<V2Manifest | null> {
+  const url = getManifestUrl();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), MANIFEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      // Bypass any intermediary cache so the kill switch takes effect on the
+      // next tick rather than whenever a CDN entry happens to expire.
+      cache: 'no-store',
+      headers: { accept: 'application/json' },
+    });
+
+    // 404 is the expected steady state until v2 ships. Treated identically to
+    // any other non-2xx: dormant, silent.
+    if (!response.ok) {
+      return noteDormant(`HTTP ${response.status}`);
+    }
+
+    const declaredLength = Number(response.headers.get('content-length') ?? '0');
+    if (Number.isFinite(declaredLength) && declaredLength > MANIFEST_MAX_BYTES) {
+      return noteDormant('body too large');
+    }
+
+    const body = await response.text();
+    if (body.length > MANIFEST_MAX_BYTES) {
+      return noteDormant('body too large');
+    }
+
+    const parsed = v2ManifestSchema.safeParse(JSON.parse(body) as unknown);
+    if (!parsed.success) {
+      return noteDormant('manifest failed validation');
+    }
+
+    return parsed.data;
+  } catch (error) {
+    // Covers abort/timeout, DNS/socket failures, and malformed JSON.
+    return noteDormant(error instanceof Error ? error.name : 'fetch failed');
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Resolve the manifest into the artifact this install should hand over to, or
+ * null when the handover does not apply (kill switch off, version floor not
+ * met, or no artifact for this platform).
+ */
+export function resolveHandover(manifest: V2Manifest): V2Artifact | null {
+  if (!manifest.enabled) return null;
+  if (!meetsMinimumV1Version(manifest, app.getVersion())) return null;
+  return selectArtifact(manifest);
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import { reportBootFailure } from './app/boot-failure';
 import { createMainWindow } from './app/window';
 import { cleanupIpcHandlers } from './ipc/register';
 import { initializeAutoUpdater } from './app/updater';
+import { initializeV2Bridge, stopV2Bridge } from './app/v2-bridge';
 import { logger, flushLogs } from './app/logger';
 import { createTray, destroyTray } from './app/tray';
 import { initializeSystemBehavior, attachTrayWindowBehavior } from './app/system-behavior';
@@ -212,6 +213,15 @@ async function bootstrap(): Promise<void> {
     } catch (error) {
       logger.warn('Failed to initialize auto-updater:', error);
     }
+
+    // Dormant until a v2 handover manifest is published. Initialized separately
+    // from the auto-updater because that one bails out on macOS (unsigned app),
+    // and macOS users still need the crossover notice.
+    try {
+      initializeV2Bridge(mainWindow, !app.isPackaged);
+    } catch (error) {
+      logger.warn('Failed to initialize the v2 handover bridge:', error);
+    }
   }
 }
 
@@ -270,6 +280,7 @@ app.on('before-quit', event => {
     try {
       cancelRecommendationRefresh();
       stopScrobbler();
+      stopV2Bridge();
     } catch (err) {
       logger.warn('[shutdown] recommendation/scrobbler stop failed', err);
     }

--- a/apps/desktop/src/main/utils/version.ts
+++ b/apps/desktop/src/main/utils/version.ts
@@ -1,0 +1,43 @@
+/**
+ * Dotted-numeric version comparison, shared by the yt-dlp updater (which sees
+ * date-based versions like `2024.01.01`) and the v2 handover bridge (which
+ * compares the running app version against a manifest floor).
+ *
+ * Deliberately dependency-free so callers do not drag a subsystem's module
+ * graph in behind a fifteen-line comparison.
+ */
+
+/** Extract the numeric `.`-separated segments from a version string. */
+export function extractVersionSegments(version: string | null | undefined): number[] {
+  if (!version) return [];
+
+  const match = version.match(/\d+(?:\.\d+)*/);
+  if (!match) return [];
+
+  return match[0]
+    .split('.')
+    .map(part => Number.parseInt(part, 10))
+    .filter(part => Number.isFinite(part));
+}
+
+/** True when `latestVersion` is strictly newer than `currentVersion`. */
+export function hasUpdate(currentVersion: string | null, latestVersion: string | null): boolean {
+  const currentSegments = extractVersionSegments(currentVersion);
+  const latestSegments = extractVersionSegments(latestVersion);
+
+  if (currentSegments.length === 0 || latestSegments.length === 0) {
+    return false;
+  }
+
+  const maxLength = Math.max(currentSegments.length, latestSegments.length);
+
+  for (let index = 0; index < maxLength; index += 1) {
+    const current = currentSegments[index] ?? 0;
+    const latest = latestSegments[index] ?? 0;
+
+    if (latest > current) return true;
+    if (latest < current) return false;
+  }
+
+  return false;
+}

--- a/apps/desktop/src/main/utils/ytdlp-spawn.ts
+++ b/apps/desktop/src/main/utils/ytdlp-spawn.ts
@@ -157,40 +157,7 @@ export function classifyYtDlpFailure(output: string): string {
   return tail || 'yt-dlp failed without producing any output';
 }
 
-/** Extract the numeric `.`-separated segments from a yt-dlp version string. */
-export function extractVersionSegments(version: string | null | undefined): number[] {
-  if (!version) return [];
-
-  const match = version.match(/\d+(?:\.\d+)*/);
-  if (!match) return [];
-
-  return match[0]
-    .split('.')
-    .map(part => Number.parseInt(part, 10))
-    .filter(part => Number.isFinite(part));
-}
-
-/** True when `latestVersion` is strictly newer than `currentVersion`. */
-export function hasUpdate(currentVersion: string | null, latestVersion: string | null): boolean {
-  const currentSegments = extractVersionSegments(currentVersion);
-  const latestSegments = extractVersionSegments(latestVersion);
-
-  if (currentSegments.length === 0 || latestSegments.length === 0) {
-    return false;
-  }
-
-  const maxLength = Math.max(currentSegments.length, latestSegments.length);
-
-  for (let index = 0; index < maxLength; index += 1) {
-    const current = currentSegments[index] ?? 0;
-    const latest = latestSegments[index] ?? 0;
-
-    if (latest > current) return true;
-    if (latest < current) return false;
-  }
-
-  return false;
-}
+export { extractVersionSegments, hasUpdate } from './version';
 
 /**
  * Parse the newline-delimited JSON output produced by `yt-dlp --dump-json`

--- a/apps/desktop/test/setup.ts
+++ b/apps/desktop/test/setup.ts
@@ -24,6 +24,7 @@ export function setMockMainWindow(win: BrowserWindow | null): void {
 // importable; captureException is a harmless no-op in tests.
 vi.mock('@sentry/electron/main', () => ({
   captureException: vi.fn(),
+  captureMessage: vi.fn(),
 }));
 
 vi.mock('electron', () => ({


### PR DESCRIPTION
## Summary

Adds a dormant v2 handover bridge to the Electron app. It polls a `v2.json`
manifest on the update tick and, while that manifest does not exist (today, and
until v2 ships), does nothing at all. When the manifest goes live it writes the
two files v2's first run needs, then hands the user over: automatically on
Windows, via a modal everywhere else.

New module: `apps/desktop/src/main/app/v2-bridge/` — `constants.ts`,
`manifest.ts`, `handoff.ts`, `handover.ts`, `index.ts`. No renderer diff.

## Context / why

`electron-updater` expects electron-builder metadata (`latest.yml`, `.blockmap`,
its own NSIS). It cannot install a Tauri artifact and there is no supported
hand-off mode, so v1.x has to carry its own bridge. The documented failure mode
is shipping further v1.x releases *without* one and discovering months later
that the tail never crossed over because it never opened the app during the
transition window — which is why the hook ships before any v2 code exists.

**How the dormant no-op is guaranteed.** Everything downstream hangs off one
condition in `checkForV2Handover`:

```ts
const manifest = await fetchV2Manifest();
if (!manifest) return 'dormant';

const artifact = resolveHandover(manifest);
if (!artifact) return 'not-applicable';
```

- `fetchV2Manifest()` returns `null` for every failure — 404, offline, DNS,
  timeout, oversized body, non-JSON, schema-invalid — and never throws.
- `resolveHandover()` returns `null` when the manifest's `enabled` kill switch
  is off, the `min_v1_version` floor is not met, or this platform has no
  artifact.
- Dormant failures log at most **one** line per process, never warn/error, never
  reach the renderer, and never report to Sentry.
- The poll is off the startup path: first tick 5s after launch, then hourly, on
  `unref`'d timers, with a 5s request timeout and a 64 KB body cap.

`v2.json` lives at a URL separate from `latest.yml` so v1's own updater never
parses it. `SHIRANAMI_V2_MANIFEST_URL` overrides it for the Spike B rehearsal.

**Active path.** Writes `v2-handoff.json` (userData, DB path, downloads
location, v1 version) and `renderer-state.json` (every `shiranami.*`
localStorage key) next to the library DB, fires a one-time crossover ping gated
on the existing Sentry opt-in, then:

- **Windows (packaged):** downloads the Tauri installer, verifies sha256 and
  length against the manifest, spawns it detached in passive mode, quits. A
  digest mismatch or a URL that is not a plain `.exe` basename refuses to run,
  and any failure degrades to the modal.
- **macOS / anything else:** a modal linking to the download. v1 has no
  auto-updater on macOS at all (unsigned app), so there is nothing to hand over
  from and no regression.

## How to test

```
pnpm vitest run --project desktop src/main/app/v2-bridge   # 80 tests
pnpm typecheck
pnpm lint
```

The suite covers the dormant path (manifest absent/404, other non-2xx, network
failure, timeout, malformed JSON, schema-invalid, malformed digest, oversized
body, log-gating, no renderer contact, kill switch, version floor, missing
platform artifact) and the active path against a mocked manifest (both handoff
files, Windows automatic handover, digest/length/URL rejection, fallback to the
modal, once-per-session, crossover-ping gating, timer scheduling and teardown).

Manual dormant check — run the packaged app and confirm the app behaves exactly
as before, with a single `[v2-bridge] No handover manifest (HTTP 404) — staying
dormant` line in the log and nothing else.

Manual active check — serve a `v2.json` locally and launch with
`SHIRANAMI_V2_MANIFEST_URL=http://localhost:8080/v2.json`; the modal should
appear and both handoff files should land in `userData`.

Full repo suite: 386 files, 2846 passed / 1 skipped.

## Linked issue

<!-- no tracking issue yet -->
