### PR TITLE
ci: run format:check in the lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Lint meta
         run: pnpm lint:meta
 
+      - name: Format check
+        run: pnpm format:check
+
   typecheck:
     name: Type Check
     needs: [changes]


### PR DESCRIPTION
## Summary
- Adds a `Format check` step (`pnpm format:check`) to the `lint` job in `.github/workflows/ci.yml`, right after the `Lint meta` step introduced in #365
- Prettier formatting was made repo-wide clean in #365; this wires the check into CI so future formatting drift is caught automatically

## Test plan
- [x] `pnpm format:check` passes locally on this branch
- [x] Confirmed step placement/style matches the existing `Lint meta` step (name + `run:` only, no extra config)
- [ ] CI green on this PR

**Note (out of scope, not addressed here):** the `lint` job only runs when the `changes` job's `code` or `landing` filters match. Those filters don't cover several paths that `prettier --check .` does check, so formatting-only edits to them won't trigger the lint job: `docs/**` (e.g. `docs/ci.md`), `.design-sync/**` (`.mjs`/`.ts`/`.md`/`.json`), `README.pl.md` (only `README.md` is filtered), `commitlint.config.mjs`, and a few root `scripts/*.mjs` files (`dev-sentry.mjs`, `generate-icons.mjs`, `screenshot-app.mjs`) not in the `root`/`ci` filter lists. Flagging for a future filter pass — didn't restructure the filters here.