### PR TITLE
feat(lyrics): keep fetched lyrics as .lrc sidecars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5131,10 +5131,13 @@ dependencies = [
  "shiranami-core",
  "shiranami-db",
  "shiranami-net",
+ "specta",
+ "specta-typescript",
  "sqlx",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "tracing",
  "url",
 ]

--- a/apps/desktop-tauri/src-tauri/src/bindings.rs
+++ b/apps/desktop-tauri/src-tauri/src/bindings.rs
@@ -250,6 +250,10 @@ mod tests {
             "discordRpcUpdatePresence",
             "discordRpcClearPresence",
             "lyricsFetch",
+            // Port no v1 channels: v1 kept fetched lyrics in memory only, so
+            // there was no library-wide write-back pass. See NON_V1_COMMANDS.
+            "lyricsSaveBatch",
+            "lyricsSaveCancel",
             "windowMinimize",
             "windowMaximize",
             "windowClose",

--- a/apps/desktop-tauri/src-tauri/src/boot/services.rs
+++ b/apps/desktop-tauri/src-tauri/src/boot/services.rs
@@ -307,12 +307,21 @@ impl LyricsPolicy for CachePolicy {
     }
 
     fn is_lyrics_write_allowed(&self, path: &std::path::Path) -> bool {
-        // Deliberately **not** `is_path_allowed`, which the read side calls.
-        // That guard also grants the app data directory and any row in the
-        // `tracks` table — right for a read, too wide for a write: a standalone
-        // file imported through a file dialog years ago would be a writable
-        // destination anywhere on the disk. Writing is confined to the roots the
-        // user actually pointed the library at.
+        // `is_within_library_folder`, not `is_path_allowed` and not a bare
+        // containment check against `allowed_roots()`. Both of the differences
+        // are the reason this method exists at all:
+        //
+        // - **The root set is narrower.** The read gate grants the app's own
+        //   data directory, the downloads location, and any row in the `tracks`
+        //   table — the last of which would make a standalone file imported
+        //   through a file dialog years ago a writable destination anywhere on
+        //   the disk. A write is confined to the folders the user actually
+        //   pointed the library at.
+        // - **Symlinks are resolved.** `is_path_within_any` is purely textual
+        //   by design (see `paths::safety`), so a junction inside a watched
+        //   folder pointing outside it reads as contained and the write lands
+        //   outside the library. Resolving first is what makes this gate
+        //   genuinely stricter than the read gate rather than merely different.
         //
         // The *directory* is the subject rather than the file, because that is
         // what is written into, and a containment check on the file itself would
@@ -322,7 +331,7 @@ impl LyricsPolicy for CachePolicy {
             return false;
         };
 
-        shiranami_core::paths::is_path_within_any(directory, &self.folders.allowed_roots())
+        self.folders.is_within_library_folder(directory)
     }
 }
 

--- a/apps/desktop-tauri/src-tauri/src/boot/services.rs
+++ b/apps/desktop-tauri/src-tauri/src/boot/services.rs
@@ -18,6 +18,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use serde_json::Value;
 use shiranami_core::models::SHIRANAMI_DISCORD_CLIENT_ID;
 use shiranami_core::notice::NoticeGate;
 use shiranami_core::paths::FoldersCache;
@@ -245,8 +246,16 @@ fn build_lyrics(
     Arc::new(LyricsService::new(LrclibClient::new(http.clone()), policy))
 }
 
-/// The two app-level facts the lyrics ladder consults, answered from the two
-/// places that own them.
+/// The field inside the renderer `settings` blob that carries the lyrics
+/// write-back opt-in.
+///
+/// One constant rather than a literal at the read site, because the renderer
+/// writes the same name through `useSettingsQuery` and the two have to agree —
+/// a typo on either side is a toggle that silently never takes effect.
+const SAVE_FETCHED_LYRICS_FIELD: &str = "saveFetchedLyrics";
+
+/// The app-level facts the lyrics ladder consults, answered from the places
+/// that own them.
 struct CachePolicy {
     folders: Arc<FoldersCache>,
     settings: Arc<SettingsStore>,
@@ -271,12 +280,30 @@ impl LyricsPolicy for CachePolicy {
     }
 
     fn should_save_fetched_lyrics(&self) -> bool {
-        // `== Some(true)` and not `!= Some(false)`: an absent key is a user who
-        // has never opted in, and the one direction this must never get wrong is
-        // reading "unset" as "yes, write into my music folders".
+        // Read as a field **inside** the renderer's `settings` blob rather than
+        // from a dot-path key of its own, and that is not a stylistic choice.
+        //
+        // `RendererStoreKey` is pinned by `store::keys`' test to match v1's
+        // `RENDERER_STORE_KEYS` tuple *exactly*, so a dedicated key here would
+        // force a matching entry in `apps/desktop` — a v1 Electron file that v2
+        // work does not touch. Without that entry the Electron shell's zod
+        // guard rejects the write and the toggle breaks; with it, a v2-only
+        // feature has edited the legacy app. The blob is the way out: `settings`
+        // is already allowlisted on both sides and is typed
+        // `Record<string, unknown>` / `z.unknown()`, so a new field inside it is
+        // accepted by the Electron store and by this one with no schema change
+        // anywhere. `discord::settings` reads its legacy flag out of the same
+        // blob the same way.
+        //
+        // `== Some(true)` and not `!= Some(false)`: an absent field is a user
+        // who has never opted in, and the one direction this must never get
+        // wrong is reading "unset" as "yes, write into my music folders". An
+        // unreadable or unexpectedly shaped blob answers "off" for the same
+        // reason.
         self.settings
-            .get(shiranami_core::store::RendererStoreKey::LyricsSaveFetchedLyrics)
-            == Some(serde_json::Value::Bool(true))
+            .get(shiranami_core::store::RendererStoreKey::Settings)
+            .and_then(|blob| blob.get(SAVE_FETCHED_LYRICS_FIELD).and_then(Value::as_bool))
+            .unwrap_or(false)
     }
 
     fn is_lyrics_write_allowed(&self, path: &std::path::Path) -> bool {

--- a/apps/desktop-tauri/src-tauri/src/boot/services.rs
+++ b/apps/desktop-tauri/src-tauri/src/boot/services.rs
@@ -269,6 +269,34 @@ impl LyricsPolicy for CachePolicy {
             .get(shiranami_core::store::RendererStoreKey::LyricsPreferSyncedFromLrclib)
             == Some(serde_json::Value::Bool(true))
     }
+
+    fn should_save_fetched_lyrics(&self) -> bool {
+        // `== Some(true)` and not `!= Some(false)`: an absent key is a user who
+        // has never opted in, and the one direction this must never get wrong is
+        // reading "unset" as "yes, write into my music folders".
+        self.settings
+            .get(shiranami_core::store::RendererStoreKey::LyricsSaveFetchedLyrics)
+            == Some(serde_json::Value::Bool(true))
+    }
+
+    fn is_lyrics_write_allowed(&self, path: &std::path::Path) -> bool {
+        // Deliberately **not** `is_path_allowed`, which the read side calls.
+        // That guard also grants the app data directory and any row in the
+        // `tracks` table — right for a read, too wide for a write: a standalone
+        // file imported through a file dialog years ago would be a writable
+        // destination anywhere on the disk. Writing is confined to the roots the
+        // user actually pointed the library at.
+        //
+        // The *directory* is the subject rather than the file, because that is
+        // what is written into, and a containment check on the file itself would
+        // pass for a path whose parent this app has no business creating files
+        // in.
+        let Some(directory) = path.parent() else {
+            return false;
+        };
+
+        shiranami_core::paths::is_path_within_any(directory, &self.folders.allowed_roots())
+    }
 }
 
 #[cfg(test)]

--- a/apps/desktop-tauri/src-tauri/src/commands/lyrics.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/lyrics.rs
@@ -19,7 +19,7 @@
 //!
 //! # Both write paths answer to one setting
 //!
-//! `lyrics.saveFetchedLyrics` gates the automatic write-back **and** this batch,
+//! `settings.saveFetchedLyrics` gates the automatic write-back **and** this batch,
 //! and the batch refuses outright ([`LYRICS_SAVE_DISABLED_CODE`]) rather than
 //! running to an all-skipped summary. Pressing a button is a clear intent, and
 //! it would be defensible to read it as consent on its own — but then there
@@ -142,7 +142,7 @@ pub async fn lyrics_save_cancel(runs: State<'_, LyricsSaveRuns>) -> CommandResul
 
 /// `lyrics:save-batch` — fetch and save lyrics for a set of tracks.
 ///
-/// Refuses when `lyrics.saveFetchedLyrics` is off (see the module docs) and when
+/// Refuses when `settings.saveFetchedLyrics` is off (see the module docs) and when
 /// a run already holds the slot. Otherwise it always resolves with a summary,
 /// including a cancelled or entirely-failed one: a run over a read-only library
 /// answers `failed == total` rather than throwing, because the counts are what

--- a/apps/desktop-tauri/src-tauri/src/commands/lyrics.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/lyrics.rs
@@ -1,11 +1,31 @@
-//! `lyrics:fetch` — the one lyrics channel.
+//! `lyrics:*` — the ported fetch channel, plus v2's write-back batch.
 //!
-//! Ported from `apps/desktop/src/main/ipc/lyrics.ts`, which is a one-line
-//! delegate to `fetchLyrics`. Everything interesting is one rank down and stays
-//! there: the precedence ladder (local synced → embedded synced → local plain →
-//! embedded plain → LRCLIB, reordered by `lyrics.preferSyncedFromLrclib`), the
-//! sidecar probing order, the LRU, the request coalescing, and the containment
-//! gate that keeps this channel from becoming an arbitrary-file reader.
+//! [`lyrics_fetch`] is ported from `apps/desktop/src/main/ipc/lyrics.ts`, which
+//! is a one-line delegate to `fetchLyrics`. Everything interesting is one rank
+//! down and stays there: the precedence ladder (local synced → embedded synced →
+//! local plain → embedded plain → LRCLIB, reordered by
+//! `lyrics.preferSyncedFromLrclib`), the sidecar probing order, the LRU, the
+//! request coalescing, and the containment gate that keeps this channel from
+//! becoming an arbitrary-file reader.
+//!
+//! # The write-back pair ports no v1 channel
+//!
+//! v1 kept fetched lyrics in a 200-entry in-memory MRU and nowhere else, so
+//! there was no library-wide pass to have a channel. [`lyrics_save_batch`] and
+//! [`lyrics_save_cancel`] are v2's, and what they do is written down in
+//! `shiranami_integrations::lyrics::writeback`: a synced LRCLIB hit becomes a
+//! `.lrc` beside the track, which the *existing* sidecar reader then serves on
+//! the next play with no network.
+//!
+//! # Both write paths answer to one setting
+//!
+//! `lyrics.saveFetchedLyrics` gates the automatic write-back **and** this batch,
+//! and the batch refuses outright ([`LYRICS_SAVE_DISABLED_CODE`]) rather than
+//! running to an all-skipped summary. Pressing a button is a clear intent, and
+//! it would be defensible to read it as consent on its own — but then there
+//! would be two answers to "may this app write into my music folders" and a user
+//! who turned the setting off would still have a button that wrote files. One
+//! switch, and the renderer disables the button when it is off.
 //!
 //! # What this layer owns
 //!
@@ -35,13 +55,23 @@
 //! send.
 
 use std::path::PathBuf;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 
+use shiranami_core::error::ErrorPayload;
 use shiranami_core::models::lyrics::LyricsResult;
-use shiranami_integrations::lyrics::LyricsRequest;
-use tauri::State;
+use shiranami_integrations::lyrics::{
+    LyricsBatchProgress, LyricsBatchSummary, LyricsBatchTrack, LyricsRequest, LyricsService,
+    save_lyrics_for_tracks,
+};
+use tauri::{AppHandle, State};
+use tauri_specta::Event as _;
+use tokio_util::sync::CancellationToken;
 
 use crate::error::{CommandResult, WireResultExt as _, bad_request, not_booted};
+use crate::events::LyricsSaveProgress as LyricsSaveProgressEvent;
 use crate::state::AppState;
+use crate::wire::Json;
 
 /// Register this namespace's commands with [`crate::commands::registry`].
 macro_rules! commands {
@@ -50,11 +80,26 @@ macro_rules! commands {
             queue = [$($tail,)*],
             collected = [$($collected)*
                 crate::commands::lyrics::lyrics_fetch,
+                crate::commands::lyrics::lyrics_save_batch,
+                crate::commands::lyrics::lyrics_save_cancel,
             ]
         }
     };
 }
 pub(crate) use commands;
+
+/// The renderer-visible code for "a write-back run is already going".
+///
+/// Born in v2, so the declaration here *is* the contract — the same footing
+/// `analysis.busy` is on.
+pub const LYRICS_SAVE_BUSY_CODE: &str = "lyrics.save_busy";
+
+/// The renderer-visible code for "saving lyrics is turned off".
+///
+/// A refusal rather than an empty run, so a renderer that somehow reached the
+/// channel with the setting off gets an answer it can explain instead of a
+/// summary of nothing that looks like a failed fetch.
+pub const LYRICS_SAVE_DISABLED_CODE: &str = "lyrics.save_disabled";
 
 /// `lyrics:fetch` — resolve lyrics for one track.
 ///
@@ -80,6 +125,175 @@ pub async fn lyrics_fetch(
         .ok_or_else(|| not_booted("the lyrics service"))?;
 
     service.fetch(&request).await.wire()
+}
+
+/// `lyrics:save-cancel` — stop the active write-back run.
+///
+/// Best-effort and a no-op when idle: a queued track notices at its turn and the
+/// run resolves with its partial counts. Cancelling while nothing runs must not
+/// leave a flag behind that pre-cancels the next run — the regression
+/// `enrich::slot` records from v1.
+#[tauri::command]
+#[specta::specta]
+pub async fn lyrics_save_cancel(runs: State<'_, LyricsSaveRuns>) -> CommandResult<()> {
+    runs.cancel();
+    Ok(())
+}
+
+/// `lyrics:save-batch` — fetch and save lyrics for a set of tracks.
+///
+/// Refuses when `lyrics.saveFetchedLyrics` is off (see the module docs) and when
+/// a run already holds the slot. Otherwise it always resolves with a summary,
+/// including a cancelled or entirely-failed one: a run over a read-only library
+/// answers `failed == total` rather than throwing, because the counts are what
+/// the user needs told.
+#[tauri::command]
+#[specta::specta]
+pub async fn lyrics_save_batch(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    runs: State<'_, LyricsSaveRuns>,
+    tracks: Vec<LyricsBatchTrack>,
+) -> CommandResult<LyricsBatchSummary> {
+    let service = lyrics_service(&state)?;
+
+    // Asked before the slot is claimed, so a refused run leaves nothing behind.
+    // Asked of the *policy* rather than of the settings store directly: the
+    // service owns which key answers this, and a second reader here is a second
+    // place for the answer to drift.
+    if !service.is_saving_enabled() {
+        return Err(ErrorPayload {
+            code: LYRICS_SAVE_DISABLED_CODE.to_owned(),
+            message: "Saving fetched lyrics is turned off.".to_owned(),
+            details: None,
+        });
+    }
+
+    let guard = runs.claim()?;
+    let emit_app = app.clone();
+    let progress = move |progress: LyricsBatchProgress| emit(&emit_app, progress);
+
+    Ok(save_lyrics_for_tracks(&service, &tracks, guard.token(), &progress).await)
+}
+
+/// Emit one progress tick.
+///
+/// A dropped emit is logged and swallowed: the run is the point, and a webview
+/// that has gone away between two tracks is not a reason to abort a
+/// library-wide pass.
+fn emit(app: &AppHandle, progress: LyricsBatchProgress) {
+    let Ok(payload) = serde_json::to_value(&progress) else {
+        tracing::warn!("a lyrics write-back progress tick could not be serialized");
+        return;
+    };
+
+    if let Err(error) = LyricsSaveProgressEvent(Json(payload)).emit(app) {
+        tracing::debug!(%error, "dropped a lyrics write-back progress tick");
+    }
+}
+
+/// The service, or the not-booted error every lyrics command answers with.
+fn lyrics_service(state: &AppState) -> CommandResult<std::sync::Arc<LyricsService>> {
+    state
+        .deferred()
+        .lyrics
+        .as_ref()
+        .map(std::sync::Arc::clone)
+        .ok_or_else(|| not_booted("the lyrics service"))
+}
+
+// ── the run slot ─────────────────────────────────────────────────────────────
+
+/// Holds the one in-flight write-back run, if any.
+///
+/// Mirrors [`crate::commands::analysis::AnalysisRuns`] field for field — see
+/// `shiranami_metadata::enrich::slot` for why the mutex is `std::sync` and what
+/// the generation number closes (a run that finishes late must not clear a
+/// *newer* run's slot).
+///
+/// One slot rather than a queue because the renderer has one button and one
+/// progress bar, and a second concurrent run would have nowhere to report.
+#[derive(Debug, Default)]
+pub struct LyricsSaveRuns {
+    active: Mutex<Option<Run>>,
+    generations: AtomicU64,
+}
+
+/// The run currently holding the slot.
+#[derive(Debug)]
+struct Run {
+    token: CancellationToken,
+    generation: u64,
+}
+
+impl LyricsSaveRuns {
+    /// Take the slot, or fail with [`LYRICS_SAVE_BUSY_CODE`].
+    fn claim(&self) -> CommandResult<RunGuard<'_>> {
+        let mut active = lock(&self.active);
+
+        if active.is_some() {
+            return Err(ErrorPayload {
+                code: LYRICS_SAVE_BUSY_CODE.to_owned(),
+                message: "A lyrics save run is already in progress.".to_owned(),
+                details: None,
+            });
+        }
+
+        let token = CancellationToken::new();
+        let generation = self.generations.fetch_add(1, Ordering::SeqCst);
+        *active = Some(Run {
+            token: token.clone(),
+            generation,
+        });
+
+        Ok(RunGuard {
+            runs: self,
+            token,
+            generation,
+        })
+    }
+
+    /// Cancel the active run. Silently a no-op when idle.
+    fn cancel(&self) {
+        if let Some(run) = lock(&self.active).as_ref() {
+            tracing::info!("lyrics write-back cancellation requested");
+            run.token.cancel();
+        }
+    }
+}
+
+/// Proof that the caller holds the run slot; releases it on drop.
+#[derive(Debug)]
+struct RunGuard<'runs> {
+    runs: &'runs LyricsSaveRuns,
+    token: CancellationToken,
+    generation: u64,
+}
+
+impl RunGuard<'_> {
+    fn token(&self) -> &CancellationToken {
+        &self.token
+    }
+}
+
+impl Drop for RunGuard<'_> {
+    fn drop(&mut self) {
+        let mut active = lock(&self.runs.active);
+
+        if active
+            .as_ref()
+            .is_some_and(|current| current.generation == self.generation)
+        {
+            *active = None;
+        }
+    }
+}
+
+/// `lock_or_recover` for this module's one mutex.
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 /// v1's `lyricsFetchArgs`, applied to the arguments serde has already typed.

--- a/apps/desktop-tauri/src-tauri/src/commands/registry.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/registry.rs
@@ -61,7 +61,7 @@
 /// Raising it is how a lane records that it landed. Lowering it means a
 /// namespace was dropped, which is exactly the regression R13 names — museeks
 /// lost six features across its migration and noticed afterwards.
-pub const COMMAND_COUNT: usize = 148;
+pub const COMMAND_COUNT: usize = 150;
 
 /// The invoke half of the 155-channel parity checklist (§2.6): 135 invoke plus
 /// 20 events. [`COMMAND_COUNT`] may exceed it only by the commands that port no
@@ -71,7 +71,7 @@ pub const V1_INVOKE_CHANNEL_COUNT: usize = 135;
 /// Commands in this crate that port no v1 channel and are therefore not counted
 /// against [`V1_INVOKE_CHANNEL_COUNT`].
 ///
-/// Thirteen of them:
+/// Fifteen of them:
 ///
 /// - `health_check`.
 /// - `dialog_save_file` — v1 opened its save panel inside the
@@ -103,7 +103,11 @@ pub const V1_INVOKE_CHANNEL_COUNT: usize = 135;
 ///   reason.
 /// - `companion_set_species` — the Shio/Hotaru switch
 ///   (`docs/v2/companion/decision.md`); born in v2 for the same reason.
-pub const NON_V1_COMMANDS: usize = 13;
+/// - `lyrics_save_batch` and `lyrics_save_cancel` — the write-back batch. v1
+///   kept fetched lyrics in an in-memory MRU and nowhere else, so there was no
+///   library-wide pass for it to have a channel for. See
+///   [`crate::commands::lyrics`].
+pub const NON_V1_COMMANDS: usize = 15;
 
 /// Every namespace, in one list, expanded through `$callback`.
 ///

--- a/apps/desktop-tauri/src-tauri/src/events.rs
+++ b/apps/desktop-tauri/src-tauri/src/events.rs
@@ -177,6 +177,13 @@ events! {
     /// Progress through a Library Doctor health check (F8, v2-only).
     DoctorProgress = "doctor:progress" => Json;
 
+    /// Progress through a lyrics write-back batch (v2, no v1 counterpart).
+    ///
+    /// v1 fetched lyrics one track at a time and kept them in memory, so there
+    /// was no library-wide pass to report on. See
+    /// `crate::commands::lyrics`.
+    LyricsSaveProgress = "lyrics:save-progress" => Json;
+
     /// The companion accrued XP from a recorded play (v2 companion, no v1
     /// counterpart). Fired by `db:history:record-play`'s accrual hook; the
     /// payload carries the delta, the new lifetime total, the (possibly
@@ -229,7 +236,12 @@ mod tests {
     /// manifest, and everything else must. Today: the one-pass analysis
     /// engine's progress, the Library Doctor's progress (F8), and the
     /// companion's XP accrual.
-    const V2_EVENT_CHANNELS: &[&str] = &["analysis:progress", "doctor:progress", "companion:xp"];
+    const V2_EVENT_CHANNELS: &[&str] = &[
+        "analysis:progress",
+        "doctor:progress",
+        "companion:xp",
+        "lyrics:save-progress",
+    ];
 
     #[test]
     fn every_event_channel_has_a_typed_event() {

--- a/apps/desktop-tauri/src-tauri/src/lib.rs
+++ b/apps/desktop-tauri/src-tauri/src/lib.rs
@@ -193,15 +193,16 @@ pub fn run() {
             let folders = std::sync::Arc::clone(&booted.folders);
             app.manage(booted.state);
             app.manage(folders);
-            // The three cancel slots. Without these, `library:scan-cancel`,
-            // `metadata:enrich-cancel` and `audio:loudness-cancel` fail at
-            // runtime with "state not managed" — an accumulated Phase 16
-            // obligation, and one with no compile-time signal at all.
+            // The cancel slots. Without these, `library:scan-cancel`,
+            // `metadata:enrich-cancel`, `audio:loudness-cancel` and their v2
+            // siblings fail at runtime with "state not managed" — an accumulated
+            // Phase 16 obligation, and one with no compile-time signal at all.
             app.manage(commands::library::ScanSlot::default());
             app.manage(commands::metadata::EnrichRuns::default());
             app.manage(commands::loudness::LoudnessRuns::default());
             app.manage(commands::analysis::AnalysisRuns::default());
             app.manage(commands::doctor::DoctorRuns::default());
+            app.manage(commands::lyrics::LyricsSaveRuns::default());
             // Keeps the log appender's worker and the Sentry client alive for
             // the process's lifetime; both flush on drop.
             app.manage(preflight.logging);

--- a/apps/desktop/src/main/app/store.ts
+++ b/apps/desktop/src/main/app/store.ts
@@ -65,12 +65,6 @@ export interface StoreSchema {
   // files. Default implicit `undefined` → false (local-first).
   'lyrics.preferSyncedFromLrclib': boolean;
 
-  // Renderer-writable (settings UI); read by the v2 lyrics service before it
-  // writes anything. When true, a synced LRCLIB hit is saved as a `.lrc` beside
-  // the track so it survives going offline. Default implicit `undefined` →
-  // false: nothing is ever written into a music folder without an opt-in.
-  'lyrics.saveFetchedLyrics': boolean;
-
   // Main-only (downloader.ts).
   'downloads.location': string;
   'downloads.toolStatusCache': ToolStatusCache;

--- a/apps/desktop/src/main/app/store.ts
+++ b/apps/desktop/src/main/app/store.ts
@@ -65,6 +65,12 @@ export interface StoreSchema {
   // files. Default implicit `undefined` → false (local-first).
   'lyrics.preferSyncedFromLrclib': boolean;
 
+  // Renderer-writable (settings UI); read by the v2 lyrics service before it
+  // writes anything. When true, a synced LRCLIB hit is saved as a `.lrc` beside
+  // the track so it survives going offline. Default implicit `undefined` →
+  // false: nothing is ever written into a music folder without an opt-in.
+  'lyrics.saveFetchedLyrics': boolean;
+
   // Main-only (downloader.ts).
   'downloads.location': string;
   'downloads.toolStatusCache': ToolStatusCache;

--- a/apps/desktop/src/main/ipc/schemas/store.ts
+++ b/apps/desktop/src/main/ipc/schemas/store.ts
@@ -28,7 +28,6 @@ const RENDERER_STORE_KEYS = [
   'system.minimizeToTray',
   'system.closeToTray',
   'lyrics.preferSyncedFromLrclib',
-  'lyrics.saveFetchedLyrics',
 ] as const;
 
 // Compile-time guarantee: every entry is a StoreSchema key.

--- a/apps/desktop/src/main/ipc/schemas/store.ts
+++ b/apps/desktop/src/main/ipc/schemas/store.ts
@@ -28,6 +28,7 @@ const RENDERER_STORE_KEYS = [
   'system.minimizeToTray',
   'system.closeToTray',
   'lyrics.preferSyncedFromLrclib',
+  'lyrics.saveFetchedLyrics',
 ] as const;
 
 // Compile-time guarantee: every entry is a StoreSchema key.

--- a/apps/web/src/components/settings/LyricsSection/LyricsSection.hooks.ts
+++ b/apps/web/src/components/settings/LyricsSection/LyricsSection.hooks.ts
@@ -3,6 +3,11 @@ import {
   usePreferSyncedFromLrclibQuery,
   useUpdatePreferSyncedFromLrclibMutation,
 } from '@/hooks/queries/useLyrics';
+import {
+  useSaveFetchedLyricsQuery,
+  useUpdateSaveFetchedLyricsMutation,
+} from '@/hooks/queries/useLyricsSavePrefs';
+import { useLyricsSave } from '@/hooks/useLyricsSave';
 import { IS_ELECTRON } from '@/lib/platform';
 import {
   useLyricsAppearanceStore,
@@ -19,6 +24,7 @@ import {
   LYRICS_PRESENTATION_DEFAULT,
 } from '@/stores/useLyricsAppearanceStore';
 import { useUIStore } from '@/stores/useUIStore';
+import type { LyricsBatchSummary } from '@shiranami/contracts';
 import type { ILyricsSectionView } from './LyricsSection.types';
 
 export function useLyricsSection(): ILyricsSectionView {
@@ -29,6 +35,12 @@ export function useLyricsSection(): ILyricsSectionView {
   // the useSystemPrefs pattern for main-consumed settings.
   const { data: preferSynced } = usePreferSyncedFromLrclibQuery();
   const updatePreferSynced = useUpdatePreferSyncedFromLrclibMutation();
+
+  // The write-back opt-in and the library run it gates. Same query-seeded
+  // pattern; the run is a live backend batch rather than a stored value.
+  const { data: saveFetched } = useSaveFetchedLyricsQuery();
+  const updateSaveFetched = useUpdateSaveFetchedLyricsMutation();
+  const lyricsSave = useLyricsSave();
 
   const lyricsPlainOpacity = useLyricsAppearanceStore(s => s.lyricsPlainOpacity);
   const lyricsPlainFontSize = useLyricsAppearanceStore(s => s.lyricsPlainFontSize);
@@ -63,6 +75,31 @@ export function useLyricsSection(): ILyricsSectionView {
     preferSyncedDisabled: !IS_ELECTRON || preferSynced === undefined,
     onSetPreferSyncedFromLrclib: value => updatePreferSynced.mutate(value),
 
+    // `=== true` rather than a truthiness check, deliberately: an unseeded
+    // `undefined` must read as off. This is the one setting that lets the app
+    // write into the user's music folders, and a switch that looked on while
+    // the backend had not agreed would be a promise nobody made.
+    saveFetchedLyrics: saveFetched === true,
+    saveFetchedDisabled: !IS_ELECTRON || saveFetched === undefined,
+    onSetSaveFetchedLyrics: value => updateSaveFetched.mutate(value),
+
+    saveRunning: lyricsSave.running,
+    // The button follows the opt-in, matching the backend, which refuses the
+    // channel outright with `lyrics.save_disabled` when the setting is off. Two
+    // gates saying the same thing, so the UI never offers a click that throws.
+    saveRunDisabled: !IS_ELECTRON || saveFetched !== true || lyricsSave.running,
+    saveProgressLabel: lyricsSave.running
+      ? t('lyr.sources.saveProgress', {
+          current: lyricsSave.current,
+          total: lyricsSave.total,
+        })
+      : null,
+    saveSummaryLabel: summaryLabel(lyricsSave.summary, t),
+    saveDisabledHint:
+      IS_ELECTRON && saveFetched === false ? t('lyr.sources.saveDisabledHint') : null,
+    onRunSave: () => void lyricsSave.start(),
+    onCancelSave: lyricsSave.cancel,
+
     lyricsPlainOpacity,
     lyricsPlainFontSize,
     onSetPlainOpacity: setLyricsPlainOpacity,
@@ -89,4 +126,30 @@ export function useLyricsSection(): ILyricsSectionView {
     isModified,
     onReset: resetLyricsAppearance,
   };
+}
+
+/**
+ * The counts line for a finished run, or `null` before one.
+ *
+ * `notFound` and `failed` stay apart rather than being summed into "didn't
+ * work": the directory not having a track is settled, while a lookup that could
+ * not complete or a file that could not be written is worth another run, and
+ * only the second is a reason to press the button again.
+ */
+function summaryLabel(
+  summary: LyricsBatchSummary | null,
+  t: ILyricsSectionView['t']
+): string | null {
+  if (summary === null) return null;
+
+  const counts = {
+    saved: summary.saved,
+    skipped: summary.skipped,
+    notFound: summary.notFound,
+    failed: summary.failed,
+  };
+
+  return summary.cancelled
+    ? t('lyr.sources.saveSummaryCancelled', counts)
+    : t('lyr.sources.saveSummary', counts);
 }

--- a/apps/web/src/components/settings/LyricsSection/LyricsSection.hooks.ts
+++ b/apps/web/src/components/settings/LyricsSection/LyricsSection.hooks.ts
@@ -4,6 +4,7 @@ import {
   useUpdatePreferSyncedFromLrclibMutation,
 } from '@/hooks/queries/useLyrics';
 import {
+  saveFetchedLyricsPatch,
   useSaveFetchedLyricsQuery,
   useUpdateSaveFetchedLyricsMutation,
 } from '@/hooks/queries/useLyricsSavePrefs';
@@ -81,7 +82,7 @@ export function useLyricsSection(): ILyricsSectionView {
     // the backend had not agreed would be a promise nobody made.
     saveFetchedLyrics: saveFetched === true,
     saveFetchedDisabled: !IS_ELECTRON || saveFetched === undefined,
-    onSetSaveFetchedLyrics: value => updateSaveFetched.mutate(value),
+    onSetSaveFetchedLyrics: value => updateSaveFetched.mutate(saveFetchedLyricsPatch(value)),
 
     saveRunning: lyricsSave.running,
     // The button follows the opt-in, matching the backend, which refuses the

--- a/apps/web/src/components/settings/LyricsSection/LyricsSection.tsx
+++ b/apps/web/src/components/settings/LyricsSection/LyricsSection.tsx
@@ -1,4 +1,4 @@
-import { Captions, MonitorPlay } from 'lucide-react';
+import { Captions, Download, Loader2, MonitorPlay } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
   SettingsCard,
@@ -6,6 +6,7 @@ import {
   SettingsToggleRow,
 } from '@/components/settings/SettingsCard';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
+import { Button } from '@/components/ui/button';
 import { Slider } from '@/components/ui/slider';
 import {
   LYR_SIZE_CLASS,
@@ -27,6 +28,16 @@ export default function LyricsSection() {
     preferSyncedFromLrclib,
     preferSyncedDisabled,
     onSetPreferSyncedFromLrclib,
+    saveFetchedLyrics,
+    saveFetchedDisabled,
+    onSetSaveFetchedLyrics,
+    saveRunning,
+    saveRunDisabled,
+    saveProgressLabel,
+    saveSummaryLabel,
+    saveDisabledHint,
+    onRunSave,
+    onCancelSave,
     lyricsPlainOpacity,
     lyricsPlainFontSize,
     onSetPlainOpacity,
@@ -59,6 +70,26 @@ export default function LyricsSection() {
             checked={preferSyncedFromLrclib}
             onCheckedChange={onSetPreferSyncedFromLrclib}
             disabled={preferSyncedDisabled}
+          />
+          <SettingsToggleRow
+            label={t('lyr.sources.saveFetchedTitle')}
+            description={t('lyr.sources.saveFetchedDesc')}
+            checked={saveFetchedLyrics}
+            onCheckedChange={onSetSaveFetchedLyrics}
+            disabled={saveFetchedDisabled}
+          />
+          <SaveLibraryControl
+            title={t('lyr.sources.saveRunTitle')}
+            description={t('lyr.sources.saveRunDesc')}
+            runLabel={t('lyr.sources.saveRun')}
+            cancelLabel={t('lyr.sources.saveCancel')}
+            running={saveRunning}
+            disabled={saveRunDisabled}
+            progressLabel={saveProgressLabel}
+            summaryLabel={saveSummaryLabel}
+            disabledHint={saveDisabledHint}
+            onRun={onRunSave}
+            onCancel={onCancelSave}
           />
         </Subsection>
 
@@ -149,6 +180,89 @@ function Subsection({ title, subtitle, children }: ISubsectionProps) {
         <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
       </div>
       <div className="space-y-5">{children}</div>
+    </div>
+  );
+}
+
+interface ISaveLibraryControlProps {
+  title: string;
+  description: string;
+  runLabel: string;
+  cancelLabel: string;
+  running: boolean;
+  disabled: boolean;
+  progressLabel: string | null;
+  summaryLabel: string | null;
+  disabledHint: string | null;
+  onRun: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * The library-wide write-back run: one button, its progress, and its counts.
+ *
+ * Shaped after `LibraryAnalysisCard` — the same run/cancel swap and the same
+ * inline progress strip — because this is the same kind of thing to a user: one
+ * long pass over the library they can stop. It lives inside the Sources
+ * subsection rather than in its own card so it sits directly under the opt-in
+ * that gates it, which is the only place the disabled state reads as an
+ * explanation rather than as a bug.
+ */
+function SaveLibraryControl({
+  title,
+  description,
+  runLabel,
+  cancelLabel,
+  running,
+  disabled,
+  progressLabel,
+  summaryLabel,
+  disabledHint,
+  onRun,
+  onCancel,
+}: ISaveLibraryControlProps) {
+  // The three "show this strip" decisions, named here rather than chained in the
+  // markup: a run replaces both the hint and the counts while it is going, and
+  // that rule reads as one idea only when it is written as one.
+  const showHint = disabledHint !== null && !running;
+  const showProgress = running && progressLabel !== null;
+  const showSummary = !running && summaryLabel !== null;
+
+  return (
+    <div className="px-3 space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground mb-1">{title}</p>
+          <p className="text-xs text-muted-foreground">{description}</p>
+        </div>
+        {running ? (
+          <Button variant="ghost" size="sm" onClick={onCancel} className="shrink-0">
+            {cancelLabel}
+          </Button>
+        ) : (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onRun}
+            disabled={disabled}
+            className="shrink-0 [&_svg]:size-3.5"
+          >
+            <Download />
+            {runLabel}
+          </Button>
+        )}
+      </div>
+
+      {showHint && <p className="text-xs text-muted-foreground">{disabledHint}</p>}
+
+      {showProgress && (
+        <div className="flex items-center gap-2 px-3 py-2.5 rounded-xl bg-background/50 border border-border/20">
+          <Loader2 className="w-4 h-4 animate-spin text-muted-foreground shrink-0" />
+          <span className="text-sm text-muted-foreground truncate">{progressLabel}</span>
+        </div>
+      )}
+
+      {showSummary && <p className="text-xs text-muted-foreground tabular-nums">{summaryLabel}</p>}
     </div>
   );
 }

--- a/apps/web/src/components/settings/LyricsSection/LyricsSection.types.ts
+++ b/apps/web/src/components/settings/LyricsSection/LyricsSection.types.ts
@@ -17,6 +17,32 @@ export interface ILyricsSectionView {
   /** Persist the source-precedence toggle and re-resolve current lyrics. */
   readonly onSetPreferSyncedFromLrclib: (value: boolean) => void;
 
+  // --- Write-back ---
+  /**
+   * When true, a synced hit from LRCLIB is saved as a `.lrc` beside the track.
+   * Off unless the user has said otherwise: this is the one setting that makes
+   * the app write into their music folders.
+   */
+  readonly saveFetchedLyrics: boolean;
+  /** True until the persisted value has seeded (or outside Electron). */
+  readonly saveFetchedDisabled: boolean;
+  /** Persist the write-back opt-in. */
+  readonly onSetSaveFetchedLyrics: (value: boolean) => void;
+  /** Whether a library-wide write-back run is going. */
+  readonly saveRunning: boolean;
+  /** Whether the run button is inert — the opt-in is off, or a run is queued. */
+  readonly saveRunDisabled: boolean;
+  /** Localized progress line while a run is going; `null` otherwise. */
+  readonly saveProgressLabel: string | null;
+  /** Localized counts from the last finished run; `null` before one. */
+  readonly saveSummaryLabel: string | null;
+  /** Localized note explaining why the run button is inert; `null` when it is not. */
+  readonly saveDisabledHint: string | null;
+  /** Start a library-wide write-back run. */
+  readonly onRunSave: () => void;
+  /** Stop the active run. */
+  readonly onCancelSave: () => void;
+
   // --- Plain lyrics ---
   /** Plain-lyrics text opacity (0–1). */
   readonly lyricsPlainOpacity: number;

--- a/apps/web/src/hooks/queries/useLyrics.ts
+++ b/apps/web/src/hooks/queries/useLyrics.ts
@@ -45,8 +45,15 @@ export function useLyricsQuery(
 
 const PREFER_SYNCED_STORE_KEY = 'lyrics.preferSyncedFromLrclib';
 
+/**
+ * Both lyric-preference query keys, kept together here even though the
+ * write-back pair's hooks live in `useLyricsSavePrefs` — they are one namespace
+ * to invalidate, and splitting the keys along with the hooks would leave two
+ * places to look for "what does a lyrics preference cache under?".
+ */
 export const lyricsPrefKeys = {
   preferSynced: ['lyrics-prefs', 'prefer-synced-from-lrclib'] as const,
+  saveFetched: ['lyrics-prefs', 'save-fetched-lyrics'] as const,
 };
 
 export function usePreferSyncedFromLrclibQuery() {

--- a/apps/web/src/hooks/queries/useLyrics.ts
+++ b/apps/web/src/hooks/queries/useLyrics.ts
@@ -46,14 +46,12 @@ export function useLyricsQuery(
 const PREFER_SYNCED_STORE_KEY = 'lyrics.preferSyncedFromLrclib';
 
 /**
- * Both lyric-preference query keys, kept together here even though the
- * write-back pair's hooks live in `useLyricsSavePrefs` — they are one namespace
- * to invalidate, and splitting the keys along with the hooks would leave two
- * places to look for "what does a lyrics preference cache under?".
+ * The lyric-preference query keys. Only `preferSyncedFromLrclib` has one: the
+ * write-back opt-in lives as a field inside the renderer settings blob and so
+ * caches under `useSettingsQuery`'s `['settings']` key, not here.
  */
 export const lyricsPrefKeys = {
   preferSynced: ['lyrics-prefs', 'prefer-synced-from-lrclib'] as const,
-  saveFetched: ['lyrics-prefs', 'save-fetched-lyrics'] as const,
 };
 
 export function usePreferSyncedFromLrclibQuery() {

--- a/apps/web/src/hooks/queries/useLyricsSavePrefs.ts
+++ b/apps/web/src/hooks/queries/useLyricsSavePrefs.ts
@@ -1,0 +1,65 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { IS_ELECTRON } from '@/lib/platform';
+import i18n from '@/lib/i18n';
+import { lyricsPrefKeys } from './useLyrics';
+
+/**
+ * The write-back opt-in, split out of `useLyrics` to keep each query file under
+ * the four-hook cap.
+ *
+ * `lyrics.saveFetchedLyrics` lives as an electron-store key rather than in the
+ * renderer settings blob for the same reason `lyrics.preferSyncedFromLrclib`
+ * does: the backend consumes it, here before it writes anything to disk.
+ *
+ * It is the only renderer-writable setting that causes the app to write into the
+ * user's own music folders, so it is opt-in and the backend refuses at the trait
+ * level until it is set — and `lyrics:save-batch` rejects with
+ * `lyrics.save_disabled` rather than running to an all-skipped summary.
+ */
+const SAVE_FETCHED_STORE_KEY = 'lyrics.saveFetchedLyrics';
+
+export function useSaveFetchedLyricsQuery() {
+  return useQuery({
+    queryKey: lyricsPrefKeys.saveFetched,
+    queryFn: async (): Promise<boolean> => {
+      const value = await window.electronAPI.store.get<boolean>(SAVE_FETCHED_STORE_KEY);
+      // `=== true` and not a truthiness check: an absent key is a user who has
+      // never opted in, and the one direction this must never get wrong is
+      // reading "unset" as "yes, write into my music folders".
+      return value === true;
+    },
+    enabled: IS_ELECTRON,
+    staleTime: Infinity,
+  });
+}
+
+export function useUpdateSaveFetchedLyricsMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (value: boolean) => {
+      if (!IS_ELECTRON) return;
+      await window.electronAPI.store.set(SAVE_FETCHED_STORE_KEY, value);
+    },
+    // Optimistic flip with rollback, matching the precedence toggle in
+    // `useLyrics`: the switch tracks the click, and a failed write restores the
+    // previous value synchronously before the invalidate re-syncs.
+    onMutate: async value => {
+      await queryClient.cancelQueries({ queryKey: lyricsPrefKeys.saveFetched });
+      const previous = queryClient.getQueryData<boolean>(lyricsPrefKeys.saveFetched);
+      queryClient.setQueryData<boolean>(lyricsPrefKeys.saveFetched, value);
+      return { previous };
+    },
+    onError: (_err, _value, context) => {
+      if (context) {
+        queryClient.setQueryData(lyricsPrefKeys.saveFetched, context.previous);
+      }
+      toast.error(i18n.t('failedSaveSettings', { ns: 'toast' }));
+      queryClient.invalidateQueries({ queryKey: lyricsPrefKeys.saveFetched });
+    },
+    // Deliberately does NOT invalidate `lyricsKeys.all`: this setting changes
+    // what happens to a *file* after a fetch, never which source wins, so
+    // re-resolving the current track would be work with no visible result.
+  });
+}

--- a/apps/web/src/hooks/queries/useLyricsSavePrefs.ts
+++ b/apps/web/src/hooks/queries/useLyricsSavePrefs.ts
@@ -1,65 +1,52 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
-import { IS_ELECTRON } from '@/lib/platform';
-import i18n from '@/lib/i18n';
-import { lyricsPrefKeys } from './useLyrics';
+import { useSettingsQuery, useUpdateSettingsMutation } from './useSettings';
 
 /**
- * The write-back opt-in, split out of `useLyrics` to keep each query file under
- * the four-hook cap.
+ * The lyrics write-back opt-in, kept as a field inside the renderer `settings`
+ * blob rather than as a dedicated electron-store key.
  *
- * `lyrics.saveFetchedLyrics` lives as an electron-store key rather than in the
- * renderer settings blob for the same reason `lyrics.preferSyncedFromLrclib`
- * does: the backend consumes it, here before it writes anything to disk.
+ * That placement is load-bearing, not incidental. A dot-path key of its own
+ * would have to be added to `RendererStoreKey`, which `store::keys`' test pins
+ * against v1's `RENDERER_STORE_KEYS` tuple *exactly* — so it would also have to
+ * be registered in `apps/desktop`, a v1 Electron file that v2 work does not
+ * touch. Skipping that registration is worse than untidy: the Electron shell
+ * guards `store:set` with a zod enum over that tuple, so the write would be
+ * rejected and the toggle would look like it saved when it had not.
  *
- * It is the only renderer-writable setting that causes the app to write into the
- * user's own music folders, so it is opt-in and the backend refuses at the trait
- * level until it is set — and `lyrics:save-batch` rejects with
- * `lyrics.save_disabled` rather than running to an all-skipped summary.
+ * The blob has neither problem. `settings` is already allowlisted on both
+ * sides and is typed `Record<string, unknown>` there and `z.unknown()` in the
+ * IPC schema, so a new field inside it is accepted by both shells with no
+ * schema change anywhere. The Rust policy reads the same field name out of the
+ * same blob (`boot::services::SAVE_FETCHED_LYRICS_FIELD`).
+ *
+ * The name is duplicated across that boundary and cannot be shared, so it is
+ * spelled once on each side and nowhere else — a typo is a toggle that never
+ * takes effect.
  */
-const SAVE_FETCHED_STORE_KEY = 'lyrics.saveFetchedLyrics';
+const SAVE_FETCHED_FIELD = 'saveFetchedLyrics';
 
+/**
+ * Whether fetched lyrics are saved beside the track.
+ *
+ * `=== true` rather than a truthiness check: an absent field is a user who has
+ * never opted in, and the one direction this must never get wrong is reading
+ * "unset" as "yes, write into my music folders" — the same rule the Rust side
+ * applies to the same field.
+ */
 export function useSaveFetchedLyricsQuery() {
-  return useQuery({
-    queryKey: lyricsPrefKeys.saveFetched,
-    queryFn: async (): Promise<boolean> => {
-      const value = await window.electronAPI.store.get<boolean>(SAVE_FETCHED_STORE_KEY);
-      // `=== true` and not a truthiness check: an absent key is a user who has
-      // never opted in, and the one direction this must never get wrong is
-      // reading "unset" as "yes, write into my music folders".
-      return value === true;
-    },
-    enabled: IS_ELECTRON,
-    staleTime: Infinity,
-  });
+  const query = useSettingsQuery();
+  return {
+    ...query,
+    data: query.data === undefined ? undefined : query.data?.[SAVE_FETCHED_FIELD] === true,
+  };
 }
 
 export function useUpdateSaveFetchedLyricsMutation() {
-  const queryClient = useQueryClient();
+  // The shared settings mutation already merges the patch over the cached blob
+  // and resyncs on failure, so the write cannot clobber a sibling field.
+  return useUpdateSettingsMutation();
+}
 
-  return useMutation({
-    mutationFn: async (value: boolean) => {
-      if (!IS_ELECTRON) return;
-      await window.electronAPI.store.set(SAVE_FETCHED_STORE_KEY, value);
-    },
-    // Optimistic flip with rollback, matching the precedence toggle in
-    // `useLyrics`: the switch tracks the click, and a failed write restores the
-    // previous value synchronously before the invalidate re-syncs.
-    onMutate: async value => {
-      await queryClient.cancelQueries({ queryKey: lyricsPrefKeys.saveFetched });
-      const previous = queryClient.getQueryData<boolean>(lyricsPrefKeys.saveFetched);
-      queryClient.setQueryData<boolean>(lyricsPrefKeys.saveFetched, value);
-      return { previous };
-    },
-    onError: (_err, _value, context) => {
-      if (context) {
-        queryClient.setQueryData(lyricsPrefKeys.saveFetched, context.previous);
-      }
-      toast.error(i18n.t('failedSaveSettings', { ns: 'toast' }));
-      queryClient.invalidateQueries({ queryKey: lyricsPrefKeys.saveFetched });
-    },
-    // Deliberately does NOT invalidate `lyricsKeys.all`: this setting changes
-    // what happens to a *file* after a fetch, never which source wins, so
-    // re-resolving the current track would be work with no visible result.
-  });
+/** The patch this toggle sends. Keeps the field name off the call site. */
+export function saveFetchedLyricsPatch(value: boolean) {
+  return { [SAVE_FETCHED_FIELD]: value };
 }

--- a/apps/web/src/hooks/useLyricsSave.ts
+++ b/apps/web/src/hooks/useLyricsSave.ts
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import type {
+  LyricsBatchProgress,
+  LyricsBatchSummary,
+  LyricsBatchTrack,
+} from '@shiranami/contracts';
+import { useLibraryStore } from '@/stores/useLibraryStore';
+import type { Track } from '@/stores/types';
+import { IS_ELECTRON } from '@/lib/platform';
+import { isRadioTrack } from '@/lib/utils';
+import { logger } from '@/lib/logger';
+
+interface LyricsSaveState {
+  running: boolean;
+  current: number;
+  total: number;
+  trackName: string;
+}
+
+const IDLE: LyricsSaveState = { running: false, current: 0, total: 0, trackName: '' };
+
+/**
+ * The tracks a write-back run submits: every real file in the library. Radio
+ * pseudo-tracks never submit — there is no file to write a `.lrc` beside, and
+ * the backend would only skip them at the cost of a progress tick each.
+ *
+ * Nothing else is filtered here. Whether a track already has a lyric file, and
+ * whether its folder may be written to, are the backend's questions: it answers
+ * both from disk before it spends an LRCLIB request, and a renderer-side guess
+ * would only be a second answer to keep in agreement. Exported for tests.
+ */
+export function pendingLyricsSaveInput(library: Track[]): LyricsBatchTrack[] {
+  return library
+    .filter(track => !isRadioTrack(track.filePath))
+    .map(track => ({
+      id: track.id,
+      filePath: track.filePath,
+      title: track.title,
+      artist: track.artist,
+      // Both are always present on a display track. The placeholder album is
+      // dropped backend-side, where the LRCLIB query is built — narrowing the
+      // search to records literally titled "Unknown Album" is worse than
+      // sending none.
+      album: track.album,
+      durationSeconds: track.duration,
+    }));
+}
+
+/**
+ * Drives a library-wide lyrics write-back run. Streams progress and exposes
+ * start/cancel, and hands the finished summary back so the caller can report
+ * what the run managed.
+ *
+ * The library store is deliberately not refreshed afterwards: write-back adds
+ * files beside tracks and changes no database row, and the lyrics panel re-reads
+ * disk on every track change already.
+ */
+export function useLyricsSave() {
+  const [state, setState] = useState<LyricsSaveState>(IDLE);
+  const [summary, setSummary] = useState<LyricsBatchSummary | null>(null);
+  const runningRef = useRef(false);
+  const { t: tToast } = useTranslation('toast');
+
+  useEffect(() => {
+    if (!IS_ELECTRON || window.electronAPI.lyrics?.onSaveProgress == null) return;
+    return window.electronAPI.lyrics.onSaveProgress((data: LyricsBatchProgress) => {
+      setState(prev => ({
+        ...prev,
+        // The tick is a settled count and delivery order between two racing
+        // ticks is not guaranteed, so the bar takes the max and never goes
+        // backwards.
+        current: Math.max(prev.current, data.current),
+        total: data.total,
+        trackName: data.trackName,
+      }));
+    });
+  }, []);
+
+  const start = useCallback(async () => {
+    const api = IS_ELECTRON ? window.electronAPI.lyrics : undefined;
+    if (api?.saveBatch == null || runningRef.current) return;
+
+    const pending = pendingLyricsSaveInput(useLibraryStore.getState().library);
+    if (pending.length === 0) return;
+
+    runningRef.current = true;
+    setSummary(null);
+    setState({ running: true, current: 0, total: pending.length, trackName: '' });
+    try {
+      setSummary(await api.saveBatch(pending));
+    } catch (err) {
+      logger.error('Lyrics write-back failed', err);
+      toast.error(tToast('lyricsSaveFailed'), { id: 'lyrics-save-error' });
+    } finally {
+      runningRef.current = false;
+      setState(IDLE);
+    }
+  }, [tToast]);
+
+  const cancel = useCallback(() => {
+    if (!IS_ELECTRON || window.electronAPI.lyrics?.saveCancel == null) return;
+    void window.electronAPI.lyrics.saveCancel();
+  }, []);
+
+  return { ...state, summary, start, cancel };
+}

--- a/apps/web/src/lib/bridge/bridge.contract.test.ts
+++ b/apps/web/src/lib/bridge/bridge.contract.test.ts
@@ -63,9 +63,9 @@ describe('bridge channel coverage', () => {
     expect(mapped).toHaveLength(ALL_IPC_CHANNELS.length);
   });
 
-  it('covers all 166 channels — 135 v1 invoke, 8 v2 invoke, 20 v1 + 3 v2 events', () => {
-    expect(ALL_IPC_CHANNELS.length).toBe(166);
-    expect(mapped).toHaveLength(166);
+  it('covers all 169 channels — 135 v1 invoke, 10 v2 invoke, 20 v1 + 4 v2 events', () => {
+    expect(ALL_IPC_CHANNELS.length).toBe(169);
+    expect(mapped).toHaveLength(169);
   });
 
   it('resolves every mapped channel to a function on the installed surface', () => {

--- a/apps/web/src/lib/bridge/manifest.ts
+++ b/apps/web/src/lib/bridge/manifest.ts
@@ -83,6 +83,9 @@ export const CHANNEL_IMPLEMENTATIONS: Record<IpcChannelName, ChannelPath> = {
 
   // ── lyrics / weather ────────────────────────────────────────────────────
   'lyrics:fetch': ['lyrics', 'fetch'],
+  'lyrics:save-batch': ['lyrics', 'saveBatch'],
+  'lyrics:save-cancel': ['lyrics', 'saveCancel'],
+  'lyrics:save-progress': ['lyrics', 'onSaveProgress'],
   'weather:geocode': ['weather', 'geocode'],
   'weather:get-current': ['weather', 'getCurrent'],
 

--- a/apps/web/src/lib/bridge/namespaces/lyrics.ts
+++ b/apps/web/src/lib/bridge/namespaces/lyrics.ts
@@ -1,5 +1,10 @@
-import type { LyricsApi } from '@shiranami/contracts';
+import { IPC_CHANNELS, type LyricsApi, type LyricsBatchProgress } from '@shiranami/contracts';
+import { events } from '@shiranami/contracts/bindings';
 import { commands } from '../commands';
+import { subscribeChannel } from '../events';
+import { lyricsSaveProgress } from '../narrowers';
+
+const C = IPC_CHANNELS.lyrics;
 
 export const lyricsApi: LyricsApi = {
   // Three optional positional arguments become three nullable ones: v1 sent
@@ -7,4 +12,18 @@ export const lyricsApi: LyricsApi = {
   // serde needs the absence stated.
   fetch: (title, artist, album, duration, filePath) =>
     commands.lyricsFetch(title, artist, album ?? null, duration ?? null, filePath ?? null),
+  // The per-track hints need no such translation: they are `#[specta(optional)]`
+  // fields, so an absent key deserializes to `None` and the JSON encoding drops
+  // an `undefined` value on the way out.
+  saveBatch: tracks => commands.lyricsSaveBatch(tracks),
+  saveCancel: async () => {
+    await commands.lyricsSaveCancel();
+  },
+  onSaveProgress: callback =>
+    subscribeChannel<LyricsBatchProgress>(
+      C.saveProgress,
+      events.lyricsSaveProgress,
+      lyricsSaveProgress,
+      callback
+    ),
 };

--- a/apps/web/src/lib/bridge/narrowers.ts
+++ b/apps/web/src/lib/bridge/narrowers.ts
@@ -78,6 +78,9 @@ export const doctorProgress = predicate(z.object(progressBase));
 /** `metadata:enrich:progress`. */
 export const enrichProgress = predicate(z.object({ ...progressBase, status: z.string() }));
 
+/** `lyrics:save-progress`. */
+export const lyricsSaveProgress = predicate(z.object({ ...progressBase, status: z.string() }));
+
 /** `playlist:extract-progress`. */
 export const extractProgress = predicate(z.object(progressBase));
 

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -328,7 +328,17 @@
       "title": "Sources",
       "subtitle": "Where lyrics are looked up for your tracks",
       "preferSyncedTitle": "Prefer synced lyrics from LRCLIB",
-      "preferSyncedDesc": "When a track only has a plain-text lyrics file, fetch synced lyrics from LRCLIB instead. Local and embedded synced lyrics always win."
+      "preferSyncedDesc": "When a track only has a plain-text lyrics file, fetch synced lyrics from LRCLIB instead. Local and embedded synced lyrics always win.",
+      "saveFetchedTitle": "Save fetched lyrics beside your music",
+      "saveFetchedDesc": "When lyrics are found online, keep a timed .lrc file next to the track so they still work offline. A lyrics file you already have is never replaced.",
+      "saveRunTitle": "Fetch and save lyrics for your library",
+      "saveRunDesc": "Look up every track once and save what is found. Tracks that already have a lyrics file are skipped without a lookup.",
+      "saveRun": "Save lyrics for library",
+      "saveCancel": "Cancel",
+      "saveProgress": "Saving {{current}} / {{total}}…",
+      "saveSummary": "Saved {{saved}} · skipped {{skipped}} · not found {{notFound}} · failed {{failed}}",
+      "saveSummaryCancelled": "Cancelled — saved {{saved}} · skipped {{skipped}} · not found {{notFound}} · failed {{failed}}",
+      "saveDisabledHint": "Turn on saving above to run this."
     },
     "plain": {
       "title": "Plain text",

--- a/apps/web/src/locales/en/toast.json
+++ b/apps/web/src/locales/en/toast.json
@@ -123,5 +123,6 @@
   "scanCancelled": "Scan cancelled",
   "loudnessAnalysisFailed": "Loudness analysis failed",
   "analysisFailed": "Library analysis failed",
+  "lyricsSaveFailed": "Saving lyrics failed",
   "doctorScanFailed": "Library health check failed"
 }

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -350,7 +350,17 @@
       "title": "Źródła",
       "subtitle": "Skąd pobierany jest tekst dla Twoich utworów",
       "preferSyncedTitle": "Preferuj zsynchronizowany tekst z LRCLIB",
-      "preferSyncedDesc": "Gdy utwór ma tylko zwykły plik tekstowy, pobierz zsynchronizowany tekst z LRCLIB. Lokalny i osadzony zsynchronizowany tekst zawsze ma pierwszeństwo."
+      "preferSyncedDesc": "Gdy utwór ma tylko zwykły plik tekstowy, pobierz zsynchronizowany tekst z LRCLIB. Lokalny i osadzony zsynchronizowany tekst zawsze ma pierwszeństwo.",
+      "saveFetchedTitle": "Zapisuj pobrane teksty obok muzyki",
+      "saveFetchedDesc": "Gdy teksty zostaną znalezione w sieci, zachowaj plik .lrc z synchronizacją obok utworu, aby działały też offline. Plik tekstu, który już masz, nigdy nie zostanie zastąpiony.",
+      "saveRunTitle": "Pobierz i zapisz teksty dla biblioteki",
+      "saveRunDesc": "Wyszukaj każdy utwór raz i zapisz to, co zostanie znalezione. Utwory, które mają już plik tekstu, są pomijane bez wyszukiwania.",
+      "saveRun": "Zapisz teksty dla biblioteki",
+      "saveCancel": "Anuluj",
+      "saveProgress": "Zapisywanie {{current}} / {{total}}…",
+      "saveSummary": "Zapisano {{saved}} · pominięto {{skipped}} · nie znaleziono {{notFound}} · błędy {{failed}}",
+      "saveSummaryCancelled": "Anulowano — zapisano {{saved}} · pominięto {{skipped}} · nie znaleziono {{notFound}} · błędy {{failed}}",
+      "saveDisabledHint": "Włącz zapisywanie powyżej, aby to uruchomić."
     },
     "plain": {
       "title": "Tekst zwykły",

--- a/apps/web/src/locales/pl/toast.json
+++ b/apps/web/src/locales/pl/toast.json
@@ -139,5 +139,6 @@
   "scanCancelled": "Skanowanie anulowane",
   "loudnessAnalysisFailed": "Analiza głośności nie powiodła się",
   "analysisFailed": "Analiza biblioteki nie powiodła się",
+  "lyricsSaveFailed": "Zapisywanie tekstów nie powiodło się",
   "doctorScanFailed": "Sprawdzanie biblioteki nie powiodło się"
 }

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -171,6 +171,9 @@ function createElectronAPIMock(): ElectronAPI {
     },
     lyrics: {
       fetch: asyncFn({ synced: null, plain: null, source: null }),
+      saveBatch: asyncFn({ saved: 0, skipped: 0, notFound: 0, failed: 0, cancelled: false }),
+      saveCancel: asyncFn(undefined),
+      onSaveProgress: vi.fn(() => noopUnsub()),
     },
     weather: {
       geocode: asyncFn(null),

--- a/crates/shiranami-core/src/paths/folders_cache.rs
+++ b/crates/shiranami-core/src/paths/folders_cache.rs
@@ -23,10 +23,25 @@ use crate::sync::lock_or_recover;
 /// How many positive authorizations to remember. Ported verbatim.
 const ALLOWED_PATHS_LIMIT: usize = 1024;
 
+/// The two normalized root sets, built together from one read of the tables.
+///
+/// Two sets rather than one because reading and writing are different
+/// questions. A read may reach anything the shell handlers may reach; a write
+/// must land inside a folder the user actually pointed the library at, and
+/// nowhere else. Built in one pass so the narrower set costs no extra database
+/// round-trip.
+#[derive(Clone)]
+struct Roots {
+    /// Data directory, downloads location and every watched folder.
+    allowed: Vec<PathBuf>,
+    /// The watched folders alone.
+    library: Vec<PathBuf>,
+}
+
 #[derive(Default)]
 struct CacheState {
-    /// Normalized allowed roots; `None` until the first build.
-    roots: Option<Vec<PathBuf>>,
+    /// Normalized roots; `None` until the first build.
+    roots: Option<Roots>,
     /// Paths already authorized, mapped to the tick at which they last hit.
     granted: HashMap<PathBuf, u64>,
     /// Monotonic counter providing the recency ordering for eviction.
@@ -46,6 +61,9 @@ struct CacheState {
 /// a file dialog legitimately live outside every registered root. That
 /// deliberately means removing a folder does **not** immediately revoke access
 /// to tracks beneath it — they stay in the database until the user removes them.
+///
+/// [`FoldersCache::is_within_library_folder`] answers the narrower question a
+/// *write* has to ask, against the watched folders alone.
 pub struct FoldersCache {
     data_dir: PathBuf,
     authority: Arc<dyn PathAuthority>,
@@ -88,6 +106,39 @@ impl FoldersCache {
     /// [`Self::invalidate`] refuses to install its stale result, so a removed
     /// folder can never be resurrected by an in-flight rebuild.
     pub fn allowed_roots(&self) -> Vec<PathBuf> {
+        self.roots().allowed
+    }
+
+    /// Whether `directory` is inside a folder the user pointed the library at.
+    ///
+    /// The **write** containment gate, and narrower than [`Self::is_path_allowed`]
+    /// in both of the ways a write needs it to be:
+    ///
+    /// - Only the `folders` rows count. The read gate also grants the app's own
+    ///   data directory, the downloads location, and any row in the `tracks`
+    ///   table — the last of which would make the folder of a standalone file
+    ///   imported through a file dialog years ago a writable destination
+    ///   anywhere on the disk.
+    /// - Symlinks are resolved first, for [`Self::is_path_allowed`]'s reason:
+    ///   [`crate::paths::safety`] is purely textual, so a link inside a watched
+    ///   folder pointing outside it reads as contained, and the downstream
+    ///   `open` would happily follow it out of the library.
+    ///
+    /// Not cached. A grant table exists on the read path because the audio route
+    /// re-checks on every Range request of a seek; a write happens once per
+    /// file, so the `realpath` is not worth a second cache to keep coherent.
+    ///
+    /// Fails closed: an empty path and an empty root set both deny.
+    pub fn is_within_library_folder(&self, directory: &Path) -> bool {
+        if directory.as_os_str().is_empty() {
+            return false;
+        }
+
+        is_path_within_any(&resolve_symlinks(directory), &self.roots().library)
+    }
+
+    /// Both root sets, building them on first call. See [`Self::allowed_roots`].
+    fn roots(&self) -> Roots {
         let generation = {
             let state = lock_or_recover(&self.state);
             if let Some(roots) = &state.roots {
@@ -165,10 +216,10 @@ impl FoldersCache {
         }
     }
 
-    /// Assemble the roots: data dir, downloads location, then the watched
+    /// Assemble both sets: data dir, downloads location, then the watched
     /// folders. Each is symlink-resolved once here — cheap, because the count is
     /// O(10) — then normalized and de-duplicated, preserving first-seen order.
-    fn build_roots(&self) -> Vec<PathBuf> {
+    fn build_roots(&self) -> Roots {
         let folder_roots = self.authority.folder_roots().unwrap_or_else(|error| {
             // Ported behaviour: a folders-table read failure degrades to "no
             // folder roots" rather than taking path handling down with it. The
@@ -180,21 +231,14 @@ impl FoldersCache {
             Vec::new()
         });
 
-        let candidates = [self.data_dir.clone(), self.authority.download_location()]
-            .into_iter()
-            .chain(folder_roots);
+        let library = normalize_all(folder_roots.iter().cloned());
+        let allowed = normalize_all(
+            [self.data_dir.clone(), self.authority.download_location()]
+                .into_iter()
+                .chain(folder_roots),
+        );
 
-        let mut roots: Vec<PathBuf> = Vec::new();
-        for candidate in candidates {
-            if candidate.as_os_str().is_empty() {
-                continue;
-            }
-            let normalized = normalize_for_compare(&resolve_symlinks(&candidate));
-            if !roots.contains(&normalized) {
-                roots.push(normalized);
-            }
-        }
-        roots
+        Roots { allowed, library }
     }
 
     fn is_granted(&self, path: &Path) -> bool {
@@ -230,6 +274,23 @@ impl FoldersCache {
             state.granted.remove(&oldest);
         }
     }
+}
+
+/// Resolve, normalize and de-duplicate a run of roots, preserving first-seen
+/// order. Empty entries are dropped: they would normalize to the process's
+/// working directory and authorize half the disk.
+fn normalize_all(candidates: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = Vec::new();
+    for candidate in candidates {
+        if candidate.as_os_str().is_empty() {
+            continue;
+        }
+        let normalized = normalize_for_compare(&resolve_symlinks(&candidate));
+        if !roots.contains(&normalized) {
+            roots.push(normalized);
+        }
+    }
+    roots
 }
 
 /// Resolve symlinks, falling back to the input when the path does not exist yet.

--- a/crates/shiranami-core/src/store/keys.rs
+++ b/crates/shiranami-core/src/store/keys.rs
@@ -78,6 +78,14 @@ pub enum RendererStoreKey {
     /// Whether to prefer LRCLIB's synced lyrics over local files.
     #[serde(rename = "lyrics.preferSyncedFromLrclib")]
     LyricsPreferSyncedFromLrclib,
+    /// Whether a synced LRCLIB hit is saved as a `.lrc` beside the track.
+    ///
+    /// Absent means **off**, and absent is the shipped state: this is the only
+    /// renderer-writable key that causes a write into the user's own music
+    /// folders, so it is opt-in and the lyrics service refuses at the trait
+    /// level until it is set.
+    #[serde(rename = "lyrics.saveFetchedLyrics")]
+    LyricsSaveFetchedLyrics,
 }
 
 /// A settings key only the main process may touch.
@@ -115,7 +123,7 @@ pub enum MainStoreKey {
 
 impl RendererStoreKey {
     /// Every renderer-writable key, in the order the TypeScript tuple lists them.
-    pub const ALL: [Self; 17] = [
+    pub const ALL: [Self; 18] = [
         Self::Settings,
         Self::MusicFolders,
         Self::PlayerState,
@@ -133,6 +141,7 @@ impl RendererStoreKey {
         Self::SystemMinimizeToTray,
         Self::SystemCloseToTray,
         Self::LyricsPreferSyncedFromLrclib,
+        Self::LyricsSaveFetchedLyrics,
     ];
 
     /// The electron-store dot path this key lives at in the document.
@@ -159,6 +168,7 @@ impl RendererStoreKey {
             Self::SystemMinimizeToTray => "system.minimizeToTray",
             Self::SystemCloseToTray => "system.closeToTray",
             Self::LyricsPreferSyncedFromLrclib => "lyrics.preferSyncedFromLrclib",
+            Self::LyricsSaveFetchedLyrics => "lyrics.saveFetchedLyrics",
         }
     }
 }

--- a/crates/shiranami-core/src/store/keys.rs
+++ b/crates/shiranami-core/src/store/keys.rs
@@ -78,14 +78,6 @@ pub enum RendererStoreKey {
     /// Whether to prefer LRCLIB's synced lyrics over local files.
     #[serde(rename = "lyrics.preferSyncedFromLrclib")]
     LyricsPreferSyncedFromLrclib,
-    /// Whether a synced LRCLIB hit is saved as a `.lrc` beside the track.
-    ///
-    /// Absent means **off**, and absent is the shipped state: this is the only
-    /// renderer-writable key that causes a write into the user's own music
-    /// folders, so it is opt-in and the lyrics service refuses at the trait
-    /// level until it is set.
-    #[serde(rename = "lyrics.saveFetchedLyrics")]
-    LyricsSaveFetchedLyrics,
 }
 
 /// A settings key only the main process may touch.
@@ -123,7 +115,7 @@ pub enum MainStoreKey {
 
 impl RendererStoreKey {
     /// Every renderer-writable key, in the order the TypeScript tuple lists them.
-    pub const ALL: [Self; 18] = [
+    pub const ALL: [Self; 17] = [
         Self::Settings,
         Self::MusicFolders,
         Self::PlayerState,
@@ -141,7 +133,6 @@ impl RendererStoreKey {
         Self::SystemMinimizeToTray,
         Self::SystemCloseToTray,
         Self::LyricsPreferSyncedFromLrclib,
-        Self::LyricsSaveFetchedLyrics,
     ];
 
     /// The electron-store dot path this key lives at in the document.
@@ -168,7 +159,6 @@ impl RendererStoreKey {
             Self::SystemMinimizeToTray => "system.minimizeToTray",
             Self::SystemCloseToTray => "system.closeToTray",
             Self::LyricsPreferSyncedFromLrclib => "lyrics.preferSyncedFromLrclib",
-            Self::LyricsSaveFetchedLyrics => "lyrics.saveFetchedLyrics",
         }
     }
 }

--- a/crates/shiranami-core/tests/folders_cache.rs
+++ b/crates/shiranami-core/tests/folders_cache.rs
@@ -246,6 +246,80 @@ fn rejects_a_symlink_inside_an_allowed_root_pointing_outside() {
     assert!(!cache.is_path_allowed(&link));
 }
 
+/* ------------------------ is_within_library_folder ------------------------ */
+
+#[test]
+fn a_directory_inside_a_watched_folder_may_be_written_to() {
+    let (cache, _) = cache_with(FakeAuthority {
+        folder_roots: vec![PathBuf::from("/mock/library/music")],
+        ..default_authority()
+    });
+    assert!(cache.is_within_library_folder(Path::new("/mock/library/music/Artist/Album")));
+}
+
+/// The write gate is narrower than the read gate on purpose: the app's own data
+/// directory and the downloads location authorize *reads* and are not folders
+/// the user asked to have lyric files written into.
+#[test]
+fn the_data_dir_and_downloads_location_are_not_write_targets() {
+    let (cache, _) = cache_with(FakeAuthority {
+        folder_roots: vec![PathBuf::from("/mock/library/music")],
+        ..default_authority()
+    });
+
+    assert!(cache.is_path_allowed(Path::new(MOCK_DATA_DIR)));
+    assert!(!cache.is_within_library_folder(Path::new(MOCK_DATA_DIR)));
+    assert!(!cache.is_within_library_folder(Path::new(MOCK_DEFAULT_DOWNLOADS)));
+}
+
+/// The `tracks` fallback is a read-side courtesy for standalone imports. Left in
+/// place for writes it would make the folder of a file imported years ago a
+/// destination anywhere on the disk.
+#[test]
+fn a_known_track_outside_every_folder_is_still_not_a_write_target() {
+    let standalone = PathBuf::from("/somewhere/else/standalone.mp3");
+    let (cache, _) = cache_with(FakeAuthority {
+        track_paths: Mutex::new(vec![standalone.clone()]),
+        ..default_authority()
+    });
+
+    assert!(cache.is_path_allowed(&standalone));
+    assert!(!cache.is_within_library_folder(standalone.parent().expect("a parent")));
+}
+
+#[test]
+fn nothing_is_a_write_target_when_no_folder_is_registered() {
+    let (cache, _) = cache_with(default_authority());
+    assert!(!cache.is_within_library_folder(Path::new("/mock/library/music")));
+    assert!(!cache.is_within_library_folder(Path::new("")));
+}
+
+/// A textual containment check would pass here and the write would land outside
+/// the library, which is the whole reason the gate resolves first.
+#[test]
+fn rejects_a_symlinked_directory_inside_a_watched_folder_pointing_outside() {
+    let allowed = tempfile::tempdir().expect("create the watched folder");
+    let outside = tempfile::tempdir().expect("create the outside dir");
+
+    let link = allowed.path().join("Album");
+    #[cfg(unix)]
+    let created = std::os::unix::fs::symlink(outside.path(), &link).is_ok();
+    #[cfg(windows)]
+    let created = std::os::windows::fs::symlink_dir(outside.path(), &link).is_ok();
+    if !created {
+        // Windows without developer mode cannot create symlinks.
+        return;
+    }
+
+    let (cache, _) = cache_with(FakeAuthority {
+        folder_roots: vec![allowed.path().to_path_buf()],
+        ..default_authority()
+    });
+
+    assert!(cache.is_within_library_folder(allowed.path()));
+    assert!(!cache.is_within_library_folder(&link));
+}
+
 #[test]
 fn caches_a_positive_authorization_so_a_repeat_check_skips_the_lookup() {
     let standalone = PathBuf::from("/cached/standalone.mp3");

--- a/crates/shiranami-integrations/Cargo.toml
+++ b/crates/shiranami-integrations/Cargo.toml
@@ -41,8 +41,18 @@ sqlx = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+# The lyrics write-back batch is the only wire surface this crate declares:
+# `lyrics:save-batch`'s input, its progress tick and its summary. Same reason
+# `shiranami-metadata` takes the pair — `specta_typescript::Number` pins the
+# `usize` counters and the duration hint to `number` rather than to specta's
+# default `number | null`.
+specta = { workspace = true }
+specta-typescript = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
+# `CancellationToken`, for the write-back batch's cancel. The batch mirrors
+# `shiranami_metadata::enrich::batch`, which takes it for the same reason.
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 

--- a/crates/shiranami-integrations/src/lyrics/batch.rs
+++ b/crates/shiranami-integrations/src/lyrics/batch.rs
@@ -1,0 +1,456 @@
+//! Running write-back over a set of tracks.
+//!
+//! Shaped after `shiranami_metadata::enrich::batch`, whose two survivability
+//! properties this batch needs for the same reasons and keeps verbatim:
+//!
+//! - **One failure never aborts the run.** Every track settles into a counted
+//!   outcome — including a refused write and an unreachable directory — because
+//!   a library-wide pass must not die on track 400 of 2,000.
+//! - **Cancellation is prompt and reports once.** A queued track whose turn
+//!   arrives after the cancel does no work at all, and exactly one `cancelled`
+//!   tick is emitted per run rather than one per abandoned track.
+//!
+//! # Concurrency, and why it is lower than enrichment's
+//!
+//! `lrclib.net` sits in [`shiranami_net::HOST_GATES`] at 250 ms, so the real
+//! rate limit is the gate and not this number — [`SAVE_CONCURRENCY`] exists only
+//! so one track's sidecar write overlaps the next track's gate wait. Two rather
+//! than enrichment's four: the overlapped work here is a single small file
+//! write, not a cover download plus a whole-file tag rewrite, so there is much
+//! less to hide behind the gate and a wider fan-out would only queue up more
+//! futures waiting on the same 250 ms.
+//!
+//! # The summary counts tracks, not writes
+//!
+//! Every input lands in exactly one bucket of [`LyricsBatchSummary`] and the
+//! buckets sum to the number of tracks the run reached. A cancelled run
+//! therefore reports a total *lower* than its input, which is what tells the
+//! renderer the pass was partial without a separate flag.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use futures::StreamExt as _;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use specta_typescript::Number;
+use tokio_util::sync::CancellationToken;
+
+use crate::lyrics::service::{LyricsRequest, LyricsService, SaveOutcome};
+use crate::lyrics::writeback::SidecarSkip;
+
+/// How many tracks are in flight at once. See the module docs.
+pub const SAVE_CONCURRENCY: usize = 2;
+
+/// One track offered up for write-back.
+///
+/// The same five facts `lyrics:fetch` takes, plus the row id so a caller can
+/// match a tick to a track. `file_path` is required rather than optional: a
+/// track with nowhere to write a file beside is not a candidate for this run,
+/// and the caller filters those out before submitting.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct LyricsBatchTrack {
+    /// Database id, echoed on every progress tick.
+    pub id: String,
+    /// The audio file the sidecar is written beside.
+    pub file_path: String,
+    /// Track title — the search term.
+    pub title: String,
+    /// Track artist.
+    pub artist: String,
+    /// Album, when known.
+    #[specta(optional)]
+    pub album: Option<String>,
+    /// Track length in seconds, as a matching hint.
+    #[specta(optional, type = Option<Number>)]
+    pub duration_seconds: Option<f64>,
+}
+
+/// What happened to one track, as the progress tick reports it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "kebab-case")]
+pub enum LyricsBatchStatus {
+    /// The lookup is under way.
+    Searching,
+    /// A `.lrc` was written.
+    Saved,
+    /// Nothing to do: already answered, not allowed, not synced, or off.
+    Skipped,
+    /// The directory has no lyrics for this track.
+    NotFound,
+    /// The lookup or the write failed.
+    Failed,
+    /// The run was cancelled. Emitted exactly once.
+    Cancelled,
+}
+
+/// One progress tick.
+///
+/// `current` is a settled count, so it is monotonic per the counter even though
+/// delivery order between two racing ticks is not guaranteed — a consumer takes
+/// the max, as `analysis:progress` documents for the same reason.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct LyricsBatchProgress {
+    /// Tracks settled so far.
+    #[specta(type = Number)]
+    pub current: usize,
+    /// Tracks submitted.
+    #[specta(type = Number)]
+    pub total: usize,
+    /// The track this tick is about.
+    pub track_name: String,
+    /// What happened to it.
+    pub status: LyricsBatchStatus,
+}
+
+/// What a finished — or cancelled — run counted.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct LyricsBatchSummary {
+    /// Tracks that gained a `.lrc`.
+    #[specta(type = Number)]
+    pub saved: usize,
+    /// Tracks that already had one, or that the run may not write beside.
+    #[specta(type = Number)]
+    pub skipped: usize,
+    /// Tracks the directory does not have.
+    #[specta(type = Number)]
+    pub not_found: usize,
+    /// Tracks whose lookup or write failed. Worth another run.
+    #[specta(type = Number)]
+    pub failed: usize,
+    /// Whether the run was cut short.
+    pub cancelled: bool,
+}
+
+impl LyricsBatchSummary {
+    /// Fold one track's outcome in.
+    fn count(&mut self, outcome: &SaveOutcome) {
+        match outcome {
+            SaveOutcome::Saved(_) => self.saved += 1,
+            SaveOutcome::Skipped(_) => self.skipped += 1,
+            SaveOutcome::NotFound => self.not_found += 1,
+            SaveOutcome::LookupFailed | SaveOutcome::WriteFailed => self.failed += 1,
+        }
+    }
+}
+
+/// Progress sink. Called from several tasks, so it must be `Sync`.
+pub type ProgressFn<'a> = &'a (dyn Fn(LyricsBatchProgress) + Send + Sync);
+
+/// Fetch and save lyrics for every track, [`SAVE_CONCURRENCY`] at a time.
+///
+/// Never fails: every track contributes to the summary, and a run that could not
+/// write a single file answers with `failed == total` rather than an error. The
+/// caller's next move — tell the user what the run managed — is the same either
+/// way, and an error would throw away the counts that make it worth telling.
+pub async fn save_lyrics_for_tracks(
+    service: &LyricsService,
+    tracks: &[LyricsBatchTrack],
+    cancel: &CancellationToken,
+    progress: ProgressFn<'_>,
+) -> LyricsBatchSummary {
+    let state = RunState::new(tracks.len());
+
+    // Owned inputs and a named `async fn`, not `iter()` and an `async move`
+    // block — `enrich::batch::settle` documents the "implementation of `FnOnce`
+    // is not general enough" trap that shape walks into at the command layer.
+    futures::stream::iter(tracks.to_vec())
+        .map(|track| settle(service, track, cancel, progress, &state))
+        .buffered(SAVE_CONCURRENCY)
+        .collect::<Vec<()>>()
+        .await;
+
+    state.into_summary()
+}
+
+/// Settle one track: skip it if the run is cancelled, save it otherwise.
+async fn settle(
+    service: &LyricsService,
+    track: LyricsBatchTrack,
+    cancel: &CancellationToken,
+    progress: ProgressFn<'_>,
+    state: &RunState,
+) {
+    if cancel.is_cancelled() {
+        state.report_cancelled_once(progress, &track.title);
+        return;
+    }
+
+    state.report(progress, &track.title, LyricsBatchStatus::Searching);
+
+    // Bound rather than inlined into the `select!`: a temporary built inside the
+    // arm is dropped at the end of the statement while the future still borrows
+    // it (E0716).
+    let request = request_for(&track);
+
+    let outcome = tokio::select! {
+        biased;
+        () = cancel.cancelled() => {
+            state.report_cancelled_once(progress, &track.title);
+            return;
+        }
+        outcome = service.save_lyrics(&request) => outcome,
+    };
+
+    let (settled, status) = state.complete(&outcome);
+    progress(LyricsBatchProgress {
+        current: settled,
+        total: state.total,
+        track_name: track.title,
+        status,
+    });
+}
+
+/// Project a batch row onto the request the service takes.
+fn request_for(track: &LyricsBatchTrack) -> LyricsRequest {
+    LyricsRequest {
+        title: track.title.clone(),
+        artist: track.artist.clone(),
+        album: track.album.clone(),
+        duration_seconds: track.duration_seconds,
+        file_path: Some(std::path::PathBuf::from(&track.file_path)),
+    }
+}
+
+/// Counters shared by every task in a run.
+struct RunState {
+    total: usize,
+    summary: Mutex<LyricsBatchSummary>,
+    completed: Mutex<usize>,
+    /// The `cancelled` tick is emitted once per run, not once per abandoned
+    /// track — `enrich::batch`'s `let cancelled = false` guard.
+    cancel_reported: AtomicBool,
+}
+
+impl RunState {
+    fn new(total: usize) -> Self {
+        Self {
+            total,
+            summary: Mutex::new(LyricsBatchSummary::default()),
+            completed: Mutex::new(0),
+            cancel_reported: AtomicBool::new(false),
+        }
+    }
+
+    /// Count `outcome`, returning the settled count and the tick's status.
+    fn complete(&self, outcome: &SaveOutcome) -> (usize, LyricsBatchStatus) {
+        let mut summary = lock(&self.summary);
+        summary.count(outcome);
+        drop(summary);
+
+        let mut completed = lock(&self.completed);
+        *completed += 1;
+        (*completed, status_of(outcome))
+    }
+
+    /// The in-flight `current`: `min(completed + 1, total)`.
+    fn in_flight(&self) -> usize {
+        (*lock(&self.completed) + 1).min(self.total)
+    }
+
+    fn report(&self, progress: ProgressFn<'_>, track_name: &str, status: LyricsBatchStatus) {
+        progress(LyricsBatchProgress {
+            current: self.in_flight(),
+            total: self.total,
+            track_name: track_name.to_owned(),
+            status,
+        });
+    }
+
+    fn report_cancelled_once(&self, progress: ProgressFn<'_>, track_name: &str) {
+        lock(&self.summary).cancelled = true;
+
+        if self.cancel_reported.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        self.report(progress, track_name, LyricsBatchStatus::Cancelled);
+    }
+
+    fn into_summary(self) -> LyricsBatchSummary {
+        *lock(&self.summary)
+    }
+}
+
+/// The tick status one outcome reports as.
+fn status_of(outcome: &SaveOutcome) -> LyricsBatchStatus {
+    match outcome {
+        SaveOutcome::Saved(_) => LyricsBatchStatus::Saved,
+        SaveOutcome::Skipped(_) => LyricsBatchStatus::Skipped,
+        SaveOutcome::NotFound => LyricsBatchStatus::NotFound,
+        SaveOutcome::LookupFailed | SaveOutcome::WriteFailed => LyricsBatchStatus::Failed,
+    }
+}
+
+/// `lock_or_recover` for this module's mutexes: they guard plain counters with
+/// no invariant a panic could have broken, so recovering beats turning one
+/// crash into two.
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Every skip reason, so a caller can explain one. Not used by the batch itself
+/// — it counts them together — but a single skipped track reaching a caller
+/// through [`SaveOutcome`] is worth a specific message.
+pub const fn skip_reason(skip: SidecarSkip) -> &'static str {
+    match skip {
+        SidecarSkip::Disabled => "saving fetched lyrics is turned off",
+        SidecarSkip::NoDestination => "the track has no file to write beside",
+        SidecarSkip::NotAllowed => "the track is not inside a library folder",
+        SidecarSkip::AlreadyExists => "a lyric file is already there",
+        SidecarSkip::NotSynced => "the directory has no timed lyrics for it",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn track(id: &str) -> LyricsBatchTrack {
+        LyricsBatchTrack {
+            id: id.to_owned(),
+            file_path: format!("/music/{id}.mp3"),
+            title: format!("Track {id}"),
+            artist: "Artist".to_owned(),
+            album: None,
+            duration_seconds: None,
+        }
+    }
+
+    #[test]
+    fn the_summary_buckets_every_outcome_exactly_once() {
+        let mut summary = LyricsBatchSummary::default();
+        for outcome in [
+            SaveOutcome::Saved("/music/a.lrc".into()),
+            SaveOutcome::Skipped(SidecarSkip::AlreadyExists),
+            SaveOutcome::Skipped(SidecarSkip::Disabled),
+            SaveOutcome::NotFound,
+            SaveOutcome::LookupFailed,
+            SaveOutcome::WriteFailed,
+        ] {
+            summary.count(&outcome);
+        }
+
+        assert_eq!(summary.saved, 1);
+        assert_eq!(summary.skipped, 2);
+        assert_eq!(summary.not_found, 1);
+        assert_eq!(
+            summary.failed, 2,
+            "an unreachable directory and a refused write are both worth retrying"
+        );
+    }
+
+    /// The distinction the summary exists to keep: a track the directory does
+    /// not have is settled, and one it could not answer for is not.
+    #[test]
+    fn a_miss_and_a_failure_land_in_different_buckets() {
+        let mut summary = LyricsBatchSummary::default();
+        summary.count(&SaveOutcome::NotFound);
+        summary.count(&SaveOutcome::LookupFailed);
+
+        assert_eq!(summary.not_found, 1);
+        assert_eq!(summary.failed, 1);
+    }
+
+    #[test]
+    fn the_request_carries_every_matching_hint_through() {
+        let mut input = track("a");
+        input.album = Some("Album".to_owned());
+        input.duration_seconds = Some(204.5);
+
+        let request = request_for(&input);
+
+        assert_eq!(request.title, "Track a");
+        assert_eq!(request.artist, "Artist");
+        assert_eq!(request.album.as_deref(), Some("Album"));
+        assert_eq!(request.duration_seconds, Some(204.5));
+        assert_eq!(
+            request.file_path.as_deref(),
+            Some(std::path::Path::new("/music/a.mp3"))
+        );
+    }
+
+    /// One tick per run, however many tracks were abandoned — the counter the
+    /// renderer's progress bar would otherwise see thrash.
+    #[test]
+    fn the_cancelled_tick_is_emitted_once_per_run() {
+        let state = RunState::new(3);
+        let ticks = Mutex::new(Vec::new());
+        let sink = |progress: LyricsBatchProgress| lock(&ticks).push(progress.status);
+
+        for _ in 0..3 {
+            state.report_cancelled_once(&sink, "Track");
+        }
+
+        assert_eq!(lock(&ticks).as_slice(), &[LyricsBatchStatus::Cancelled]);
+        assert!(state.into_summary().cancelled);
+    }
+
+    #[tokio::test]
+    async fn a_run_cancelled_before_it_starts_touches_nothing() {
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let ticks = Mutex::new(Vec::new());
+        let sink = |progress: LyricsBatchProgress| lock(&ticks).push(progress.status);
+        let service = crate::lyrics::service::tests::offline_service();
+
+        let summary =
+            save_lyrics_for_tracks(&service, &[track("a"), track("b")], &cancel, &sink).await;
+
+        assert_eq!(
+            summary,
+            LyricsBatchSummary {
+                cancelled: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            lock(&ticks).as_slice(),
+            &[LyricsBatchStatus::Cancelled],
+            "no track did any work, and the cancel reported once"
+        );
+    }
+
+    /// An empty run is a no-op with an all-zero summary, not a division by zero
+    /// in the progress arithmetic.
+    #[tokio::test]
+    async fn an_empty_run_settles_immediately() {
+        let service = crate::lyrics::service::tests::offline_service();
+        let summary = save_lyrics_for_tracks(&service, &[], &CancellationToken::new(), &|_| {
+            unreachable!("nothing to report")
+        })
+        .await;
+
+        assert_eq!(summary, LyricsBatchSummary::default());
+    }
+
+    /// The default policy refuses to write, so a run under one is all-skipped
+    /// and spends no request — the opt-in guard, asserted from the batch's side.
+    #[tokio::test]
+    async fn a_run_under_the_default_policy_writes_nothing() {
+        let service = crate::lyrics::service::tests::offline_service();
+
+        let summary = save_lyrics_for_tracks(
+            &service,
+            &[track("a"), track("b")],
+            &CancellationToken::new(),
+            &|_| {},
+        )
+        .await;
+
+        assert_eq!(
+            summary,
+            LyricsBatchSummary {
+                skipped: 2,
+                ..Default::default()
+            },
+            "a policy that never opted in must not reach the network at all"
+        );
+    }
+}

--- a/crates/shiranami-integrations/src/lyrics/cache.rs
+++ b/crates/shiranami-integrations/src/lyrics/cache.rs
@@ -227,10 +227,13 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn found(text: &str) -> LrclibOutcome {
-        LrclibOutcome::Found(shiranami_core::models::lyrics::LyricsResult {
-            synced: None,
-            plain: Some(text.to_owned()),
-            source: Some(shiranami_core::models::lyrics::LyricsSource::Lrclib),
+        LrclibOutcome::Found(crate::lyrics::lrclib::LrclibLyrics {
+            result: shiranami_core::models::lyrics::LyricsResult {
+                synced: None,
+                plain: Some(text.to_owned()),
+                source: Some(shiranami_core::models::lyrics::LyricsSource::Lrclib),
+            },
+            synced_lrc: None,
         })
     }
 

--- a/crates/shiranami-integrations/src/lyrics/local.rs
+++ b/crates/shiranami-integrations/src/lyrics/local.rs
@@ -106,6 +106,37 @@ fn candidate_paths(audio_file: &Path) -> Vec<PathBuf> {
     candidates
 }
 
+/// The first `.lrc` candidate that already exists on disk, if any.
+///
+/// The question write-back asks before it writes anything: *is one of the
+/// user's own timed files already answering for this track?* It is answered
+/// from [`candidate_paths`] rather than from a path this module builds a second
+/// time, because the whole safety of "never overwrite" rests on asking about the
+/// same six locations the reader consults. A `Lyrics/Song.lrc` the user
+/// hand-timed outranks nothing if a fresh sibling `Song.lrc` appears above it in
+/// the ladder — so *any* existing `.lrc` stops the write, not just one at the
+/// target path.
+///
+/// `.txt` candidates deliberately do not stop it. A plain-text file is only ever
+/// reached when the ladder found no timing at all, and the one path that fetches
+/// from the directory despite holding a local `.txt` is the user having asked
+/// for exactly that with `lyrics.preferSyncedFromLrclib`.
+///
+/// Synchronous: it is called from inside `spawn_blocking` beside the write.
+pub fn existing_lrc_sidecar(audio_file: &Path) -> Option<PathBuf> {
+    candidate_paths(audio_file)
+        .into_iter()
+        .filter(|candidate| {
+            candidate
+                .extension()
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("lrc"))
+        })
+        // `try_exists` rather than `exists`: a permission error on a NAS share
+        // is not "there is no file there", and treating it as one is how a
+        // write-back lands on top of something it could not see.
+        .find(|candidate| candidate.try_exists().unwrap_or(true))
+}
+
 /// Load lyrics from a sidecar file, or `None` when no candidate exists.
 ///
 /// Never fails: an unreadable candidate is logged and skipped, because the

--- a/crates/shiranami-integrations/src/lyrics/local.rs
+++ b/crates/shiranami-integrations/src/lyrics/local.rs
@@ -106,31 +106,55 @@ fn candidate_paths(audio_file: &Path) -> Vec<PathBuf> {
     candidates
 }
 
-/// The first `.lrc` candidate that already exists on disk, if any.
+/// Which of the reader's candidates count as "the user already has this".
+///
+/// The distinction is the `lyrics.preferSyncedFromLrclib` setting and nothing
+/// else. With it **off** — the default — anything found locally beats the
+/// network outright, so a `Song.txt` the user typed out themselves is as good a
+/// reason not to write as a `Song.lrc` would be. With it **on** the user has
+/// asked for the opposite: LRCLIB's timings are to outrank plain text they
+/// happen to own, and a `.txt` must not block the file that delivers them.
+///
+/// Shadowing is why the untimed case matters at all. [`candidate_paths`] orders
+/// `.lrc` *everywhere* ahead of `.txt` *anywhere*, so a freshly written sibling
+/// `Song.lrc` retires `Song.txt` from the ladder permanently — losing the user's
+/// file as surely as overwriting it would.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SidecarGuard {
+    /// Only an existing `.lrc` stops the write.
+    TimedOnly,
+    /// Any lyric file the reader would find stops it, `.txt` included.
+    AnyLyricFile,
+}
+
+impl SidecarGuard {
+    /// Whether a file existing at `candidate` would stop the write.
+    fn blocks(self, candidate: &Path) -> bool {
+        match self {
+            Self::AnyLyricFile => true,
+            Self::TimedOnly => candidate
+                .extension()
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("lrc")),
+        }
+    }
+}
+
+/// The first existing candidate `guard` treats as the user's own, if any.
 ///
 /// The question write-back asks before it writes anything: *is one of the
-/// user's own timed files already answering for this track?* It is answered
-/// from [`candidate_paths`] rather than from a path this module builds a second
-/// time, because the whole safety of "never overwrite" rests on asking about the
-/// same six locations the reader consults. A `Lyrics/Song.lrc` the user
-/// hand-timed outranks nothing if a fresh sibling `Song.lrc` appears above it in
-/// the ladder — so *any* existing `.lrc` stops the write, not just one at the
-/// target path.
-///
-/// `.txt` candidates deliberately do not stop it. A plain-text file is only ever
-/// reached when the ladder found no timing at all, and the one path that fetches
-/// from the directory despite holding a local `.txt` is the user having asked
-/// for exactly that with `lyrics.preferSyncedFromLrclib`.
+/// user's own files already answering for this track?* It is answered from
+/// [`candidate_paths`] rather than from a path this module builds a second time,
+/// because the whole safety of "never overwrite" rests on asking about the same
+/// six locations the reader consults. A `Lyrics/Song.lrc` the user hand-timed
+/// outranks nothing if a fresh sibling `Song.lrc` appears above it in the ladder
+/// — so *any* blocking candidate stops the write, not just one at the target
+/// path.
 ///
 /// Synchronous: it is called from inside `spawn_blocking` beside the write.
-pub fn existing_lrc_sidecar(audio_file: &Path) -> Option<PathBuf> {
+pub fn existing_lyric_sidecar(audio_file: &Path, guard: SidecarGuard) -> Option<PathBuf> {
     candidate_paths(audio_file)
         .into_iter()
-        .filter(|candidate| {
-            candidate
-                .extension()
-                .is_some_and(|extension| extension.eq_ignore_ascii_case("lrc"))
-        })
+        .filter(|candidate| guard.blocks(candidate))
         // `try_exists` rather than `exists`: a permission error on a NAS share
         // is not "there is no file there", and treating it as one is how a
         // write-back lands on top of something it could not see.
@@ -471,6 +495,59 @@ mod tests {
                 "Lyrics/Song.txt",
                 "lyrics/Song.txt",
             ]
+        );
+    }
+
+    /// The default position. A `.txt` the user wrote is shadowed for good by a
+    /// sibling `.lrc`, because `.lrc` outranks `.txt` everywhere in the ladder —
+    /// so with the preference off it has to stop the write.
+    #[test]
+    fn a_txt_blocks_the_write_unless_the_user_asked_for_lrclib_timings() {
+        let dir = temp_dir();
+        let audio = dir.path().join("Song.mp3");
+        write(&dir.path().join("Song.txt"), "Mine, typed by hand");
+
+        assert_eq!(
+            existing_lyric_sidecar(&audio, SidecarGuard::AnyLyricFile),
+            Some(dir.path().join("Song.txt"))
+        );
+        assert_eq!(
+            existing_lyric_sidecar(&audio, SidecarGuard::TimedOnly),
+            None,
+            "`preferSyncedFromLrclib` is the user asking for timings over their own plain text"
+        );
+    }
+
+    /// …including one filed under `Lyrics/`, which the reader probes too.
+    #[test]
+    fn a_txt_in_a_subfolder_blocks_the_write_as_well() {
+        let dir = temp_dir();
+        let audio = dir.path().join("Song.mp3");
+        write(&dir.path().join("lyrics").join("Song.txt"), "Mine");
+
+        assert!(existing_lyric_sidecar(&audio, SidecarGuard::AnyLyricFile).is_some());
+    }
+
+    /// An existing `.lrc` stops the write under either guard: that one is not a
+    /// preference, it is the never-overwrite rule.
+    #[test]
+    fn an_lrc_blocks_the_write_under_both_guards() {
+        let dir = temp_dir();
+        let audio = dir.path().join("Song.mp3");
+        write(&dir.path().join("Lyrics").join("Song.lrc"), "[00:01.00]Hi");
+
+        assert!(existing_lyric_sidecar(&audio, SidecarGuard::AnyLyricFile).is_some());
+        assert!(existing_lyric_sidecar(&audio, SidecarGuard::TimedOnly).is_some());
+    }
+
+    #[test]
+    fn nothing_on_disk_blocks_nothing() {
+        let dir = temp_dir();
+        let audio = dir.path().join("Song.mp3");
+
+        assert_eq!(
+            existing_lyric_sidecar(&audio, SidecarGuard::AnyLyricFile),
+            None
         );
     }
 

--- a/crates/shiranami-integrations/src/lyrics/lrclib.rs
+++ b/crates/shiranami-integrations/src/lyrics/lrclib.rs
@@ -41,9 +41,28 @@ pub const LRCLIB_API_BASE: &str = "https://lrclib.net/api";
 pub enum LrclibOutcome {
     /// The directory answered with a record. May still hold no lyric text —
     /// v1 took the first search hit unconditionally, and so does this.
-    Found(LyricsResult),
+    Found(LrclibLyrics),
     /// The directory was reached and genuinely has nothing. Cacheable.
     Missing,
+}
+
+/// One LRCLIB hit: the parsed result the renderer wants, plus the **raw** LRC
+/// document the record carried.
+///
+/// The raw text is kept because [`crate::lyrics::writeback`] writes it to a
+/// sidecar byte for byte. Reconstructing it from [`LyricsResult::synced`] would
+/// not round-trip: a refrain is spelled by stacking several timestamps on one
+/// line and the parser expands it into one entry per timestamp, and a two-digit
+/// fraction (centiseconds) and a three-digit one (milliseconds) both land in the
+/// same `f64`. A re-rendered file would be a different file that happens to play
+/// the same — and the point of write-back is that the user keeps what the
+/// directory actually published.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LrclibLyrics {
+    /// The result the ladder ranks and the renderer displays.
+    pub result: LyricsResult,
+    /// The record's `syncedLyrics` field, unparsed, when it carried one.
+    pub synced_lrc: Option<String>,
 }
 
 /// One track to look up.
@@ -148,7 +167,7 @@ impl LrclibClient {
     async fn fetch_record(
         &self,
         query: &LrclibQuery,
-    ) -> Result<Option<LyricsResult>, LookupFailure> {
+    ) -> Result<Option<LrclibLyrics>, LookupFailure> {
         let mut params: Vec<(&str, String)> = vec![
             ("track_name", query.title.clone()),
             ("artist_name", query.artist.clone()),
@@ -185,7 +204,7 @@ impl LrclibClient {
     }
 
     /// `GET /search` — the fuzzy endpoint, one variant at a time.
-    async fn search(&self, variant: &str) -> Result<Option<LyricsResult>, LookupFailure> {
+    async fn search(&self, variant: &str) -> Result<Option<LrclibLyrics>, LookupFailure> {
         let url = format!(
             "{}/search{}",
             self.base,
@@ -202,10 +221,13 @@ impl LrclibClient {
         // *with* lyrics. A first hit carrying neither is still a hit, and still
         // ends the chain.
         Ok(records.into_iter().next().map(|record| {
-            into_result(record).unwrap_or(LyricsResult {
-                synced: None,
-                plain: None,
-                source: Some(LyricsSource::Lrclib),
+            into_result(record).unwrap_or(LrclibLyrics {
+                result: LyricsResult {
+                    synced: None,
+                    plain: None,
+                    source: Some(LyricsSource::Lrclib),
+                },
+                synced_lrc: None,
             })
         }))
     }
@@ -213,7 +235,7 @@ impl LrclibClient {
 
 /// Project an LRCLIB record onto the shared result, or `None` when it holds no
 /// lyric text in either form.
-fn into_result(record: LrclibRecord) -> Option<LyricsResult> {
+fn into_result(record: LrclibRecord) -> Option<LrclibLyrics> {
     let synced = record.synced_lyrics.filter(|text| !text.is_empty());
     let plain = record.plain_lyrics.filter(|text| !text.is_empty());
 
@@ -221,10 +243,13 @@ fn into_result(record: LrclibRecord) -> Option<LyricsResult> {
         return None;
     }
 
-    Some(LyricsResult {
-        synced: synced.as_deref().map(parse_lrc),
-        plain,
-        source: Some(LyricsSource::Lrclib),
+    Some(LrclibLyrics {
+        result: LyricsResult {
+            synced: synced.as_deref().map(parse_lrc),
+            plain,
+            source: Some(LyricsSource::Lrclib),
+        },
+        synced_lrc: synced,
     })
 }
 
@@ -287,15 +312,52 @@ mod tests {
 
     #[test]
     fn synced_text_is_parsed_and_plain_text_is_passed_through() {
-        let result = into_result(LrclibRecord {
+        let found = into_result(LrclibRecord {
             synced_lyrics: Some("[00:01.00]Hi".to_owned()),
             plain_lyrics: Some("Hi".to_owned()),
         })
         .expect("a result");
 
-        assert_eq!(result.source, Some(LyricsSource::Lrclib));
-        assert_eq!(result.synced.as_ref().map(Vec::len), Some(1));
-        assert_eq!(result.plain.as_deref(), Some("Hi"));
+        assert_eq!(found.result.source, Some(LyricsSource::Lrclib));
+        assert_eq!(found.result.synced.as_ref().map(Vec::len), Some(1));
+        assert_eq!(found.result.plain.as_deref(), Some("Hi"));
+    }
+
+    /// The raw document is kept beside the parsed one, unaltered. Write-back
+    /// copies these bytes to the sidecar, so anything this pass normalised
+    /// would be normalised into the user's file too.
+    #[test]
+    fn the_raw_synced_document_is_carried_alongside_the_parsed_one() {
+        let found = into_result(LrclibRecord {
+            // Two timestamps on one line and a three-digit fraction: both are
+            // shapes a re-render from the parsed lines could not reproduce.
+            synced_lyrics: Some("[00:02.03][00:01.000]Refrain\r\n".to_owned()),
+            plain_lyrics: None,
+        })
+        .expect("a result");
+
+        assert_eq!(
+            found.synced_lrc.as_deref(),
+            Some("[00:02.03][00:01.000]Refrain\r\n")
+        );
+        assert_eq!(
+            found.result.synced.as_ref().map(Vec::len),
+            Some(2),
+            "the parsed view still expands the refrain"
+        );
+    }
+
+    /// A record with only plain text carries no document to write back — the
+    /// sidecar lane is synced-only, so `None` here is what stops it.
+    #[test]
+    fn a_plain_only_record_carries_no_raw_document() {
+        let found = into_result(LrclibRecord {
+            synced_lyrics: None,
+            plain_lyrics: Some("Just words".to_owned()),
+        })
+        .expect("a result");
+
+        assert_eq!(found.synced_lrc, None);
     }
 
     #[test]

--- a/crates/shiranami-integrations/src/lyrics/mod.rs
+++ b/crates/shiranami-integrations/src/lyrics/mod.rs
@@ -10,8 +10,20 @@
 //! 3. [`lrclib`] — the LRCLIB directory, over the gated HTTP client.
 //!
 //! [`service`] owns the ladder itself and is the only module a caller needs.
+//!
+//! # …and one way back down it
+//!
+//! [`writeback`] closes the loop the three sources left open: a synced LRCLIB
+//! hit is written to a `.lrc` beside the track, so the *next* play is answered
+//! by source 1 with no network at all. That is the whole design — there is no
+//! second read path, because the sidecar reader is already the top of the
+//! ladder. [`batch`] runs the same write over a whole library.
+//!
+//! Both are **off by default** and refuse at the trait level: see
+//! [`LyricsPolicy::should_save_fetched_lyrics`].
 #![warn(missing_docs)]
 
+pub mod batch;
 pub mod cache;
 pub mod embedded;
 pub mod error;
@@ -20,9 +32,15 @@ pub mod lrclib;
 pub mod parse;
 pub mod query;
 pub mod service;
+pub mod writeback;
 
+pub use batch::{
+    LyricsBatchProgress, LyricsBatchStatus, LyricsBatchSummary, LyricsBatchTrack,
+    save_lyrics_for_tracks,
+};
 pub use error::{LookupFailure, LyricsError, Result};
-pub use lrclib::{LrclibClient, LrclibOutcome, LrclibQuery};
+pub use lrclib::{LrclibClient, LrclibLyrics, LrclibOutcome, LrclibQuery};
 pub use parse::{has_plain_lyrics, has_synced_lyrics, parse_lrc};
 pub use query::build_search_queries;
-pub use service::{LyricsPolicy, LyricsRequest, LyricsService};
+pub use service::{LyricsPolicy, LyricsRequest, LyricsService, SaveOutcome};
+pub use writeback::{SidecarOutcome, SidecarSkip};

--- a/crates/shiranami-integrations/src/lyrics/service.rs
+++ b/crates/shiranami-integrations/src/lyrics/service.rs
@@ -33,7 +33,7 @@ use shiranami_core::models::lyrics::LyricsResult;
 use crate::lyrics::cache::{InflightLookups, LyricsCache, cache_key};
 use crate::lyrics::embedded::read_embedded_lyrics;
 use crate::lyrics::error::{LyricsError, Result};
-use crate::lyrics::local::{existing_lrc_sidecar, load_local_lyrics};
+use crate::lyrics::local::{SidecarGuard, existing_lyric_sidecar, load_local_lyrics};
 use crate::lyrics::lrclib::{LrclibClient, LrclibOutcome, LrclibQuery};
 use crate::lyrics::parse::{has_plain_lyrics, has_synced_lyrics};
 use crate::lyrics::writeback::{SidecarOutcome, SidecarSkip, save_synced_sidecar};
@@ -208,6 +208,12 @@ impl LyricsService {
     /// so local and embedded sources are consulted only through the
     /// never-overwrite check inside the write itself — which is also what keeps
     /// a track that already has a `.lrc` from spending an LRCLIB request.
+    ///
+    /// That check is the *only* thing standing between this and a library-wide
+    /// overwrite, which is why it consults [`Self::sidecar_guard`] rather than
+    /// assuming the ladder already ruled a local file out: with
+    /// `lyrics.preferSyncedFromLrclib` off, this is the one path that reaches
+    /// the directory while the user holds a plain-text lyric of their own.
     pub async fn save_lyrics(&self, request: &LyricsRequest) -> SaveOutcome {
         let Some(path) = request.file_path.as_deref() else {
             return SaveOutcome::Skipped(SidecarSkip::NoDestination);
@@ -217,9 +223,11 @@ impl LyricsService {
             return SaveOutcome::Skipped(refusal);
         }
 
+        let guard = self.sidecar_guard();
+
         // Asked before the request, not after: a track the user has already
-        // timed themselves must not cost the directory a lookup.
-        if let Some(refusal) = already_answered(path).await {
+        // answered for themselves must not cost the directory a lookup.
+        if let Some(refusal) = already_answered(path, guard).await {
             return SaveOutcome::Skipped(refusal);
         }
 
@@ -238,7 +246,7 @@ impl LyricsService {
             return SaveOutcome::Skipped(SidecarSkip::NotSynced);
         };
 
-        match save_synced_sidecar(path, lrc).await {
+        match save_synced_sidecar(path, lrc, guard).await {
             SidecarOutcome::Written(path) => SaveOutcome::Saved(path),
             SidecarOutcome::Skipped(reason) => SaveOutcome::Skipped(reason),
             SidecarOutcome::Failed => SaveOutcome::WriteFailed,
@@ -260,7 +268,22 @@ impl LyricsService {
             return;
         }
 
-        save_synced_sidecar(path, lrc).await;
+        save_synced_sidecar(path, lrc, self.sidecar_guard()).await;
+    }
+
+    /// Which lyric files already on disk stop a write-back.
+    ///
+    /// Read per call rather than captured, for [`Self::write_refusal`]'s reason.
+    /// `lyrics.preferSyncedFromLrclib` is the whole input: with it off — the
+    /// default — anything local beats the network, so a `.txt` the user wrote is
+    /// a file to leave alone; with it on they have asked for LRCLIB's timings
+    /// over their own plain text, and a `.txt` must not stand in the way.
+    fn sidecar_guard(&self) -> SidecarGuard {
+        if self.policy.prefer_synced_from_lrclib() {
+            SidecarGuard::TimedOnly
+        } else {
+            SidecarGuard::AnyLyricFile
+        }
     }
 
     /// Which gate refuses a write beside `path`, if either does.
@@ -370,9 +393,9 @@ pub enum SaveOutcome {
 }
 
 /// Whether a lyric file already answers for `path`, off the async worker.
-async fn already_answered(path: &Path) -> Option<SidecarSkip> {
+async fn already_answered(path: &Path, guard: SidecarGuard) -> Option<SidecarSkip> {
     let owned = path.to_path_buf();
-    match tokio::task::spawn_blocking(move || existing_lrc_sidecar(&owned)).await {
+    match tokio::task::spawn_blocking(move || existing_lyric_sidecar(&owned, guard)).await {
         Ok(Some(existing)) => {
             tracing::debug!(
                 existing = %existing.display(),

--- a/crates/shiranami-integrations/src/lyrics/service.rs
+++ b/crates/shiranami-integrations/src/lyrics/service.rs
@@ -33,9 +33,10 @@ use shiranami_core::models::lyrics::LyricsResult;
 use crate::lyrics::cache::{InflightLookups, LyricsCache, cache_key};
 use crate::lyrics::embedded::read_embedded_lyrics;
 use crate::lyrics::error::{LyricsError, Result};
-use crate::lyrics::local::load_local_lyrics;
+use crate::lyrics::local::{existing_lrc_sidecar, load_local_lyrics};
 use crate::lyrics::lrclib::{LrclibClient, LrclibOutcome, LrclibQuery};
 use crate::lyrics::parse::{has_plain_lyrics, has_synced_lyrics};
+use crate::lyrics::writeback::{SidecarOutcome, SidecarSkip, save_synced_sidecar};
 
 /// The two app-level facts the ladder consults.
 ///
@@ -61,6 +62,32 @@ pub trait LyricsPolicy: Send + Sync {
     /// Read on every fetch rather than captured, so toggling it in settings
     /// takes effect on the next track without a restart.
     fn prefer_synced_from_lrclib(&self) -> bool;
+
+    /// The `lyrics.saveFetchedLyrics` setting: may a synced LRCLIB hit be
+    /// written to a `.lrc` beside the track?
+    ///
+    /// **Defaults to `false` on the trait**, which is not a convenience. Writing
+    /// into a music library is opt-in, and a default here means a policy written
+    /// before this lane existed — or a test double, or a future implementation
+    /// whose author never read this file — cannot accidentally start writing to
+    /// somebody's rips. Opting in has to be a positive act in the implementation.
+    fn should_save_fetched_lyrics(&self) -> bool {
+        false
+    }
+
+    /// Whether a lyric file may be *written* beside `path`.
+    ///
+    /// A separate question from [`Self::is_local_resolution_allowed`] and a
+    /// stricter one. Reading is granted to anything the shell handlers may
+    /// reach, which includes the app's own data directory and any row in the
+    /// `tracks` table — appropriate for a read, and too wide for a write, which
+    /// must land inside a folder the user actually pointed the library at.
+    ///
+    /// Defaults closed, for [`Self::should_save_fetched_lyrics`]'s reason.
+    /// Implementations must fail **closed**.
+    fn is_lyrics_write_allowed(&self, _path: &Path) -> bool {
+        false
+    }
 }
 
 /// One lyrics request.
@@ -121,11 +148,21 @@ impl LyricsService {
         }
 
         // LRCLIB is needed to settle the decision.
-        let (network, failure) = match self.lookup(request).await {
-            Ok(LrclibOutcome::Found(result)) => (Some(result), None),
+        let (found, failure) = match self.lookup(request).await {
+            Ok(LrclibOutcome::Found(found)) => (Some(found), None),
             Ok(LrclibOutcome::Missing) => (None, None),
             Err(error) => (None, Some(error)),
         };
+
+        // Before the ranking, and regardless of which candidate goes on to win:
+        // the reason to keep the file is that the network was reachable *now*
+        // and may not be later, which has nothing to do with what the ladder
+        // decides to display this time round.
+        if let Some(lrc) = found.as_ref().and_then(|found| found.synced_lrc.as_deref()) {
+            self.save_sidecar(request, lrc).await;
+        }
+
+        let network = found.map(|found| found.result);
 
         let ordered: Vec<Option<&LyricsResult>> = if prefer_synced {
             vec![
@@ -148,6 +185,103 @@ impl LyricsService {
             Some(error) => Err(LyricsError::Lookup(error)),
             None => Ok(empty_result()),
         }
+    }
+
+    /// Whether the user has opted in to saving fetched lyrics.
+    ///
+    /// Exposed so the command layer can refuse a batch up front rather than run
+    /// one to an all-skipped summary, without reaching past the service for the
+    /// settings key — which would be a second place for the answer to live.
+    pub fn is_saving_enabled(&self) -> bool {
+        self.policy.should_save_fetched_lyrics()
+    }
+
+    /// Fetch `request` from LRCLIB and keep the result as a `.lrc`, reporting
+    /// what happened.
+    ///
+    /// The library batch's per-track unit, and the reason it is a method rather
+    /// than a second copy of [`Self::fetch`]'s tail: it shares the same client,
+    /// the same MRU and the same policy, so a run over a library the user has
+    /// been playing costs nothing for the tracks already answered.
+    ///
+    /// Deliberately **not** the ladder. A batch is not deciding what to display,
+    /// so local and embedded sources are consulted only through the
+    /// never-overwrite check inside the write itself — which is also what keeps
+    /// a track that already has a `.lrc` from spending an LRCLIB request.
+    pub async fn save_lyrics(&self, request: &LyricsRequest) -> SaveOutcome {
+        let Some(path) = request.file_path.as_deref() else {
+            return SaveOutcome::Skipped(SidecarSkip::NoDestination);
+        };
+
+        if let Some(refusal) = self.write_refusal(path) {
+            return SaveOutcome::Skipped(refusal);
+        }
+
+        // Asked before the request, not after: a track the user has already
+        // timed themselves must not cost the directory a lookup.
+        if let Some(refusal) = already_answered(path).await {
+            return SaveOutcome::Skipped(refusal);
+        }
+
+        let found = match self.lookup(request).await {
+            Ok(LrclibOutcome::Found(found)) => found,
+            Ok(LrclibOutcome::Missing) => return SaveOutcome::NotFound,
+            Err(error) => {
+                tracing::debug!(title = request.title, %error, "lyrics lookup failed");
+                return SaveOutcome::LookupFailed;
+            }
+        };
+
+        let Some(lrc) = found.synced_lrc.as_deref() else {
+            // The directory has the track but only as plain text. Nothing to
+            // write: a `.lrc` with no timings would shadow a future timed one.
+            return SaveOutcome::Skipped(SidecarSkip::NotSynced);
+        };
+
+        match save_synced_sidecar(path, lrc).await {
+            SidecarOutcome::Written(path) => SaveOutcome::Saved(path),
+            SidecarOutcome::Skipped(reason) => SaveOutcome::Skipped(reason),
+            SidecarOutcome::Failed => SaveOutcome::WriteFailed,
+        }
+    }
+
+    /// Write-back on the fetch path: the two policy gates, then the write.
+    ///
+    /// Awaited rather than spawned. The write is one small file on the blocking
+    /// pool, and detaching it would let a fetch resolve while its sidecar is
+    /// still in flight — which is exactly the window in which a shutdown loses
+    /// the file the feature exists to keep.
+    async fn save_sidecar(&self, request: &LyricsRequest, lrc: &str) {
+        let Some(path) = request.file_path.as_deref() else {
+            return;
+        };
+
+        if self.write_refusal(path).is_some() {
+            return;
+        }
+
+        save_synced_sidecar(path, lrc).await;
+    }
+
+    /// Which gate refuses a write beside `path`, if either does.
+    ///
+    /// Both are read per call rather than captured, for the same reason
+    /// [`LyricsPolicy::prefer_synced_from_lrclib`] is: turning the setting off
+    /// has to stop the *next* write, not the next launch.
+    fn write_refusal(&self, path: &Path) -> Option<SidecarSkip> {
+        if !self.policy.should_save_fetched_lyrics() {
+            return Some(SidecarSkip::Disabled);
+        }
+
+        if !self.policy.is_lyrics_write_allowed(path) {
+            tracing::debug!(
+                path = %path.display(),
+                "lyric write-back skipped (path not inside a library folder)"
+            );
+            return Some(SidecarSkip::NotAllowed);
+        }
+
+        None
     }
 
     /// Read the two file-backed sources, short-circuiting on a synced hit.
@@ -214,6 +348,48 @@ impl LyricsService {
     }
 }
 
+/// What one [`LyricsService::save_lyrics`] attempt concluded.
+///
+/// Five outcomes rather than a `Result`, because the batch's summary needs all
+/// five kept apart: "the directory does not have it" and "we could not ask" and
+/// "we could not write" are three different things for a user deciding whether
+/// to run again, and collapsing any pair loses the answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SaveOutcome {
+    /// Written. Carries the sidecar path.
+    Saved(PathBuf),
+    /// Nothing to do, for a reason that is not a failure.
+    Skipped(SidecarSkip),
+    /// The directory was reached and genuinely has no lyrics for this track.
+    NotFound,
+    /// The directory could not be reached. Worth trying again later — which is
+    /// exactly what [`SaveOutcome::NotFound`] is not.
+    LookupFailed,
+    /// Lyrics were found and the filesystem refused the write.
+    WriteFailed,
+}
+
+/// Whether a lyric file already answers for `path`, off the async worker.
+async fn already_answered(path: &Path) -> Option<SidecarSkip> {
+    let owned = path.to_path_buf();
+    match tokio::task::spawn_blocking(move || existing_lrc_sidecar(&owned)).await {
+        Ok(Some(existing)) => {
+            tracing::debug!(
+                existing = %existing.display(),
+                "skipping a track that already has a lyric file"
+            );
+            Some(SidecarSkip::AlreadyExists)
+        }
+        Ok(None) => None,
+        Err(error) => {
+            // Fail closed: not knowing whether the user's file is there is not a
+            // licence to write over it.
+            tracing::warn!(%error, "lyric sidecar probe panicked");
+            Some(SidecarSkip::AlreadyExists)
+        }
+    }
+}
+
 /// What the file-backed sources produced.
 enum FileSources {
     /// A synced hit that ends the search before the network.
@@ -264,5 +440,184 @@ fn empty_result() -> LyricsResult {
         synced: None,
         plain: None,
         source: None,
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    //! The ladder itself is exercised end to end over a socket in
+    //! `tests/lyrics_precedence.rs`; what is unit-tested here is the write-back
+    //! gate, which is a decision this module makes before any I/O and which
+    //! therefore needs no server to pin.
+
+    use super::*;
+    use shiranami_net::HttpClient;
+
+    /// A policy that answers "no" to everything — the shape a caller gets by
+    /// implementing only the two required methods.
+    struct DefaultPolicy;
+
+    impl LyricsPolicy for DefaultPolicy {
+        fn is_local_resolution_allowed(&self, _path: &Path) -> bool {
+            false
+        }
+
+        fn prefer_synced_from_lrclib(&self) -> bool {
+            false
+        }
+    }
+
+    /// A policy that has opted in and allows writes anywhere.
+    struct WritingPolicy;
+
+    impl LyricsPolicy for WritingPolicy {
+        fn is_local_resolution_allowed(&self, _path: &Path) -> bool {
+            false
+        }
+
+        fn prefer_synced_from_lrclib(&self) -> bool {
+            false
+        }
+
+        fn should_save_fetched_lyrics(&self) -> bool {
+            true
+        }
+
+        fn is_lyrics_write_allowed(&self, _path: &Path) -> bool {
+            true
+        }
+    }
+
+    fn service_with(policy: Arc<dyn LyricsPolicy>) -> LyricsService {
+        // Port 1 is reserved and refuses instantly, so nothing here waits on a
+        // timeout to prove it never dialled.
+        LyricsService::new(
+            LrclibClient::with_base(
+                HttpClient::new().expect("the shared client builds"),
+                "http://127.0.0.1:1/api",
+            ),
+            policy,
+        )
+    }
+
+    /// A service whose directory is unreachable and whose policy is the default
+    /// — used by `crate::lyrics::batch`'s tests, where the assertion is that no
+    /// request is made at all.
+    pub(crate) fn offline_service() -> LyricsService {
+        service_with(Arc::new(DefaultPolicy))
+    }
+
+    /// The default is not "write" — a `LyricsPolicy` written before this lane
+    /// existed, or a test double, must not start writing into a music folder.
+    #[test]
+    fn the_trait_defaults_refuse_to_write() {
+        let policy = DefaultPolicy;
+
+        assert!(!policy.should_save_fetched_lyrics());
+        assert!(!policy.is_lyrics_write_allowed(Path::new("/music/Song.mp3")));
+    }
+
+    #[test]
+    fn the_opt_out_is_reported_before_the_containment_question() {
+        let service = service_with(Arc::new(DefaultPolicy));
+
+        assert_eq!(
+            service.write_refusal(Path::new("/music/Song.mp3")),
+            Some(SidecarSkip::Disabled)
+        );
+    }
+
+    /// Opting in is not enough on its own: a path outside every library folder
+    /// is still refused, so a stray `tracks` row cannot become a write target.
+    #[test]
+    fn containment_is_asked_separately_from_the_setting() {
+        struct OptedInButContained;
+
+        impl LyricsPolicy for OptedInButContained {
+            fn is_local_resolution_allowed(&self, _path: &Path) -> bool {
+                true
+            }
+
+            fn prefer_synced_from_lrclib(&self) -> bool {
+                false
+            }
+
+            fn should_save_fetched_lyrics(&self) -> bool {
+                true
+            }
+
+            fn is_lyrics_write_allowed(&self, path: &Path) -> bool {
+                path.starts_with("/music")
+            }
+        }
+
+        let service = service_with(Arc::new(OptedInButContained));
+
+        assert_eq!(service.write_refusal(Path::new("/music/Song.mp3")), None);
+        assert_eq!(
+            service.write_refusal(Path::new("/elsewhere/Song.mp3")),
+            Some(SidecarSkip::NotAllowed)
+        );
+    }
+
+    /// A stream has no file to write beside, and the refusal happens before the
+    /// directory is consulted — so a radio session costs LRCLIB nothing.
+    #[tokio::test]
+    async fn a_track_with_no_path_is_skipped_without_a_request() {
+        let service = service_with(Arc::new(WritingPolicy));
+
+        let outcome = service
+            .save_lyrics(&LyricsRequest {
+                title: "Song".to_owned(),
+                artist: "Artist".to_owned(),
+                ..LyricsRequest::default()
+            })
+            .await;
+
+        assert_eq!(outcome, SaveOutcome::Skipped(SidecarSkip::NoDestination));
+    }
+
+    /// The never-overwrite check runs *before* the lookup, so a library already
+    /// full of hand-timed files costs the directory nothing to re-run over.
+    #[tokio::test]
+    async fn an_existing_sidecar_is_answered_without_a_lookup() {
+        let dir = tempfile::tempdir().expect("a temp dir");
+        let audio = dir.path().join("Song.mp3");
+        std::fs::write(dir.path().join("Song.lrc"), "[00:01.00]Mine").expect("seed the file");
+
+        let service = service_with(Arc::new(WritingPolicy));
+        let outcome = service
+            .save_lyrics(&LyricsRequest {
+                title: "Song".to_owned(),
+                artist: "Artist".to_owned(),
+                file_path: Some(audio),
+                ..LyricsRequest::default()
+            })
+            .await;
+
+        assert_eq!(outcome, SaveOutcome::Skipped(SidecarSkip::AlreadyExists));
+    }
+
+    /// An unreachable directory is `LookupFailed`, never `NotFound`. The batch
+    /// summary reports the first as worth retrying and the second as settled.
+    #[tokio::test]
+    async fn an_unreachable_directory_is_not_reported_as_a_miss() {
+        let dir = tempfile::tempdir().expect("a temp dir");
+        let service = service_with(Arc::new(WritingPolicy));
+
+        let outcome = service
+            .save_lyrics(&LyricsRequest {
+                title: "Song".to_owned(),
+                artist: "Artist".to_owned(),
+                file_path: Some(dir.path().join("Song.mp3")),
+                ..LyricsRequest::default()
+            })
+            .await;
+
+        assert_eq!(outcome, SaveOutcome::LookupFailed);
+        assert!(
+            !dir.path().join("Song.lrc").exists(),
+            "a failed lookup must not leave a file behind"
+        );
     }
 }

--- a/crates/shiranami-integrations/src/lyrics/service.rs
+++ b/crates/shiranami-integrations/src/lyrics/service.rs
@@ -34,7 +34,7 @@ use crate::lyrics::cache::{InflightLookups, LyricsCache, cache_key};
 use crate::lyrics::embedded::read_embedded_lyrics;
 use crate::lyrics::error::{LyricsError, Result};
 use crate::lyrics::local::{SidecarGuard, existing_lyric_sidecar, load_local_lyrics};
-use crate::lyrics::lrclib::{LrclibClient, LrclibOutcome, LrclibQuery};
+use crate::lyrics::lrclib::{LrclibClient, LrclibLyrics, LrclibOutcome, LrclibQuery};
 use crate::lyrics::parse::{has_plain_lyrics, has_synced_lyrics};
 use crate::lyrics::writeback::{SidecarOutcome, SidecarSkip, save_synced_sidecar};
 
@@ -158,7 +158,10 @@ impl LyricsService {
         // the reason to keep the file is that the network was reachable *now*
         // and may not be later, which has nothing to do with what the ladder
         // decides to display this time round.
-        if let Some(lrc) = found.as_ref().and_then(|found| found.synced_lrc.as_deref()) {
+        //
+        // Gated on the *parsed* view, not on the raw document being non-empty:
+        // see [`synced_document_of`].
+        if let Some(lrc) = found.as_ref().and_then(synced_document_of) {
             self.save_sidecar(request, lrc).await;
         }
 
@@ -240,8 +243,8 @@ impl LyricsService {
             }
         };
 
-        let Some(lrc) = found.synced_lrc.as_deref() else {
-            // The directory has the track but only as plain text. Nothing to
+        let Some(lrc) = synced_document_of(&found) else {
+            // The directory has the track but nothing timed to save. Nothing to
             // write: a `.lrc` with no timings would shadow a future timed one.
             return SaveOutcome::Skipped(SidecarSkip::NotSynced);
         };
@@ -390,6 +393,26 @@ pub enum SaveOutcome {
     LookupFailed,
     /// Lyrics were found and the filesystem refused the write.
     WriteFailed,
+}
+
+/// The raw LRC document behind `found`, but only when it actually carries timed
+/// lines.
+///
+/// The gate the write-back is phrased in, and it is deliberately the *parsed*
+/// view rather than "the server sent a non-empty `syncedLyrics`". LRCLIB's
+/// records are user-submitted, and a payload of nothing but ID tags
+/// (`[ar:…]`, `[ti:…]`, `[by:…]`) — or of whitespace — is non-empty and parses
+/// to zero lines. Written out, such a file is worse than no file at all: the
+/// reader finds it, `parse_lrc` yields nothing, the timestampless fallback
+/// serves the tag junk as plain text, and with the default precedence that
+/// non-empty plain text stops the ladder before the network is ever consulted
+/// again. The never-overwrite guard then blocks every future attempt to
+/// replace it.
+fn synced_document_of(found: &LrclibLyrics) -> Option<&str> {
+    found
+        .synced_lrc
+        .as_deref()
+        .filter(|_| has_synced_lyrics(Some(&found.result)))
 }
 
 /// Whether a lyric file already answers for `path`, off the async worker.

--- a/crates/shiranami-integrations/src/lyrics/service.rs
+++ b/crates/shiranami-integrations/src/lyrics/service.rs
@@ -63,7 +63,7 @@ pub trait LyricsPolicy: Send + Sync {
     /// takes effect on the next track without a restart.
     fn prefer_synced_from_lrclib(&self) -> bool;
 
-    /// The `lyrics.saveFetchedLyrics` setting: may a synced LRCLIB hit be
+    /// The `settings.saveFetchedLyrics` setting: may a synced LRCLIB hit be
     /// written to a `.lrc` beside the track?
     ///
     /// **Defaults to `false` on the trait**, which is not a convenience. Writing

--- a/crates/shiranami-integrations/src/lyrics/writeback.rs
+++ b/crates/shiranami-integrations/src/lyrics/writeback.rs
@@ -1,0 +1,379 @@
+//! Keeping what the directory answered: the `.lrc` sidecar write.
+//!
+//! Shiranami is local-first everywhere except here — lyrics fetched from LRCLIB
+//! lived in a 200-entry in-memory MRU and nowhere else, so losing the network
+//! lost them. This module closes that: a synced hit is written to a `.lrc` file
+//! beside the track, and [`crate::lyrics::local`]'s existing precedence ladder
+//! finds it on the next play with no new read path.
+//!
+//! # Every rule here is a refusal
+//!
+//! Writing into a music library is the most destructive thing this app does, and
+//! all five guards below exist to *not* do it:
+//!
+//! - **Opt-in.** [`crate::lyrics::LyricsPolicy::should_save_fetched_lyrics`]
+//!   defaults to `false` on the trait itself, so a policy that has never heard
+//!   of write-back is a policy that does not write.
+//! - **Containment.** The destination is *derived* from the track's own path and
+//!   never accepted from a caller, and the track's directory is then put to
+//!   [`crate::lyrics::LyricsPolicy::is_lyrics_write_allowed`], which also
+//!   defaults closed.
+//! - **Never overwrite.** Any existing `.lrc` in any of the reader's locations
+//!   is the user's own file and wins outright — see
+//!   [`crate::lyrics::local::existing_lrc_sidecar`].
+//! - **Read-only is normal, not exceptional.** NAS shares and deliberately
+//!   read-only folders are ordinary places to keep music. A failed write is a
+//!   `debug` line and [`SidecarOutcome::Failed`]; the lyrics still reach the
+//!   renderer from memory exactly as they did before this module existed.
+//! - **Atomic.** Temp file, `sync_data`, rename — the pattern
+//!   `shiranami_core::store::atomic` documents, so a reader mid-write sees the
+//!   old file or the new one and never a torn one.
+//!
+//! # Why the write is not `shiranami_core::store::atomic::write_atomic`
+//!
+//! That function creates its temp file `0600` on Unix, because the file it was
+//! written for holds a Last.fm session key. A lyric file is the opposite kind of
+//! object: it lives in the user's music folder beside tracks their other players
+//! and their household read, and a library that suddenly grew owner-only lyric
+//! files would be a bug reported as one. The sequence is the same; the mode is
+//! deliberately the process umask's.
+//!
+//! # `create_new`, not `create`
+//!
+//! The final step is a rename, which *does* clobber. The existence check above
+//! it is therefore advisory — a `.lrc` appearing between the check and the
+//! rename would be overwritten. Nothing in this app writes lyric files
+//! concurrently, but "the user dropped a file in while a library batch ran" is a
+//! real sequence, so the rename is preceded by one last [`Path::try_exists`] and
+//! the temp file itself is opened `create_new`, which makes the nonce collision
+//! a failure rather than a silent truncation of somebody else's temp file.
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use crate::lyrics::local::existing_lrc_sidecar;
+
+/// What one write-back attempt did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SidecarOutcome {
+    /// The file was written. Carries the path, for the log line and the batch.
+    Written(PathBuf),
+    /// Nothing was written, for a reason that is not a failure.
+    Skipped(SidecarSkip),
+    /// The write was attempted and the filesystem refused.
+    ///
+    /// Deliberately carries no error: every caller's response is the same
+    /// (count it and carry on), the detail is already in the log line, and a
+    /// `std::io::Error` here would make the outcome neither `Clone` nor `Eq`
+    /// for the sake of information nobody reads.
+    Failed,
+}
+
+/// Why a write-back did not happen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SidecarSkip {
+    /// The user has not opted in.
+    Disabled,
+    /// A stream, or a track whose path has no parent or no basename — there is
+    /// no "beside the file" to write to.
+    NoDestination,
+    /// The track's folder is not one the app may write into.
+    NotAllowed,
+    /// A `.lrc` is already there. It is the user's, and it wins.
+    AlreadyExists,
+    /// The directory answered, but with no timed lyrics to save.
+    NotSynced,
+}
+
+/// The sidecar this track's lyrics would be written to.
+///
+/// Sibling and same basename — the first entry of the reader's candidate list,
+/// so a file written here is found first on the next play. Built by
+/// concatenation rather than [`Path::with_extension`] for the reason
+/// [`crate::lyrics::local`] spells out: `with_extension` reads the stem of
+/// `Song. Pt. 2.mp3` as carrying an extension already and would produce
+/// `Song. Pt.lrc`.
+///
+/// `None` when the path has no parent or no basename, which is what makes a
+/// radio pseudo-path unwritable rather than merely unlikely.
+pub fn sidecar_path(audio_file: &Path) -> Option<PathBuf> {
+    let directory = audio_file.parent()?;
+    let stem = audio_file.file_stem()?;
+    if stem.is_empty() {
+        return None;
+    }
+
+    let mut name = stem.to_os_string();
+    name.push(".lrc");
+    Some(directory.join(name))
+}
+
+/// Write `lrc` beside `audio_file`, unless one of the guards says not to.
+///
+/// `lrc` is written **verbatim**: the bytes LRCLIB published, timing lines and
+/// all. Never returns an error — see the module docs on why a read-only library
+/// is an ordinary configuration rather than a failure to report.
+///
+/// The filesystem work runs on the blocking pool (architecture §2.3), so this
+/// does not stall the async worker the fetch is running on.
+pub async fn save_synced_sidecar(audio_file: &Path, lrc: &str) -> SidecarOutcome {
+    let Some(destination) = sidecar_path(audio_file) else {
+        return SidecarOutcome::Skipped(SidecarSkip::NoDestination);
+    };
+
+    let audio_file = audio_file.to_path_buf();
+    let contents = lrc.to_owned();
+
+    match tokio::task::spawn_blocking(move || write_sidecar(&audio_file, &destination, &contents))
+        .await
+    {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            tracing::warn!(%error, "lyric sidecar write panicked");
+            SidecarOutcome::Failed
+        }
+    }
+}
+
+/// The blocking half: the existence check, the temp file, the rename.
+fn write_sidecar(audio_file: &Path, destination: &Path, lrc: &str) -> SidecarOutcome {
+    if let Some(existing) = existing_lrc_sidecar(audio_file) {
+        tracing::debug!(
+            existing = %existing.display(),
+            "a lyric file is already there; leaving it alone"
+        );
+        return SidecarOutcome::Skipped(SidecarSkip::AlreadyExists);
+    }
+
+    match write_atomic_beside(destination, lrc.as_bytes()) {
+        Ok(()) => {
+            tracing::info!(sidecar = %destination.display(), "saved fetched lyrics");
+            SidecarOutcome::Written(destination.to_path_buf())
+        }
+        Err(error) => {
+            // `debug`, not `warn`: a read-only music folder is a configuration,
+            // not a fault, and a library-wide batch over one would otherwise
+            // fill the shipped log with thousands of identical warnings.
+            tracing::debug!(
+                sidecar = %destination.display(),
+                %error,
+                "could not save fetched lyrics; keeping them in memory only"
+            );
+            SidecarOutcome::Failed
+        }
+    }
+}
+
+/// Temp file, flush, rename — at the umask's mode rather than owner-only.
+///
+/// See the module docs for why this is not `store::atomic::write_atomic`.
+fn write_atomic_beside(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let directory = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("lyrics");
+
+    // pid + nanos, matching the store's construction: two writers targeting
+    // different files in one directory cannot collide on the temp name.
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_nanos())
+        .unwrap_or(0);
+    let temp = directory.join(format!(".{file_name}.{}.{nonce}.tmp", std::process::id()));
+
+    let write_then_rename = || -> std::io::Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp)?;
+        file.write_all(bytes)?;
+        file.sync_data()?;
+        drop(file);
+
+        // The last-moment re-check described in the module docs. `rename`
+        // clobbers, and this is the only thing standing between a file the user
+        // dropped in mid-batch and losing it.
+        if path.try_exists().unwrap_or(true) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "a lyric file appeared at the destination while it was being written",
+            ));
+        }
+
+        std::fs::rename(&temp, path)
+    };
+
+    let result = write_then_rename();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    const LRC: &str = "[00:01.00]One\n[00:02.50]Two\n";
+
+    fn temp_dir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("a temp dir")
+    }
+
+    #[test]
+    fn the_destination_is_a_sibling_sharing_the_basename() {
+        let path = sidecar_path(Path::new("/music/Album/Song.mp3")).expect("a destination");
+        assert_eq!(path, Path::new("/music/Album/Song.lrc"));
+    }
+
+    /// The same dotted-title trap `local::candidate_paths` documents: a
+    /// `with_extension` here would aim at `Song. Pt.lrc`, which the reader would
+    /// never look for.
+    #[test]
+    fn only_the_final_extension_is_replaced() {
+        let path = sidecar_path(Path::new("/music/Song. Pt. 2.flac")).expect("a destination");
+        assert_eq!(
+            path.file_name(),
+            Some(std::ffi::OsStr::new("Song. Pt. 2.lrc"))
+        );
+    }
+
+    /// A radio pseudo-path is the case this closes: there is no file to write
+    /// beside, and inventing one would put a `.lrc` somewhere arbitrary.
+    #[test]
+    fn a_path_with_no_basename_has_no_destination() {
+        assert_eq!(sidecar_path(Path::new("/")), None);
+    }
+
+    #[tokio::test]
+    async fn writes_the_document_byte_for_byte() {
+        let dir = temp_dir();
+        let audio = dir.path().join("Song.mp3");
+
+        let outcome = save_synced_sidecar(&audio, LRC).await;
+
+        let written = dir.path().join("Song.lrc");
+        assert_eq!(outcome, SidecarOutcome::Written(written.clone()));
+        assert_eq!(fs::read_to_string(&written).expect("read it back"), LRC);
+    }
+
+    /// The whole point of carrying the raw document: CRLF, stacked timestamps
+    /// and three-digit fractions survive, because nothing re-renders them.
+    #[tokio::test]
+    async fn the_original_timing_lines_are_preserved_exactly() {
+        let dir = temp_dir();
+        let audio = dir.path().join("Song.mp3");
+        let original = "[00:02.030][00:01.00]Refrain\r\n[03:04.5]not a line\r\n";
+
+        save_synced_sidecar(&audio, original).await;
+
+        assert_eq!(
+            fs::read_to_string(dir.path().join("Song.lrc")).expect("read it back"),
+            original
+        );
+    }
+
+    /// The non-negotiable one. The user's file is the user's file.
+    #[tokio::test]
+    async fn an_existing_sidecar_is_never_overwritten() {
+        let dir = temp_dir();
+        let audio = dir.path().join("Song.mp3");
+        let sidecar = dir.path().join("Song.lrc");
+        fs::write(&sidecar, "[00:09.00]Mine, hand-timed").expect("seed the user's file");
+
+        let outcome = save_synced_sidecar(&audio, LRC).await;
+
+        assert_eq!(outcome, SidecarOutcome::Skipped(SidecarSkip::AlreadyExists));
+        assert_eq!(
+            fs::read_to_string(&sidecar).expect("read it back"),
+            "[00:09.00]Mine, hand-timed"
+        );
+    }
+
+    /// …including one filed under `Lyrics/`. A fresh sibling would outrank it in
+    /// the reader's ladder, which shadows the user's file as surely as
+    /// overwriting it.
+    #[tokio::test]
+    async fn a_sidecar_in_a_lyrics_subfolder_also_wins() {
+        let dir = temp_dir();
+        let audio = dir.path().join("Song.mp3");
+        let subfolder = dir.path().join("Lyrics");
+        fs::create_dir_all(&subfolder).expect("create the subfolder");
+        fs::write(subfolder.join("Song.lrc"), "[00:09.00]Mine").expect("seed the user's file");
+
+        let outcome = save_synced_sidecar(&audio, LRC).await;
+
+        assert_eq!(outcome, SidecarOutcome::Skipped(SidecarSkip::AlreadyExists));
+        assert!(
+            !dir.path().join("Song.lrc").exists(),
+            "no sibling may appear above the user's own file"
+        );
+    }
+
+    /// A `.txt` does not block: the only route that reaches the directory while
+    /// one exists is the user having asked for synced lyrics over plain ones.
+    #[tokio::test]
+    async fn a_plain_text_sidecar_does_not_block_the_write() {
+        let dir = temp_dir();
+        let audio = dir.path().join("Song.mp3");
+        fs::write(dir.path().join("Song.txt"), "Just words").expect("seed a txt");
+
+        let outcome = save_synced_sidecar(&audio, LRC).await;
+
+        assert!(matches!(outcome, SidecarOutcome::Written(_)));
+    }
+
+    /// The read-only-library contract: a refused write is an outcome, never an
+    /// error and never a panic. A directory at the destination refuses the
+    /// rename on every platform, which is the portable way to force it.
+    #[tokio::test]
+    async fn a_refused_write_degrades_quietly() {
+        let dir = temp_dir();
+        let audio = dir.path().join("Song.mp3");
+        fs::create_dir(dir.path().join("Song.lrc")).expect("create the blocking directory");
+
+        // The existence check sees the directory first, so this is a skip rather
+        // than a failure — either way nothing is written and nothing is thrown.
+        let outcome = save_synced_sidecar(&audio, LRC).await;
+        assert!(matches!(outcome, SidecarOutcome::Skipped(_)));
+    }
+
+    /// A write into a folder that does not exist is the NAS-gone-away shape:
+    /// refused by the filesystem, counted, and carried on from.
+    #[tokio::test]
+    async fn a_missing_directory_is_a_failure_and_not_a_panic() {
+        let dir = temp_dir();
+        let audio = dir.path().join("nowhere").join("Song.mp3");
+
+        assert_eq!(
+            save_synced_sidecar(&audio, LRC).await,
+            SidecarOutcome::Failed
+        );
+    }
+
+    /// A failed write must leave no `.Song.lrc.<pid>.<nonce>.tmp` litter in the
+    /// user's music folder.
+    #[tokio::test]
+    async fn a_failed_write_leaves_no_temp_file_behind() {
+        let dir = temp_dir();
+        // Occupy the destination *after* the existence check would have run, by
+        // driving the inner writer directly.
+        let destination = dir.path().join("Song.lrc");
+        fs::create_dir(&destination).expect("block the rename");
+
+        assert!(write_atomic_beside(&destination, LRC.as_bytes()).is_err());
+
+        let leftovers: Vec<String> = fs::read_dir(dir.path())
+            .expect("read the folder")
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.ends_with(".tmp"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "temp litter left behind: {leftovers:?}"
+        );
+    }
+}

--- a/crates/shiranami-integrations/src/lyrics/writeback.rs
+++ b/crates/shiranami-integrations/src/lyrics/writeback.rs
@@ -18,9 +18,13 @@
 //!   never accepted from a caller, and the track's directory is then put to
 //!   [`crate::lyrics::LyricsPolicy::is_lyrics_write_allowed`], which also
 //!   defaults closed.
-//! - **Never overwrite.** Any existing `.lrc` in any of the reader's locations
-//!   is the user's own file and wins outright — see
-//!   [`crate::lyrics::local::existing_lrc_sidecar`].
+//! - **Never overwrite, and never shadow.** Any lyric file already sitting in
+//!   one of the reader's six locations is the user's own and wins outright —
+//!   see [`crate::lyrics::local::existing_lyric_sidecar`]. A `.txt` counts too
+//!   unless the user has set `lyrics.preferSyncedFromLrclib`, because a fresh
+//!   `.lrc` outranks a `.txt` everywhere in the ladder and retires it as
+//!   thoroughly as an overwrite would; [`crate::lyrics::local::SidecarGuard`]
+//!   carries that decision in from the caller that knows the setting.
 //! - **Read-only is normal, not exceptional.** NAS shares and deliberately
 //!   read-only folders are ordinary places to keep music. A failed write is a
 //!   `debug` line and [`SidecarOutcome::Failed`]; the lyrics still reach the
@@ -51,7 +55,7 @@
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
-use crate::lyrics::local::existing_lrc_sidecar;
+use crate::lyrics::local::{SidecarGuard, existing_lyric_sidecar};
 
 /// What one write-back attempt did.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -79,7 +83,7 @@ pub enum SidecarSkip {
     NoDestination,
     /// The track's folder is not one the app may write into.
     NotAllowed,
-    /// A `.lrc` is already there. It is the user's, and it wins.
+    /// A lyric file is already there. It is the user's, and it wins.
     AlreadyExists,
     /// The directory answered, but with no timed lyrics to save.
     NotSynced,
@@ -110,13 +114,21 @@ pub fn sidecar_path(audio_file: &Path) -> Option<PathBuf> {
 
 /// Write `lrc` beside `audio_file`, unless one of the guards says not to.
 ///
+/// `guard` decides which files the user is deemed to already have; the caller
+/// owns that decision because it is the one holding the
+/// `lyrics.preferSyncedFromLrclib` answer. See [`SidecarGuard`].
+///
 /// `lrc` is written **verbatim**: the bytes LRCLIB published, timing lines and
 /// all. Never returns an error — see the module docs on why a read-only library
 /// is an ordinary configuration rather than a failure to report.
 ///
 /// The filesystem work runs on the blocking pool (architecture §2.3), so this
 /// does not stall the async worker the fetch is running on.
-pub async fn save_synced_sidecar(audio_file: &Path, lrc: &str) -> SidecarOutcome {
+pub async fn save_synced_sidecar(
+    audio_file: &Path,
+    lrc: &str,
+    guard: SidecarGuard,
+) -> SidecarOutcome {
     let Some(destination) = sidecar_path(audio_file) else {
         return SidecarOutcome::Skipped(SidecarSkip::NoDestination);
     };
@@ -124,8 +136,10 @@ pub async fn save_synced_sidecar(audio_file: &Path, lrc: &str) -> SidecarOutcome
     let audio_file = audio_file.to_path_buf();
     let contents = lrc.to_owned();
 
-    match tokio::task::spawn_blocking(move || write_sidecar(&audio_file, &destination, &contents))
-        .await
+    match tokio::task::spawn_blocking(move || {
+        write_sidecar(&audio_file, &destination, &contents, guard)
+    })
+    .await
     {
         Ok(outcome) => outcome,
         Err(error) => {
@@ -136,8 +150,13 @@ pub async fn save_synced_sidecar(audio_file: &Path, lrc: &str) -> SidecarOutcome
 }
 
 /// The blocking half: the existence check, the temp file, the rename.
-fn write_sidecar(audio_file: &Path, destination: &Path, lrc: &str) -> SidecarOutcome {
-    if let Some(existing) = existing_lrc_sidecar(audio_file) {
+fn write_sidecar(
+    audio_file: &Path,
+    destination: &Path,
+    lrc: &str,
+    guard: SidecarGuard,
+) -> SidecarOutcome {
+    if let Some(existing) = existing_lyric_sidecar(audio_file, guard) {
         tracing::debug!(
             existing = %existing.display(),
             "a lyric file is already there; leaving it alone"
@@ -252,7 +271,7 @@ mod tests {
         let dir = temp_dir();
         let audio = dir.path().join("Song.mp3");
 
-        let outcome = save_synced_sidecar(&audio, LRC).await;
+        let outcome = save_synced_sidecar(&audio, LRC, SidecarGuard::AnyLyricFile).await;
 
         let written = dir.path().join("Song.lrc");
         assert_eq!(outcome, SidecarOutcome::Written(written.clone()));
@@ -267,7 +286,7 @@ mod tests {
         let audio = dir.path().join("Song.mp3");
         let original = "[00:02.030][00:01.00]Refrain\r\n[03:04.5]not a line\r\n";
 
-        save_synced_sidecar(&audio, original).await;
+        save_synced_sidecar(&audio, original, SidecarGuard::AnyLyricFile).await;
 
         assert_eq!(
             fs::read_to_string(dir.path().join("Song.lrc")).expect("read it back"),
@@ -283,7 +302,7 @@ mod tests {
         let sidecar = dir.path().join("Song.lrc");
         fs::write(&sidecar, "[00:09.00]Mine, hand-timed").expect("seed the user's file");
 
-        let outcome = save_synced_sidecar(&audio, LRC).await;
+        let outcome = save_synced_sidecar(&audio, LRC, SidecarGuard::AnyLyricFile).await;
 
         assert_eq!(outcome, SidecarOutcome::Skipped(SidecarSkip::AlreadyExists));
         assert_eq!(
@@ -303,7 +322,7 @@ mod tests {
         fs::create_dir_all(&subfolder).expect("create the subfolder");
         fs::write(subfolder.join("Song.lrc"), "[00:09.00]Mine").expect("seed the user's file");
 
-        let outcome = save_synced_sidecar(&audio, LRC).await;
+        let outcome = save_synced_sidecar(&audio, LRC, SidecarGuard::AnyLyricFile).await;
 
         assert_eq!(outcome, SidecarOutcome::Skipped(SidecarSkip::AlreadyExists));
         assert!(
@@ -312,17 +331,41 @@ mod tests {
         );
     }
 
-    /// A `.txt` does not block: the only route that reaches the directory while
-    /// one exists is the user having asked for synced lyrics over plain ones.
+    /// A `.txt` blocks by default. A fresh `Song.lrc` outranks `Song.txt`
+    /// everywhere in the reader's ladder, so writing one retires the file the
+    /// user typed out — and the shipped copy promises it will not.
     #[tokio::test]
-    async fn a_plain_text_sidecar_does_not_block_the_write() {
+    async fn a_plain_text_sidecar_blocks_the_write_by_default() {
         let dir = temp_dir();
         let audio = dir.path().join("Song.mp3");
         fs::write(dir.path().join("Song.txt"), "Just words").expect("seed a txt");
 
-        let outcome = save_synced_sidecar(&audio, LRC).await;
+        let outcome = save_synced_sidecar(&audio, LRC, SidecarGuard::AnyLyricFile).await;
+
+        assert_eq!(outcome, SidecarOutcome::Skipped(SidecarSkip::AlreadyExists));
+        assert!(
+            !dir.path().join("Song.lrc").exists(),
+            "the user's plain text must not be shadowed by a fetched file"
+        );
+    }
+
+    /// …and stops blocking exactly when the user asks for it to. That is what
+    /// `lyrics.preferSyncedFromLrclib` means: timings from the directory are
+    /// wanted over plain text already on disk.
+    #[tokio::test]
+    async fn a_plain_text_sidecar_yields_when_the_user_prefers_lrclib_timings() {
+        let dir = temp_dir();
+        let audio = dir.path().join("Song.mp3");
+        fs::write(dir.path().join("Song.txt"), "Just words").expect("seed a txt");
+
+        let outcome = save_synced_sidecar(&audio, LRC, SidecarGuard::TimedOnly).await;
 
         assert!(matches!(outcome, SidecarOutcome::Written(_)));
+        assert_eq!(
+            fs::read_to_string(dir.path().join("Song.txt")).expect("read it back"),
+            "Just words",
+            "and the `.txt` itself is still never touched"
+        );
     }
 
     /// The read-only-library contract: a refused write is an outcome, never an
@@ -336,7 +379,7 @@ mod tests {
 
         // The existence check sees the directory first, so this is a skip rather
         // than a failure — either way nothing is written and nothing is thrown.
-        let outcome = save_synced_sidecar(&audio, LRC).await;
+        let outcome = save_synced_sidecar(&audio, LRC, SidecarGuard::AnyLyricFile).await;
         assert!(matches!(outcome, SidecarOutcome::Skipped(_)));
     }
 
@@ -348,7 +391,7 @@ mod tests {
         let audio = dir.path().join("nowhere").join("Song.mp3");
 
         assert_eq!(
-            save_synced_sidecar(&audio, LRC).await,
+            save_synced_sidecar(&audio, LRC, SidecarGuard::AnyLyricFile).await,
             SidecarOutcome::Failed
         );
     }

--- a/crates/shiranami-integrations/src/lyrics/writeback.rs
+++ b/crates/shiranami-integrations/src/lyrics/writeback.rs
@@ -49,11 +49,12 @@
 //! rename would be overwritten. Nothing in this app writes lyric files
 //! concurrently, but "the user dropped a file in while a library batch ran" is a
 //! real sequence, so the rename is preceded by one last [`Path::try_exists`] and
-//! the temp file itself is opened `create_new`, which makes the nonce collision
-//! a failure rather than a silent truncation of somebody else's temp file.
+//! the temp file itself is opened `create_new`, which makes a temp-name
+//! collision a failure rather than a silent truncation of somebody else's file.
 
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::lyrics::local::{SidecarGuard, existing_lyric_sidecar};
 
@@ -187,19 +188,7 @@ fn write_sidecar(
 ///
 /// See the module docs for why this is not `store::atomic::write_atomic`.
 fn write_atomic_beside(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let directory = path.parent().unwrap_or_else(|| Path::new("."));
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("lyrics");
-
-    // pid + nanos, matching the store's construction: two writers targeting
-    // different files in one directory cannot collide on the temp name.
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|elapsed| elapsed.as_nanos())
-        .unwrap_or(0);
-    let temp = directory.join(format!(".{file_name}.{}.{nonce}.tmp", std::process::id()));
+    let temp = temp_path(path);
 
     let write_then_rename = || -> std::io::Result<()> {
         let mut file = std::fs::OpenOptions::new()
@@ -228,6 +217,39 @@ fn write_atomic_beside(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
         let _ = std::fs::remove_file(&temp);
     }
     result
+}
+
+/// Where `destination` is staged before the rename.
+///
+/// **The name is kept short on purpose.** Windows refuses a path over 260
+/// characters unless long paths are enabled, and a routine
+/// `Artist/Album/Disc 2/NN - Long Title.flac` layout puts the `.lrc`
+/// destination within a couple of dozen characters of that ceiling. The store's
+/// `pid` + 19-digit nanosecond stamp would add ~31 characters *over the
+/// destination*, so a library that can hold the file cannot hold the temp file
+/// it is written through — `create_new` fails with `ERROR_FILENAME_EXCED_RANGE`
+/// and the user sees an unexplained `failed` count. Hex pid plus a run-local
+/// counter costs about a dozen.
+///
+/// It is no less unique for the shortening. Two live processes never share a
+/// pid, and within one process the counter never repeats, so the only collision
+/// left is a temp file orphaned by a crash of an earlier process whose pid has
+/// since been recycled — which `create_new` turns into a refused write rather
+/// than a truncation of somebody else's file.
+fn temp_path(destination: &Path) -> PathBuf {
+    static SEQUENCE: AtomicU32 = AtomicU32::new(0);
+
+    let directory = destination.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("lyrics");
+
+    let sequence = SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    directory.join(format!(
+        ".{file_name}.{:x}-{sequence:x}.tmp",
+        std::process::id()
+    ))
 }
 
 #[cfg(test)]
@@ -396,7 +418,7 @@ mod tests {
         );
     }
 
-    /// A failed write must leave no `.Song.lrc.<pid>.<nonce>.tmp` litter in the
+    /// A failed write must leave no `.Song.lrc.<pid>-<n>.tmp` litter in the
     /// user's music folder.
     #[tokio::test]
     async fn a_failed_write_leaves_no_temp_file_behind() {
@@ -418,5 +440,33 @@ mod tests {
             leftovers.is_empty(),
             "temp litter left behind: {leftovers:?}"
         );
+    }
+
+    /// The MAX_PATH guard. A destination the filesystem can hold must not be
+    /// staged through a name it cannot: on Windows a deep
+    /// `Artist/Album/Disc 2/NN - Title.lrc` sits close enough to 260 characters
+    /// that a long temp suffix is the difference between a saved lyric and an
+    /// unexplained `failed` count.
+    #[test]
+    fn the_temp_name_stays_close_to_the_destination_it_stages() {
+        let destination = Path::new("/music/Artist/Album/Disc 2/07 - A Long Title.lrc");
+        let temp = temp_path(destination);
+
+        let length = |path: &Path| path.as_os_str().len();
+        let overhead = length(&temp) - length(destination);
+        assert!(
+            overhead <= 20,
+            "the temp path is {overhead} characters longer than the destination: {}",
+            temp.display()
+        );
+        assert_eq!(temp.parent(), destination.parent());
+    }
+
+    /// …and it is still distinct per attempt, or `create_new` would start
+    /// refusing writes that have nothing wrong with them.
+    #[test]
+    fn two_temp_names_for_one_destination_differ() {
+        let destination = Path::new("/music/Song.lrc");
+        assert_ne!(temp_path(destination), temp_path(destination));
     }
 }

--- a/crates/shiranami-integrations/tests/lyrics_lrclib.rs
+++ b/crates/shiranami-integrations/tests/lyrics_lrclib.rs
@@ -52,8 +52,8 @@ async fn an_exact_match_is_returned_without_a_search() {
     let LrclibOutcome::Found(found) = outcome else {
         panic!("expected a hit, got {outcome:?}");
     };
-    assert_eq!(found.synced.as_ref().map(Vec::len), Some(1));
-    assert_eq!(found.plain.as_deref(), Some("Hi"));
+    assert_eq!(found.result.synced.as_ref().map(Vec::len), Some(1));
+    assert_eq!(found.result.plain.as_deref(), Some("Hi"));
 
     assert_eq!(server.received(), 1, "a hit must not also run the searches");
     assert_eq!(
@@ -173,7 +173,7 @@ async fn a_record_with_no_lyrics_falls_through_to_the_search_endpoint() {
     let LrclibOutcome::Found(found) = outcome else {
         panic!("expected a hit, got {outcome:?}");
     };
-    assert_eq!(found.plain.as_deref(), Some("Found"));
+    assert_eq!(found.result.plain.as_deref(), Some("Found"));
 }
 
 /// The variants are tried in order until one answers, and no further.
@@ -208,7 +208,10 @@ async fn the_first_search_result_wins_even_when_it_carries_no_lyrics() {
     let LrclibOutcome::Found(found) = outcome else {
         panic!("expected a hit, got {outcome:?}");
     };
-    assert_eq!(found.plain, None, "the *first* result won, empty as it was");
+    assert_eq!(
+        found.result.plain, None,
+        "the *first* result won, empty as it was"
+    );
     assert_eq!(server.received(), 2, "the chain stopped at the first hit");
 }
 
@@ -286,7 +289,7 @@ async fn a_hit_after_a_failure_still_wins() {
     let LrclibOutcome::Found(found) = outcome else {
         panic!("expected a hit, got {outcome:?}");
     };
-    assert_eq!(found.plain.as_deref(), Some("Recovered"));
+    assert_eq!(found.result.plain.as_deref(), Some("Recovered"));
 }
 
 /// An unparseable body is a failure, not a miss — the same reasoning as a 500.

--- a/crates/shiranami-integrations/tests/lyrics_writeback.rs
+++ b/crates/shiranami-integrations/tests/lyrics_writeback.rs
@@ -1,0 +1,138 @@
+//! What the write-back lane refuses to put in a music folder.
+//!
+//! The unit tests in `lyrics::writeback` pin the filesystem mechanics; this
+//! suite drives the whole per-track unit — real socket, real LRCLIB decoding,
+//! real sidecar probe — because the rule under test is a decision made *across*
+//! those layers and is not visible from inside any one of them:
+//!
+//! **A file the user already has is never shadowed.** With
+//! `lyrics.preferSyncedFromLrclib` off, a hand-written `Song.txt` stops the
+//! write, because a fresh `Song.lrc` outranks it everywhere in the reader's
+//! ladder and would retire it for good. With the setting on it does not — that
+//! setting *is* the user asking for the directory's timings instead.
+
+mod support;
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use shiranami_integrations::lyrics::{
+    LrclibClient, LyricsPolicy, LyricsRequest, LyricsService, SaveOutcome, SidecarSkip,
+};
+use shiranami_net::HttpClient;
+use support::test_server::{Reply, TestServer};
+
+/// An opted-in policy that may write anywhere, with a settable preference.
+struct WritingPolicy {
+    prefer_synced: AtomicBool,
+}
+
+impl LyricsPolicy for WritingPolicy {
+    fn is_local_resolution_allowed(&self, _path: &Path) -> bool {
+        true
+    }
+
+    fn prefer_synced_from_lrclib(&self) -> bool {
+        self.prefer_synced.load(Ordering::SeqCst)
+    }
+
+    fn should_save_fetched_lyrics(&self) -> bool {
+        true
+    }
+
+    fn is_lyrics_write_allowed(&self, _path: &Path) -> bool {
+        true
+    }
+}
+
+/// A record body for `/api/get`.
+fn record(synced: Option<&str>, plain: Option<&str>) -> String {
+    serde_json::json!({ "syncedLyrics": synced, "plainLyrics": plain }).to_string()
+}
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    audio: PathBuf,
+    service: LyricsService,
+    server: TestServer,
+}
+
+impl Fixture {
+    async fn new(prefer_synced: bool, replies: Vec<Reply>) -> Self {
+        let directory = tempfile::tempdir().expect("a temp dir");
+        let audio = directory.path().join("Song.mp3");
+        let server = TestServer::start(replies).await;
+
+        let service = LyricsService::new(
+            LrclibClient::with_base(
+                HttpClient::new().expect("the shared client builds"),
+                server.url(""),
+            ),
+            Arc::new(WritingPolicy {
+                prefer_synced: AtomicBool::new(prefer_synced),
+            }) as Arc<dyn LyricsPolicy>,
+        );
+
+        Self {
+            _directory: directory,
+            audio,
+            service,
+            server,
+        }
+    }
+
+    fn sidecar(&self, extension: &str) -> PathBuf {
+        self.audio.with_extension(extension)
+    }
+
+    fn seed(&self, extension: &str, contents: &str) {
+        std::fs::write(self.sidecar(extension), contents).expect("seeding the user's file");
+    }
+
+    fn request(&self) -> LyricsRequest {
+        LyricsRequest {
+            title: "Song".to_owned(),
+            artist: "Artist".to_owned(),
+            file_path: Some(self.audio.clone()),
+            ..LyricsRequest::default()
+        }
+    }
+}
+
+/* ------------------------- the user's own files ------------------------- */
+
+/// The default. One click on "save lyrics for library" must not walk over a
+/// curated `.txt` collection — and it must not spend a lookup finding out.
+#[tokio::test]
+async fn a_hand_written_txt_stops_the_batch_before_the_lookup() {
+    let fixture = Fixture::new(false, vec![Reply::ok(&record(Some("[00:01.00]Net"), None))]).await;
+    fixture.seed("txt", "The words I typed myself");
+
+    let outcome = fixture.service.save_lyrics(&fixture.request()).await;
+
+    assert_eq!(outcome, SaveOutcome::Skipped(SidecarSkip::AlreadyExists));
+    assert!(!fixture.sidecar("lrc").exists());
+    assert_eq!(
+        fixture.server.received(),
+        0,
+        "a track the user has already answered for costs the directory nothing"
+    );
+}
+
+/// …and the setting is what lifts it, exactly as it lifts the same rule on the
+/// fetch ladder.
+#[tokio::test]
+async fn preferring_lrclib_timings_lets_the_write_past_a_txt() {
+    let fixture = Fixture::new(true, vec![Reply::ok(&record(Some("[00:01.00]Net"), None))]).await;
+    fixture.seed("txt", "The words I typed myself");
+
+    let outcome = fixture.service.save_lyrics(&fixture.request()).await;
+
+    assert_eq!(outcome, SaveOutcome::Saved(fixture.sidecar("lrc")));
+    assert_eq!(
+        std::fs::read_to_string(fixture.sidecar("txt")).expect("read it back"),
+        "The words I typed myself",
+        "the plain-text file is still never touched"
+    );
+}

--- a/crates/shiranami-integrations/tests/lyrics_writeback.rs
+++ b/crates/shiranami-integrations/tests/lyrics_writeback.rs
@@ -1,15 +1,20 @@
 //! What the write-back lane refuses to put in a music folder.
 //!
-//! The unit tests in `lyrics::writeback` pin the filesystem mechanics; this
-//! suite drives the whole per-track unit — real socket, real LRCLIB decoding,
-//! real sidecar probe — because the rule under test is a decision made *across*
-//! those layers and is not visible from inside any one of them:
+//! The unit tests in `lyrics::writeback` pin the filesystem mechanics; these
+//! drive the whole per-track unit — real socket, real LRCLIB decoding, real
+//! sidecar probe — because both rules under test are decisions made *across*
+//! those layers and neither is visible from inside one of them:
 //!
-//! **A file the user already has is never shadowed.** With
-//! `lyrics.preferSyncedFromLrclib` off, a hand-written `Song.txt` stops the
-//! write, because a fresh `Song.lrc` outranks it everywhere in the reader's
-//! ladder and would retire it for good. With the setting on it does not — that
-//! setting *is* the user asking for the directory's timings instead.
+//! 1. **A file the user already has is never shadowed.** With
+//!    `lyrics.preferSyncedFromLrclib` off, a hand-written `Song.txt` stops the
+//!    write, because a fresh `Song.lrc` outranks it everywhere in the reader's
+//!    ladder and would retire it for good. With the setting on it does not —
+//!    that setting *is* the user asking for the directory's timings instead.
+//! 2. **A document with no timings is not a lyric file.** LRCLIB records are
+//!    user-submitted, and `syncedLyrics` carrying only ID tags or whitespace is
+//!    non-empty while parsing to nothing. Written out it would be found by the
+//!    reader, served as plain text, and — under the default precedence — stop
+//!    the ladder before the network was ever consulted again.
 
 mod support;
 
@@ -134,5 +139,86 @@ async fn preferring_lrclib_timings_lets_the_write_past_a_txt() {
         std::fs::read_to_string(fixture.sidecar("txt")).expect("read it back"),
         "The words I typed myself",
         "the plain-text file is still never touched"
+    );
+}
+
+/* ---------------------- documents with no timings ---------------------- */
+
+/// ID tags are ordinary in user-submitted LRC and parse to zero timed lines.
+/// Kept, the file would serve `[ar:Artist]` as the lyric — forever, because the
+/// never-overwrite guard then blocks every later attempt to replace it.
+#[tokio::test]
+async fn an_id_tags_only_document_is_not_kept() {
+    let payload = "[ar:Artist]\n[ti:Title]\n[by:Someone]\n";
+    let fixture = Fixture::new(
+        false,
+        vec![Reply::ok(&record(Some(payload), Some("Real words")))],
+    )
+    .await;
+
+    let outcome = fixture.service.save_lyrics(&fixture.request()).await;
+
+    assert_eq!(outcome, SaveOutcome::Skipped(SidecarSkip::NotSynced));
+    assert!(
+        !fixture.sidecar("lrc").exists(),
+        "a `.lrc` with no timings would shadow a future timed one"
+    );
+}
+
+/// The blank-pane variant of the same bug: non-empty by the byte, empty by the
+/// parser.
+#[tokio::test]
+async fn a_whitespace_only_document_is_not_kept() {
+    let fixture = Fixture::new(
+        false,
+        vec![Reply::ok(&record(
+            Some("   \n\n \t \n"),
+            Some("Real words"),
+        ))],
+    )
+    .await;
+
+    let outcome = fixture.service.save_lyrics(&fixture.request()).await;
+
+    assert_eq!(outcome, SaveOutcome::Skipped(SidecarSkip::NotSynced));
+    assert!(!fixture.sidecar("lrc").exists());
+}
+
+/// The control: a document that does parse is written verbatim.
+#[tokio::test]
+async fn a_timed_document_is_kept_byte_for_byte() {
+    let payload = "[ar:Artist]\n[00:01.00]One\n[00:02.50]Two\n";
+    let fixture = Fixture::new(false, vec![Reply::ok(&record(Some(payload), None))]).await;
+
+    let outcome = fixture.service.save_lyrics(&fixture.request()).await;
+
+    assert_eq!(outcome, SaveOutcome::Saved(fixture.sidecar("lrc")));
+    assert_eq!(
+        std::fs::read_to_string(fixture.sidecar("lrc")).expect("read it back"),
+        payload,
+        "tags and all — nothing re-renders the document"
+    );
+}
+
+/// The fetch path shares the gate. It writes as a side effect of displaying, so
+/// an untimed document reaching it would plant the same permanent shadow.
+#[tokio::test]
+async fn the_fetch_path_refuses_an_untimed_document_too() {
+    let fixture = Fixture::new(
+        false,
+        vec![Reply::ok(&record(Some("[ti:Title]\n"), Some("Real words")))],
+    )
+    .await;
+
+    let found = fixture
+        .service
+        .fetch(&fixture.request())
+        .await
+        .expect("a result");
+
+    assert_eq!(found.plain.as_deref(), Some("Real words"));
+    assert!(
+        !fixture.sidecar("lrc").exists(),
+        "nothing timed was found, so there is nothing to keep"
     );
 }

--- a/packages/contracts/src/generated/bindings.ts
+++ b/packages/contracts/src/generated/bindings.ts
@@ -2502,7 +2502,13 @@ export type LyricsResult = {
 	source: LyricsSource | null,
 };
 
-/**  Progress through a lyrics write-back batch (v2, no v1 counterpart). */
+/**
+ *  Progress through a lyrics write-back batch (v2, no v1 counterpart).
+ * 
+ *  v1 fetched lyrics one track at a time and kept them in memory, so there
+ *  was no library-wide pass to report on. See
+ *  `crate::commands::lyrics`.
+ */
 export type LyricsSaveProgress = Json;
 
 /**

--- a/packages/contracts/src/generated/bindings.ts
+++ b/packages/contracts/src/generated/bindings.ts
@@ -939,7 +939,7 @@ export const commands = {
 	/**
 	 *  `lyrics:save-batch` — fetch and save lyrics for a set of tracks.
 	 * 
-	 *  Refuses when `lyrics.saveFetchedLyrics` is off (see the module docs) and when
+	 *  Refuses when `settings.saveFetchedLyrics` is off (see the module docs) and when
 	 *  a run already holds the slot. Otherwise it always resolves with a summary,
 	 *  including a cancelled or entirely-failed one: a run over a read-only library
 	 *  answers `failed == total` rather than throwing, because the counts are what

--- a/packages/contracts/src/generated/bindings.ts
+++ b/packages/contracts/src/generated/bindings.ts
@@ -937,6 +937,25 @@ export const commands = {
 	 */
 	lyricsFetch: (title: string, artist: string, album: string | null, duration: number | null, filePath: string | null) => __TAURI_INVOKE<LyricsResult>("lyrics_fetch", { title, artist, album, duration, filePath }),
 	/**
+	 *  `lyrics:save-batch` — fetch and save lyrics for a set of tracks.
+	 * 
+	 *  Refuses when `lyrics.saveFetchedLyrics` is off (see the module docs) and when
+	 *  a run already holds the slot. Otherwise it always resolves with a summary,
+	 *  including a cancelled or entirely-failed one: a run over a read-only library
+	 *  answers `failed == total` rather than throwing, because the counts are what
+	 *  the user needs told.
+	 */
+	lyricsSaveBatch: (tracks: LyricsBatchTrack[]) => __TAURI_INVOKE<LyricsBatchSummary>("lyrics_save_batch", { tracks }),
+	/**
+	 *  `lyrics:save-cancel` — stop the active write-back run.
+	 * 
+	 *  Best-effort and a no-op when idle: a queued track notices at its turn and the
+	 *  run resolves with its partial counts. Cancelling while nothing runs must not
+	 *  leave a flag behind that pre-cancels the next run — the regression
+	 *  `enrich::slot` records from v1.
+	 */
+	lyricsSaveCancel: () => __TAURI_INVOKE<null>("lyrics_save_cancel"),
+	/**
 	 *  `media:playback-state` — show this track on every OS surface.
 	 * 
 	 *  The parameter is named `playback` rather than v1's `state` only because
@@ -1305,6 +1324,7 @@ export const events = {
 	downloaderQueueState: makeEvent<DownloaderQueueState>("downloader:queue-state"),
 	libraryScanProgress: makeEvent<LibraryScanProgress>("library:scan-progress"),
 	loudnessProgress: makeEvent<LoudnessProgress>("loudness:progress"),
+	lyricsSaveProgress: makeEvent<LyricsSaveProgress>("lyrics:save-progress"),
 	mediaCommand: makeEvent<MediaCommand>("media:command"),
 	metadataEnrichProgress: makeEvent<MetadataEnrichProgress>("metadata:enrich:progress"),
 	playlistExtractProgress: makeEvent<PlaylistExtracting>("playlist:extract-progress"),
@@ -2435,6 +2455,43 @@ export type LyricLine = {
 	text: string,
 };
 
+/**  What a finished — or cancelled — run counted. */
+export type LyricsBatchSummary = {
+	/**  Tracks that gained a `.lrc`. */
+	saved: number,
+	/**  Tracks that already had one, or that the run may not write beside. */
+	skipped: number,
+	/**  Tracks the directory does not have. */
+	notFound: number,
+	/**  Tracks whose lookup or write failed. Worth another run. */
+	failed: number,
+	/**  Whether the run was cut short. */
+	cancelled: boolean,
+};
+
+/**
+ *  One track offered up for write-back.
+ * 
+ *  The same five facts `lyrics:fetch` takes, plus the row id so a caller can
+ *  match a tick to a track. `file_path` is required rather than optional: a
+ *  track with nowhere to write a file beside is not a candidate for this run,
+ *  and the caller filters those out before submitting.
+ */
+export type LyricsBatchTrack = {
+	/**  Database id, echoed on every progress tick. */
+	id: string,
+	/**  The audio file the sidecar is written beside. */
+	filePath: string,
+	/**  Track title — the search term. */
+	title: string,
+	/**  Track artist. */
+	artist: string,
+	/**  Album, when known. */
+	album?: string | null,
+	/**  Track length in seconds, as a matching hint. */
+	durationSeconds?: number | null,
+};
+
 /**  The `lyrics:fetch` result. */
 export type LyricsResult = {
 	/**  Timestamped lyrics, or `None` when only plain text (or nothing) exists. */
@@ -2444,6 +2501,9 @@ export type LyricsResult = {
 	/**  Which source won; `None` when nothing was found. */
 	source: LyricsSource | null,
 };
+
+/**  Progress through a lyrics write-back batch (v2, no v1 counterpart). */
+export type LyricsSaveProgress = Json;
 
 /**
  *  Where resolved lyrics came from.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -18,6 +18,7 @@ export * from './ipc/metadata';
 export * from './ipc/analysis';
 export * from './ipc/companion';
 export * from './ipc/doctor';
+export * from './ipc/lyrics';
 export * from './ipc/loudness';
 export * from './ipc/waveform';
 export * from './ipc/database';

--- a/packages/contracts/src/ipc/channels.ts
+++ b/packages/contracts/src/ipc/channels.ts
@@ -80,7 +80,7 @@ export const IPC_CHANNELS = {
     fetch: 'lyrics:fetch',
     // Write-back (v2-only): fetch synced lyrics for a set of tracks and save
     // each as a `.lrc` beside its audio file, so they survive going offline.
-    // Gated on the `lyrics.saveFetchedLyrics` opt-in; never overwrites a lyric
+    // Gated on the `settings.saveFetchedLyrics` opt-in; never overwrites a lyric
     // file the user already has.
     saveBatch: 'lyrics:save-batch',
     saveCancel: 'lyrics:save-cancel',

--- a/packages/contracts/src/ipc/channels.ts
+++ b/packages/contracts/src/ipc/channels.ts
@@ -78,6 +78,13 @@ export const IPC_CHANNELS = {
   },
   lyrics: {
     fetch: 'lyrics:fetch',
+    // Write-back (v2-only): fetch synced lyrics for a set of tracks and save
+    // each as a `.lrc` beside its audio file, so they survive going offline.
+    // Gated on the `lyrics.saveFetchedLyrics` opt-in; never overwrites a lyric
+    // file the user already has.
+    saveBatch: 'lyrics:save-batch',
+    saveCancel: 'lyrics:save-cancel',
+    saveProgress: 'lyrics:save-progress',
   },
   weather: {
     geocode: 'weather:geocode',
@@ -344,4 +351,7 @@ export const V2_ONLY_CHANNELS = [
   'companion:set-name',
   'companion:set-species',
   'companion:xp',
+  'lyrics:save-batch',
+  'lyrics:save-cancel',
+  'lyrics:save-progress',
 ] as const;

--- a/packages/contracts/src/ipc/lyrics.ts
+++ b/packages/contracts/src/ipc/lyrics.ts
@@ -1,0 +1,51 @@
+// Wire types for the lyrics write-back IPC surface (v2-only).
+//
+// Fetched lyrics used to live in an in-memory MRU and nowhere else, so losing
+// the network lost them. Write-back saves a synced LRCLIB hit as a `.lrc` file
+// beside the audio file, which the existing sidecar reader then serves on the
+// next play with no network at all.
+//
+// Two rules the renderer must not work around:
+//  - the whole surface is gated on the `lyrics.saveFetchedLyrics` opt-in, and
+//    `lyrics:save-batch` rejects with `lyrics.save_disabled` when it is off;
+//  - a lyric file the user already has is never overwritten — it is counted as
+//    skipped.
+
+/**
+ * Input track for a lyrics write-back run. The two hints are nullable as well
+ * as optional because that is what the generated binding declares — serde reads
+ * an absent key and an explicit `null` alike as "no hint".
+ */
+export interface LyricsBatchTrack {
+  id: string;
+  filePath: string;
+  title: string;
+  artist: string;
+  album?: string | null;
+  durationSeconds?: number | null;
+}
+
+/**
+ * Per-track progress event streamed during a write-back run. `current` is a
+ * settled-count; `cancelled` is emitted at most once per run.
+ */
+export interface LyricsBatchProgress {
+  current: number;
+  total: number;
+  trackName: string;
+  status: 'searching' | 'saved' | 'skipped' | 'not-found' | 'failed' | 'cancelled';
+}
+
+/**
+ * What a finished — or cancelled — write-back run counted. `notFound` is
+ * settled (the directory does not have the track); `failed` is not (the
+ * directory was unreachable, or the file could not be written), so only the
+ * second is worth running again.
+ */
+export interface LyricsBatchSummary {
+  saved: number;
+  skipped: number;
+  notFound: number;
+  failed: number;
+  cancelled: boolean;
+}

--- a/packages/contracts/src/ipc/lyrics.ts
+++ b/packages/contracts/src/ipc/lyrics.ts
@@ -6,7 +6,7 @@
 // next play with no network at all.
 //
 // Two rules the renderer must not work around:
-//  - the whole surface is gated on the `lyrics.saveFetchedLyrics` opt-in, and
+//  - the whole surface is gated on the `settings.saveFetchedLyrics` opt-in, and
 //    `lyrics:save-batch` rejects with `lyrics.save_disabled` when it is off;
 //  - a lyric file the user already has is never overwritten — it is counted as
 //    skipped.

--- a/packages/contracts/src/ipc/preload-api.ts
+++ b/packages/contracts/src/ipc/preload-api.ts
@@ -18,6 +18,7 @@
 
 import type { WatchedFolder } from '../domain/folder';
 import type { LyricsResult } from '../domain/lyrics';
+import type { LyricsBatchProgress, LyricsBatchSummary, LyricsBatchTrack } from './lyrics';
 import type { PlaylistExtractResult, SearchResult, TrackMetadata } from '../domain/media';
 import type { InstallDependenciesResult } from '../domain/dependencies';
 import type { DownloadQueueSnapshot, EnqueueDownloadInput } from '../domain/download-queue';
@@ -238,6 +239,22 @@ export interface LyricsApi {
     duration?: number,
     filePath?: string
   ) => Promise<LyricsResult>;
+  /**
+   * Fetch and save lyrics for a set of tracks. Rejects with
+   * `lyrics.save_disabled` when the opt-in is off, and `lyrics.save_busy`
+   * when a run is already going.
+   *
+   * v2-only, hence optional — as with `analysis` and `doctor`, the v1 preload
+   * implements this interface and has no write-back to run, so the renderer
+   * feature-detects and hides the control where these are absent. Optional on
+   * the *members* rather than on the namespace because `lyrics.fetch` is a
+   * ported v1 channel and must stay unconditionally present.
+   */
+  saveBatch?: (tracks: LyricsBatchTrack[]) => Promise<LyricsBatchSummary>;
+  /** Stop the active write-back run. A no-op when idle. v2-only. */
+  saveCancel?: () => Promise<void>;
+  /** Subscribe to write-back progress. Returns an unsubscribe function. v2-only. */
+  onSaveProgress?: (callback: (progress: LyricsBatchProgress) => void) => () => void;
 }
 
 // ── weather ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Lyrics fetched from LRCLIB can now be saved as `.lrc` sidecars beside the track, so they survive
going offline and are never re-fetched.

Adds `crates/shiranami-integrations/src/lyrics/writeback.rs`, which writes the raw synced LRC
verbatim to a sidecar via atomic temp-and-rename, and `lyrics/batch.rs`, a cancellable library-wide
pass shaped after `enrich/batch.rs` whose summary splits saved / skipped / not-found / failed. Both
are exposed as `lyrics:save-batch` and `lyrics:save-cancel` with a `lyrics:save-progress` event, and
a settings toggle plus a "run over library" control lands in `LyricsSection`.

## Context / why

The lyrics feature reads local `.lrc` files and embedded tags, but anything fetched from LRCLIB lived
only in a bounded in-memory MRU — lose the network, lose the lyrics. That is a silent cloud
dependency in an app whose whole premise is that you own your files. Because the local-file rung of
the existing precedence ladder already reads sidecars, writing one is enough: no new read path was
needed.

The safety constraints matter more than the feature here, and each is pinned by a test:

- **Default off**, enforced at the `LyricsPolicy` trait level, so a policy predating this change
  cannot write.
- **An existing `.lrc` always wins** — checked across all six reader locations, including one under
  `Lyrics/` that a freshly written sibling would otherwise shadow.
- **Refused writes degrade quietly** to today's in-memory behaviour with a debug line: no dialog, no
  retry loop. Read-only NAS shares and intentionally read-only folders are normal here.
- **Writes use a stricter write-only containment gate** than the read path's `is_path_allowed`, so
  the write path cannot inherit the read path's laxity.
- **Sidecars only.** Embedded-tag writing was left out deliberately — the task treated it as
  optional, and writing into the audio file itself risks a user's rips for no proportionate gain.

The opt-in is stored in the renderer `settings` blob rather than as a dedicated store key. A
dedicated key is not possible: `store::keys`' test pins `RendererStoreKey` against v1's
`RENDERER_STORE_KEYS` tuple exactly, so a Rust-side-only key would have left the toggle silently
failing to persist under the Electron shell, which guards `store:set` with a zod enum over that
tuple. The `settings` blob is already allowlisted on both sides and typed
`Record<string, unknown>` / `z.unknown()`, so a new field inside it needs no schema change anywhere —
the same mechanism `discord::settings` uses for its legacy flag. Absent still means off, and a
malformed blob still answers off.

Out of scope by design: lyrics re-search / alternative-match picking, and per-track timing offsets.
Both are real gaps, both are separate work.

## How to test

1. With the toggle off (the default), play tracks with LRCLIB-sourced lyrics and confirm nothing is
   written into your music folders.
2. Enable it, play a track whose lyrics come from LRCLIB, and confirm a `.lrc` appears beside the
   file and is picked up on the next play with the network disabled.
3. Put a read-only folder in the library and confirm a refused write does not surface an error.
4. Run the library-wide pass, cancel it mid-run, and check the summary counts.
5. `cargo test -p shiranami-integrations` (226 tests) and `pnpm test`.

## Notes for review

- `packages/contracts/src/generated/bindings.ts` was hand-applied from a scaffold in a crate that
  does run, because `cargo test -p shiranami-desktop --lib bindings` cannot launch on the
  development machine (`STATUS_ENTRYPOINT_NOT_FOUND`, reproducible on a clean checkout). The diff is
  additions-only in the generator's style, but **CI's regenerate-and-diff gate is the authority
  here** — this is the one part of the branch that could not be verified locally.
- Pre-existing failures unrelated to this change, all verified identical on clean `v2`: 15
  `shiranami-core` plus `shiranami-db`/`downloader`/`serve` Unix-path and process-spawn tests failing
  on Windows, and `format:check` / `cargo fmt --check` flagging untouched files because
  `core.autocrlf=true` yields a CRLF tree against LF-emitting tooling.

## Linked issue

None.
