### PR TITLE
fix(deps): patch brace-expansion DoS via pnpm override (#117)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ overrides:
   '@xhmikosr/decompress': '>=11.1.3'
   valibot: '>=1.4.2'
   brace-expansion@1: 1.1.16
-  brace-expansion@2: 2.1.2
+  brace-expansion@2: ^2.1.3
   brace-expansion@5: '>=5.0.8'
 
 importers:
@@ -5508,8 +5508,8 @@ packages:
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -16980,7 +16980,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -20393,11 +20393,11 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,11 +39,13 @@ overrides:
   svgo: '>=4.0.2'
   '@xhmikosr/decompress': '>=11.1.3'
   valibot: '>=1.4.2'
-  # CVE-2026-14257 is only patched on the 5.x line. The @1/@2 pins just hold
-  # those lines at their newest release — they cannot clear the advisory, which
-  # needs the `minimatch` parents dragging them in to move to 5.x.
+  # CVE-2026-14257 (GHSA-mh99-v99m-4gvg): each major line has its own
+  # patched release. @2 clears Dependabot alert #117 (>=2.0.0 <2.1.3,
+  # patched at 2.1.3). @1 is left at 1.1.16 — its alert (#118, <1.1.17)
+  # is auto-dismissed by GitHub, so it's out of scope here; a patched
+  # 1.1.17+ is available if that line needs bumping later.
   'brace-expansion@1': 1.1.16
-  'brace-expansion@2': 2.1.2
+  'brace-expansion@2': '^2.1.3'
   'brace-expansion@5': '>=5.0.8'
 
 onlyBuiltDependencies:


### PR DESCRIPTION
## Summary

- Bumps the `brace-expansion@2` pnpm-workspace override from `2.1.2` to `^2.1.3`, clearing Dependabot alert [#117](https://github.com/Shironex/shiranami/security/dependabot/117) (GHSA-mh99-v99m-4gvg, CVE-2026-14257, **high**).
- The advisory: `expand()` bounds result *count* but not result *length* — a small (~7.5 KB) attacker-controlled brace pattern can exhaust memory and crash the Node process with an uncatchable OOM error.
- The prior override comment claimed the CVE was "only patched on the 5.x line" — that was true when the override was first added, but a patched `2.x` release (`2.1.3`) is now out, so the fix stays scoped to the 2.x line instead of forcing dependents up to 5.x.
- `brace-expansion@1` (pinned `1.1.16`) is left untouched — its alert (#118, `<1.1.17`) is auto-dismissed by GitHub, so it's out of scope for this PR.

Reaches the tree transitively via `minimatch@9`/`minimatch@5` (glob-pattern matching, dev/build tooling — `@nestjs/cli`, `@expo/fingerprint`, `jake`, etc.), not via `minimatch@10` (already pinned to the 5.x line for eslint) or `minimatch@3` (still on `brace-expansion@1`).

## Test plan

- [x] `pnpm install` — lockfile regenerated cleanly, no peer-dep regressions beyond pre-existing warnings
- [x] `grep -E "brace-expansion@2\.(0|1\.[0-2])" pnpm-lock.yaml` — empty, no vulnerable-range entries remain
- [x] `pnpm why brace-expansion` (recursive across workspace) — `minimatch@9`/`minimatch@5` now resolve to `2.1.4` (patched), `minimatch@10` stays on `5.0.8`, `minimatch@3` stays on `1.1.16` (unaffected consumers untouched)
- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes
