### PR TITLE
feat(appearance): custom background images and GIFs as a sixth theme

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/boot/reconcile.rs
+++ b/apps/desktop-tauri/src-tauri/src/boot/reconcile.rs
@@ -16,6 +16,7 @@
 //! | queue hydrate and resume | immediately             | IPC registration              |
 //! | tool status              | immediately             | `fetchAndCacheToolStatus()`   |
 //! | art orphan prune         | immediately             | `pruneOrphanedAlbumArt()`     |
+//! | background sweep         | immediately             | v2-born; see `sweep_backgrounds` |
 //! | updater first check      | 5 s, then hourly        | `app/updater.ts`              |
 //! | recommendation refresh   | 30 s, stale-gated       | `REFRESH_STARTUP_DELAY_MS`    |
 //! | scrobbler flush          | every 60 s              | `FLUSH_INTERVAL_MS`           |
@@ -24,7 +25,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use shiranami_metadata::art;
+use shiranami_metadata::{art, background};
 use tauri::{AppHandle, Manager as _};
 
 use crate::boot::services::{DiscordService, Handles};
@@ -39,6 +40,7 @@ pub fn spawn(app: &AppHandle, e2e: bool, handles: &Handles) {
     hydrate_download_queue(app);
     warm_tool_status(app);
     prune_album_art(app);
+    sweep_backgrounds(app);
 
     if e2e {
         // v1 gated the scrobbler and the recommendation refresh in the same
@@ -141,6 +143,50 @@ fn prune_album_art(app: &AppHandle) {
                 "album-art prune complete"
             ),
             Err(error) => tracing::warn!(?error, "the album-art prune did not complete"),
+        }
+    });
+}
+
+/// Collect background files the current record does not name.
+///
+/// The same shape as [`prune_album_art`] and for the same reason, but with a far
+/// smaller reference set: one settings entry rather than two table scans. What
+/// carries over exactly is the fail-safe — the sweep is handed a
+/// [`BackgroundReference`], which has no variant a failed read can be squeezed
+/// into, so "the record did not parse" cannot arrive at the deletion site
+/// wearing the face of "nothing is referenced".
+///
+/// What this collects: the predecessor of every replacement, and any file
+/// orphaned by a crash between the copy and the record that names it.
+fn sweep_backgrounds(app: &AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let Some(state) = app.try_state::<AppState>() else {
+            return;
+        };
+        let Ok(data_dir) = app.path().app_data_dir() else {
+            return;
+        };
+
+        // Read inside the closure, not before it: `off_thread` schedules, so a
+        // reference resolved out here would be a snapshot taken before the scan
+        // it guards. An import completing in that window would look like an
+        // orphan and be deleted out from under the record naming it.
+        let settings = std::sync::Arc::clone(state.settings());
+        let report = crate::wire::off_thread("sweep orphaned backgrounds", move || {
+            let reference = crate::commands::background::read_record(&settings);
+            Ok(background::sweep_orphans(&data_dir, &reference))
+        })
+        .await;
+
+        match report {
+            Ok(report) => tracing::info!(
+                scanned = report.scanned,
+                deleted = report.deleted,
+                referenced = report.referenced,
+                "background sweep complete"
+            ),
+            Err(error) => tracing::warn!(?error, "the background sweep did not complete"),
         }
     });
 }

--- a/apps/desktop-tauri/src-tauri/src/boot/sequence.rs
+++ b/apps/desktop-tauri/src-tauri/src/boot/sequence.rs
@@ -278,8 +278,12 @@ pub async fn finish(app: &AppHandle, preflight: &mut Preflight) -> Result<Booted
     // server hands out back into the files under it, so the two reading a
     // different directory would silently cost every now-playing thumbnail.
     let art_dir = shiranami_metadata::art::art_dir(&data_dir);
-    let mut serve_config =
-        shiranami_serve::ServeConfig::new(Arc::clone(&cache), art_dir.clone(), (*http).clone());
+    let mut serve_config = shiranami_serve::ServeConfig::new(
+        Arc::clone(&cache),
+        art_dir.clone(),
+        shiranami_metadata::background::background_dir(&data_dir),
+        (*http).clone(),
+    );
     // The radio proxy de-frames ICY metadata but has no `AppHandle` to announce
     // it with (§2.1: the crates never reach for the composition root), so the
     // crossing is a callback the composition root supplies. It runs on the task

--- a/apps/desktop-tauri/src-tauri/src/commands/background.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/background.rs
@@ -1,0 +1,242 @@
+//! `background:*` — import, read and clear the user's custom app background.
+//!
+//! Three v2-born commands with no v1 channel behind them, so nothing here is a
+//! compatibility port. The work lives in
+//! [`shiranami_metadata::background`]; this file is the wiring §2.1 says it
+//! should be.
+//!
+//! # The picker opens *here*, and the path never crosses the boundary
+//!
+//! The obvious shape would be `dialog_open_file` in the renderer followed by
+//! `background_set(path)`. That shape is rejected. It would make the renderer
+//! the thing that names a file for the backend to read, and the read gate
+//! [`crate::paths::ensure_allowed`] cannot cover it: a wallpaper legitimately
+//! lives in Pictures, outside every allowed root, so the command would have to
+//! opt out of containment entirely and accept any path it was handed.
+//!
+//! Opening the dialog inside the command closes that: the only path
+//! [`background_pick`] ever reads is one the user chose in a native picker
+//! parented to our own window, and the renderer learns nothing but the content-
+//! addressed name of the copy. It is the same reasoning that keeps the webview
+//! without a dialog capability at all — see [`crate::commands::dialog`].
+//!
+//! # Write the record, then sweep — never the other way round
+//!
+//! Importing a replacement leaves the previous wallpaper on disk, and the order
+//! the two steps run in decides which failure a crash produces. Persisting first
+//! means a crash costs an unreferenced file that the next sweep collects.
+//! Deleting first would mean a crash leaves the *record* pointing at a file that
+//! is already gone — a broken background the user has to notice and fix. One of
+//! those is invisible housekeeping and the other is a bug report.
+
+use std::path::PathBuf;
+
+use shiranami_core::store::{MainStoreKey, SettingsStore};
+use shiranami_metadata::background::{
+    ALLOWED_EXTENSIONS, BackgroundReference, CustomBackground, background_dir, import_background,
+    sweep_orphans,
+};
+use tauri::{AppHandle, State};
+use tauri_plugin_dialog::DialogExt as _;
+
+use crate::error::{CommandResult, WireResultExt as _, bad_request};
+use crate::state::AppState;
+
+/// Register this namespace's commands with [`crate::commands::registry`].
+macro_rules! commands {
+    (queue = [$($tail:ident,)*], collected = [$($collected:tt)*]) => {
+        crate::commands::registry::gather! {
+            queue = [$($tail,)*],
+            collected = [$($collected)*
+                crate::commands::background::background_pick,
+                crate::commands::background::background_get,
+                crate::commands::background::background_clear,
+            ]
+        }
+    };
+}
+pub(crate) use commands;
+
+/// `background:pick` — choose an image and adopt it, or `null` if cancelled.
+///
+/// Cancelling is not an error, matching every other picker in the app: the
+/// renderer's "the user changed their mind" branch is an `if`, not a `catch`.
+/// A *refusal* is an error, and a specific one — see
+/// `shiranami_core::error::codes::background`.
+#[tauri::command]
+#[specta::specta]
+pub async fn background_pick(
+    app: AppHandle,
+    window: tauri::Window,
+    state: State<'_, AppState>,
+) -> CommandResult<Option<CustomBackground>> {
+    let Some(source) = pick_image(&window).await else {
+        return Ok(None);
+    };
+
+    let data_dir = crate::paths::data_dir(&app)?;
+    let settings = std::sync::Arc::clone(state.settings());
+
+    let record = blocking("the background import", {
+        let data_dir = data_dir.clone();
+        move || import_background(&data_dir, &source)
+    })
+    .await?
+    .wire()?;
+
+    settings
+        .set_main(
+            MainStoreKey::AppearanceCustomBackground,
+            serde_json::to_value(&record).map_err(|error| {
+                bad_request(format!("the background record did not serialise: {error}"))
+            })?,
+        )
+        .wire()?;
+
+    // Only now is the predecessor unreferenced. See the module docs on ordering.
+    let swept = record.clone();
+    blocking("the background sweep", move || {
+        sweep_orphans(&data_dir, &BackgroundReference::Known(Some(swept)))
+    })
+    .await?;
+
+    Ok(Some(record))
+}
+
+/// `background:get` — the current background, if one is set and still on disk.
+///
+/// Self-healing: a record naming a file that has vanished (an external delete, a
+/// restored profile, a half-copied app-data move) is removed rather than
+/// returned, so the renderer never has to render a URL that 404s. The filesystem
+/// is the source of truth for existence; the settings entry only names things.
+#[tauri::command]
+#[specta::specta]
+pub async fn background_get(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> CommandResult<Option<CustomBackground>> {
+    let BackgroundReference::Known(Some(mut record)) = read_record(state.settings()) else {
+        // Unreadable is deliberately *not* healed. Deleting a value this process
+        // could not parse would destroy the only evidence of what went wrong, and
+        // the cost of keeping it is one background that does not paint.
+        return Ok(None);
+    };
+
+    // Both files are checked, not just the main one. A record whose *still* has
+    // gone missing is the worse shape of the two: the renderer would resolve to
+    // it under reduced motion, paint a URL that 404s, and still report that a
+    // background exists — scrim and chrome rules over nothing. Dropping the
+    // stale name degrades that to "the animation plays", which is a preference
+    // not honoured rather than a broken screen.
+    let directory = background_dir(&crate::paths::data_dir(&app)?);
+    let names = (record.file_name.clone(), record.still_file_name.clone());
+    let (main_exists, still_exists) = blocking("the background existence check", move || {
+        let (file_name, still) = names;
+        (
+            directory.join(file_name).is_file(),
+            still.is_none_or(|name| directory.join(name).is_file()),
+        )
+    })
+    .await?;
+
+    if !main_exists {
+        tracing::warn!("the imported background is gone from disk; clearing the record");
+        state
+            .settings()
+            .delete_main(MainStoreKey::AppearanceCustomBackground)
+            .wire()?;
+        return Ok(None);
+    }
+
+    if !still_exists {
+        tracing::warn!("the background's poster still is gone; falling back to the animation");
+        record.still_file_name = None;
+    }
+
+    Ok(Some(record))
+}
+
+/// `background:clear` — forget the background and delete its files.
+#[tauri::command]
+#[specta::specta]
+pub async fn background_clear(app: AppHandle, state: State<'_, AppState>) -> CommandResult<()> {
+    state
+        .settings()
+        .delete_main(MainStoreKey::AppearanceCustomBackground)
+        .wire()?;
+
+    // The record is gone, which is the part the user asked for and the part that
+    // decides what the app shows. Tidying the bytes is housekeeping, so a
+    // failure here is logged rather than returned: answering "the background
+    // could not be removed" after it demonstrably has been would leave the
+    // renderer holding a record the backend no longer has.
+    let data_dir = crate::paths::data_dir(&app)?;
+    match blocking("the background sweep", move || {
+        sweep_orphans(&data_dir, &BackgroundReference::Known(None))
+    })
+    .await
+    {
+        Ok(report) => tracing::debug!(deleted = report.deleted, "background cleared"),
+        Err(error) => tracing::warn!(?error, "the background files were not swept"),
+    }
+
+    Ok(())
+}
+
+/// Read the stored record, distinguishing "unset" from "unreadable".
+///
+/// The two are the same `Option` to a naive reader and must never be the same
+/// answer to the sweep — see [`shiranami_metadata::background::sweep`], where
+/// one of them deletes files and the other refuses to.
+pub(crate) fn read_record(settings: &SettingsStore) -> BackgroundReference {
+    // A quarantined document reads absent for *every* key, so "no background is
+    // set" and "the settings file was corrupt this boot" are indistinguishable
+    // below — and one of them authorises deleting the user's wallpaper while the
+    // quarantined backup beside it still names the file. Answering `Unreadable`
+    // is the same refusal the album-art prune makes when its lookup fails.
+    if settings.started_from_quarantine() {
+        return BackgroundReference::Unreadable;
+    }
+
+    let Some(value) = settings.get_main(MainStoreKey::AppearanceCustomBackground) else {
+        return BackgroundReference::Known(None);
+    };
+
+    match serde_json::from_value::<CustomBackground>(value) {
+        Ok(record) => BackgroundReference::Known(Some(record)),
+        Err(error) => {
+            tracing::warn!(%error, "the stored background record did not parse");
+            BackgroundReference::Unreadable
+        }
+    }
+}
+
+/// Open the native picker, filtered to the formats the importer accepts.
+///
+/// The filter is advisory — a user can always type a name past it — which is
+/// why the importer re-checks the extension and then the bytes behind it.
+async fn pick_image(window: &tauri::Window) -> Option<PathBuf> {
+    let (sender, mut receiver) = tauri::async_runtime::channel(1);
+
+    window
+        .dialog()
+        .file()
+        .set_parent(window)
+        .add_filter("Images", &ALLOWED_EXTENSIONS)
+        .pick_file(move |picked| {
+            let _ = sender.try_send(picked.and_then(|path| path.into_path().ok()));
+        });
+
+    receiver.recv().await.flatten()
+}
+
+/// Run blocking disk work off the webview's thread, per §2.3.
+async fn blocking<T, F>(what: &'static str, work: F) -> CommandResult<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(work)
+        .await
+        .map_err(|error| bad_request(format!("{what} panicked: {error}")))
+}

--- a/apps/desktop-tauri/src-tauri/src/commands/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/mod.rs
@@ -41,6 +41,7 @@ pub mod registry;
 // list, and a namespace listed there without a module here is a compile error.
 pub mod analysis;
 pub mod app;
+pub mod background;
 pub mod companion;
 pub mod db_backup;
 pub mod db_folders;

--- a/apps/desktop-tauri/src-tauri/src/commands/registry.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/registry.rs
@@ -61,7 +61,7 @@
 /// Raising it is how a lane records that it landed. Lowering it means a
 /// namespace was dropped, which is exactly the regression R13 names — museeks
 /// lost six features across its migration and noticed afterwards.
-pub const COMMAND_COUNT: usize = 152;
+pub const COMMAND_COUNT: usize = 155;
 
 /// The invoke half of the 155-channel parity checklist (§2.6): 135 invoke plus
 /// 20 events. [`COMMAND_COUNT`] may exceed it only by the commands that port no
@@ -71,7 +71,7 @@ pub const V1_INVOKE_CHANNEL_COUNT: usize = 135;
 /// Commands in this crate that port no v1 channel and are therefore not counted
 /// against [`V1_INVOKE_CHANNEL_COUNT`].
 ///
-/// Fifteen of them:
+/// Twenty of them:
 ///
 /// - `health_check`.
 /// - `dialog_save_file` — v1 opened its save panel inside the
@@ -110,7 +110,12 @@ pub const V1_INVOKE_CHANNEL_COUNT: usize = 135;
 /// - `radio_log_record` and `radio_log_get` — the radio diary. v1's stream
 ///   proxy declined ICY metadata, so no station title ever reached the app and
 ///   there was nothing to keep a record of. See [`crate::commands::radio`].
-pub const NON_V1_COMMANDS: usize = 17;
+/// - `background_pick`, `background_get` and `background_clear` — the custom
+///   app background. v1's themes were five bundled bitmaps and nothing else, so
+///   there was no import to have a channel for. `background_pick` opens its own
+///   dialog rather than taking a path, which is why it is not simply a caller of
+///   `dialog_open_file`. See [`crate::commands::background`].
+pub const NON_V1_COMMANDS: usize = 20;
 
 /// Every namespace, in one list, expanded through `$callback`.
 ///
@@ -131,6 +136,7 @@ macro_rules! namespace_list {
             // ══════════════ THE SHARED LINE LIST ══════════════
             analysis
             app
+            background
             companion
             db_backup
             db_folders

--- a/apps/desktop-tauri/src-tauri/src/commands/store.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/store.rs
@@ -196,6 +196,9 @@ mod tests {
             "downloads.toolStatusCache",
             "migrations.albumArtV1",
             "v2.crossoverPinged",
+            // Main-only because it *names a file the serve route will open*.
+            // Renderer-writable would mean the renderer chooses that name.
+            "appearance.customBackground",
         ] {
             let parsed: Result<RendererStoreKey, _> =
                 serde_json::from_value(Value::String(main_only.to_owned()));

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -76,6 +76,7 @@ import { useRadioDiaryRecorder } from '@/hooks/useRadioDiaryRecorder';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { useSanctuaryAutoEnter } from '@/hooks/useSanctuaryAutoEnter';
 import { useTempoBreathingPublisher } from '@/hooks/useTempoBreathing';
+import { useReconcileCustomTheme } from '@/hooks/queries/useCustomBackground';
 import { useDebugPanel } from '@/hooks/useDebugPanel';
 import { DevProfiler } from '@/components/debug/DevProfiler';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
@@ -155,6 +156,7 @@ function App() {
   useKeyboardShortcuts();
   useSanctuaryAutoEnter();
   useTempoBreathingPublisher();
+  useReconcileCustomTheme();
   const debugOpen = useDebugPanel();
 
   useEffect(() => {

--- a/apps/web/src/components/onboarding/steps/AppearanceStep/AppearanceStep.tsx
+++ b/apps/web/src/components/onboarding/steps/AppearanceStep/AppearanceStep.tsx
@@ -71,7 +71,11 @@ export default function AppearanceStep() {
       <div className="space-y-4">
         <div className="space-y-3">
           <p className="text-xs font-medium text-foreground">{t('appearance.themeTitle')}</p>
-          <ThemeTileGrid value={theme} onSelect={onSelectTheme} columns={2} />
+          {/* No custom tile during first run: selecting it opens a native file
+              picker, and a modal OS dialog inside onboarding is a different
+              contract from the same affordance in Settings. It stays one tap
+              away in Appearance once the app is actually running. */}
+          <ThemeTileGrid value={theme} onSelect={onSelectTheme} columns={2} showCustom={false} />
           <p className="text-center text-[11px] text-muted-foreground/70">
             {t('appearance.themeHint')}
           </p>

--- a/apps/web/src/components/settings/AppearanceSection/AppearanceSection.hooks.ts
+++ b/apps/web/src/components/settings/AppearanceSection/AppearanceSection.hooks.ts
@@ -7,7 +7,7 @@ import {
   UI_SCALE_DEFAULT,
   UI_SCALE_PRESETS,
 } from '@/stores/useUIStore';
-import { useThemeStore } from '@/stores/useThemeStore';
+import { useThemeStore, CUSTOM_THEME } from '@/stores/useThemeStore';
 import {
   useThemeBgStore,
   THEME_BG_OPACITY_MIN,
@@ -22,8 +22,16 @@ import {
   THEME_BG_DIM_MAX,
   THEME_BG_DIM_STEP,
   THEME_BG_DIM_DEFAULT,
+  THEME_BG_FITS,
+  THEME_BG_FIT_DEFAULT,
 } from '@/stores/useThemeBgStore';
 import { useAccentStore } from '@/stores/useAccentStore';
+import {
+  backgroundUrls,
+  useCustomBackgroundQuery,
+  usePickCustomBackground,
+  useClearCustomBackground,
+} from '@/hooks/queries/useCustomBackground';
 import { SUPPORTED_LANGUAGES, persistLanguage, type SupportedLanguage } from '@/lib/i18n';
 import type { IAppearanceSectionView } from './AppearanceSection.types';
 
@@ -41,7 +49,16 @@ export function useAppearanceSection(): IAppearanceSectionView {
   const setBgBlur = useThemeBgStore(s => s.setBgBlur);
   const bgDim = useThemeBgStore(s => s.bgDim);
   const setBgDim = useThemeBgStore(s => s.setBgDim);
+  const bgFit = useThemeBgStore(s => s.bgFit);
+  const setBgFit = useThemeBgStore(s => s.setBgFit);
   const resetBg = useThemeBgStore(s => s.resetBg);
+  const {
+    data: customBackground,
+    isError: customBackgroundFailed,
+    refetch: refetchCustomBackground,
+  } = useCustomBackgroundQuery();
+  const pickBackground = usePickCustomBackground();
+  const clearBackground = useClearCustomBackground();
   const accentColor = useAccentStore(s => s.accentColor);
   const resetAccent = useAccentStore(s => s.resetAccent);
   const followArtAccent = useAccentStore(s => s.followArtAccent);
@@ -61,7 +78,10 @@ export function useAppearanceSection(): IAppearanceSectionView {
   const isBgModified =
     bgOpacity !== THEME_BG_OPACITY_DEFAULT ||
     bgBlur !== THEME_BG_BLUR_DEFAULT ||
-    bgDim !== THEME_BG_DIM_DEFAULT;
+    bgDim !== THEME_BG_DIM_DEFAULT ||
+    bgFit !== THEME_BG_FIT_DEFAULT;
+
+  const isCustomTheme = theme === CUSTOM_THEME;
 
   function onSelectLanguage(lang: SupportedLanguage): void {
     void i18n.changeLanguage(lang);
@@ -85,8 +105,24 @@ export function useAppearanceSection(): IAppearanceSectionView {
     onResetUiScale: resetUiScale,
 
     theme,
-    hasThemeBackground: theme !== 'none',
+    // `custom` unlocks the same adjust panel every other image theme gets, but
+    // only once an image actually resolves: sliders over an empty background
+    // adjust nothing and read as broken.
+    // `!= null`, not `!== null`: `data` is `undefined` while the query is in
+    // flight and after it fails, and the strict form reads that as "yes there is
+    // one" — opening the adjust panel over a preview that correctly renders
+    // nothing, which is the broken-looking state this gate exists to prevent.
+    hasThemeBackground: isCustomTheme ? customBackground != null : theme !== 'none',
     onSelectTheme: setTheme,
+
+    isCustomTheme,
+    customThumb: backgroundUrls(customBackground).url,
+    hasCustomBackground: customBackground != null,
+    isPickingBackground: pickBackground.isPending,
+    customBackgroundFailed,
+    onRetryCustomBackground: () => void refetchCustomBackground(),
+    onPickBackground: () => pickBackground.mutate(),
+    onClearBackground: () => clearBackground.mutate(),
 
     isBgModified,
     bgOpacity,
@@ -106,6 +142,9 @@ export function useAppearanceSection(): IAppearanceSectionView {
     onSetBgOpacity: setBgOpacity,
     onSetBgBlur: setBgBlur,
     onSetBgDim: setBgDim,
+    bgFit,
+    bgFitOptions: THEME_BG_FITS,
+    onSetBgFit: setBgFit,
     onResetBg: resetBg,
 
     hasAccentOverride: accentColor !== null || followArtAccent,

--- a/apps/web/src/components/settings/AppearanceSection/AppearanceSection.stories.tsx
+++ b/apps/web/src/components/settings/AppearanceSection/AppearanceSection.stories.tsx
@@ -4,6 +4,8 @@ import { useThemeStore } from '@/stores/useThemeStore';
 import { useThemeBgStore } from '@/stores/useThemeBgStore';
 import { useAccentStore } from '@/stores/useAccentStore';
 import { useUIStore } from '@/stores/useUIStore';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { customBackgroundKeys } from '@/hooks/queries/useCustomBackground';
 
 import AppearanceSection from './AppearanceSection';
 
@@ -25,11 +27,19 @@ const meta: Meta<typeof AppearanceSection> = {
   // component-file change out of this story's scope. The labelled siblings
   // (LyricsSection) are ratcheted to 'error' instead.
   decorators: [
-    Story => (
-      <div className="max-w-[680px] p-4">
-        <Story />
-      </div>
-    ),
+    // The Theme card reads the imported-background record, so every story needs
+    // a client. Seeded empty; the Custom story overrides it.
+    Story => {
+      const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      client.setQueryData(customBackgroundKeys.current, null);
+      return (
+        <QueryClientProvider client={client}>
+          <div className="max-w-[680px] p-4">
+            <Story />
+          </div>
+        </QueryClientProvider>
+      );
+    },
   ],
 };
 
@@ -79,5 +89,26 @@ export const ThemedWithAccent: Story = {
     // its labels, and three sliders are exposed (opacity / blur / dim).
     await expect(canvas.getByText('Background adjustments')).toBeInTheDocument();
     await expect(canvas.getAllByRole('slider')).toHaveLength(4);
+  },
+};
+
+/**
+ * The custom theme with nothing imported yet: the picker is offered and the
+ * adjust panel stays hidden, because sliders over an empty background adjust
+ * nothing and read as broken.
+ */
+export const CustomThemeEmpty: Story = {
+  decorators: [
+    Story => {
+      useUIStore.setState({ uiScale: 100 });
+      useThemeStore.setState({ theme: 'custom' });
+      useAccentStore.setState({ accentColor: null });
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: /Choose an image/ })).toBeInTheDocument();
+    await expect(canvas.queryByText('Background adjustments')).not.toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/settings/AppearanceSection/AppearanceSection.test.tsx
+++ b/apps/web/src/components/settings/AppearanceSection/AppearanceSection.test.tsx
@@ -1,11 +1,38 @@
+import type { ReactElement } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useUIStore } from '@/stores/useUIStore';
 import { useThemeStore } from '@/stores/useThemeStore';
 import { useAccentStore } from '@/stores/useAccentStore';
+import { customBackgroundKeys } from '@/hooks/queries/useCustomBackground';
+import type { CustomBackground } from '@shiranami/contracts/bindings';
 
 import AppearanceSection from './AppearanceSection';
+
+vi.mock('@/lib/bridge/stream-urls', () => ({
+  toBackgroundUrl: (fileName: string) => `http://127.0.0.1:1234/tok/background/${fileName}`,
+}));
+
+const IMPORTED: CustomBackground = {
+  fileName: 'bg-abc.png',
+  stillFileName: null,
+  width: 1920,
+  height: 1080,
+  animated: false,
+};
+
+function renderSection(record: CustomBackground | null = null): void {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  client.setQueryData(customBackgroundKeys.current, record);
+  const ui: ReactElement = (
+    <QueryClientProvider client={client}>
+      <AppearanceSection />
+    </QueryClientProvider>
+  );
+  render(ui);
+}
 
 function reset(): void {
   useUIStore.setState({ uiScale: 100 });
@@ -19,7 +46,7 @@ afterEach(reset);
 
 describe('AppearanceSection', () => {
   it('renders the language, theme, and accent cards', () => {
-    render(<AppearanceSection />);
+    renderSection();
 
     expect(screen.getByRole('heading', { name: 'Language & scale' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Theme' })).toBeInTheDocument();
@@ -30,10 +57,50 @@ describe('AppearanceSection', () => {
     const user = userEvent.setup();
     const setUiScale = vi.fn();
     useUIStore.setState({ setUiScale });
-    render(<AppearanceSection />);
+    renderSection();
 
     await user.click(screen.getByRole('button', { name: '120%' }));
 
     expect(setUiScale).toHaveBeenCalledWith(120);
+  });
+
+  it('offers the picker only once the custom theme is selected', () => {
+    renderSection();
+    expect(screen.queryByRole('button', { name: /Choose an image/ })).not.toBeInTheDocument();
+  });
+
+  it('offers the picker when the custom theme is selected', () => {
+    useThemeStore.setState({ theme: 'custom' });
+
+    renderSection();
+
+    expect(screen.getByRole('button', { name: /Choose an image/ })).toBeInTheDocument();
+  });
+
+  it('offers replace and remove once an image is imported', () => {
+    useThemeStore.setState({ theme: 'custom' });
+
+    renderSection(IMPORTED);
+
+    expect(screen.getByRole('button', { name: /Replace image/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Remove/ })).toBeInTheDocument();
+  });
+
+  it('offers the fit toggle only for an imported image', () => {
+    // The five bundled photos are composed for `cover`; offering to letterbox
+    // one would be offering a worse version of a deliberate crop.
+    useThemeStore.setState({ theme: 'lofi-night' });
+
+    renderSection();
+
+    expect(screen.queryByRole('radiogroup', { name: 'Fit' })).not.toBeInTheDocument();
+  });
+
+  it('offers the fit toggle for an imported image', () => {
+    useThemeStore.setState({ theme: 'custom' });
+
+    renderSection(IMPORTED);
+
+    expect(screen.getByRole('radiogroup', { name: 'Fit' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/settings/AppearanceSection/AppearanceSection.tsx
+++ b/apps/web/src/components/settings/AppearanceSection/AppearanceSection.tsx
@@ -1,4 +1,4 @@
-import { Languages, Paintbrush, Palette, RotateCcw } from 'lucide-react';
+import { ImagePlus, Languages, Paintbrush, Palette, RotateCcw, Trash2 } from 'lucide-react';
 import { SettingsCard, SettingsToggleRow } from '@/components/settings/SettingsCard';
 import { Slider } from '@/components/ui/slider';
 import { cn } from '@/lib/utils';
@@ -27,6 +27,14 @@ export default function AppearanceSection() {
     theme,
     hasThemeBackground,
     onSelectTheme,
+    isCustomTheme,
+    customThumb,
+    hasCustomBackground,
+    isPickingBackground,
+    customBackgroundFailed,
+    onRetryCustomBackground,
+    onPickBackground,
+    onClearBackground,
     isBgModified,
     bgOpacity,
     bgOpacityPercent,
@@ -45,6 +53,9 @@ export default function AppearanceSection() {
     onSetBgOpacity,
     onSetBgBlur,
     onSetBgDim,
+    bgFit,
+    bgFitOptions,
+    onSetBgFit,
     onResetBg,
     hasAccentOverride,
     onResetAccent,
@@ -79,6 +90,40 @@ export default function AppearanceSection() {
       )}
     >
       {preset.value}%
+    </button>
+  ));
+
+  const showBackgroundReadError = isCustomTheme && customBackgroundFailed;
+
+  // Roving tabindex: exactly one radio in a group is tabbable and the arrows
+  // move between them. Two native buttons both carrying `role="radio"` would
+  // otherwise put two stops in the tab order and answer nothing to an arrow
+  // key — a dead end in forms mode, even though it looks correct.
+  const onFitKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp'].includes(e.key)) return;
+    e.preventDefault();
+    const current = Math.max(0, bgFitOptions.indexOf(bgFit));
+    const delta = e.key === 'ArrowRight' || e.key === 'ArrowDown' ? 1 : -1;
+    onSetBgFit(bgFitOptions[(current + delta + bgFitOptions.length) % bgFitOptions.length]);
+  };
+
+  const fitButtons = bgFitOptions.map(option => (
+    <button
+      key={option}
+      type="button"
+      role="radio"
+      aria-checked={bgFit === option}
+      tabIndex={bgFit === option ? 0 : -1}
+      onClick={() => onSetBgFit(option)}
+      className={cn(
+        'rounded-lg border px-2.5 py-1.5 text-xs font-medium transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+        bgFit === option
+          ? 'border-primary/60 bg-primary/10 text-foreground'
+          : 'border-border/50 text-muted-foreground hover:text-foreground'
+      )}
+    >
+      {t(`app.bgAdjust.fitOptions.${option}`)}
     </button>
   ));
 
@@ -132,7 +177,53 @@ export default function AppearanceSection() {
 
       {/* Card 2 — Theme */}
       <SettingsCard icon={Palette} title={t('app.theme.title')} subtitle={t('app.theme.desc')}>
-        <ThemeTileGrid value={theme} onSelect={onSelectTheme} />
+        <ThemeTileGrid value={theme} onSelect={onSelectTheme} customThumb={customThumb} />
+
+        {isCustomTheme && (
+          <div className="mt-3 flex items-center gap-2 px-3">
+            {/* aria-disabled rather than disabled: a `disabled` button under the
+                user's focus leaves the a11y tree and blurs to <body>, and this
+                import runs for seconds on a large GIF — they would be tabbing
+                from the top of the document by the time it finished. */}
+            <button
+              type="button"
+              onClick={onPickBackground}
+              aria-disabled={isPickingBackground}
+              aria-busy={isPickingBackground}
+              aria-describedby="bg-format-hint"
+              className="flex items-center gap-1.5 rounded-lg border border-border/50 px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-disabled:pointer-events-none aria-disabled:opacity-60"
+            >
+              <ImagePlus className="size-3.5" />
+              {hasCustomBackground ? t('app.background.replace') : t('app.background.choose')}
+            </button>
+            {hasCustomBackground && (
+              <button
+                type="button"
+                onClick={onClearBackground}
+                className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <Trash2 className="size-3.5" />
+                {t('app.background.remove')}
+              </button>
+            )}
+            <p id="bg-format-hint" className="ml-auto text-[11px] text-muted-foreground">
+              {t('app.background.hint')}
+            </p>
+          </div>
+        )}
+
+        {showBackgroundReadError && (
+          <div className="mt-2 flex items-center gap-2 px-3" role="alert">
+            <p className="text-[11px] text-destructive">{t('app.background.errors.readFailed')}</p>
+            <button
+              type="button"
+              onClick={onRetryCustomBackground}
+              className="rounded-lg px-2 py-1 text-[11px] font-medium text-foreground underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {t('app.background.retry')}
+            </button>
+          </div>
+        )}
 
         {hasThemeBackground && (
           <div className="px-3 pt-4 border-t border-border/40 space-y-5">
@@ -199,6 +290,24 @@ export default function AppearanceSection() {
                 onValueChange={([v]) => onSetBgDim(v)}
               />
             </div>
+
+            {/* Fit — only meaningful for an imported image. The five bundled
+                photos are cropped for `cover`, so offering `contain` on them
+                would letterbox a picture that was composed not to be. */}
+            {isCustomTheme && (
+              <div>
+                <p className="text-sm font-medium text-foreground mb-1">{t('app.bgAdjust.fit')}</p>
+                <p className="text-xs text-muted-foreground mb-3">{t('app.bgAdjust.fitDesc')}</p>
+                <div
+                  role="radiogroup"
+                  aria-label={t('app.bgAdjust.fit')}
+                  onKeyDown={onFitKeyDown}
+                  className="flex gap-2"
+                >
+                  {fitButtons}
+                </div>
+              </div>
+            )}
 
             {/* Contained preview — the settings glass panel covers most of the
                 live canvas, so a scaled sample is the only honest way to judge

--- a/apps/web/src/components/settings/AppearanceSection/AppearanceSection.types.ts
+++ b/apps/web/src/components/settings/AppearanceSection/AppearanceSection.types.ts
@@ -1,5 +1,6 @@
 import type { useTranslation } from 'react-i18next';
 import type { ThemeId } from '@/stores/useThemeStore';
+import type { ThemeBgFit } from '@/stores/useThemeBgStore';
 import type { SupportedLanguage } from '@/lib/i18n';
 
 type TranslateFn = ReturnType<typeof useTranslation>['t'];
@@ -60,6 +61,28 @@ export interface IAppearanceSectionView {
   /** Select a theme. */
   readonly onSelectTheme: (theme: ThemeId) => void;
 
+  // --- Custom background ---
+  /** Whether the "your own image" theme is the active one. */
+  readonly isCustomTheme: boolean;
+  /** Loopback URL of the imported image, for the tile thumbnail. */
+  readonly customThumb: string | null;
+  /** Whether an image has been imported (controls the remove button). */
+  readonly hasCustomBackground: boolean;
+  /** Whether the native picker is open or the import is still running. */
+  readonly isPickingBackground: boolean;
+  /**
+   * Whether reading the imported background failed. Distinct from "none is
+   * imported": without the distinction a failed read looks like an empty state,
+   * and the card offers to import an image the user already has.
+   */
+  readonly customBackgroundFailed: boolean;
+  /** Try the read again. */
+  readonly onRetryCustomBackground: () => void;
+  /** Open the picker and import the chosen image. */
+  readonly onPickBackground: () => void;
+  /** Forget the imported image and delete its files. */
+  readonly onClearBackground: () => void;
+
   // --- Background adjustments ---
   /** Whether any background adjustment differs from default (shows reset). */
   readonly isBgModified: boolean;
@@ -91,6 +114,12 @@ export interface IAppearanceSectionView {
   readonly onSetBgBlur: (value: number) => void;
   /** Set background dim. */
   readonly onSetBgDim: (value: number) => void;
+  /** How the image fills the viewport. */
+  readonly bgFit: ThemeBgFit;
+  /** Every available fit mode, in display order. */
+  readonly bgFitOptions: readonly ThemeBgFit[];
+  /** Set the fit mode. */
+  readonly onSetBgFit: (value: ThemeBgFit) => void;
   /** Reset all background adjustments. */
   readonly onResetBg: () => void;
 

--- a/apps/web/src/components/settings/ThemeBackgroundPreview/ThemeBackgroundPreview.hooks.ts
+++ b/apps/web/src/components/settings/ThemeBackgroundPreview/ThemeBackgroundPreview.hooks.ts
@@ -1,22 +1,41 @@
 import { useTranslation } from 'react-i18next';
-import { useThemeStore } from '@/stores/useThemeStore';
+import { useThemeStore, CUSTOM_THEME } from '@/stores/useThemeStore';
 import { useThemeBgStore } from '@/stores/useThemeBgStore';
+import { backgroundUrls, useCustomBackgroundQuery } from '@/hooks/queries/useCustomBackground';
 import type { IThemeBackgroundPreviewView } from './ThemeBackgroundPreview.types';
 
+/**
+ * The preview's own copy of the source resolution.
+ *
+ * It deliberately does *not* freeze an animated import the way `ThemeBackground`
+ * does: this tile exists so the user can judge what they picked, and showing a
+ * still frame of the GIF they just chose would answer a question they did not
+ * ask. The full-bleed layer is where the motion preference is honoured.
+ */
 export function useThemeBackgroundPreview(): IThemeBackgroundPreviewView {
   const { t } = useTranslation('settings');
   const theme = useThemeStore(s => s.theme);
   const bgOpacity = useThemeBgStore(s => s.bgOpacity);
   const bgBlur = useThemeBgStore(s => s.bgBlur);
   const bgDim = useThemeBgStore(s => s.bgDim);
+  const bgFit = useThemeBgStore(s => s.bgFit);
+  const { data: record } = useCustomBackgroundQuery();
+
+  const isCustom = theme === CUSTOM_THEME;
+  const customUrl = isCustom ? backgroundUrls(record).url : null;
+  const hasBackground = isCustom ? customUrl !== null : theme !== 'none';
 
   return {
     theme,
-    hasBackground: theme !== 'none',
-    backgroundImage: `url(./themes/${theme}.webp)`,
+    hasBackground,
+    backgroundImage: `url("${customUrl ?? `./themes/${theme}.webp`}")`,
     bgOpacity,
     blurFilter: `blur(${bgBlur}px)`,
     bgDim,
+    // Mirrors the stylesheet, which scopes fit to `[data-theme='custom']`: a
+    // preview that letterboxed a bundled photo the real background renders
+    // full-bleed would be lying about the thing it exists to show.
+    bgFit: isCustom ? bgFit : 'cover',
     previewTrack: t('app.bgAdjust.previewTrack'),
     previewArtist: t('app.bgAdjust.previewArtist'),
   };

--- a/apps/web/src/components/settings/ThemeBackgroundPreview/ThemeBackgroundPreview.stories.tsx
+++ b/apps/web/src/components/settings/ThemeBackgroundPreview/ThemeBackgroundPreview.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { within, expect } from 'storybook/test';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useThemeStore } from '@/stores/useThemeStore';
 import { useThemeBgStore } from '@/stores/useThemeBgStore';
+import { customBackgroundKeys } from '@/hooks/queries/useCustomBackground';
 
 import ThemeBackgroundPreview from './ThemeBackgroundPreview';
 
@@ -23,11 +25,19 @@ const meta: Meta<typeof ThemeBackgroundPreview> = {
   title: 'settings/ThemeBackgroundPreview',
   component: ThemeBackgroundPreview,
   decorators: [
-    Story => (
-      <div className="max-w-[420px] p-4">
-        <Story />
-      </div>
-    ),
+    // The preview reads the imported-background record now, so every story
+    // needs a client. Seeded empty: these stories all show bundled themes.
+    Story => {
+      const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      client.setQueryData(customBackgroundKeys.current, null);
+      return (
+        <QueryClientProvider client={client}>
+          <div className="max-w-[420px] p-4">
+            <Story />
+          </div>
+        </QueryClientProvider>
+      );
+    },
   ],
 };
 

--- a/apps/web/src/components/settings/ThemeBackgroundPreview/ThemeBackgroundPreview.test.tsx
+++ b/apps/web/src/components/settings/ThemeBackgroundPreview/ThemeBackgroundPreview.test.tsx
@@ -1,13 +1,40 @@
+import type { ReactElement } from 'react';
 import { render, screen } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useThemeStore } from '@/stores/useThemeStore';
 import { useThemeBgStore } from '@/stores/useThemeBgStore';
+import { customBackgroundKeys } from '@/hooks/queries/useCustomBackground';
+import type { CustomBackground } from '@shiranami/contracts/bindings';
 
 import ThemeBackgroundPreview from './ThemeBackgroundPreview';
 
+vi.mock('@/lib/bridge/stream-urls', () => ({
+  toBackgroundUrl: (fileName: string) => `http://127.0.0.1:1234/tok/background/${fileName}`,
+}));
+
+const IMPORTED: CustomBackground = {
+  fileName: 'bg-abc.png',
+  stillFileName: null,
+  width: 1920,
+  height: 1080,
+  animated: false,
+};
+
+function renderPreview(record: CustomBackground | null = null): HTMLElement {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  client.setQueryData(customBackgroundKeys.current, record);
+  const ui: ReactElement = (
+    <QueryClientProvider client={client}>
+      <ThemeBackgroundPreview />
+    </QueryClientProvider>
+  );
+  return render(ui).container;
+}
+
 function reset(): void {
   useThemeStore.setState({ theme: 'none' });
-  useThemeBgStore.setState({ bgOpacity: 1, bgBlur: 0, bgDim: 0 });
+  useThemeBgStore.setState({ bgOpacity: 1, bgBlur: 0, bgDim: 0, bgFit: 'cover' });
 }
 
 beforeEach(reset);
@@ -15,16 +42,46 @@ afterEach(reset);
 
 describe('ThemeBackgroundPreview', () => {
   it('renders nothing when no theme background is active', () => {
-    const { container } = render(<ThemeBackgroundPreview />);
-
-    expect(container).toBeEmptyDOMElement();
+    expect(renderPreview()).toBeEmptyDOMElement();
   });
 
   it('renders the sample chrome once a theme is selected', () => {
     useThemeStore.setState({ theme: 'lofi-night' });
-    render(<ThemeBackgroundPreview />);
+    renderPreview();
 
     expect(screen.getByText('Sample Track')).toBeInTheDocument();
     expect(screen.getByText('Now playing over your background')).toBeInTheDocument();
+  });
+
+  it('previews the imported image rather than a themes/custom.webp that does not exist', () => {
+    useThemeStore.setState({ theme: 'custom' });
+
+    const container = renderPreview(IMPORTED);
+
+    expect(container.querySelector('.theme-bg-image')).toHaveStyle({
+      backgroundImage: 'url(http://127.0.0.1:1234/tok/background/bg-abc.png)',
+    });
+  });
+
+  it('renders nothing for the custom theme while no image is imported', () => {
+    useThemeStore.setState({ theme: 'custom' });
+
+    expect(renderPreview(null)).toBeEmptyDOMElement();
+  });
+
+  it('reflects the sliders and the fit mode, so the preview is honest', () => {
+    // The implementation this feature is modelled on showed the raw image at
+    // full opacity while the user dragged three sliders that changed nothing
+    // they could see. This is the assertion that we do not.
+    useThemeStore.setState({ theme: 'custom' });
+    useThemeBgStore.setState({ bgOpacity: 0.4, bgBlur: 6, bgDim: 0.3, bgFit: 'contain' });
+
+    const image = renderPreview(IMPORTED).querySelector('.theme-bg-image');
+
+    expect(image).toHaveStyle({
+      opacity: '0.4',
+      filter: 'blur(6px)',
+      backgroundSize: 'contain',
+    });
   });
 });

--- a/apps/web/src/components/settings/ThemeBackgroundPreview/ThemeBackgroundPreview.tsx
+++ b/apps/web/src/components/settings/ThemeBackgroundPreview/ThemeBackgroundPreview.tsx
@@ -23,6 +23,7 @@ export default function ThemeBackgroundPreview() {
     bgOpacity,
     blurFilter,
     bgDim,
+    bgFit,
     previewTrack,
     previewArtist,
   } = useThemeBackgroundPreview();
@@ -37,6 +38,7 @@ export default function ThemeBackgroundPreview() {
         className="theme-bg-image absolute inset-0"
         style={{
           backgroundImage,
+          backgroundSize: bgFit,
           opacity: bgOpacity,
           filter: blurFilter,
         }}

--- a/apps/web/src/components/settings/ThemeBackgroundPreview/ThemeBackgroundPreview.types.ts
+++ b/apps/web/src/components/settings/ThemeBackgroundPreview/ThemeBackgroundPreview.types.ts
@@ -1,11 +1,16 @@
 import type { ThemeId } from '@/stores/useThemeStore';
+import type { ThemeBgFit } from '@/stores/useThemeBgStore';
 
 export interface IThemeBackgroundPreviewView {
   /** Active theme id; `'none'` hides the preview entirely. */
   readonly theme: ThemeId;
-  /** Whether a background image is active (theme is not `'none'`). */
+  /**
+   * Whether a background image is active. False for `'none'`, and for
+   * `'custom'` while no image resolves — otherwise the tile would render the
+   * scrim over an empty box and read as a broken preview.
+   */
   readonly hasBackground: boolean;
-  /** Resolved `url(...)` value for the active theme's WebP image. */
+  /** Resolved `url(...)` value: the theme's WebP, or the imported image. */
   readonly backgroundImage: string;
   /** Live image opacity (0–1) from the background-adjust slider. */
   readonly bgOpacity: number;
@@ -13,6 +18,8 @@ export interface IThemeBackgroundPreviewView {
   readonly blurFilter: string;
   /** Live dim-overlay opacity (0–1) from the slider. */
   readonly bgDim: number;
+  /** Live fit mode, so the tile crops the way the real background does. */
+  readonly bgFit: ThemeBgFit;
   /** Localized sample track title shown over the preview background. */
   readonly previewTrack: string;
   /** Localized sample artist line shown over the preview background. */

--- a/apps/web/src/components/shared/ThemeBackground/ThemeBackground.hooks.ts
+++ b/apps/web/src/components/shared/ThemeBackground/ThemeBackground.hooks.ts
@@ -1,23 +1,62 @@
-import { useThemeStore } from '@/stores/useThemeStore';
+import { useThemeStore, CUSTOM_THEME } from '@/stores/useThemeStore';
 import { useThemeBgStore } from '@/stores/useThemeBgStore';
+import { useDecorativeMotion } from '@/hooks/useDecorativeMotion';
+import { backgroundUrls, useCustomBackgroundQuery } from '@/hooks/queries/useCustomBackground';
 import type { IThemeBackgroundView } from './ThemeBackground.types';
 
 /**
- * Owns the theme-background state. Resolves the active theme and the inline
- * `./themes/<id>.webp` URL (document-relative so it resolves against
- * dist/index.html under Vite base './', exactly like the Appearance picker).
+ * Owns the theme-background state. Resolves the active theme and its image URL.
+ *
+ * Bundled themes keep the inline `./themes/<id>.webp` form (document-relative so
+ * it resolves against dist/index.html under Vite base './', exactly like the
+ * Appearance picker). `custom` instead names a file the shell copied into app
+ * data, served over the loopback origin — the webview has no filesystem reach,
+ * so this is the same road album art travels.
+ *
+ * # Freezing is a URL swap, and that is the whole design
+ *
+ * An animated wallpaper breaks the premise that keeps this layer alive under
+ * `lowPerformanceMode` (see the component doc: "a single static bitmap with no
+ * animation or blur"). The freeze is resolved *here*, by choosing the poster
+ * still the importer already encoded, so the painted markup never learns that
+ * animation exists: no `<img>`, no `<video>`, no canvas, no second branch in
+ * the layer that would have to keep the scrim in the right place twice.
+ *
+ * A GIF with no still — a record written before the importer encoded them —
+ * falls back to the animated file rather than to nothing. Showing the user's
+ * wallpaper when we cannot freeze it is the lesser of the two wrongs against a
+ * background that simply disappears when they enable low-performance mode.
  */
 export function useThemeBackground(): IThemeBackgroundView {
   const theme = useThemeStore(s => s.theme);
   // No-op selector: keep the store import alive (so its onRehydrate applies
-  // --theme-bg-opacity / --theme-bg-blur / --theme-bg-dim to the DOM) WITHOUT
-  // subscribing this full-bleed layer to state. The values are consumed purely
-  // as CSS variables, so re-rendering on every slider tick would be wasted work.
+  // --theme-bg-opacity / --theme-bg-blur / --theme-bg-dim / --theme-bg-fit to
+  // the DOM) WITHOUT subscribing this full-bleed layer to state. The values are
+  // consumed purely as CSS variables, so re-rendering on every slider tick
+  // would be wasted work.
   useThemeBgStore(() => null);
+
+  // These two do re-render the layer, and are meant to: one changes when the
+  // user imports or clears an image, the other when they toggle a motion
+  // preference. Neither fires during a drag.
+  const { data: record } = useCustomBackgroundQuery();
+  const motionAllowed = useDecorativeMotion();
+
+  if (theme !== CUSTOM_THEME) {
+    return { theme, hasThemeImage: theme !== 'none', imageUrl: `./themes/${theme}.webp` };
+  }
+
+  const { url, stillUrl } = backgroundUrls(record);
+  const frozen = !motionAllowed && record?.animated === true && stillUrl !== null;
+  const resolved = frozen ? stillUrl : url;
 
   return {
     theme,
-    hasThemeImage: theme !== 'none',
-    imageUrl: `./themes/${theme}.webp`,
+    // Unlike a bundled theme, `custom` can be selected while its image is
+    // missing — the record is healing, or the loopback origin has not answered
+    // yet. Painting the scrim over nothing is worse than painting nothing.
+    hasThemeImage: resolved !== null,
+    imageUrl: resolved ?? '',
+    isFrozen: frozen,
   };
 }

--- a/apps/web/src/components/shared/ThemeBackground/ThemeBackground.stories.tsx
+++ b/apps/web/src/components/shared/ThemeBackground/ThemeBackground.stories.tsx
@@ -1,29 +1,78 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useThemeStore } from '@/stores/useThemeStore';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useThemeStore, type ThemeId } from '@/stores/useThemeStore';
+import { useUIStore } from '@/stores/useUIStore';
+import { customBackgroundKeys } from '@/hooks/queries/useCustomBackground';
+import type { CustomBackground } from '@shiranami/contracts/bindings';
 import ThemeBackground from './ThemeBackground';
 
 /**
  * shared · ThemeBackground. The full-bleed, z-0 theme image + WCAG scrim painted
  * beneath the shell. Seeded with a non-"none" theme so the layer renders (the
  * default "none" theme deliberately renders nothing).
+ *
+ * The `custom` stories seed the query directly rather than going through
+ * `stream-urls`, whose base is only set inside the webview and is `null` here —
+ * so they name a placeholder origin that will not load. What they demonstrate is
+ * which *file* the layer resolved to, which is the decision this component owns.
  */
 const meta: Meta<typeof ThemeBackground> = {
   title: 'shared/ThemeBackground',
   component: ThemeBackground,
-  decorators: [
-    Story => {
-      useThemeStore.setState({ theme: 'lofi-night' });
-      return (
-        <div className="relative w-full h-64">
-          <Story />
-        </div>
-      );
-    },
-  ],
 };
 
 export default meta;
 
 type Story = StoryObj<typeof ThemeBackground>;
 
-export const Default: Story = {};
+const ANIMATED: CustomBackground = {
+  fileName: 'bg-abc.gif',
+  stillFileName: 'bg-abc.still.jpg',
+  width: 1920,
+  height: 1080,
+  animated: true,
+};
+
+function seeded(
+  theme: ThemeId,
+  record: CustomBackground | null,
+  lowPerformanceMode = false
+): NonNullable<Story['decorators']> {
+  return [
+    Story => {
+      useThemeStore.setState({ theme });
+      useUIStore.setState({ lowPerformanceMode });
+      const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      client.setQueryData(customBackgroundKeys.current, record);
+      return (
+        <QueryClientProvider client={client}>
+          <div className="relative w-full h-64">
+            <Story />
+          </div>
+        </QueryClientProvider>
+      );
+    },
+  ];
+}
+
+/** A bundled theme: the committed WebP, unchanged by any of this. */
+export const Default: Story = { decorators: seeded('lofi-night', null) };
+
+/** An imported animation, playing — the state a user sees by default. */
+export const CustomAnimated: Story = { decorators: seeded('custom', ANIMATED) };
+
+/** The same import, frozen to its poster still by low-performance mode. */
+export const CustomFrozen: Story = { decorators: seeded('custom', ANIMATED, true) };
+
+/** An imported still image, which low-performance mode never affects. */
+export const CustomStatic: Story = {
+  decorators: seeded('custom', {
+    ...ANIMATED,
+    fileName: 'bg-abc.png',
+    stillFileName: null,
+    animated: false,
+  }),
+};
+
+/** Custom selected with no image: renders nothing, rather than a bare scrim. */
+export const CustomMissing: Story = { decorators: seeded('custom', null) };

--- a/apps/web/src/components/shared/ThemeBackground/ThemeBackground.test.tsx
+++ b/apps/web/src/components/shared/ThemeBackground/ThemeBackground.test.tsx
@@ -1,30 +1,165 @@
+import type { ReactElement } from 'react';
 import { render } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useThemeStore } from '@/stores/useThemeStore';
+import { useUIStore } from '@/stores/useUIStore';
+import { customBackgroundKeys } from '@/hooks/queries/useCustomBackground';
+import type { CustomBackground } from '@shiranami/contracts/bindings';
 
 import ThemeBackground from './ThemeBackground';
 
+// The loopback base is only set inside the webview, so the URL builder answers
+// `null` under vitest. Stubbing it is what lets a test assert which of the two
+// files — the animation or its still — the layer resolved to.
+vi.mock('@/lib/bridge/stream-urls', () => ({
+  toBackgroundUrl: (fileName: string) => `http://127.0.0.1:1234/tok/background/${fileName}`,
+}));
+
+const ANIMATED: CustomBackground = {
+  fileName: 'bg-abc.gif',
+  stillFileName: 'bg-abc.still.jpg',
+  width: 1920,
+  height: 1080,
+  animated: true,
+};
+
+function renderWith(record: CustomBackground | null): HTMLElement {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  client.setQueryData(customBackgroundKeys.current, record);
+  const ui: ReactElement = (
+    <QueryClientProvider client={client}>
+      <ThemeBackground />
+    </QueryClientProvider>
+  );
+  return render(ui).container;
+}
+
 afterEach(() => {
   useThemeStore.setState({ theme: 'none' });
+  useUIStore.setState({ lowPerformanceMode: false });
 });
 
 describe('ThemeBackground', () => {
   it('renders nothing for the "none" theme', () => {
     useThemeStore.setState({ theme: 'none' });
 
-    const { container } = render(<ThemeBackground />);
-
-    expect(container).toBeEmptyDOMElement();
+    expect(renderWith(null)).toBeEmptyDOMElement();
   });
 
   it('paints the theme image + scrim for a non-"none" theme', () => {
     useThemeStore.setState({ theme: 'lofi-night' });
 
-    const { container } = render(<ThemeBackground />);
+    const container = renderWith(null);
 
     const image = container.querySelector('.theme-bg-image');
     expect(image).not.toBeNull();
     expect(image).toHaveStyle({ backgroundImage: 'url(./themes/lofi-night.webp)' });
     expect(container.querySelector('.theme-bg-scrim')).not.toBeNull();
+  });
+
+  it('paints the imported image for the "custom" theme', () => {
+    useThemeStore.setState({ theme: 'custom' });
+
+    const container = renderWith(ANIMATED);
+
+    expect(container.querySelector('.theme-bg-image')).toHaveStyle({
+      backgroundImage: 'url(http://127.0.0.1:1234/tok/background/bg-abc.gif)',
+    });
+  });
+
+  /**
+   * I1 — a custom image can never render un-scrimmed. The scrim is the only
+   * thing holding the contrast floor over a photo nobody vetted, and the whole
+   * reason the freeze is a URL swap rather than a second render branch is that
+   * a second branch is where a missing scrim would hide.
+   */
+  it('never renders the custom image without its scrim and dim layers', () => {
+    useThemeStore.setState({ theme: 'custom' });
+
+    for (const lowPerformanceMode of [false, true]) {
+      useUIStore.setState({ lowPerformanceMode });
+      const container = renderWith(ANIMATED);
+
+      expect(container.querySelector('.theme-bg-image')).not.toBeNull();
+      expect(container.querySelector('.theme-bg-scrim')).not.toBeNull();
+    }
+  });
+
+  /**
+   * I2 — an animated import freezes to its poster still under low-performance
+   * mode. This is what keeps the promise in the component doc that the layer is
+   * "a single static bitmap" honest for a GIF.
+   */
+  it('resolves an animated import to its still under low-performance mode', () => {
+    useThemeStore.setState({ theme: 'custom' });
+    useUIStore.setState({ lowPerformanceMode: true });
+
+    const container = renderWith(ANIMATED);
+
+    expect(container.querySelector('.theme-bg-image')).toHaveStyle({
+      backgroundImage: 'url(http://127.0.0.1:1234/tok/background/bg-abc.still.jpg)',
+    });
+  });
+
+  /** I2, the other input: the OS reduced-motion preference. */
+  it('resolves an animated import to its still under prefers-reduced-motion', () => {
+    useThemeStore.setState({ theme: 'custom' });
+    vi.spyOn(window, 'matchMedia').mockImplementation(
+      query =>
+        ({
+          matches: query === '(prefers-reduced-motion: reduce)',
+          media: query,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+          onchange: null,
+        }) as unknown as MediaQueryList
+    );
+
+    const container = renderWith(ANIMATED);
+
+    expect(container.querySelector('.theme-bg-image')).toHaveStyle({
+      backgroundImage: 'url(http://127.0.0.1:1234/tok/background/bg-abc.still.jpg)',
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('keeps a static import animating-irrelevant under low-performance mode', () => {
+    useThemeStore.setState({ theme: 'custom' });
+    useUIStore.setState({ lowPerformanceMode: true });
+
+    const container = renderWith({ ...ANIMATED, animated: false, stillFileName: null });
+
+    expect(container.querySelector('.theme-bg-image')).toHaveStyle({
+      backgroundImage: 'url(http://127.0.0.1:1234/tok/background/bg-abc.gif)',
+    });
+  });
+
+  /**
+   * An animated record written before the importer encoded stills has nothing
+   * to freeze to. Showing the animation beats showing nothing — the alternative
+   * is a background that vanishes when the user enables low-performance mode.
+   */
+  it('falls back to the animation when an animated record has no still', () => {
+    useThemeStore.setState({ theme: 'custom' });
+    useUIStore.setState({ lowPerformanceMode: true });
+
+    const container = renderWith({ ...ANIMATED, stillFileName: null });
+
+    expect(container.querySelector('.theme-bg-image')).toHaveStyle({
+      backgroundImage: 'url(http://127.0.0.1:1234/tok/background/bg-abc.gif)',
+    });
+  });
+
+  it('renders nothing for the "custom" theme while no image resolves', () => {
+    // The window between selecting `custom` and the record arriving — or after
+    // the file was deleted outside the app. Painting the scrim over an empty
+    // box would read as a broken background rather than as no background.
+    useThemeStore.setState({ theme: 'custom' });
+
+    expect(renderWith(null)).toBeEmptyDOMElement();
   });
 });

--- a/apps/web/src/components/shared/ThemeBackground/ThemeBackground.tsx
+++ b/apps/web/src/components/shared/ThemeBackground/ThemeBackground.tsx
@@ -13,10 +13,17 @@ import { useThemeBackground } from './ThemeBackground.hooks';
  *
  * The scrim ships in the same component as the image (never after) so no theme
  * can ever render un-scrimmed — it is the WCAG floor that keeps light
- * foreground text legible over the bright themes (summer/sunset). Both the
- * image and the scrim are deliberately retained under low-perf and
- * prefers-reduced-transparency: the image is a single static bitmap with no
- * animation or blur, so it carries the theme identity at near-zero cost.
+ * foreground text legible over the bright themes (summer/sunset) and over an
+ * imported image, which nobody has vetted at all. Both the image and the scrim
+ * are deliberately retained under low-perf and prefers-reduced-transparency:
+ * the image is a single static bitmap with no animation or blur, so it carries
+ * the theme identity at near-zero cost.
+ *
+ * That last sentence is a promise the `custom` theme could break, since an
+ * imported GIF is not a static bitmap. It does not, because the hook resolves
+ * an animated import to its poster still under exactly those two settings —
+ * the freeze happens in the URL, so the markup below stays one `background-image`
+ * div and the scrim cannot end up on the wrong side of a second branch.
  */
 export default function ThemeBackground() {
   const { hasThemeImage, imageUrl } = useThemeBackground();
@@ -27,7 +34,7 @@ export default function ThemeBackground() {
     <div className="fixed inset-0 z-0 overflow-hidden pointer-events-none" aria-hidden="true">
       <div
         className="theme-bg-image absolute inset-0"
-        style={{ backgroundImage: `url(${imageUrl})` }}
+        style={{ backgroundImage: `url("${imageUrl}")` }}
       />
       <div className="theme-bg-scrim absolute inset-0" />
       <div

--- a/apps/web/src/components/shared/ThemeBackground/ThemeBackground.types.ts
+++ b/apps/web/src/components/shared/ThemeBackground/ThemeBackground.types.ts
@@ -3,8 +3,21 @@ import type { ThemeId } from '@/stores/useThemeStore';
 export interface IThemeBackgroundView {
   /** Active theme id. `'none'` renders nothing (zero image bytes). */
   readonly theme: ThemeId;
-  /** False for the `'none'` theme — the full-bleed image + scrim are skipped. */
+  /**
+   * False for `'none'`, and for `'custom'` while no image resolves — a record
+   * being healed, or the loopback origin not yet reported.
+   */
   readonly hasThemeImage: boolean;
-  /** Document-relative URL of the committed theme WebP (`./themes/<id>.webp`). */
+  /**
+   * The image to paint: `./themes/<id>.webp` for a bundled theme, a loopback
+   * URL for an imported one. Empty string when `hasThemeImage` is false.
+   */
   readonly imageUrl: string;
+  /**
+   * Whether an animated import is showing its poster still instead of itself,
+   * because reduced-motion or low-performance mode is on. Always false for a
+   * bundled theme. Exposed so a story and a test can assert the freeze without
+   * reaching into URL strings.
+   */
+  readonly isFrozen?: boolean;
 }

--- a/apps/web/src/components/shared/theme/ThemeTileGrid/ThemeTileGrid.constants.ts
+++ b/apps/web/src/components/shared/theme/ThemeTileGrid/ThemeTileGrid.constants.ts
@@ -5,11 +5,22 @@ import type { ThemeId } from '@/stores/useThemeStore';
 // and renders a solid swatch so the default reads as "no photo". Lives in its
 // own module (not the shell) so the shell and its hook can both read it without
 // a circular `<shell> -> .hooks -> <shell>` import edge.
-export const THEME_TILES: Array<{ id: ThemeId; nameKey: string; thumb?: string }> = [
+export interface IThemeTile {
+  id: ThemeId;
+  nameKey: string;
+  thumb?: string;
+}
+
+export const THEME_TILES: IThemeTile[] = [
   { id: 'none', nameKey: 'none' },
   { id: 'lofi-night', nameKey: 'lofiNight', thumb: './themes/lofi-night.webp' },
   { id: 'snow', nameKey: 'snow', thumb: './themes/snow.webp' },
   { id: 'summer', nameKey: 'summer', thumb: './themes/summer.webp' },
   { id: 'sunset', nameKey: 'sunset', thumb: './themes/sunset.webp' },
   { id: 'wisteria', nameKey: 'wisteria', thumb: './themes/wisteria.webp' },
+  // Last, and the only tile whose thumb is not a committed asset: it is the
+  // user's own image, passed in as a prop because this grid is presentational
+  // and has no business fetching one. With no image imported yet it falls back
+  // to the same solid swatch `none` uses, which reads as "nothing here yet".
+  { id: 'custom', nameKey: 'custom' },
 ];

--- a/apps/web/src/components/shared/theme/ThemeTileGrid/ThemeTileGrid.hooks.ts
+++ b/apps/web/src/components/shared/theme/ThemeTileGrid/ThemeTileGrid.hooks.ts
@@ -1,14 +1,43 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { CUSTOM_THEME } from '@/stores/useThemeStore';
 import { THEME_TILES } from './ThemeTileGrid.constants';
 import type { IThemeTileGridProps, IThemeTileGridView } from './ThemeTileGrid.types';
 
 /**
- * Owns the theme-grid translator and the radiogroup roving arrow-key navigation
- * (the shell stays a thin, logic-free render). Arrow Right/Down move forward,
- * Left/Up move back, wrapping around the tile list.
+ * Owns the theme-grid translator, the visible tile list, and the radiogroup
+ * roving arrow-key navigation (the shell stays a thin, logic-free render).
+ * Arrow Right/Down move forward, Left/Up move back, wrapping around the list.
+ *
+ * Navigation is computed against the *visible* list rather than the constant.
+ * `findIndex` answers -1 for a tile that is not there, and `(-1 + delta + len) %
+ * len` lands on index 0 — so an arrow keypress while a hidden tile was selected
+ * would silently reset the theme to `none` instead of moving one step.
  */
-export function useThemeTileGrid({ value, onSelect }: IThemeTileGridProps): IThemeTileGridView {
+export function useThemeTileGrid({
+  value,
+  onSelect,
+  showCustom = true,
+  customThumb,
+}: IThemeTileGridProps): IThemeTileGridView {
   const { t } = useTranslation('settings');
+
+  const tiles = useMemo(
+    () =>
+      THEME_TILES.filter(tile => showCustom || tile.id !== CUSTOM_THEME).map(tile =>
+        tile.id === CUSTOM_THEME && customThumb ? { ...tile, thumb: customThumb } : tile
+      ),
+    [showCustom, customThumb]
+  );
+
+  // Falls back to the first tile when the selected theme is not on screen —
+  // which happens whenever onboarding is replayed by someone whose theme is
+  // `custom`. `findIndex` answers -1 there, and -1 is not merely a bad step:
+  // used as the roving index it leaves *no* tile with `tabIndex={0}`, so the
+  // whole radiogroup drops out of the tab order and the picker becomes
+  // keyboard-unreachable.
+  const found = tiles.findIndex(tile => tile.id === value);
+  const activeIndex = found === -1 ? 0 : found;
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (
@@ -19,11 +48,10 @@ export function useThemeTileGrid({ value, onSelect }: IThemeTileGridProps): IThe
     )
       return;
     e.preventDefault();
-    const currentIndex = THEME_TILES.findIndex(tile => tile.id === value);
     const delta = e.key === 'ArrowRight' || e.key === 'ArrowDown' ? 1 : -1;
-    const nextIndex = (currentIndex + delta + THEME_TILES.length) % THEME_TILES.length;
-    onSelect(THEME_TILES[nextIndex].id);
+    const nextIndex = (activeIndex + delta + tiles.length) % tiles.length;
+    onSelect(tiles[nextIndex].id);
   };
 
-  return { t, onKeyDown };
+  return { t, tiles, activeIndex, onKeyDown };
 }

--- a/apps/web/src/components/shared/theme/ThemeTileGrid/ThemeTileGrid.test.tsx
+++ b/apps/web/src/components/shared/theme/ThemeTileGrid/ThemeTileGrid.test.tsx
@@ -34,4 +34,38 @@ describe('ThemeTileGrid', () => {
 
     expect(onSelect).toHaveBeenCalledWith(THEME_TILES[0].id);
   });
+
+  it('hides the custom tile when asked, for onboarding', () => {
+    render(<ThemeTileGrid value="none" onSelect={vi.fn()} showCustom={false} />);
+
+    expect(screen.getAllByRole('radio')).toHaveLength(THEME_TILES.length - 1);
+  });
+
+  /**
+   * The trap this guards. Arrow navigation is index-based, and `findIndex`
+   * answers -1 for a tile that is not rendered — `(-1 + 1 + len) % len` is 0,
+   * so an arrow keypress would silently jump to the *first* tile instead of
+   * moving one step. Navigating the visible list rather than the constant is
+   * what makes the step honest.
+   */
+  it('steps from the last visible tile when the custom tile is hidden', () => {
+    const onSelect = vi.fn();
+    const visible = THEME_TILES.filter(tile => tile.id !== 'custom');
+    const last = visible[visible.length - 1].id;
+    render(<ThemeTileGrid value={last} onSelect={onSelect} showCustom={false} />);
+
+    fireEvent.keyDown(screen.getByRole('radiogroup'), { key: 'ArrowRight' });
+
+    expect(onSelect).toHaveBeenCalledWith(visible[0].id);
+    expect(onSelect).not.toHaveBeenCalledWith('custom');
+  });
+
+  it('uses the imported image as the custom tile thumbnail', () => {
+    render(
+      <ThemeTileGrid value="custom" onSelect={vi.fn()} customThumb="http://127.0.0.1:1/t/bg.png" />
+    );
+
+    const custom = screen.getAllByRole('radio')[THEME_TILES.length - 1];
+    expect(custom.querySelector('img')).toHaveAttribute('src', 'http://127.0.0.1:1/t/bg.png');
+  });
 });

--- a/apps/web/src/components/shared/theme/ThemeTileGrid/ThemeTileGrid.tsx
+++ b/apps/web/src/components/shared/theme/ThemeTileGrid/ThemeTileGrid.tsx
@@ -1,7 +1,6 @@
 import { Check } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useThemeTileGrid } from './ThemeTileGrid.hooks';
-import { THEME_TILES } from './ThemeTileGrid.constants';
 import type { IThemeTileGridProps } from './ThemeTileGrid.types';
 
 /**
@@ -11,9 +10,9 @@ import type { IThemeTileGridProps } from './ThemeTileGrid.types';
  */
 export default function ThemeTileGrid(props: IThemeTileGridProps) {
   const { value, onSelect, columns = 3 } = props;
-  const { t, onKeyDown } = useThemeTileGrid(props);
+  const { t, tiles: visibleTiles, activeIndex, onKeyDown } = useThemeTileGrid(props);
 
-  const tiles = THEME_TILES.map(tile => {
+  const tiles = visibleTiles.map((tile, index) => {
     const isActive = value === tile.id;
     const name = t(`app.theme.names.${tile.nameKey}`);
     return (
@@ -23,7 +22,7 @@ export default function ThemeTileGrid(props: IThemeTileGridProps) {
         role="radio"
         aria-checked={isActive}
         aria-label={t('app.theme.apply', { name })}
-        tabIndex={isActive ? 0 : -1}
+        tabIndex={index === activeIndex ? 0 : -1}
         onClick={() => onSelect(tile.id)}
         className={cn(
           'group relative aspect-video rounded-xl overflow-hidden border text-left transition-all',

--- a/apps/web/src/components/shared/theme/ThemeTileGrid/ThemeTileGrid.types.ts
+++ b/apps/web/src/components/shared/theme/ThemeTileGrid/ThemeTileGrid.types.ts
@@ -1,6 +1,7 @@
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { useTranslation } from 'react-i18next';
 import type { ThemeId } from '@/stores/useThemeStore';
+import type { IThemeTile } from './ThemeTileGrid.constants';
 
 type TranslateFn = ReturnType<typeof useTranslation>['t'];
 
@@ -9,11 +10,35 @@ export interface IThemeTileGridProps {
   readonly onSelect: (id: ThemeId) => void;
   /** Tailwind grid-column count (default 3, matching Settings · Appearance). */
   readonly columns?: 2 | 3;
+  /**
+   * Whether to offer the "your own image" tile. Default true.
+   *
+   * Onboarding passes false: selecting it opens a native file picker, and a
+   * modal OS dialog in the middle of first-run is a different contract from the
+   * same affordance in Settings, where the user came looking for it.
+   */
+  readonly showCustom?: boolean;
+  /** URL of the imported image, for the custom tile's thumbnail. */
+  readonly customThumb?: string | null;
 }
 
 export interface IThemeTileGridView {
   /** Bound `settings` namespace translator. */
   readonly t: TranslateFn;
+  /**
+   * The tiles to render, already filtered and with the custom thumb applied.
+   *
+   * The same list drives rendering *and* arrow-key navigation, which is the
+   * point of returning it: navigating a list that differs from the rendered one
+   * by even a single entry silently selects the wrong theme.
+   */
+  readonly tiles: readonly IThemeTile[];
+  /**
+   * Which tile holds `tabIndex={0}`. Equal to the selected tile's index, or 0
+   * when the selection is not among the visible tiles — otherwise the group
+   * would have no tab stop at all.
+   */
+  readonly activeIndex: number;
   /** Roving arrow-key navigation across the tiles (radiogroup pattern). */
   readonly onKeyDown: (e: ReactKeyboardEvent<HTMLDivElement>) => void;
 }

--- a/apps/web/src/hooks/queries/useCustomBackground.test.tsx
+++ b/apps/web/src/hooks/queries/useCustomBackground.test.tsx
@@ -1,0 +1,154 @@
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useThemeStore } from '@/stores/useThemeStore';
+import {
+  backgroundUrls,
+  customBackgroundKeys,
+  useReconcileCustomTheme,
+} from './useCustomBackground';
+import type { CustomBackground } from '@shiranami/contracts/bindings';
+
+vi.mock('@/lib/bridge/stream-urls', () => ({
+  toBackgroundUrl: (fileName: string) => `http://127.0.0.1:1234/tok/background/${fileName}`,
+}));
+
+const RECORD: CustomBackground = {
+  fileName: 'bg-abc.gif',
+  stillFileName: 'bg-abc.still.jpg',
+  width: 1920,
+  height: 1080,
+  animated: true,
+};
+
+function wrapperFor(record: CustomBackground | null) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  client.setQueryData(customBackgroundKeys.current, record);
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+function reset(): void {
+  useThemeStore.setState({ theme: 'none' });
+  document.documentElement.removeAttribute('data-theme');
+}
+
+beforeEach(reset);
+afterEach(reset);
+
+describe('backgroundUrls', () => {
+  it('builds both URLs for an animated record', () => {
+    expect(backgroundUrls(RECORD)).toEqual({
+      url: 'http://127.0.0.1:1234/tok/background/bg-abc.gif',
+      stillUrl: 'http://127.0.0.1:1234/tok/background/bg-abc.still.jpg',
+    });
+  });
+
+  it('has no still URL for a static record', () => {
+    expect(backgroundUrls({ ...RECORD, animated: false, stillFileName: null }).stillUrl).toBeNull();
+  });
+
+  it('answers nulls for no record at all', () => {
+    expect(backgroundUrls(null)).toEqual({ url: null, stillUrl: null });
+    expect(backgroundUrls(undefined)).toEqual({ url: null, stillUrl: null });
+  });
+});
+
+describe('useReconcileCustomTheme', () => {
+  /**
+   * I3, runtime half. The theme id lives in localStorage and the file it refers
+   * to lives in a Rust settings document, so the two can disagree — after an
+   * external delete, after restoring a profile without its `backgrounds/`
+   * directory, or on any machine where localStorage outlived an app-data wipe.
+   */
+  it('falls back to the default theme when custom is selected but nothing is imported', async () => {
+    useThemeStore.setState({ theme: 'custom' });
+
+    renderHook(() => useReconcileCustomTheme(), { wrapper: wrapperFor(null) });
+
+    await waitFor(() => {
+      expect(useThemeStore.getState().theme).toBe('none');
+    });
+  });
+
+  it('leaves the custom theme alone when an image is imported', async () => {
+    useThemeStore.setState({ theme: 'custom' });
+
+    renderHook(() => useReconcileCustomTheme(), { wrapper: wrapperFor(RECORD) });
+
+    await waitFor(() => {
+      expect(useThemeStore.getState().theme).toBe('custom');
+    });
+  });
+
+  /**
+   * `applyTheme` withholds `data-theme="custom"` until a record is confirmed,
+   * because the attribute switches on chrome-contrast rules and a heavier scrim
+   * that all assume a photo is behind them. This is the confirmation.
+   */
+  it('sets data-theme="custom" only once the record is confirmed', async () => {
+    useThemeStore.setState({ theme: 'custom' });
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+
+    renderHook(() => useReconcileCustomTheme(), { wrapper: wrapperFor(RECORD) });
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.theme).toBe('custom');
+    });
+  });
+
+  it('never sets data-theme="custom" when no image is imported', async () => {
+    useThemeStore.setState({ theme: 'custom' });
+
+    renderHook(() => useReconcileCustomTheme(), { wrapper: wrapperFor(null) });
+
+    await waitFor(() => {
+      expect(useThemeStore.getState().theme).toBe('none');
+    });
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+  });
+
+  /**
+   * The regression this latch exists for, and the reason it is a test rather
+   * than a comment.
+   *
+   * Selecting the "your image" tile before importing anything sets the theme to
+   * `custom` with no record present — which, to an unlatched reconciler, is
+   * indistinguishable from a stale persisted selection. It would reset the theme
+   * on the very next effect pass, unmounting the "Choose an image…" button one
+   * frame after it appeared and making the feature impossible to turn on from a
+   * clean state.
+   *
+   * The whole suite was green while that was true, because nothing mounted the
+   * reconciler and changed the theme afterwards. This does both.
+   */
+  it('does not undo a theme the user selects after the first answer', async () => {
+    renderHook(() => useReconcileCustomTheme(), { wrapper: wrapperFor(null) });
+
+    // Let the first (empty) answer be reconciled.
+    await waitFor(() => {
+      expect(useThemeStore.getState().theme).toBe('none');
+    });
+
+    // Now the user picks the custom tile, still with nothing imported.
+    useThemeStore.getState().setTheme('custom');
+
+    // It must survive: this is how they reach the picker.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(useThemeStore.getState().theme).toBe('custom');
+  });
+
+  it('leaves a bundled theme alone when nothing is imported', async () => {
+    // Having no custom background is the normal state for most users; it must
+    // not reset a theme they deliberately picked.
+    useThemeStore.setState({ theme: 'wisteria' });
+
+    renderHook(() => useReconcileCustomTheme(), { wrapper: wrapperFor(null) });
+
+    await waitFor(() => {
+      expect(useThemeStore.getState().theme).toBe('wisteria');
+    });
+  });
+});

--- a/apps/web/src/hooks/queries/useCustomBackground.ts
+++ b/apps/web/src/hooks/queries/useCustomBackground.ts
@@ -98,7 +98,11 @@ export function backgroundUrls(record: CustomBackground | null | undefined): {
   if (!record) return { url: null, stillUrl: null };
   return {
     url: toBackgroundUrl(record.fileName),
-    stillUrl: record.stillFileName === null ? null : toBackgroundUrl(record.stillFileName),
+    // `== null`, covering undefined as well: `still_file_name` carries
+    // `#[serde(default)]` so the generated type is optional, and a record
+    // written before stills existed omits the key entirely rather than
+    // sending null.
+    stillUrl: record.stillFileName == null ? null : toBackgroundUrl(record.stillFileName),
   };
 }
 

--- a/apps/web/src/hooks/queries/useCustomBackground.ts
+++ b/apps/web/src/hooks/queries/useCustomBackground.ts
@@ -1,0 +1,182 @@
+import { useEffect, useRef } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { BACKGROUND_ERROR_CODES, isIpcError } from '@shiranami/contracts';
+import type { CustomBackground } from '@shiranami/contracts/bindings';
+import { commands } from '@/lib/bridge/commands';
+import { toBackgroundUrl } from '@/lib/bridge/stream-urls';
+import { IS_ELECTRON } from '@/lib/platform';
+import { useThemeStore, applyTheme, DEFAULT_THEME, CUSTOM_THEME } from '@/stores/useThemeStore';
+import i18n from '@/lib/i18n';
+import { logger } from '@/lib/logger';
+
+export type { CustomBackground } from '@shiranami/contracts/bindings';
+
+export const customBackgroundKeys = {
+  current: ['custom-background'] as const,
+};
+
+/**
+ * The imported background, as the backend knows it.
+ *
+ * The **backend is the source of truth** and nothing about the file is mirrored
+ * into localStorage. That is the whole reason this is a query rather than a
+ * zustand slice: the record names a file on disk, and only the process that can
+ * stat that file is entitled to say whether a background exists. `background_get`
+ * heals a record whose file has vanished, so a `null` here means "no background",
+ * never "a background we cannot show".
+ */
+export function useCustomBackgroundQuery() {
+  return useQuery({
+    queryKey: customBackgroundKeys.current,
+    queryFn: async (): Promise<CustomBackground | null> => {
+      if (!IS_ELECTRON) return null;
+      return await commands.backgroundGet();
+    },
+    // The file only changes through the two mutations below, both of which
+    // write this key directly. Nothing else on the machine touches it.
+    staleTime: Infinity,
+    // One retry, unlike most queries here. A failure is not cosmetic: it makes
+    // the wallpaper disappear app-wide and makes Settings offer to import one
+    // that already exists, so it is worth a second attempt before the Appearance
+    // card surfaces it.
+    retry: 1,
+  });
+}
+
+/**
+ * Reconcile a persisted `custom` theme against the backend's answer.
+ *
+ * The two halves of "the user chose their own wallpaper" live in different
+ * stores by necessity — the *choice* is a localStorage theme id, the *file* is a
+ * Rust settings entry — so they can disagree. They do disagree whenever the file
+ * is deleted outside the app, whenever a profile is restored without its
+ * `backgrounds/` directory, and on any machine where localStorage survived an
+ * app-data wipe.
+ *
+ * Returning to the default theme is the resolution rather than, say, showing an
+ * empty `custom`, because `data-theme="custom"` with no image behind it is not a
+ * neutral state: it turns on eight chrome-contrast rules that assume a photo is
+ * there. `theme-init.ts` already refuses to set the attribute pre-paint for the
+ * same reason, so this only has to correct the store, never the DOM mid-flight.
+ */
+export function useReconcileCustomTheme(): void {
+  const { data, isSuccess } = useCustomBackgroundQuery();
+  const reconciled = useRef(false);
+
+  useEffect(() => {
+    if (!isSuccess || reconciled.current) return;
+    // Latched to the FIRST answer. Without the latch this effect also fires on
+    // every later theme change, and would then undo the user's own selection:
+    // picking the custom tile before importing anything sets the theme with no
+    // record present, which is indistinguishable here from a stale persisted
+    // one. Correcting persistence is a startup job; after that the user's
+    // choices are theirs.
+    reconciled.current = true;
+
+    if (data === null && useThemeStore.getState().theme === CUSTOM_THEME) {
+      logger.warn('[background] no imported background; falling back to the default theme');
+      useThemeStore.getState().setTheme(DEFAULT_THEME);
+    }
+  }, [isSuccess, data]);
+
+  // `applyTheme` withholds `data-theme="custom"` until the record is confirmed,
+  // because the attribute turns on chrome-contrast rules that assume a photo is
+  // behind them. This is where the confirmation arrives.
+  useEffect(() => {
+    if (isSuccess && data !== null && useThemeStore.getState().theme === CUSTOM_THEME) {
+      applyTheme(CUSTOM_THEME, true);
+    }
+  }, [isSuccess, data]);
+}
+
+/** The loopback URLs for a record, or `null` before the shell has answered. */
+export function backgroundUrls(record: CustomBackground | null | undefined): {
+  url: string | null;
+  stillUrl: string | null;
+} {
+  if (!record) return { url: null, stillUrl: null };
+  return {
+    url: toBackgroundUrl(record.fileName),
+    stillUrl: record.stillFileName === null ? null : toBackgroundUrl(record.stillFileName),
+  };
+}
+
+/**
+ * Import an image, or do nothing if the picker was cancelled.
+ *
+ * The refusals are the reason this reports rather than swallows. Four of them
+ * are things the user can fix by choosing a different file, and each carries its
+ * own code so the toast can say which — the alternative, which the
+ * implementation this is modelled on shipped, is a `logger.error` the user never
+ * sees and a picker that appears to do nothing.
+ */
+export function usePickCustomBackground() {
+  const queryClient = useQueryClient();
+  const setTheme = useThemeStore(s => s.setTheme);
+
+  return useMutation({
+    mutationFn: async (): Promise<CustomBackground | null> => {
+      if (!IS_ELECTRON) return null;
+      return await commands.backgroundPick();
+    },
+    onSuccess: record => {
+      if (record === null) return;
+      queryClient.setQueryData(customBackgroundKeys.current, record);
+      // Selecting the image *is* selecting the theme. Importing one and then
+      // having to pick a tile to see it would be two steps for one intent.
+      setTheme(CUSTOM_THEME);
+      // The record now exists, so the attribute the store withheld can land.
+      applyTheme(CUSTOM_THEME, true);
+    },
+    onError: (error: unknown) => {
+      toast.error(importErrorMessage(error));
+    },
+  });
+}
+
+/** Remove the background and return to the default theme. */
+export function useClearCustomBackground() {
+  const queryClient = useQueryClient();
+  const theme = useThemeStore(s => s.theme);
+  const setTheme = useThemeStore(s => s.setTheme);
+
+  return useMutation({
+    mutationFn: async (): Promise<void> => {
+      if (!IS_ELECTRON) return;
+      await commands.backgroundClear();
+    },
+    onSuccess: () => {
+      queryClient.setQueryData(customBackgroundKeys.current, null);
+      // Only if it is the one showing: clearing from a state where a bundled
+      // theme is active should not also change the theme.
+      if (theme === CUSTOM_THEME) setTheme(DEFAULT_THEME);
+    },
+    onError: (error: unknown) => {
+      logger.error('[background] the background could not be cleared', error);
+      toast.error(i18n.t('settings:app.background.errors.generic'));
+    },
+  });
+}
+
+/** Map a rejected import onto the sentence that explains it. */
+function importErrorMessage(error: unknown): string {
+  if (!isIpcError(error)) return i18n.t('settings:app.background.errors.generic');
+
+  switch (error.code) {
+    case BACKGROUND_ERROR_CODES.TOO_LARGE:
+      return i18n.t('settings:app.background.errors.tooLarge');
+    case BACKGROUND_ERROR_CODES.UNSUPPORTED_FORMAT:
+      return i18n.t('settings:app.background.errors.unsupportedFormat');
+    case BACKGROUND_ERROR_CODES.NOT_AN_IMAGE:
+      return i18n.t('settings:app.background.errors.notAnImage');
+    case BACKGROUND_ERROR_CODES.DIMENSIONS_TOO_LARGE:
+      return i18n.t('settings:app.background.errors.dimensionsTooLarge');
+    default:
+      // Everything the user cannot act on — a full disk, a permission error —
+      // arrives as INTERNAL and gets the one message that does not pretend to
+      // know what went wrong.
+      logger.error('[background] the import failed', error);
+      return i18n.t('settings:app.background.errors.generic');
+  }
+}

--- a/apps/web/src/lib/bridge/stream-urls.ts
+++ b/apps/web/src/lib/bridge/stream-urls.ts
@@ -207,6 +207,28 @@ export function toArtUrl(value: string): string {
 }
 
 /**
+ * The loopback URL for one imported-background file name.
+ *
+ * Unlike {@link toArtUrl} this is a builder, not a rewriter: a background is
+ * never stored as a URL anywhere, so there is no v1 form to translate and
+ * nothing for the deep-walk chokepoint to find. The command returns a bare file
+ * name and the caller asks for its address, which also means a background URL
+ * cannot be accidentally round-tripped back into the settings document the way
+ * `tracks.album_art` was — {@link toStoredArtUrl} exists because that happened.
+ *
+ * `null` when there is no base yet (outside the webview, or before the shell
+ * has answered), so a caller renders nothing rather than a relative URL that
+ * resolves against the app's own origin.
+ */
+export function toBackgroundUrl(fileName: string): string | null {
+  if (base === null) return null;
+  // The name is passed through verbatim for the same reason `toArtUrl` does it:
+  // the server refuses a name with a separator in it, and reshaping one here
+  // would turn a 403 into a path that resolves.
+  return `${base}/background/${fileName}`;
+}
+
+/**
  * Rewrite one string back to the form the database holds, or return it
  * unchanged.
  *

--- a/apps/web/src/lib/theme-init.test.ts
+++ b/apps/web/src/lib/theme-init.test.ts
@@ -30,6 +30,20 @@ describe('applyPersistedTheme', () => {
     expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
   });
 
+  /**
+   * I3, pre-paint half. Every other theme's image is a committed asset that is
+   * certain to exist; `custom` names a file on disk that this module cannot
+   * check and must not block on. Setting the attribute anyway would light up all
+   * eight attribute-keyed chrome rules over a bare `--background` with no photo
+   * behind them, for as long as the backend round trip takes — and permanently
+   * if the file turned out to be gone.
+   */
+  it('refuses to restore the custom theme, which has no bundled image', () => {
+    persist('custom');
+    applyPersistedTheme();
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+  });
+
   it('ignores a corrupt bucket', () => {
     localStorage.setItem(THEME_STORE_KEY, '{not json');
     applyPersistedTheme();

--- a/apps/web/src/lib/theme-init.ts
+++ b/apps/web/src/lib/theme-init.ts
@@ -19,6 +19,23 @@
 const THEME_STORE_KEY = 'shiranami.theme';
 const DEFAULT_THEME = 'none';
 
+/**
+ * The one theme this module will not restore, also inlined from `useThemeStore`.
+ *
+ * Every other theme's image is a bundled asset that is certain to exist, so
+ * setting the attribute pre-paint is free. `custom` is the exception: its image
+ * is a file on disk named by the settings document, which this module cannot
+ * read (it is a Rust-side settings file, not localStorage) and must not block on.
+ *
+ * Writing `data-theme="custom"` here would light up all eight attribute-keyed
+ * chrome rules — the translucent topbar, sidebar and hero surfaces — over a bare
+ * `--background`, with no photo behind them, for as long as the round trip
+ * takes. Skipping it costs one frame of the default background on a launch with
+ * a custom image set, and makes cold start default-safe: nothing can paint a
+ * theme whose image turns out not to exist.
+ */
+const CUSTOM_THEME = 'custom';
+
 interface PersistedThemeBucket {
   state?: { theme?: unknown };
 }
@@ -36,7 +53,12 @@ export function applyPersistedTheme(): void {
     if (raw === null) return;
     const bucket = JSON.parse(raw) as PersistedThemeBucket | null;
     const theme = bucket?.state?.theme;
-    if (typeof theme === 'string' && theme !== '' && theme !== DEFAULT_THEME) {
+    if (
+      typeof theme === 'string' &&
+      theme !== '' &&
+      theme !== DEFAULT_THEME &&
+      theme !== CUSTOM_THEME
+    ) {
       document.documentElement.dataset.theme = theme;
     }
   } catch {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -510,7 +510,8 @@
         "snow": "Snow",
         "summer": "Summer",
         "sunset": "Sunset",
-        "wisteria": "Wisteria"
+        "wisteria": "Wisteria",
+        "custom": "Your image"
       }
     },
     "accent": {
@@ -619,10 +620,31 @@
       "blurDesc": "Soften the background image edges",
       "dim": "Dim overlay",
       "dimDesc": "Dark layer over the image to keep text readable",
+      "fit": "Fit",
+      "fitDesc": "How your image fills the window. Contain shows all of it; cover crops to fill.",
+      "fitOptions": {
+        "cover": "Cover",
+        "contain": "Contain"
+      },
       "reset": "Reset",
       "previewTitle": "Preview",
       "previewTrack": "Sample Track",
       "previewArtist": "Now playing over your background"
+    },
+    "background": {
+      "choose": "Choose an image…",
+      "replace": "Replace image…",
+      "remove": "Remove",
+      "hint": "PNG, JPEG, WebP or GIF · up to 20 MB",
+      "retry": "Try again",
+      "errors": {
+        "tooLarge": "That image is too large. Pick one under 20 MB.",
+        "unsupportedFormat": "That file type is not supported. Use a PNG, JPEG, WebP or GIF.",
+        "notAnImage": "That file is not the image its name claims to be.",
+        "dimensionsTooLarge": "That image is too big to display. Its longest edge must be under 8192 pixels.",
+        "generic": "The background could not be changed.",
+        "readFailed": "Could not read the current background."
+      }
     }
   },
   "dl": {

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -532,7 +532,8 @@
         "snow": "Śnieg",
         "summer": "Lato",
         "sunset": "Zachód słońca",
-        "wisteria": "Glicynia"
+        "wisteria": "Glicynia",
+        "custom": "Twój obraz"
       }
     },
     "accent": {
@@ -643,10 +644,31 @@
       "blurDesc": "Zmiękczenie krawędzi obrazu tła",
       "dim": "Przyciemnienie",
       "dimDesc": "Ciemna warstwa nad obrazem poprawiająca czytelność tekstu",
+      "fit": "Dopasowanie",
+      "fitDesc": "Jak obraz wypełnia okno. „Zmieść\" pokazuje całość, „Wypełnij\" przycina do krawędzi.",
+      "fitOptions": {
+        "cover": "Wypełnij",
+        "contain": "Zmieść"
+      },
       "reset": "Przywróć domyślne",
       "previewTitle": "Podgląd",
       "previewTrack": "Przykładowy utwór",
       "previewArtist": "Odtwarzanie na Twoim tle"
+    },
+    "background": {
+      "choose": "Wybierz obraz…",
+      "replace": "Zmień obraz…",
+      "remove": "Usuń",
+      "hint": "PNG, JPEG, WebP lub GIF · do 20 MB",
+      "retry": "Spróbuj ponownie",
+      "errors": {
+        "tooLarge": "Ten obraz jest za duży. Wybierz plik poniżej 20 MB.",
+        "unsupportedFormat": "Ten typ pliku nie jest obsługiwany. Użyj PNG, JPEG, WebP lub GIF.",
+        "notAnImage": "Ten plik nie jest obrazem, na jaki wskazuje jego nazwa.",
+        "dimensionsTooLarge": "Ten obraz jest zbyt duży, aby go wyświetlić. Dłuższy bok musi mieć mniej niż 8192 piksele.",
+        "generic": "Nie udało się zmienić tła.",
+        "readFailed": "Nie udało się odczytać bieżącego tła."
+      }
     }
   },
   "dl": {

--- a/apps/web/src/stores/useThemeBgStore.test.ts
+++ b/apps/web/src/stores/useThemeBgStore.test.ts
@@ -114,4 +114,35 @@ describe('useThemeBgStore rehydration sanitizing', () => {
     expect(state.bgBlur).toBe(mod.THEME_BG_BLUR_DEFAULT); // 'broken' -> default
     expect(state.bgDim).toBe(mod.THEME_BG_DIM_MIN); // -3 -> clamped to 0
   });
+
+  /**
+   * `bgFit` was added without touching `version`, which is the only safe way to
+   * add a field here: `createPersistedStore` passes no `migrate` to zustand, so
+   * a version mismatch yields no migrated state at all and this bucket's three
+   * tuned values would come back as defaults. This test is what says the
+   * addition costs an existing user nothing.
+   */
+  it('keeps values written before bgFit existed, and defaults the new field', async () => {
+    localStorage.setItem(
+      STORE_KEY,
+      JSON.stringify({ state: { bgOpacity: 0.42, bgBlur: 7, bgDim: 0.25 }, version: 1 })
+    );
+
+    const mod = await import('./useThemeBgStore');
+    const state = mod.useThemeBgStore.getState();
+    expect(state.bgOpacity).toBe(0.42);
+    expect(state.bgBlur).toBe(7);
+    expect(state.bgDim).toBe(0.25);
+    expect(state.bgFit).toBe(mod.THEME_BG_FIT_DEFAULT);
+  });
+
+  it('coerces an unrecognised persisted fit back to the default', async () => {
+    localStorage.setItem(
+      STORE_KEY,
+      JSON.stringify({ state: { bgFit: 'stretch-to-fill' }, version: 1 })
+    );
+
+    const mod = await import('./useThemeBgStore');
+    expect(mod.useThemeBgStore.getState().bgFit).toBe(mod.THEME_BG_FIT_DEFAULT);
+  });
 });

--- a/apps/web/src/stores/useThemeBgStore.ts
+++ b/apps/web/src/stores/useThemeBgStore.ts
@@ -1,4 +1,24 @@
-import { createPersistedStore, clampNumber, acceptStoreHmr } from '@/lib/createPersistedStore';
+import {
+  createPersistedStore,
+  clampNumber,
+  coerceEnum,
+  acceptStoreHmr,
+} from '@/lib/createPersistedStore';
+
+/**
+ * How the theme image fills the viewport.
+ *
+ * `cover` is what every bundled theme wants and what the five shipped photos are
+ * cropped for. `contain` exists for imported images: a tall phone wallpaper under
+ * `cover` is cropped to its middle third with no recourse, which was the single
+ * most-felt limitation of the implementation this one is modelled on. The
+ * letterbox bars it produces are already handled — `.theme-bg-image` paints
+ * `background-color: var(--background)` beneath the image.
+ */
+export type ThemeBgFit = 'cover' | 'contain';
+
+export const THEME_BG_FITS: readonly ThemeBgFit[] = ['cover', 'contain'] as const;
+export const THEME_BG_FIT_DEFAULT: ThemeBgFit = 'cover';
 
 export const THEME_BG_OPACITY_MIN = 0;
 export const THEME_BG_OPACITY_MAX = 1;
@@ -17,17 +37,19 @@ export const THEME_BG_DIM_DEFAULT = 0;
 
 const STORE_KEY = 'shiranami.theme-bg-store';
 
-function applyThemeBgToDOM(opacity: number, blur: number, dim: number): void {
+function applyThemeBgToDOM(opacity: number, blur: number, dim: number, fit: ThemeBgFit): void {
   const root = document.documentElement;
   root.style.setProperty('--theme-bg-opacity', String(opacity));
   root.style.setProperty('--theme-bg-blur', `${blur}px`);
   root.style.setProperty('--theme-bg-dim', String(dim));
+  root.style.setProperty('--theme-bg-fit', fit);
 }
 
 interface PersistedThemeBgState {
   bgOpacity: number;
   bgBlur: number;
   bgDim: number;
+  bgFit: ThemeBgFit;
 }
 
 function sanitize(
@@ -56,6 +78,15 @@ function sanitize(
       THEME_BG_DIM_MAX,
       THEME_BG_DIM_DEFAULT
     );
+  // Presence-checked like the three above, which is why `bgFit` needs no
+  // version bump and no migration: a bucket written before this field existed
+  // simply does not carry the key, and the initial state's default stands.
+  // Bumping `version` would have been worse than unnecessary —
+  // `createPersistedStore` passes no `migrate` to zustand, so a version
+  // mismatch yields no migrated state and every user's opacity, blur and dim
+  // would silently reset to defaults.
+  if (persisted.bgFit !== undefined)
+    out.bgFit = coerceEnum(persisted.bgFit, THEME_BG_FITS, THEME_BG_FIT_DEFAULT);
   return out;
 }
 
@@ -63,13 +94,28 @@ interface ThemeBgState {
   bgOpacity: number;
   bgBlur: number;
   bgDim: number;
+  bgFit: ThemeBgFit;
 }
 
 interface ThemeBgActions {
   setBgOpacity: (v: number) => void;
   setBgBlur: (v: number) => void;
   setBgDim: (v: number) => void;
+  setBgFit: (v: ThemeBgFit) => void;
   resetBg: () => void;
+}
+
+/**
+ * Push the whole tuple to the DOM from current state.
+ *
+ * The setters below call this instead of assembling the argument list
+ * themselves. With three values that was a readable `set` followed by a
+ * two-`getState` call; with four it stops being readable, and every setter
+ * would have to be edited again the next time one is added.
+ */
+function applyFromState(): void {
+  const { bgOpacity, bgBlur, bgDim, bgFit } = useThemeBgStore.getState();
+  applyThemeBgToDOM(bgOpacity, bgBlur, bgDim, bgFit);
 }
 
 export const useThemeBgStore = createPersistedStore<ThemeBgState & ThemeBgActions>(
@@ -77,42 +123,39 @@ export const useThemeBgStore = createPersistedStore<ThemeBgState & ThemeBgAction
     bgOpacity: THEME_BG_OPACITY_DEFAULT,
     bgBlur: THEME_BG_BLUR_DEFAULT,
     bgDim: THEME_BG_DIM_DEFAULT,
+    bgFit: THEME_BG_FIT_DEFAULT,
 
     setBgOpacity: v => {
-      const next = clampNumber(
-        v,
-        THEME_BG_OPACITY_MIN,
-        THEME_BG_OPACITY_MAX,
-        THEME_BG_OPACITY_DEFAULT
-      );
-      set({ bgOpacity: next });
-      applyThemeBgToDOM(next, useThemeBgStore.getState().bgBlur, useThemeBgStore.getState().bgDim);
+      set({
+        bgOpacity: clampNumber(
+          v,
+          THEME_BG_OPACITY_MIN,
+          THEME_BG_OPACITY_MAX,
+          THEME_BG_OPACITY_DEFAULT
+        ),
+      });
+      applyFromState();
     },
     setBgBlur: v => {
-      const next = clampNumber(v, THEME_BG_BLUR_MIN, THEME_BG_BLUR_MAX, THEME_BG_BLUR_DEFAULT);
-      set({ bgBlur: next });
-      applyThemeBgToDOM(
-        useThemeBgStore.getState().bgOpacity,
-        next,
-        useThemeBgStore.getState().bgDim
-      );
+      set({ bgBlur: clampNumber(v, THEME_BG_BLUR_MIN, THEME_BG_BLUR_MAX, THEME_BG_BLUR_DEFAULT) });
+      applyFromState();
     },
     setBgDim: v => {
-      const next = clampNumber(v, THEME_BG_DIM_MIN, THEME_BG_DIM_MAX, THEME_BG_DIM_DEFAULT);
-      set({ bgDim: next });
-      applyThemeBgToDOM(
-        useThemeBgStore.getState().bgOpacity,
-        useThemeBgStore.getState().bgBlur,
-        next
-      );
+      set({ bgDim: clampNumber(v, THEME_BG_DIM_MIN, THEME_BG_DIM_MAX, THEME_BG_DIM_DEFAULT) });
+      applyFromState();
+    },
+    setBgFit: v => {
+      set({ bgFit: coerceEnum(v, THEME_BG_FITS, THEME_BG_FIT_DEFAULT) });
+      applyFromState();
     },
     resetBg: () => {
       set({
         bgOpacity: THEME_BG_OPACITY_DEFAULT,
         bgBlur: THEME_BG_BLUR_DEFAULT,
         bgDim: THEME_BG_DIM_DEFAULT,
+        bgFit: THEME_BG_FIT_DEFAULT,
       });
-      applyThemeBgToDOM(THEME_BG_OPACITY_DEFAULT, THEME_BG_BLUR_DEFAULT, THEME_BG_DIM_DEFAULT);
+      applyFromState();
     },
   }),
   {
@@ -122,13 +165,14 @@ export const useThemeBgStore = createPersistedStore<ThemeBgState & ThemeBgAction
       bgOpacity: s.bgOpacity,
       bgBlur: s.bgBlur,
       bgDim: s.bgDim,
+      bgFit: s.bgFit,
     }),
     sanitize: (persisted, current) => ({
       ...current,
       ...sanitize(persisted as Partial<PersistedThemeBgState>),
     }),
     onRehydrate: state => {
-      applyThemeBgToDOM(state.bgOpacity, state.bgBlur, state.bgDim);
+      applyThemeBgToDOM(state.bgOpacity, state.bgBlur, state.bgDim, state.bgFit);
     },
   }
 );

--- a/apps/web/src/stores/useThemeStore.ts
+++ b/apps/web/src/stores/useThemeStore.ts
@@ -1,6 +1,6 @@
 import { createPersistedStore, coerceEnum, acceptStoreHmr } from '@/lib/createPersistedStore';
 
-export type ThemeId = 'none' | 'lofi-night' | 'snow' | 'summer' | 'sunset' | 'wisteria';
+export type ThemeId = 'none' | 'lofi-night' | 'snow' | 'summer' | 'sunset' | 'wisteria' | 'custom';
 
 export const THEME_IDS: readonly ThemeId[] = [
   'none',
@@ -9,7 +9,23 @@ export const THEME_IDS: readonly ThemeId[] = [
   'summer',
   'sunset',
   'wisteria',
+  'custom',
 ] as const;
+
+/**
+ * The theme whose image comes from disk instead of `./themes/<id>.webp`.
+ *
+ * Modelled as a sixth theme rather than a layer above one, which is what buys
+ * the whole feature for the price of a URL: the scrim, the dim layer, the
+ * opacity/blur sliders and every `[data-theme]` chrome-contrast rule already
+ * apply to it. The cost is that a custom image and a bundled theme are
+ * alternatives, not a stack.
+ *
+ * It is the one theme whose selection can be *invalid*: the record naming the
+ * file lives in the settings document, and the file itself can be gone. See
+ * `useCustomBackground`, which reconciles the two on first read.
+ */
+export const CUSTOM_THEME: ThemeId = 'custom';
 
 /** None/Solid: byte-identical to today, no data-theme attribute, zero image bytes. */
 export const DEFAULT_THEME: ThemeId = 'none';
@@ -20,10 +36,27 @@ function coerceTheme(v: unknown): ThemeId {
   return coerceEnum(v, THEME_IDS, DEFAULT_THEME);
 }
 
-/** Side-effect — mirrors applyLowPerformanceMode in useUIStore exactly. */
-export function applyTheme(theme: ThemeId): void {
+/**
+ * Side-effect — mirrors applyLowPerformanceMode in useUIStore exactly, with one
+ * exception.
+ *
+ * `custom` does **not** get its attribute here, and `confirmed` is how it
+ * eventually does. Every other theme's image is a bundled asset that certainly
+ * exists, so writing `data-theme` immediately is free. `custom` names a file on
+ * disk that this store cannot see, and the attribute is not decoration: it
+ * switches on the translucent topbar, sidebar and hero surfaces, plus a heavier
+ * scrim, all of which assume a photo is behind them. Setting it before the
+ * record is confirmed paints that chrome over a bare `--background` — briefly on
+ * every launch, and permanently when the file turns out to be gone.
+ *
+ * `theme-init.ts` makes the same refusal pre-paint. This is the other half: the
+ * store's own rehydrate runs synchronously at module evaluation and would
+ * otherwise undo it a line later. `useReconcileCustomTheme` calls this with
+ * `confirmed` once the backend answers.
+ */
+export function applyTheme(theme: ThemeId, confirmed = false): void {
   if (typeof document === 'undefined') return;
-  if (theme === DEFAULT_THEME) {
+  if (theme === DEFAULT_THEME || (theme === CUSTOM_THEME && !confirmed)) {
     delete document.documentElement.dataset.theme; // bare :root == today
   } else {
     document.documentElement.dataset.theme = theme; // -> <html data-theme="snow">

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -868,6 +868,32 @@
     radial-gradient(50% 50% at 20% 100%, oklch(0.1 0.04 280 / 0.4), transparent 70%);
 }
 
+/* Fit is offered for an imported image only, so it is applied for one only.
+   `--theme-bg-fit` is written to :root like the other three, but reading it on
+   the shared rule would let a `contain` chosen for a wallpaper follow the user
+   into lofi-night — letterboxing a photo that was composed for `cover`, with
+   the control that set it hidden because it is not the custom theme. The five
+   bundled images are cropped for `cover` and stay that way.
+
+   The background-color above is what makes `contain` safe here: the bars it
+   leaves are painted --background rather than showing through. */
+[data-theme='custom'] .theme-bg-image {
+  background-size: var(--theme-bg-fit, cover);
+}
+
+/* An imported image takes summer's heavier scrim, not the shared default.
+   The five bundled photos were each checked against the contrast floor and
+   exactly one of them — the daytime lake — needed more than the default; a
+   user's own image is unvetted, so assuming it is one of the four safe ones
+   ships a WCAG regression that only appears when someone imports a bright
+   photo. Erring heavy costs some punch on dark wallpapers, which the opacity
+   slider can give back; erring light costs legibility, which nothing does. */
+[data-theme='custom'] .theme-bg-scrim {
+  background:
+    linear-gradient(180deg, oklch(0.05 0.018 280 / 0.5) 0%, oklch(0.04 0.012 280 / 0.62) 100%),
+    radial-gradient(50% 50% at 20% 100%, oklch(0.1 0.04 280 / 0.4), transparent 70%);
+}
+
 /* NowPlayingHero (library hero card) paints only a faint ambient-color wash for
    its background — fine over the solid default --background, but its text sits
    on a bare photo under an image theme (the card is ~90% transparent), washing

--- a/crates/shiranami-core/src/error/codes.rs
+++ b/crates/shiranami-core/src/error/codes.rs
@@ -55,6 +55,26 @@ pub mod validation {
     pub const FORBIDDEN: &str = "FORBIDDEN";
 }
 
+/// Custom-background ingest refusals — `packages/contracts/src/ipc/error-codes.ts`.
+///
+/// A v2-born registry, so it has no v1 counterpart to stay faithful to. Each
+/// code is a *refusal the user can act on* — pick a smaller file, pick a real
+/// image — which is why they are distinct codes rather than one
+/// `background.import_failed`: the renderer shows a different sentence for each,
+/// and a single code would collapse "your 40 MB file is too big" into the same
+/// unhelpful toast as "that .png is not a .png". Failures the user cannot act on
+/// (a full disk, a permission error) stay [`INTERNAL`].
+pub mod background {
+    /// The file is larger than the import cap.
+    pub const TOO_LARGE: &str = "background.too_large";
+    /// The extension is not one of the accepted image formats.
+    pub const UNSUPPORTED_FORMAT: &str = "background.unsupported_format";
+    /// The bytes did not decode as the image the extension claimed.
+    pub const NOT_AN_IMAGE: &str = "background.not_an_image";
+    /// The image decoded, but its longest edge is past the cap.
+    pub const DIMENSIONS_TOO_LARGE: &str = "background.dimensions_too_large";
+}
+
 /// Classified yt-dlp failures — `apps/desktop/src/main/utils/ytdlp-spawn.ts`.
 ///
 /// Produced by the failure classifier that lands in `shiranami-downloader` in
@@ -145,6 +165,22 @@ mod tests {
                 (super::playlist::NO_TRACKS, "NO_TRACKS"),
                 (super::validation::BAD_REQUEST, "BAD_REQUEST"),
                 (super::validation::FORBIDDEN, "FORBIDDEN"),
+            ],
+        );
+    }
+
+    #[test]
+    fn background_codes_mirror_the_typescript_registry() {
+        assert_mirrors(
+            "packages/contracts/src/ipc/error-codes.ts",
+            &[
+                (super::background::TOO_LARGE, "TOO_LARGE"),
+                (super::background::UNSUPPORTED_FORMAT, "UNSUPPORTED_FORMAT"),
+                (super::background::NOT_AN_IMAGE, "NOT_AN_IMAGE"),
+                (
+                    super::background::DIMENSIONS_TOO_LARGE,
+                    "DIMENSIONS_TOO_LARGE",
+                ),
             ],
         );
     }

--- a/crates/shiranami-core/src/store/keys.rs
+++ b/crates/shiranami-core/src/store/keys.rs
@@ -111,6 +111,14 @@ pub enum MainStoreKey {
     /// Whether the one-time v2 crossover ping has fired.
     #[serde(rename = "v2.crossoverPinged")]
     V2CrossoverPinged,
+    /// The imported custom background: file name, poster still, dimensions.
+    ///
+    /// Main-only for two reasons. The renderer allowlist is pinned to v1's
+    /// tuple, so a renderer key would fail the mirror test — but the stronger
+    /// reason is that this value *names a file the serve route will open*.
+    /// Renderer-writable would mean the renderer chooses that name.
+    #[serde(rename = "appearance.customBackground")]
+    AppearanceCustomBackground,
 }
 
 impl RendererStoreKey {
@@ -165,7 +173,7 @@ impl RendererStoreKey {
 
 impl MainStoreKey {
     /// Every main-only key.
-    pub const ALL: [Self; 8] = [
+    pub const ALL: [Self; 9] = [
         Self::DiscordRpcSettings,
         Self::CompactWindowBounds,
         Self::DownloadsLocation,
@@ -174,6 +182,7 @@ impl MainStoreKey {
         Self::MigrationsAlbumArtV1,
         Self::ScrobbleSettings,
         Self::V2CrossoverPinged,
+        Self::AppearanceCustomBackground,
     ];
 
     /// The electron-store dot path this key lives at in the document.
@@ -190,6 +199,7 @@ impl MainStoreKey {
             Self::MigrationsAlbumArtV1 => "migrations.albumArtV1",
             Self::ScrobbleSettings => "scrobble.settings",
             Self::V2CrossoverPinged => "v2.crossoverPinged",
+            Self::AppearanceCustomBackground => "appearance.customBackground",
         }
     }
 }

--- a/crates/shiranami-core/src/store/settings.rs
+++ b/crates/shiranami-core/src/store/settings.rs
@@ -54,6 +54,7 @@ pub struct SettingsStore {
     path: PathBuf,
     document: Mutex<Map<String, Value>>,
     bus: ChangeBus,
+    quarantined: bool,
 }
 
 impl SettingsStore {
@@ -99,8 +100,23 @@ impl SettingsStore {
             path,
             document: Mutex::new(document),
             bus: ChangeBus::new(),
+            quarantined: quarantined.is_some(),
         };
         (store, quarantined)
+    }
+
+    /// Whether this session started from defaults because the file was corrupt.
+    ///
+    /// The distinction matters to anything that treats an absent key as a
+    /// decision rather than as a gap. After a quarantine *every* key reads
+    /// absent, so a consumer that deletes files nothing refers to — the
+    /// background sweep — would read "nothing is referenced" and delete the
+    /// user's wallpaper, while the quarantined backup beside it still names the
+    /// file. This is the same failure the album-art prune documents, arriving
+    /// one layer lower: there the reference *lookup* failed, here the whole
+    /// document did.
+    pub fn started_from_quarantine(&self) -> bool {
+        self.quarantined
     }
 
     /// The file this store reads and writes.

--- a/crates/shiranami-metadata/src/art/image.rs
+++ b/crates/shiranami-metadata/src/art/image.rs
@@ -198,7 +198,11 @@ fn downscale(source: &DynamicImage, width: u32, height: u32) -> Result<DynamicIm
 }
 
 /// Encode as baseline JPEG at [`JPEG_QUALITY`].
-fn encode_jpeg(source: &DynamicImage) -> Result<Vec<u8>> {
+///
+/// Reachable from [`crate::background`], which needs the encoder without the
+/// 512 px downscale in front of it: a wallpaper's poster still has to keep the
+/// wallpaper's dimensions.
+pub(crate) fn encode_jpeg(source: &DynamicImage) -> Result<Vec<u8>> {
     let rgb = source.to_rgb8();
     let mut bytes = Vec::new();
 

--- a/crates/shiranami-metadata/src/background/ingest.rs
+++ b/crates/shiranami-metadata/src/background/ingest.rs
@@ -1,0 +1,461 @@
+//! Import one user-chosen image: refuse, verify, store, freeze.
+//!
+//! The order of the four checks is the design. Cheap refusals come first and
+//! each one bounds the cost of the next: the extension check costs a string
+//! compare, the byte cap costs a `stat`, the pixel cap costs an image header,
+//! and only then does anything decode. Reordering this — checking dimensions
+//! after a decode, say — turns a refusal into the very allocation it exists to
+//! refuse.
+
+use std::io::Cursor;
+use std::path::Path;
+
+use image::{AnimationDecoder, DynamicImage, ImageDecoder as _, ImageFormat, ImageReader, Limits};
+use shiranami_core::store::atomic::write_atomic;
+
+use crate::art::cache::hash_bytes;
+use crate::background::record::{
+    CustomBackground, MAX_DIMENSION, MAX_FILE_BYTES, MAX_PIXELS, background_dir, extension_of,
+    still_name_for,
+};
+use crate::error::{MetadataError, Result};
+
+/// Import `source` into the app's background directory.
+///
+/// Returns the record to persist. It does **not** persist anything and does not
+/// remove a previous background: the caller writes the record first and then
+/// runs [`crate::background::sweep_orphans`], so a crash between the two leaves
+/// an unreferenced file that the next sweep collects, rather than a live record
+/// pointing at a file that is already gone.
+///
+/// # Errors
+///
+/// [`MetadataError::BackgroundUnsupportedFormat`] for an extension outside the
+/// allowlist, [`MetadataError::BackgroundTooLarge`] past the byte cap,
+/// [`MetadataError::BackgroundDimensionsTooLarge`] past the pixel cap, and
+/// [`MetadataError::BackgroundNotAnImage`] when the bytes are not the image the
+/// extension claimed. Anything else is an ordinary I/O failure.
+pub fn import_background(data_dir: &Path, source: &Path) -> Result<CustomBackground> {
+    let claimed = claimed_format(source)?;
+
+    let size = std::fs::metadata(source)
+        .map_err(|error| MetadataError::io("read the size of", source, error))?
+        .len();
+    if size > MAX_FILE_BYTES {
+        return Err(MetadataError::BackgroundTooLarge {
+            size,
+            max: MAX_FILE_BYTES,
+        });
+    }
+
+    let bytes = std::fs::read(source).map_err(|error| MetadataError::io("read", source, error))?;
+
+    let format = sniff(&bytes)?;
+    // The extension is a claim about the bytes, and this is where the claim is
+    // tested. Storing a mislabelled file would put a name the serve route trusts
+    // on content it never inspected.
+    if format != claimed {
+        return Err(MetadataError::BackgroundNotAnImage);
+    }
+
+    // Two caps, not one. The edge cap refuses an absurdly long image; the pixel
+    // cap refuses an absurdly *large* one, which the edge cap alone lets through
+    // — 8192x8192 is inside every edge limit and is still 67 megapixels, a
+    // quarter-gigabyte of RGBA before anything has decoded it.
+    let (width, height) = dimensions(&bytes)?;
+    if width.max(height) > MAX_DIMENSION || u64::from(width) * u64::from(height) > MAX_PIXELS {
+        return Err(MetadataError::BackgroundDimensionsTooLarge {
+            width,
+            height,
+            max: MAX_DIMENSION,
+        });
+    }
+
+    let animated = is_animated(format, &bytes)?;
+
+    // Content-addressed, so nothing the user typed reaches the filesystem and
+    // re-importing the same wallpaper converges on one file. The extension comes
+    // from the sniffed format rather than the source path, so the stored name
+    // describes the bytes even when the original was misnamed in a harmless way
+    // (`.jpeg` for a JPEG).
+    let file_name = format!("bg-{}.{}", hash_bytes(&bytes), canonical_extension(format));
+    let directory = background_dir(data_dir);
+    std::fs::create_dir_all(&directory)
+        .map_err(|error| MetadataError::io("create the background directory", &directory, error))?;
+
+    // `write_atomic` creates owner-only. That is wrong for a sidecar written
+    // beside a user's music — which is why `lyrics::writeback` deliberately does
+    // not use it — and right here: this file lives in app data and is read back
+    // only by this process.
+    let path = directory.join(&file_name);
+    write_atomic(&path, &bytes)
+        .map_err(|error| MetadataError::io("write the background", &path, error))?;
+
+    let still_file_name = if animated {
+        Some(write_still(&directory, &file_name, &bytes)?)
+    } else {
+        None
+    };
+
+    Ok(CustomBackground {
+        file_name,
+        still_file_name,
+        width,
+        height,
+        animated,
+    })
+}
+
+/// Encode frame 0 beside the source and return its name.
+///
+/// Frame 0 is what a plain decode yields for both animated formats we accept —
+/// `GifDecoder` hands back the first frame through `ImageDecoder`, and the WebP
+/// decoder seeks the first `ANMF` chunk — so this needs no frame iteration.
+fn write_still(directory: &Path, file_name: &str, bytes: &[u8]) -> Result<String> {
+    let frame = decode(bytes)?;
+    let encoded = crate::art::image::encode_jpeg(&frame)?;
+
+    let still_name = still_name_for(file_name);
+    let path = directory.join(&still_name);
+    write_atomic(&path, &encoded)
+        .map_err(|error| MetadataError::io("write the background still", &path, error))?;
+
+    Ok(still_name)
+}
+
+/// The format the file's extension claims, refusing anything unlisted.
+fn claimed_format(source: &Path) -> Result<ImageFormat> {
+    let extension = extension_of(source).ok_or(MetadataError::BackgroundUnsupportedFormat {
+        extension: String::new(),
+    })?;
+
+    if !crate::background::record::is_allowed_extension(source) {
+        return Err(MetadataError::BackgroundUnsupportedFormat { extension });
+    }
+
+    ImageFormat::from_extension(&extension)
+        .ok_or(MetadataError::BackgroundUnsupportedFormat { extension })
+}
+
+/// The format the bytes actually are, by content.
+fn sniff(bytes: &[u8]) -> Result<ImageFormat> {
+    ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .map_err(|_| MetadataError::BackgroundNotAnImage)?
+        .format()
+        .ok_or(MetadataError::BackgroundNotAnImage)
+}
+
+/// Dimensions from the header, without decoding the pixels.
+fn dimensions(bytes: &[u8]) -> Result<(u32, u32)> {
+    ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .map_err(|_| MetadataError::BackgroundNotAnImage)?
+        .into_dimensions()
+        .map_err(|_| MetadataError::BackgroundNotAnImage)
+}
+
+/// Decode frame 0.
+fn decode(bytes: &[u8]) -> Result<DynamicImage> {
+    ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .map_err(|_| MetadataError::BackgroundNotAnImage)?
+        .decode()
+        .map_err(|_| MetadataError::BackgroundNotAnImage)
+}
+
+/// Whether the source carries more than one frame.
+///
+/// Three of the four accepted formats can animate: GIF, WebP, and PNG by way of
+/// APNG, which Chromium plays. Missing the PNG case would be the quiet kind of
+/// wrong — an APNG would import as static, get no poster still, and keep
+/// animating under `prefers-reduced-motion`, which is the exact promise the
+/// freeze design exists to keep.
+///
+/// The GIF answer costs two frames rather than a whole animation: `take(2)` is
+/// what stops a long GIF being fully decoded just to learn that it moves. The
+/// decoder is constructed directly rather than through `ImageReader`, which
+/// means it starts at `Limits::no_limits()` — so the default ceiling is put
+/// back explicitly. Without it, a two-frame GIF declaring a huge logical screen
+/// allocates its whole canvas here with nothing to stop it.
+fn is_animated(format: ImageFormat, bytes: &[u8]) -> Result<bool> {
+    match format {
+        ImageFormat::Gif => {
+            let mut decoder = image::codecs::gif::GifDecoder::new(Cursor::new(bytes))
+                .map_err(|_| MetadataError::BackgroundNotAnImage)?;
+            decoder
+                .set_limits(Limits::default())
+                .map_err(|_| MetadataError::BackgroundNotAnImage)?;
+            Ok(decoder.into_frames().take(2).count() > 1)
+        }
+        ImageFormat::WebP => {
+            let decoder = image::codecs::webp::WebPDecoder::new(Cursor::new(bytes))
+                .map_err(|_| MetadataError::BackgroundNotAnImage)?;
+            Ok(decoder.has_animation())
+        }
+        ImageFormat::Png => {
+            let decoder = image::codecs::png::PngDecoder::new(Cursor::new(bytes))
+                .map_err(|_| MetadataError::BackgroundNotAnImage)?;
+            Ok(decoder
+                .is_apng()
+                .map_err(|_| MetadataError::BackgroundNotAnImage)?)
+        }
+        _ => Ok(false),
+    }
+}
+
+/// The extension a stored file gets for a sniffed format.
+fn canonical_extension(format: ImageFormat) -> &'static str {
+    format.extensions_str().first().copied().unwrap_or("bin")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::background::record::background_dir;
+
+    fn write(directory: &Path, name: &str, bytes: &[u8]) -> std::path::PathBuf {
+        let path = directory.join(name);
+        std::fs::write(&path, bytes).expect("the fixture writes");
+        path
+    }
+
+    fn png(width: u32, height: u32) -> Vec<u8> {
+        let mut buffer = image::RgbImage::new(width, height);
+        for (x, y, pixel) in buffer.enumerate_pixels_mut() {
+            *pixel = image::Rgb([(x % 256) as u8, (y % 256) as u8, 200]);
+        }
+        let mut bytes = Vec::new();
+        DynamicImage::ImageRgb8(buffer)
+            .write_to(&mut Cursor::new(&mut bytes), ImageFormat::Png)
+            .expect("an in-memory PNG encodes");
+        bytes
+    }
+
+    /// A two-frame GIF, so the animation branch is exercised by a real
+    /// animation rather than by a mocked flag.
+    fn animated_gif() -> Vec<u8> {
+        use image::codecs::gif::GifEncoder;
+        use image::{Delay, Frame, RgbaImage};
+
+        let mut bytes = Vec::new();
+        {
+            let mut encoder = GifEncoder::new(&mut bytes);
+            for shade in [40_u8, 200_u8] {
+                let buffer = RgbaImage::from_pixel(8, 8, image::Rgba([shade, shade, shade, 255]));
+                encoder
+                    .encode_frame(Frame::from_parts(
+                        buffer,
+                        0,
+                        0,
+                        Delay::from_numer_denom_ms(100, 1),
+                    ))
+                    .expect("a frame encodes");
+            }
+        }
+        bytes
+    }
+
+    fn still_gif() -> Vec<u8> {
+        let mut bytes = Vec::new();
+        DynamicImage::ImageRgb8(image::RgbImage::from_pixel(8, 8, image::Rgb([10, 20, 30])))
+            .write_to(&mut Cursor::new(&mut bytes), ImageFormat::Gif)
+            .expect("a one-frame GIF encodes");
+        bytes
+    }
+
+    #[test]
+    fn an_unlisted_extension_is_refused_before_anything_is_read() {
+        let temp = tempfile::tempdir().expect("a temp dir");
+        // The bytes are a perfectly good PNG; only the extension is wrong. The
+        // refusal must not depend on the content being bad.
+        let source = write(temp.path(), "wallpaper.bmp", &png(10, 10));
+
+        assert!(matches!(
+            import_background(temp.path(), &source),
+            Err(MetadataError::BackgroundUnsupportedFormat { .. })
+        ));
+    }
+
+    /// I5: the extension is a claim, and a claim that does not match the bytes
+    /// is refused rather than stored.
+    #[test]
+    fn bytes_that_are_not_the_claimed_format_are_refused() {
+        let temp = tempfile::tempdir().expect("a temp dir");
+        let source = write(temp.path(), "wallpaper.png", b"this is not a PNG at all");
+
+        assert!(matches!(
+            import_background(temp.path(), &source),
+            Err(MetadataError::BackgroundNotAnImage)
+        ));
+    }
+
+    #[test]
+    fn a_real_image_under_the_wrong_image_extension_is_refused() {
+        let temp = tempfile::tempdir().expect("a temp dir");
+        // A genuine PNG named `.gif`. Both are allowed extensions, so only the
+        // sniff-versus-claim comparison catches this.
+        let source = write(temp.path(), "wallpaper.gif", &png(10, 10));
+
+        assert!(matches!(
+            import_background(temp.path(), &source),
+            Err(MetadataError::BackgroundNotAnImage)
+        ));
+    }
+
+    /// The edge cap alone would accept this: 7000x7000 is inside 8192 on both
+    /// sides and is still 49 megapixels. A flat image of that size compresses to
+    /// far under the byte cap, which is exactly the shape both caps together are
+    /// for — cheap on disk, expensive the moment it decodes.
+    #[test]
+    fn an_image_inside_the_edge_cap_but_past_the_pixel_cap_is_refused() {
+        let temp = tempfile::tempdir().expect("a temp dir");
+        let mut bytes = Vec::new();
+        DynamicImage::ImageRgb8(image::RgbImage::from_pixel(
+            7000,
+            7000,
+            image::Rgb([0, 0, 0]),
+        ))
+        .write_to(&mut Cursor::new(&mut bytes), ImageFormat::Png)
+        .expect("a large flat PNG encodes");
+        assert!(
+            (bytes.len() as u64) < MAX_FILE_BYTES,
+            "the fixture must pass the byte cap, or it tests the wrong refusal"
+        );
+        let source = write(temp.path(), "wallpaper.png", &bytes);
+
+        assert!(matches!(
+            import_background(temp.path(), &source),
+            Err(MetadataError::BackgroundDimensionsTooLarge { .. })
+        ));
+    }
+
+    /// The PNG animation probe must not answer yes for an ordinary PNG — every
+    /// static wallpaper would otherwise get a pointless poster still and be
+    /// reported as animated.
+    #[test]
+    fn an_ordinary_png_is_not_reported_as_animated() {
+        let temp = tempfile::tempdir().expect("a temp dir");
+        let data_dir = tempfile::tempdir().expect("a data dir");
+        let source = write(temp.path(), "wallpaper.png", &png(32, 32));
+
+        let record = import_background(data_dir.path(), &source).expect("a PNG imports");
+
+        assert!(!record.animated);
+        assert_eq!(record.still_file_name, None);
+    }
+
+    #[test]
+    fn a_file_past_the_byte_cap_is_refused() {
+        let temp = tempfile::tempdir().expect("a temp dir");
+        let source = write(
+            temp.path(),
+            "wallpaper.png",
+            &vec![0_u8; (MAX_FILE_BYTES + 1) as usize],
+        );
+
+        assert!(matches!(
+            import_background(temp.path(), &source),
+            Err(MetadataError::BackgroundTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn an_image_past_the_pixel_cap_is_refused() {
+        let temp = tempfile::tempdir().expect("a temp dir");
+        // A flat image compresses to far under the byte cap, which is exactly
+        // the shape the pixel cap exists to catch.
+        let mut bytes = Vec::new();
+        DynamicImage::ImageRgb8(image::RgbImage::from_pixel(
+            MAX_DIMENSION + 1,
+            4,
+            image::Rgb([0, 0, 0]),
+        ))
+        .write_to(&mut Cursor::new(&mut bytes), ImageFormat::Png)
+        .expect("a wide PNG encodes");
+        let source = write(temp.path(), "wallpaper.png", &bytes);
+
+        assert!(matches!(
+            import_background(temp.path(), &source),
+            Err(MetadataError::BackgroundDimensionsTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn a_static_image_is_stored_with_no_still() {
+        let temp = tempfile::tempdir().expect("a temp dir");
+        let data_dir = tempfile::tempdir().expect("a data dir");
+        let source = write(temp.path(), "wallpaper.png", &png(64, 32));
+
+        let record = import_background(data_dir.path(), &source).expect("a PNG imports");
+
+        assert_eq!((record.width, record.height), (64, 32));
+        assert!(!record.animated);
+        assert_eq!(record.still_file_name, None);
+        assert!(record.file_name.starts_with("bg-"));
+        assert!(record.file_name.ends_with(".png"));
+        assert!(
+            background_dir(data_dir.path())
+                .join(&record.file_name)
+                .exists()
+        );
+    }
+
+    /// I2's backend half: an animated source produces the frozen frame the
+    /// renderer swaps to. Without this file there is nothing to freeze *to*.
+    #[test]
+    fn an_animated_gif_gets_a_poster_still() {
+        let temp = tempfile::tempdir().expect("a temp dir");
+        let data_dir = tempfile::tempdir().expect("a data dir");
+        let source = write(temp.path(), "wallpaper.gif", &animated_gif());
+
+        let record = import_background(data_dir.path(), &source).expect("a GIF imports");
+
+        assert!(record.animated);
+        let still = record
+            .still_file_name
+            .expect("an animated import has a still");
+        assert_eq!(still, still_name_for(&record.file_name));
+
+        let still_bytes = std::fs::read(background_dir(data_dir.path()).join(&still))
+            .expect("the still exists on disk");
+        assert_eq!(
+            &still_bytes[..3],
+            &[0xFF, 0xD8, 0xFF],
+            "the frozen frame is a JPEG"
+        );
+    }
+
+    #[test]
+    fn a_single_frame_gif_is_not_treated_as_animated() {
+        let temp = tempfile::tempdir().expect("a temp dir");
+        let data_dir = tempfile::tempdir().expect("a data dir");
+        let source = write(temp.path(), "wallpaper.gif", &still_gif());
+
+        let record = import_background(data_dir.path(), &source).expect("a GIF imports");
+
+        assert!(!record.animated);
+        assert_eq!(record.still_file_name, None, "a still image needs no still");
+    }
+
+    #[test]
+    fn the_stored_name_is_derived_from_the_bytes_not_the_source_name() {
+        let temp = tempfile::tempdir().expect("a temp dir");
+        let data_dir = tempfile::tempdir().expect("a data dir");
+        let bytes = png(20, 20);
+        let first = write(temp.path(), "..%2F..%2Fetc%2Fpasswd.png", &bytes);
+        let second = write(temp.path(), "innocuous.png", &bytes);
+
+        let one = import_background(data_dir.path(), &first).expect("imports");
+        let two = import_background(data_dir.path(), &second).expect("imports");
+
+        assert_eq!(
+            one.file_name, two.file_name,
+            "the same bytes converge on one name"
+        );
+        assert!(
+            !one.file_name.contains("passwd") && !one.file_name.contains(['/', '\\']),
+            "no fragment of the source name survives into the stored name"
+        );
+    }
+}

--- a/crates/shiranami-metadata/src/background/ingest.rs
+++ b/crates/shiranami-metadata/src/background/ingest.rs
@@ -186,7 +186,13 @@ fn is_animated(format: ImageFormat, bytes: &[u8]) -> Result<bool> {
             decoder
                 .set_limits(Limits::default())
                 .map_err(|_| MetadataError::BackgroundNotAnImage)?;
-            Ok(decoder.into_frames().take(2).count() > 1)
+            // `take(2)` before the filter, not after: it bounds the work to two
+            // frame decodes whatever the file claims. The filter is what makes
+            // the count mean "frames that decoded" — `Frames` yields
+            // `Result`s, and counting those raw treats a corrupt second frame
+            // as evidence of animation, which is the opposite of what a failure
+            // to decode it says.
+            Ok(decoder.into_frames().take(2).filter(Result::is_ok).count() > 1)
         }
         ImageFormat::WebP => {
             let decoder = image::codecs::webp::WebPDecoder::new(Cursor::new(bytes))
@@ -423,6 +429,30 @@ mod tests {
             &still_bytes[..3],
             &[0xFF, 0xD8, 0xFF],
             "the frozen frame is a JPEG"
+        );
+    }
+
+    /// A frame that does not decode is not evidence of animation.
+    ///
+    /// `Frames` yields `Result`s, so counting them raw makes a truncated GIF —
+    /// one good frame, then garbage — report two frames and import as animated.
+    /// The still would be right and the flag wrong, which is the quiet kind of
+    /// wrong: nothing looks broken and the record says something untrue.
+    #[test]
+    fn a_frame_that_fails_to_decode_does_not_count_as_animation() {
+        let full = animated_gif();
+        // Cut inside the second frame's data: frame 0 still decodes, frame 1
+        // cannot. Sized off the one-frame GIF so the truncation lands after the
+        // first frame however the encoder laid the file out.
+        let cut = still_gif().len() + 8;
+        assert!(cut < full.len(), "the fixture must actually be truncated");
+
+        let format = sniff(&full[..cut]).expect("a truncated GIF still sniffs as a GIF");
+        assert_eq!(format, ImageFormat::Gif);
+
+        assert!(
+            !is_animated(format, &full[..cut]).expect("a truncated GIF is not an error here"),
+            "a frame that failed to decode was counted as animation"
         );
     }
 

--- a/crates/shiranami-metadata/src/background/mod.rs
+++ b/crates/shiranami-metadata/src/background/mod.rs
@@ -1,0 +1,50 @@
+//! The custom app background: import a user's image, freeze it, sweep orphans.
+//!
+//! A v2-born feature with no v1 counterpart, so nothing here is a compatibility
+//! constraint — but it lives beside [`crate::art`] rather than in the desktop
+//! shell for two reasons. It needs `image`, which only this crate carries; and
+//! the shell is wiring-only by architecture §2.1, enforced by a 400-code-line
+//! cap that an ingest pipeline would blow through on its own.
+//!
+//! # The shape of the trust boundary
+//!
+//! Everything here treats the user's file as untrusted input, because it is the
+//! one place in the app where arbitrary bytes chosen outside the library arrive
+//! and are then *served back over HTTP to our own webview*. Three consequences:
+//!
+//! 1. **The extension is a claim, not a fact.** [`ingest::import_background`]
+//!    decodes the bytes and compares the sniffed format against the claimed
+//!    extension, so a `.png` that is really something else is refused rather
+//!    than stored under a name the serve route would happily hand out.
+//! 2. **The stored name is ours, never theirs.** Files are content-addressed
+//!    (`bg-<hash>.<ext>`), so no fragment of a user-controlled filename reaches
+//!    the filesystem, the settings document, or a URL. It also makes
+//!    `Cache-Control: immutable` on the serve route true rather than merely
+//!    convenient, for the same reason it is true of album art.
+//! 3. **Cost is bounded before it is paid.** The byte cap is checked against
+//!    file metadata before the read, and the pixel cap against the image header
+//!    before the decode — so neither a 2 GB file nor a decompression bomb gets
+//!    to allocate first and be rejected after.
+//!
+//! # Why a poster still exists
+//!
+//! `ThemeBackground` in `apps/web` is retained under `lowPerformanceMode` and
+//! `prefers-reduced-transparency` *specifically because* a theme image is "a
+//! single static bitmap with no animation or blur" — its component doc says so.
+//! An animated GIF or WebP breaks that premise. Rather than drop the background
+//! under those settings (losing the user's chosen look) or keep decoding frames
+//! (defeating the setting), [`ingest`] encodes frame 0 to a sibling `.still.jpg`
+//! at import, and the renderer swaps the URL. The freeze then costs nothing at
+//! runtime and needs no canvas, no `<video>`, and no second code path in the
+//! paint layer.
+
+pub mod ingest;
+pub mod record;
+pub mod sweep;
+
+pub use ingest::import_background;
+pub use record::{
+    ALLOWED_EXTENSIONS, BACKGROUND_DIR_NAME, CustomBackground, MAX_DIMENSION, MAX_FILE_BYTES,
+    background_dir, is_allowed_extension, still_name_for,
+};
+pub use sweep::{BackgroundReference, SweepReport, sweep_orphans};

--- a/crates/shiranami-metadata/src/background/record.rs
+++ b/crates/shiranami-metadata/src/background/record.rs
@@ -1,0 +1,193 @@
+//! What an imported background *is*: the caps it had to pass, where it lives,
+//! and the record the settings document holds.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Directory holding imported backgrounds, relative to the app data directory.
+pub const BACKGROUND_DIR_NAME: &str = "backgrounds";
+
+/// The largest file the importer will accept, in bytes.
+///
+/// Checked against file metadata *before* the read, so an oversized file costs
+/// a `stat` rather than its own size in memory. Twenty megabytes is generous
+/// for a wallpaper and small enough that the whole-file read behind it is not a
+/// memory event worth streaming around.
+pub const MAX_FILE_BYTES: u64 = 20 * 1024 * 1024;
+
+/// The largest longest-edge the importer will accept, in pixels.
+///
+/// Checked against the image *header* before the decode, which is the point:
+/// the failure this prevents is a decompression bomb — a few kilobytes of
+/// deflate that expand to tens of gigabytes of pixels. Refusing after decoding
+/// would mean the allocation already happened.
+pub const MAX_DIMENSION: u32 = 8192;
+
+/// The largest total pixel count the importer will accept.
+///
+/// The edge cap alone is not a bound on cost: 8192x8192 satisfies it and is
+/// still 67 megapixels — a quarter of a gigabyte of RGBA before a single frame
+/// has been encoded. This is 8K-wide-by-8K-tall's *area* budget, generous
+/// enough for any real wallpaper (an 8K monitor is 33 megapixels) and small
+/// enough that the decode behind it is bounded.
+pub const MAX_PIXELS: u64 = 40_000_000;
+
+/// Accepted extensions, lowercase and without the dot.
+///
+/// A deliberate subset of what `image` can decode. Every entry here is a format
+/// the webview also renders natively, because the file is served straight to
+/// `background-image` — a format we can decode but Chromium cannot would import
+/// cleanly and then paint nothing.
+pub const ALLOWED_EXTENSIONS: [&str; 5] = ["png", "jpg", "jpeg", "webp", "gif"];
+
+/// Resolve the background directory beneath an app data directory.
+pub fn background_dir(data_dir: &Path) -> PathBuf {
+    data_dir.join(BACKGROUND_DIR_NAME)
+}
+
+/// Whether a path's extension is one this importer accepts.
+///
+/// Case-insensitive, because `.JPG` off a camera is the same file as `.jpg`,
+/// and a case-sensitive refusal here would read to the user as "this JPEG is
+/// not a JPEG".
+pub fn is_allowed_extension(path: &Path) -> bool {
+    extension_of(path).is_some_and(|extension| ALLOWED_EXTENSIONS.contains(&extension.as_str()))
+}
+
+/// A path's extension, lowercased and without the dot.
+pub(crate) fn extension_of(path: &Path) -> Option<String> {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+}
+
+/// The poster-still name that belongs to a background file name.
+///
+/// Derived rather than stored so the two can never disagree, and so the sweep
+/// can decide whether a file is referenced without parsing the record twice.
+pub fn still_name_for(file_name: &str) -> String {
+    let stem = file_name
+        .rsplit_once('.')
+        .map_or(file_name, |(stem, _extension)| stem);
+    format!("{stem}.still.jpg")
+}
+
+/// The settings record describing the currently imported background.
+///
+/// Persisted under `MainStoreKey::AppearanceCustomBackground` and returned to
+/// the renderer verbatim. Per architecture §2.3 this is a persisted *and* wire
+/// struct, so it may only ever grow, and every added field must be `Option` or
+/// `#[serde(default)]` — a record written by an older build has to keep
+/// parsing. `still_file_name` and `animated` already carry that treatment, and
+/// a test pins that a record missing both still loads.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomBackground {
+    /// The stored file name, `bg-<hash>.<ext>`. Never user-supplied.
+    pub file_name: String,
+    /// The frozen frame-0 sibling, present only for an animated source.
+    #[serde(default)]
+    pub still_file_name: Option<String>,
+    /// Width in pixels, as imported.
+    pub width: u32,
+    /// Height in pixels, as imported.
+    pub height: u32,
+    /// Whether the source carries more than one frame.
+    #[serde(default)]
+    pub animated: bool,
+}
+
+impl CustomBackground {
+    /// Every file name this record owns on disk.
+    ///
+    /// The sweep asks the record what it references rather than reconstructing
+    /// the naming scheme itself, so adding a future sibling (a thumbnail, a
+    /// blurred variant) cannot leave *this* build's sweep deleting it as an
+    /// orphan. It is not a cross-version guarantee: an older build parses a
+    /// newer record (no `deny_unknown_fields`), reports fewer owned names, and
+    /// its sweep would collect the sibling it cannot see. A future field naming
+    /// a file therefore has to assume a downgrade can delete it.
+    pub fn owned_file_names(&self) -> Vec<&str> {
+        let mut names = vec![self.file_name.as_str()];
+        if let Some(still) = self.still_file_name.as_deref() {
+            names.push(still);
+        }
+        names
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_accepted_extensions_are_case_insensitive() {
+        assert!(is_allowed_extension(Path::new("wallpaper.JPG")));
+        assert!(is_allowed_extension(Path::new("wallpaper.gif")));
+        assert!(is_allowed_extension(Path::new("wallpaper.WebP")));
+    }
+
+    #[test]
+    fn formats_the_webview_cannot_paint_are_not_accepted() {
+        // `image` decodes all of these. The webview does not paint them, so
+        // importing one would succeed and then show nothing.
+        for name in ["art.bmp", "art.tiff", "art.tga", "art.avif", "art.ico"] {
+            assert!(!is_allowed_extension(Path::new(name)), "{name}");
+        }
+    }
+
+    #[test]
+    fn a_file_with_no_extension_is_not_accepted() {
+        assert!(!is_allowed_extension(Path::new("wallpaper")));
+    }
+
+    #[test]
+    fn the_still_name_replaces_the_extension_rather_than_appending() {
+        assert_eq!(still_name_for("bg-abc123.gif"), "bg-abc123.still.jpg");
+        assert_eq!(still_name_for("bg-abc123.webp"), "bg-abc123.still.jpg");
+    }
+
+    /// The strictly-additive rule from §2.3, as a test rather than a promise: a
+    /// record written before the still and animation fields existed must still
+    /// parse, or an update would silently drop the user's background.
+    #[test]
+    fn a_record_missing_the_optional_fields_still_parses() {
+        let record: CustomBackground =
+            serde_json::from_str(r#"{"fileName":"bg-abc.png","width":1920,"height":1080}"#)
+                .expect("a record without the optional fields parses");
+
+        assert_eq!(record.file_name, "bg-abc.png");
+        assert_eq!(record.still_file_name, None);
+        assert!(!record.animated);
+    }
+
+    #[test]
+    fn a_static_record_owns_only_its_own_file() {
+        let record = CustomBackground {
+            file_name: "bg-abc.png".to_owned(),
+            still_file_name: None,
+            width: 100,
+            height: 100,
+            animated: false,
+        };
+
+        assert_eq!(record.owned_file_names(), vec!["bg-abc.png"]);
+    }
+
+    #[test]
+    fn an_animated_record_owns_its_still_as_well() {
+        let record = CustomBackground {
+            file_name: "bg-abc.gif".to_owned(),
+            still_file_name: Some("bg-abc.still.jpg".to_owned()),
+            width: 100,
+            height: 100,
+            animated: true,
+        };
+
+        assert_eq!(
+            record.owned_file_names(),
+            vec!["bg-abc.gif", "bg-abc.still.jpg"]
+        );
+    }
+}

--- a/crates/shiranami-metadata/src/background/sweep.rs
+++ b/crates/shiranami-metadata/src/background/sweep.rs
@@ -1,0 +1,214 @@
+//! Delete background files the current record does not name.
+//!
+//! Two callers, one mechanism. Importing a replacement leaves the previous
+//! wallpaper unreferenced, and so does a crash between writing a file and
+//! persisting the record that names it — the sweep collects both, so there is no
+//! separate "delete the predecessor" path that could run in the wrong order and
+//! remove a file the live record still points at.
+//!
+//! # The fail-safe, in the type
+//!
+//! [`crate::art::prune_orphans`] learned the hard way that "the reference lookup
+//! failed" and "nothing is referenced" are indistinguishable at the deletion
+//! site, and that one of them means destroying the user's data. That module
+//! defends itself by classifying every value. Here the reference set is a single
+//! settings entry, so the defence is cheaper and stronger: [`BackgroundReference`]
+//! has no variant that a failed read can be squeezed into. A caller that cannot
+//! read the record has nothing to pass but [`BackgroundReference::Unreadable`],
+//! and that variant deletes nothing.
+
+use std::fs;
+use std::path::Path;
+
+use crate::background::record::{ALLOWED_EXTENSIONS, CustomBackground, background_dir};
+
+/// What the caller was able to learn about the current background.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackgroundReference {
+    /// The settings entry was read. `None` means no background is set, which is
+    /// a real answer: every file in the directory is then an orphan.
+    Known(Option<CustomBackground>),
+    /// The settings entry could not be read or did not parse. Not evidence that
+    /// nothing is referenced, and never treated as such.
+    Unreadable,
+}
+
+/// What one sweep did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SweepReport {
+    /// Directory entries examined.
+    pub scanned: usize,
+    /// Files deleted.
+    pub deleted: usize,
+    /// File names the current record refers to.
+    pub referenced: usize,
+}
+
+/// Delete every background file the record does not own.
+///
+/// Never returns an error: a sweep is unattended boot-time housekeeping, and a
+/// failure to tidy is not a failure worth failing a launch over.
+pub fn sweep_orphans(data_dir: &Path, reference: &BackgroundReference) -> SweepReport {
+    let BackgroundReference::Known(current) = reference else {
+        tracing::warn!("background sweep: the record is unreadable, deleting nothing");
+        return SweepReport::default();
+    };
+
+    let referenced: Vec<&str> = current
+        .as_ref()
+        .map(CustomBackground::owned_file_names)
+        .unwrap_or_default();
+
+    let directory = background_dir(data_dir);
+    let entries = match fs::read_dir(&directory) {
+        Ok(entries) => entries,
+        Err(error) => {
+            // The normal state of an install that has never imported one.
+            tracing::debug!(%error, "background sweep: directory unreadable");
+            return SweepReport::default();
+        }
+    };
+
+    let mut report = SweepReport {
+        referenced: referenced.len(),
+        ..SweepReport::default()
+    };
+
+    for entry in entries.filter_map(std::result::Result::ok) {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        report.scanned += 1;
+
+        // An extension check as well as a name check, for the same reason the
+        // art prune has one: an unattended pass that deletes whatever it finds
+        // would take a half-written `.tmp` with it, and a `.tmp` surviving
+        // forever is the safe direction of that trade.
+        if referenced.contains(&name.as_str()) || !is_sweepable(&name) {
+            continue;
+        }
+
+        match fs::remove_file(entry.path()) {
+            Ok(()) => report.deleted += 1,
+            Err(error) => tracing::warn!(%error, entry = %name, "background sweep: delete failed"),
+        }
+    }
+
+    report
+}
+
+/// Whether a directory entry is one the sweep may delete.
+fn is_sweepable(name: &str) -> bool {
+    let Some((_, extension)) = name.rsplit_once('.') else {
+        return false;
+    };
+
+    ALLOWED_EXTENSIONS
+        .iter()
+        .any(|allowed| extension.eq_ignore_ascii_case(allowed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(file_name: &str, still: Option<&str>) -> CustomBackground {
+        CustomBackground {
+            file_name: file_name.to_owned(),
+            still_file_name: still.map(str::to_owned),
+            width: 100,
+            height: 100,
+            animated: still.is_some(),
+        }
+    }
+
+    fn seed(names: &[&str]) -> tempfile::TempDir {
+        let directory = tempfile::tempdir().expect("a temp dir");
+        let backgrounds = background_dir(directory.path());
+        fs::create_dir_all(&backgrounds).expect("the background dir is creatable");
+        for name in names {
+            fs::write(backgrounds.join(name), b"bytes").expect("a fixture entry writes");
+        }
+        directory
+    }
+
+    fn entries(directory: &tempfile::TempDir) -> Vec<String> {
+        let mut names: Vec<_> = fs::read_dir(background_dir(directory.path()))
+            .expect("the background dir exists")
+            .filter_map(std::result::Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn the_predecessor_is_collected_and_the_current_file_survives() {
+        let directory = seed(&["bg-old.png", "bg-new.png"]);
+
+        let report = sweep_orphans(
+            directory.path(),
+            &BackgroundReference::Known(Some(record("bg-new.png", None))),
+        );
+
+        assert_eq!(report.deleted, 1);
+        assert_eq!(entries(&directory), vec!["bg-new.png"]);
+    }
+
+    #[test]
+    fn a_still_is_referenced_by_the_record_that_owns_it() {
+        // Sweeping the still would leave an animated background with nothing to
+        // freeze to under reduced motion.
+        let directory = seed(&["bg-a.gif", "bg-a.still.jpg", "bg-old.png"]);
+
+        sweep_orphans(
+            directory.path(),
+            &BackgroundReference::Known(Some(record("bg-a.gif", Some("bg-a.still.jpg")))),
+        );
+
+        assert_eq!(entries(&directory), vec!["bg-a.gif", "bg-a.still.jpg"]);
+    }
+
+    /// The most important behaviour in the module: an unreadable record is not
+    /// evidence that nothing is referenced.
+    #[test]
+    fn an_unreadable_record_deletes_nothing() {
+        let directory = seed(&["bg-a.png", "bg-b.gif"]);
+
+        let report = sweep_orphans(directory.path(), &BackgroundReference::Unreadable);
+
+        assert_eq!(report, SweepReport::default());
+        assert_eq!(entries(&directory), vec!["bg-a.png", "bg-b.gif"]);
+    }
+
+    #[test]
+    fn no_background_set_means_every_file_is_an_orphan() {
+        // Distinct from Unreadable: this *is* a real answer, so the leftovers of
+        // a removed background get collected.
+        let directory = seed(&["bg-a.png", "bg-a.still.jpg"]);
+
+        let report = sweep_orphans(directory.path(), &BackgroundReference::Known(None));
+
+        assert_eq!(report.deleted, 2);
+        assert!(entries(&directory).is_empty());
+    }
+
+    #[test]
+    fn a_file_the_sweep_does_not_recognise_survives() {
+        let directory = seed(&["bg-a.png", "notes.txt", ".bg-a.png.1234.tmp"]);
+
+        let report = sweep_orphans(directory.path(), &BackgroundReference::Known(None));
+
+        assert_eq!(report.scanned, 3);
+        assert_eq!(report.deleted, 1);
+        assert_eq!(entries(&directory), vec![".bg-a.png.1234.tmp", "notes.txt"]);
+    }
+
+    #[test]
+    fn a_missing_directory_is_a_no_op() {
+        let directory = tempfile::tempdir().expect("a temp dir");
+
+        assert_eq!(
+            sweep_orphans(directory.path(), &BackgroundReference::Known(None)),
+            SweepReport::default()
+        );
+    }
+}

--- a/crates/shiranami-metadata/src/error.rs
+++ b/crates/shiranami-metadata/src/error.rs
@@ -101,6 +101,38 @@ pub enum MetadataError {
     /// The arguments were structurally valid but semantically wrong.
     #[error("{0}")]
     BadRequest(String),
+
+    /// A background import was refused: the file is past the byte cap.
+    #[error("the image is {size} bytes, past the {max}-byte limit")]
+    BackgroundTooLarge {
+        /// The file's size.
+        size: u64,
+        /// The cap it exceeded.
+        max: u64,
+    },
+
+    /// A background import was refused: the extension is not an accepted one.
+    #[error("`{extension}` is not an accepted image format")]
+    BackgroundUnsupportedFormat {
+        /// The extension the file carried, lowercased.
+        extension: String,
+    },
+
+    /// A background import was refused: the bytes are not the image the
+    /// extension claimed.
+    #[error("the file is not the image its extension claims")]
+    BackgroundNotAnImage,
+
+    /// A background import was refused: the image is past the pixel cap.
+    #[error("the image is {width}×{height}, past the {max}px limit on its longest edge")]
+    BackgroundDimensionsTooLarge {
+        /// Width as the header declared it.
+        width: u32,
+        /// Height as the header declared it.
+        height: u32,
+        /// The longest-edge cap it exceeded.
+        max: u32,
+    },
 }
 
 impl MetadataError {
@@ -143,6 +175,19 @@ impl WireError for MetadataError {
         match self {
             Self::EnrichBusy => Cow::Borrowed(ENRICH_BUSY_CODE),
             Self::BadRequest(_) => Cow::Borrowed(codes::validation::BAD_REQUEST),
+            // The four background refusals are the exception to the paragraph
+            // below: each one is something the *user* can fix by picking a
+            // different file, so each gets its own code and its own sentence in
+            // the Appearance card. Collapsing them into INTERNAL would answer
+            // "that didn't work" to a question with four different answers.
+            Self::BackgroundTooLarge { .. } => Cow::Borrowed(codes::background::TOO_LARGE),
+            Self::BackgroundUnsupportedFormat { .. } => {
+                Cow::Borrowed(codes::background::UNSUPPORTED_FORMAT)
+            }
+            Self::BackgroundNotAnImage => Cow::Borrowed(codes::background::NOT_AN_IMAGE),
+            Self::BackgroundDimensionsTooLarge { .. } => {
+                Cow::Borrowed(codes::background::DIMENSIONS_TOO_LARGE)
+            }
             // Everything else is a file or a network we could not work with.
             // v1 surfaced all of these as a logged warning and a best-effort
             // result, never as a code the renderer matched on, so nothing is

--- a/crates/shiranami-metadata/src/lib.rs
+++ b/crates/shiranami-metadata/src/lib.rs
@@ -46,6 +46,7 @@
 #![warn(missing_docs)]
 
 pub mod art;
+pub mod background;
 pub mod enrich;
 pub mod error;
 pub mod lookup;

--- a/crates/shiranami-serve/examples/analyser_canary.rs
+++ b/crates/shiranami-serve/examples/analyser_canary.rs
@@ -105,6 +105,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }),
             )),
             art_dir: fixture_dir.clone(),
+            background_dir: fixture_dir.clone(),
             guard: UrlGuard::system(),
             upstream: Arc::new(NoRadio),
             now_playing: shiranami_serve::NowPlayingSink::discarding(),

--- a/crates/shiranami-serve/src/routes/art.rs
+++ b/crates/shiranami-serve/src/routes/art.rs
@@ -13,24 +13,24 @@
 //! rewriting it, and then re-checks the joined path for containment anyway,
 //! because a guard that depends on one function being right is a guard with one
 //! point of failure.
+//!
+//! That name check now lives in [`crate::routes::image_file`], shared with the
+//! background route. The containment re-check below deliberately did not move
+//! with it: its value is being a *second* opinion, which it stops being the
+//! moment it sits in the same function as the first.
 
 use axum::body::Body;
 use axum::extract::{Path as UrlPath, State};
-use axum::http::{StatusCode, header};
-use axum::response::{IntoResponse, Response};
+use axum::response::Response;
 use bytes::Bytes;
 use shiranami_core::paths::is_path_within;
 use tokio_util::io::ReaderStream;
 
 use crate::art_cache::DEFAULT_MAX_BYTES;
 use crate::error::ServeError;
-use crate::media_types::{extension_of, image_mime, is_image_path};
 use crate::routes::audio::CHUNK_SIZE;
+use crate::routes::image_file::{image_response, safe_name};
 use crate::state::ServeState;
-
-/// A year, and a promise never to revalidate. Sound only because the name is a
-/// hash of the contents.
-const IMMUTABLE: &str = "public, max-age=31536000, immutable";
 
 /// Serve one cached album-art file.
 pub async fn handle(
@@ -41,7 +41,7 @@ pub async fn handle(
         return Err(ServeError::NotFound);
     }
 
-    let name = safe_name(&name)?;
+    let name = safe_name("art", &name)?;
     let path = state.art_dir().join(&name);
 
     // The joined path must still be under the art directory. It always is, given
@@ -88,114 +88,4 @@ pub async fn handle(
     state.art_cache().insert(name.clone(), bytes.clone());
 
     Ok(image_response(&name, bytes.len() as u64, Body::from(bytes)))
-}
-
-/// The requested file name, if it is a file name and not a path.
-///
-/// Rejects rather than sanitises. `path.basename('../../etc/passwd')` returns
-/// `passwd`, which is a *different file that exists* — sanitising turns an
-/// attack into a wrong answer, and a wrong answer is harder to notice than a
-/// 403.
-fn safe_name(name: &str) -> Result<String, ServeError> {
-    let refuse = |reason: &str| {
-        tracing::warn!(reason, "art route refused a name");
-        ServeError::Forbidden
-    };
-
-    if name.is_empty() {
-        return Err(ServeError::BadRequest("missing art name"));
-    }
-    // Both separators, on every platform: a Windows-style name reaching a Unix
-    // build must not be treated as an innocent file name with backslashes in it.
-    if name.contains('/') || name.contains('\\') || name.contains('\0') {
-        return Err(refuse("separator in name"));
-    }
-    if name == "." || name == ".." {
-        return Err(refuse("relative name"));
-    }
-    if !is_image_path(std::path::Path::new(name)) {
-        return Err(refuse("non-image extension"));
-    }
-
-    Ok(name.to_owned())
-}
-
-fn image_response(name: &str, length: u64, body: Body) -> Response {
-    let content_type = extension_of(std::path::Path::new(name))
-        .map_or(crate::media_types::DEFAULT_IMAGE_MIME, |extension| {
-            image_mime(&extension)
-        });
-
-    (
-        StatusCode::OK,
-        [
-            (header::CONTENT_TYPE, content_type.to_owned()),
-            (header::CONTENT_LENGTH, length.to_string()),
-            (header::CACHE_CONTROL, IMMUTABLE.to_owned()),
-        ],
-        body,
-    )
-        .into_response()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn refused(name: &str) -> ServeError {
-        safe_name(name).expect_err("the name must be refused")
-    }
-
-    #[test]
-    fn a_content_addressed_name_is_accepted() {
-        assert_eq!(
-            safe_name("6f1ed002ab5595859014ebf0951522d9.jpg").expect("a hash name is fine"),
-            "6f1ed002ab5595859014ebf0951522d9.jpg"
-        );
-    }
-
-    /// Every traversal shape is refused, not rewritten.
-    #[test]
-    fn traversal_is_refused_rather_than_stripped() {
-        for name in [
-            "../secrets.jpg",
-            "../../etc/passwd.jpg",
-            "..\\..\\windows\\system32\\config.jpg",
-            "subdir/cover.jpg",
-            "/etc/passwd.jpg",
-            "..",
-            ".",
-        ] {
-            assert!(
-                matches!(refused(name), ServeError::Forbidden),
-                "`{name}` must be refused"
-            );
-        }
-    }
-
-    /// The art directory holds images. A name that is not one is refused before
-    /// anything opens it, which is what stops the route serving the settings
-    /// file if one ever lands beside the covers.
-    #[test]
-    fn a_non_image_extension_is_refused() {
-        for name in ["config.json", "library.db", "cover", "cover.txt"] {
-            assert!(matches!(refused(name), ServeError::Forbidden));
-        }
-    }
-
-    #[test]
-    fn an_empty_name_is_a_bad_request() {
-        assert!(matches!(refused(""), ServeError::BadRequest(_)));
-    }
-
-    #[test]
-    fn a_null_byte_is_refused() {
-        assert!(matches!(refused("cover\0.jpg"), ServeError::Forbidden));
-    }
-
-    #[test]
-    fn the_cache_header_is_the_immutable_one() {
-        assert!(IMMUTABLE.contains("immutable"));
-        assert!(IMMUTABLE.contains("max-age=31536000"));
-    }
 }

--- a/crates/shiranami-serve/src/routes/background.rs
+++ b/crates/shiranami-serve/src/routes/background.rs
@@ -1,0 +1,73 @@
+//! `GET /{token}/background/{name}` — the user's imported app background.
+//!
+//! A v2-born route with no v1 protocol behind it. It exists because the webview
+//! has no filesystem reach at all: there is no `fs` plugin, the asset protocol
+//! is not enabled, and `convertFileSrc` is used nowhere. A wallpaper the user
+//! picked therefore reaches `background-image` the same way album art reaches
+//! `<img>` — over this loopback server, behind the session token. That also
+//! means the CSP needs nothing new: `img-src` already carries `http:`, which
+//! covers `http://127.0.0.1:*`.
+//!
+//! Two deliberate differences from [`crate::routes::art`], which it otherwise
+//! mirrors:
+//!
+//! - **No cache.** There is exactly one background and the browser holds it
+//!   behind an immutable header from the first request. An LRU entry here would
+//!   be a second copy of a file with a hit rate of one.
+//! - **Always streamed.** A wallpaper is allowed to be twenty megabytes, where a
+//!   cover is a few hundred kilobytes. Reading it whole to hand it over once
+//!   buys nothing and costs its own size in resident memory.
+//!
+//! The name guard is [`crate::routes::image_file::safe_name`], shared with the
+//! art route, and the containment re-check below is the same second opinion the
+//! art route keeps for the same reason.
+
+use axum::body::Body;
+use axum::extract::{Path as UrlPath, State};
+use axum::response::Response;
+use shiranami_core::paths::is_path_within;
+use tokio_util::io::ReaderStream;
+
+use crate::error::ServeError;
+use crate::routes::audio::CHUNK_SIZE;
+use crate::routes::image_file::{image_response, safe_name};
+use crate::state::ServeState;
+
+/// Serve the imported background, or its frozen still.
+///
+/// Both are ordinary files in the same directory, so one route covers them:
+/// which of the two the renderer asks for is a rendering decision, and this
+/// layer has no opinion about reduced motion.
+pub async fn handle(
+    State(state): State<ServeState>,
+    UrlPath((token, name)): UrlPath<(String, String)>,
+) -> Result<Response, ServeError> {
+    if !state.token_matches(&token) {
+        return Err(ServeError::NotFound);
+    }
+
+    let name = safe_name("background", &name)?;
+    let path = state.background_dir().join(&name);
+
+    // Always true given the name check above — which is the point: this
+    // assertion is what makes that check's failure a refusal rather than an
+    // escape.
+    if !is_path_within(&path, state.background_dir()) {
+        tracing::warn!("background route refused a name that escaped the background directory");
+        return Err(ServeError::Forbidden);
+    }
+
+    let file = tokio::fs::File::open(&path)
+        .await
+        .map_err(|_| ServeError::NotFound)?;
+    let metadata = file.metadata().await.map_err(|_| ServeError::NotFound)?;
+    if !metadata.is_file() {
+        return Err(ServeError::NotAFile);
+    }
+    let size = metadata.len();
+
+    tracing::debug!(size, "background route serving");
+
+    let body = Body::from_stream(ReaderStream::with_capacity(file, CHUNK_SIZE));
+    Ok(image_response(&name, size, body))
+}

--- a/crates/shiranami-serve/src/routes/image_file.rs
+++ b/crates/shiranami-serve/src/routes/image_file.rs
@@ -1,0 +1,150 @@
+//! The name guard and response shape shared by every route that serves one
+//! image out of one app-owned directory.
+//!
+//! Two routes fit that description — [`crate::routes::art`] and
+//! [`crate::routes::background`] — and they ask the same question: *is this a
+//! bare image file name, and if so what does a response carrying it look like*.
+//! The guard lives here once rather than once per route on purpose. Two copies
+//! of a path-traversal check are two things to keep right, and the second copy
+//! is the one that gets a fix late or not at all.
+//!
+//! What is deliberately **not** shared is containment: each route re-checks the
+//! joined path against its own directory. That check is cheap, and its whole
+//! value is being a second opinion about [`safe_name`] — folding it in here
+//! would collapse the two guards into one and take the redundancy with it.
+
+use axum::body::Body;
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+
+use crate::error::ServeError;
+use crate::media_types::{extension_of, image_mime};
+
+/// A year, and a promise never to revalidate.
+///
+/// Sound only because both callers name files by a hash of their contents: the
+/// bytes behind a given name genuinely cannot change. It is wrong on the audio
+/// route for exactly that reason, and would be wrong here the moment a caller
+/// started reusing a name.
+pub(crate) const IMMUTABLE: &str = "public, max-age=31536000, immutable";
+
+/// The requested file name, if it is a file name and not a path.
+///
+/// Rejects rather than sanitises. `path.basename('../../etc/passwd')` returns
+/// `passwd`, which is a *different file that exists* — sanitising turns an
+/// attack into a wrong answer, and a wrong answer is harder to notice than a
+/// 403.
+pub(crate) fn safe_name(route: &'static str, name: &str) -> Result<String, ServeError> {
+    let refuse = |reason: &str| {
+        tracing::warn!(route, reason, "refused a name");
+        ServeError::Forbidden
+    };
+
+    if name.is_empty() {
+        return Err(ServeError::BadRequest("missing file name"));
+    }
+    // Both separators, on every platform: a Windows-style name reaching a Unix
+    // build must not be treated as an innocent file name with backslashes in it.
+    if name.contains('/') || name.contains('\\') || name.contains('\0') {
+        return Err(refuse("separator in name"));
+    }
+    if name == "." || name == ".." {
+        return Err(refuse("relative name"));
+    }
+    if !crate::media_types::is_image_path(std::path::Path::new(name)) {
+        return Err(refuse("non-image extension"));
+    }
+
+    Ok(name.to_owned())
+}
+
+/// An image response with the immutable cache header.
+pub(crate) fn image_response(name: &str, length: u64, body: Body) -> Response {
+    let content_type = extension_of(std::path::Path::new(name))
+        .map_or(crate::media_types::DEFAULT_IMAGE_MIME, |extension| {
+            image_mime(&extension)
+        });
+
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, content_type.to_owned()),
+            (header::CONTENT_LENGTH, length.to_string()),
+            (header::CACHE_CONTROL, IMMUTABLE.to_owned()),
+        ],
+        body,
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn refused(name: &str) -> ServeError {
+        safe_name("test", name).expect_err("the name must be refused")
+    }
+
+    #[test]
+    fn a_content_addressed_name_is_accepted() {
+        assert_eq!(
+            safe_name("test", "6f1ed002ab5595859014ebf0951522d9.jpg").expect("a hash name is fine"),
+            "6f1ed002ab5595859014ebf0951522d9.jpg"
+        );
+    }
+
+    /// Every traversal shape is refused, not rewritten.
+    #[test]
+    fn traversal_is_refused_rather_than_stripped() {
+        for name in [
+            "../secrets.jpg",
+            "../../etc/passwd.jpg",
+            "..\\..\\windows\\system32\\config.jpg",
+            "subdir/cover.jpg",
+            "/etc/passwd.jpg",
+            "..",
+            ".",
+        ] {
+            assert!(
+                matches!(refused(name), ServeError::Forbidden),
+                "`{name}` must be refused"
+            );
+        }
+    }
+
+    /// The directories behind both callers hold images. A name that is not one
+    /// is refused before anything opens it, which is what stops a route serving
+    /// the settings file if one ever lands beside the covers.
+    #[test]
+    fn a_non_image_extension_is_refused() {
+        for name in ["config.json", "library.db", "cover", "cover.txt"] {
+            assert!(matches!(refused(name), ServeError::Forbidden));
+        }
+    }
+
+    #[test]
+    fn an_empty_name_is_a_bad_request() {
+        assert!(matches!(refused(""), ServeError::BadRequest(_)));
+    }
+
+    #[test]
+    fn a_null_byte_is_refused() {
+        assert!(matches!(refused("cover\0.jpg"), ServeError::Forbidden));
+    }
+
+    /// The background route stores `.gif` and `.webp`, so the shared guard has
+    /// to accept them — a name check that only knew about album art would refuse
+    /// every animated wallpaper.
+    #[test]
+    fn every_format_the_background_importer_stores_is_accepted() {
+        for name in ["bg-abc.png", "bg-abc.jpg", "bg-abc.webp", "bg-abc.gif"] {
+            assert!(safe_name("test", name).is_ok(), "{name}");
+        }
+    }
+
+    #[test]
+    fn the_cache_header_is_the_immutable_one() {
+        assert!(IMMUTABLE.contains("immutable"));
+        assert!(IMMUTABLE.contains("max-age=31536000"));
+    }
+}

--- a/crates/shiranami-serve/src/routes/mod.rs
+++ b/crates/shiranami-serve/src/routes/mod.rs
@@ -5,8 +5,17 @@
 //! | `shiranami-audio://play?path=…`  | [`audio`]       | `GET /{token}/audio?path=…`   |
 //! | `shiranami-art://art/{name}`     | [`art`]         | `GET /{token}/art/{name}`     |
 //! | `shiranami-radio://stream?url=…` | [`radio`]       | `GET /{token}/radio?url=…`    |
+//!
+//! Plus one route with no v1 protocol behind it, because v1 had no such feature:
+//!
+//! | —                                | [`background`]  | `GET /{token}/background/{name}` |
+//!
+//! [`image_file`] is not a route: it holds the name guard and response shape
+//! that [`art`] and [`background`] share.
 
 pub mod art;
 pub mod audio;
+pub mod background;
+pub mod image_file;
 pub mod query;
 pub mod radio;

--- a/crates/shiranami-serve/src/server.rs
+++ b/crates/shiranami-serve/src/server.rs
@@ -19,7 +19,7 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
 use crate::error::ServeError;
-use crate::routes::{art, audio, radio};
+use crate::routes::{art, audio, background, radio};
 use crate::state::{ServeConfig, ServeState};
 use crate::token::SessionToken;
 
@@ -141,6 +141,7 @@ pub fn router(state: ServeState) -> Router {
     Router::new()
         .route("/{token}/audio", get(audio::handle))
         .route("/{token}/art/{name}", get(art::handle))
+        .route("/{token}/background/{name}", get(background::handle))
         .route("/{token}/radio", get(radio::handle))
         .fallback(unknown)
         .layer(axum::middleware::from_fn(crate::cors::apply))

--- a/crates/shiranami-serve/src/state.rs
+++ b/crates/shiranami-serve/src/state.rs
@@ -36,6 +36,12 @@ pub struct ServeConfig {
     pub folders: Arc<FoldersCache>,
     /// Where album art lives on disk — `<userData>/album-art` in v1's layout.
     pub art_dir: PathBuf,
+    /// Where imported app backgrounds live — `<userData>/backgrounds`.
+    ///
+    /// A second directory rather than a subdirectory of the art cache, because
+    /// the art prune deletes by reference and would treat every wallpaper as an
+    /// orphan on the first boot after an import.
+    pub background_dir: PathBuf,
     /// The SSRF guard, shared with the HTTP client so both judge by one clock.
     pub guard: UrlGuard,
     /// How the radio proxy reaches a station.
@@ -55,11 +61,13 @@ impl ServeConfig {
     pub fn new(
         folders: Arc<FoldersCache>,
         art_dir: PathBuf,
+        background_dir: PathBuf,
         client: shiranami_net::HttpClient,
     ) -> Self {
         Self {
             folders,
             art_dir,
+            background_dir,
             guard: client.guard().clone(),
             upstream: Arc::new(crate::upstream::NetUpstream::new(client)),
             now_playing: NowPlayingSink::discarding(),
@@ -80,6 +88,7 @@ struct Inner {
     token: SessionToken,
     folders: Arc<FoldersCache>,
     art_dir: PathBuf,
+    background_dir: PathBuf,
     art_cache: ArtCache,
     guard: UrlGuard,
     upstream: Arc<dyn RadioUpstream>,
@@ -95,6 +104,7 @@ impl ServeState {
                 token,
                 folders: config.folders,
                 art_dir: config.art_dir,
+                background_dir: config.background_dir,
                 art_cache: ArtCache::default(),
                 guard: config.guard,
                 upstream: config.upstream,
@@ -124,6 +134,11 @@ impl ServeState {
     /// The album-art directory.
     pub fn art_dir(&self) -> &std::path::Path {
         &self.inner.art_dir
+    }
+
+    /// The imported-background directory.
+    pub fn background_dir(&self) -> &std::path::Path {
+        &self.inner.background_dir
     }
 
     /// The album-art LRU.

--- a/crates/shiranami-serve/tests/common/harness.rs
+++ b/crates/shiranami-serve/tests/common/harness.rs
@@ -30,6 +30,13 @@ pub struct Harness {
     pub music: TempDir,
     /// The album-art directory.
     pub art: TempDir,
+    /// The imported-background directory.
+    ///
+    /// A separate temp dir from [`Harness::art`] rather than the same one, so a
+    /// containment test can actually fail: if the two routes shared a directory,
+    /// "the background route cannot reach the covers" would hold for the wrong
+    /// reason and keep holding after the guard was removed.
+    pub backgrounds: TempDir,
     /// A directory that is *not* an allowed root.
     pub outside: TempDir,
     pub upstream: Arc<FakeUpstream>,
@@ -50,6 +57,7 @@ impl Harness {
         let data = TempDir::new().expect("a data dir");
         let music = TempDir::new().expect("a music dir");
         let art = TempDir::new().expect("an art dir");
+        let backgrounds = TempDir::new().expect("a background dir");
         let outside = TempDir::new().expect("a dir outside every root");
 
         let authority = TestAuthority {
@@ -68,6 +76,7 @@ impl Harness {
         let config = ServeConfig {
             folders,
             art_dir: art.path().to_owned(),
+            background_dir: backgrounds.path().to_owned(),
             guard: UrlGuard::with_resolver(Arc::new(resolver)),
             upstream: Arc::clone(&upstream) as Arc<dyn RadioUpstream>,
             now_playing: NowPlayingSink::from_fn(move |playing| {
@@ -89,6 +98,7 @@ impl Harness {
                 .expect("the test client builds"),
             music,
             art,
+            backgrounds,
             outside,
             upstream,
             titles,
@@ -141,9 +151,26 @@ impl Harness {
         self.get(&url, headers).await
     }
 
+    /// Write a fixture into the imported-background directory.
+    pub fn write_background(&self, name: &str, size: usize) -> PathBuf {
+        let path = self.backgrounds.path().join(name);
+        std::fs::write(&path, pattern(size)).expect("the fixture writes");
+        path
+    }
+
     /// `GET {base}/art/<name>`.
     pub async fn art(&self, name: &str) -> reqwest::Response {
         let url = format!("{}/art/{name}", self.base());
+        self.get(&url, &[]).await
+    }
+
+    /// `GET {base}/background/<name>`.
+    ///
+    /// `name` is interpolated raw so a test can send an encoded traversal:
+    /// axum decodes the path parameter before the handler sees it, so the
+    /// shapes that matter cannot be built by a helper that escapes them first.
+    pub async fn background(&self, name: &str) -> reqwest::Response {
+        let url = format!("{}/background/{name}", self.base());
         self.get(&url, &[]).await
     }
 
@@ -219,6 +246,7 @@ pub async fn start_stripped() -> StrippedServer {
         ServeConfig {
             folders,
             art_dir: data.path().to_owned(),
+            background_dir: data.path().to_owned(),
             guard: UrlGuard::with_resolver(Arc::new(TestResolver::new())),
             upstream: Arc::new(FakeUpstream::new()) as Arc<dyn RadioUpstream>,
             now_playing: NowPlayingSink::discarding(),

--- a/crates/shiranami-serve/tests/migrated_profile.rs
+++ b/crates/shiranami-serve/tests/migrated_profile.rs
@@ -92,6 +92,7 @@ async fn a_migrated_art_cache_serves_v1s_covers_at_v1s_names() {
         folders,
         // Exactly where the migration put it.
         art_dir: data.join("album-art"),
+        background_dir: data.join("backgrounds"),
         guard: UrlGuard::with_resolver(Arc::new(TestResolver::new())),
         upstream: Arc::new(FakeUpstream::new()) as Arc<dyn RadioUpstream>,
         now_playing: shiranami_serve::NowPlayingSink::discarding(),

--- a/crates/shiranami-serve/tests/security.rs
+++ b/crates/shiranami-serve/tests/security.rs
@@ -270,6 +270,100 @@ async fn the_art_route_cannot_reach_the_music_directory() {
     );
 }
 
+/// The background route carries the same guard as the art route, so it is held
+/// to the same shapes. It is the *newer* of the two and the one whose directory
+/// holds a file the user chose, so a traversal that works here is worth more to
+/// an attacker than one that works against the cover cache.
+#[tokio::test]
+async fn background_traversal_is_refused() {
+    let harness = Harness::start().await;
+    harness.write_background("bg-abc.png", 128);
+    let outside = harness.write_outside("secret.png", 128);
+
+    for name in [
+        "..%2F..%2Fetc%2Fpasswd.png",
+        "..%2Fsecret.png",
+        "..%5C..%5Cwindows%5Csystem32%5Cconfig.png",
+        "%2Fetc%2Fpasswd.png",
+        "..",
+        "%2e%2e%2f%2e%2e%2fsecret.png",
+    ] {
+        let response = harness.background(name).await;
+        assert!(
+            response.status().is_client_error(),
+            "background name `{name}` was answered with {}",
+            response.status()
+        );
+        let body = response.bytes().await.expect("a body");
+        assert_ne!(
+            &body[..],
+            &std::fs::read(&outside).expect("the fixture reads")[..],
+            "background name `{name}` served a file outside the background directory"
+        );
+    }
+}
+
+/// A wallpaper directory that could also hand out the settings document would be
+/// a worse leak than the art one: it sits under the same app-data root.
+#[tokio::test]
+async fn a_non_image_in_the_background_directory_is_refused() {
+    let harness = Harness::start().await;
+    harness.write_background("config.json", 128);
+    harness.write_background("notes.txt", 128);
+
+    for name in ["config.json", "notes.txt"] {
+        assert_eq!(
+            harness.background(name).await.status(),
+            StatusCode::FORBIDDEN,
+            "{name} was served by the background route"
+        );
+    }
+}
+
+/// The two image routes read different directories, and neither is a way into
+/// the other. Sharing one name guard is what makes this worth asserting: the
+/// guard says "this is a bare file name", and only the per-route directory says
+/// *which* file that names.
+#[tokio::test]
+async fn the_background_route_cannot_reach_the_art_or_music_directories() {
+    let harness = Harness::start().await;
+    harness.write_art("cover.jpg", 128);
+    harness.write_audio("track.png", 128);
+
+    assert_eq!(
+        harness.background("cover.jpg").await.status(),
+        StatusCode::NOT_FOUND
+    );
+    assert_eq!(
+        harness.background("track.png").await.status(),
+        StatusCode::NOT_FOUND
+    );
+}
+
+/// And the reverse: a wallpaper is not reachable through the art route.
+#[tokio::test]
+async fn the_art_route_cannot_reach_the_background_directory() {
+    let harness = Harness::start().await;
+    harness.write_background("bg-abc.png", 128);
+
+    assert_eq!(
+        harness.art("bg-abc.png").await.status(),
+        StatusCode::NOT_FOUND
+    );
+}
+
+/// A wrong token is a 404 on this route too — the background is behind the same
+/// per-session credential as everything else, not merely obscure.
+#[tokio::test]
+async fn a_background_needs_the_session_token() {
+    let harness = Harness::start().await;
+    harness.write_background("bg-abc.png", 128);
+
+    let url = format!("{}/background/bg-abc.png", harness.base_with_wrong_token());
+
+    assert_eq!(harness.get(&url, &[]).await.status(), StatusCode::NOT_FOUND);
+}
+
 /// Two servers, two tokens. A token learned from one session is worthless
 /// against the next, which is what makes the credential per-session.
 #[tokio::test]

--- a/packages/contracts/src/generated/bindings.ts
+++ b/packages/contracts/src/generated/bindings.ts
@@ -54,7 +54,18 @@ export const commands = {
 	 *  A *refusal* is an error, and a specific one — see
 	 *  `shiranami_core::error::codes::background`.
 	 */
-	backgroundPick: () => __TAURI_INVOKE<CustomBackground | null>("background_pick"),
+	backgroundPick: () => __TAURI_INVOKE<{
+	/**  The stored file name, `bg-<hash>.<ext>`. Never user-supplied. */
+	fileName: string,
+	/**  The frozen frame-0 sibling, present only for an animated source. */
+	stillFileName?: string | null,
+	/**  Width in pixels, as imported. */
+	width: number,
+	/**  Height in pixels, as imported. */
+	height: number,
+	/**  Whether the source carries more than one frame. */
+	animated?: boolean,
+} | null>("background_pick"),
 	/**
 	 *  `background:get` — the current background, if one is set and still on disk.
 	 * 
@@ -63,7 +74,18 @@ export const commands = {
 	 *  returned, so the renderer never has to render a URL that 404s. The filesystem
 	 *  is the source of truth for existence; the settings entry only names things.
 	 */
-	backgroundGet: () => __TAURI_INVOKE<CustomBackground | null>("background_get"),
+	backgroundGet: () => __TAURI_INVOKE<{
+	/**  The stored file name, `bg-<hash>.<ext>`. Never user-supplied. */
+	fileName: string,
+	/**  The frozen frame-0 sibling, present only for an animated source. */
+	stillFileName?: string | null,
+	/**  Width in pixels, as imported. */
+	width: number,
+	/**  Height in pixels, as imported. */
+	height: number,
+	/**  Whether the source carries more than one frame. */
+	animated?: boolean,
+} | null>("background_get"),
 	/**  `background:clear` — forget the background and delete its files. */
 	backgroundClear: () => __TAURI_INVOKE<null>("background_clear"),
 	/**
@@ -1558,13 +1580,13 @@ export type CustomBackground = {
 	/**  The stored file name, `bg-<hash>.<ext>`. Never user-supplied. */
 	fileName: string,
 	/**  The frozen frame-0 sibling, present only for an animated source. */
-	stillFileName: string | null,
+	stillFileName?: string | null,
 	/**  Width in pixels, as imported. */
 	width: number,
 	/**  Height in pixels, as imported. */
 	height: number,
 	/**  Whether the source carries more than one frame. */
-	animated: boolean,
+	animated?: boolean,
 };
 
 /**  What `db:backup:export` resolves to — v1's `DbExportResult`. */

--- a/packages/contracts/src/generated/bindings.ts
+++ b/packages/contracts/src/generated/bindings.ts
@@ -47,6 +47,26 @@ export const commands = {
 	 */
 	appGetLocaleCountry: () => __TAURI_INVOKE<string>("app_get_locale_country"),
 	/**
+	 *  `background:pick` — choose an image and adopt it, or `null` if cancelled.
+	 * 
+	 *  Cancelling is not an error, matching every other picker in the app: the
+	 *  renderer's "the user changed their mind" branch is an `if`, not a `catch`.
+	 *  A *refusal* is an error, and a specific one — see
+	 *  `shiranami_core::error::codes::background`.
+	 */
+	backgroundPick: () => __TAURI_INVOKE<CustomBackground | null>("background_pick"),
+	/**
+	 *  `background:get` — the current background, if one is set and still on disk.
+	 * 
+	 *  Self-healing: a record naming a file that has vanished (an external delete, a
+	 *  restored profile, a half-copied app-data move) is removed rather than
+	 *  returned, so the renderer never has to render a URL that 404s. The filesystem
+	 *  is the source of truth for existence; the settings entry only names things.
+	 */
+	backgroundGet: () => __TAURI_INVOKE<CustomBackground | null>("background_get"),
+	/**  `background:clear` — forget the background and delete its files. */
+	backgroundClear: () => __TAURI_INVOKE<null>("background_clear"),
+	/**
 	 *  `companion:get-state` — the singleton, hatched from history on first read.
 	 * 
 	 *  The first call ever seeds `xp` from `SUM(played_seconds)` over the whole
@@ -1522,6 +1542,29 @@ export type Coordinates = {
 	lat: number | null,
 	/**  Degrees east, −180 to 180. */
 	lon: number | null,
+};
+
+/**
+ *  The settings record describing the currently imported background.
+ * 
+ *  Persisted under `MainStoreKey::AppearanceCustomBackground` and returned to
+ *  the renderer verbatim. Per architecture §2.3 this is a persisted *and* wire
+ *  struct, so it may only ever grow, and every added field must be `Option` or
+ *  `#[serde(default)]` — a record written by an older build has to keep
+ *  parsing. `still_file_name` and `animated` already carry that treatment, and
+ *  a test pins that a record missing both still loads.
+ */
+export type CustomBackground = {
+	/**  The stored file name, `bg-<hash>.<ext>`. Never user-supplied. */
+	fileName: string,
+	/**  The frozen frame-0 sibling, present only for an animated source. */
+	stillFileName: string | null,
+	/**  Width in pixels, as imported. */
+	width: number,
+	/**  Height in pixels, as imported. */
+	height: number,
+	/**  Whether the source carries more than one frame. */
+	animated: boolean,
 };
 
 /**  What `db:backup:export` resolves to — v1's `DbExportResult`. */

--- a/packages/contracts/src/ipc/error-codes.ts
+++ b/packages/contracts/src/ipc/error-codes.ts
@@ -49,7 +49,25 @@ export const VALIDATION_ERROR_CODES = {
   FORBIDDEN: 'FORBIDDEN',
 } as const;
 
+/**
+ * Custom-background import refusals.
+ *
+ * v2-born, so unlike the registries above there is no v1 literal to stay
+ * faithful to. Each is a refusal the user can act on, which is why they are four
+ * codes and not one: the Appearance card shows a different sentence for each.
+ * Failures the user cannot act on (a full disk, a permission error) arrive as
+ * `INTERNAL` and get the generic message.
+ */
+export const BACKGROUND_ERROR_CODES = {
+  TOO_LARGE: 'background.too_large',
+  UNSUPPORTED_FORMAT: 'background.unsupported_format',
+  NOT_AN_IMAGE: 'background.not_an_image',
+  DIMENSIONS_TOO_LARGE: 'background.dimensions_too_large',
+} as const;
+
 export type ShareErrorCode = (typeof SHARE_ERROR_CODES)[keyof typeof SHARE_ERROR_CODES];
 export type PlaylistErrorCode = (typeof PLAYLIST_ERROR_CODES)[keyof typeof PLAYLIST_ERROR_CODES];
 export type ValidationErrorCode =
   (typeof VALIDATION_ERROR_CODES)[keyof typeof VALIDATION_ERROR_CODES];
+export type BackgroundErrorCode =
+  (typeof BACKGROUND_ERROR_CODES)[keyof typeof BACKGROUND_ERROR_CODES];


### PR DESCRIPTION
Adds "your image" alongside the five bundled photo themes: pick a PNG, JPEG, WebP or GIF and it becomes the full-bleed app background, with the opacity, blur and dim sliders that already existed applying to it.

## The seam

Modelled as `ThemeId = 'custom'` rather than as a layer above the themes, so it inherits the image → scrim → dim stack, the adjust panel, and every `[data-theme]` chrome-contrast rule instead of duplicating them. The cost of that choice is that an imported image and a bundled theme are alternatives, not a stack — `docs/v2/feature-wave/research-visual.md` warns against adding a third z-0 layer without deciding the z-order first, and this adds none.

## Ingest treats the file as untrusted

`shiranami-metadata::background` runs four refusals in cost order, each bounding the next: extension allowlist (string compare) → 20 MB cap against file metadata (a `stat`) → edge and pixel caps read from the image header (no decode) → sniffed format compared against the one the extension claimed. Nothing allocates before the caps.

Files are content-addressed as `bg-<hash>.<ext>`, so no fragment of a user-chosen name reaches the filesystem, the settings document, or a URL. That also makes `Cache-Control: immutable` on the serve route true rather than merely convenient, for the same reason it is true of album art.

## Animation

Animated sources get frame 0 encoded to a sibling `.still.jpg` at import. Under `prefers-reduced-motion` or `lowPerformanceMode` the renderer resolves to that still — the freeze is a URL swap, so the paint layer stays one `background-image` div and the scrim cannot end up on the wrong side of a second branch. This keeps `ThemeBackground`'s documented "single static bitmap with no animation or blur" promise honest for a GIF. APNG counts as animated for the same reason: Chromium plays it.

## Serving

`GET /{token}/background/{name}` on the existing loopback server, behind the same session token as album art. The name guard and response shape are now **shared** with the art route in `routes/image_file.rs` rather than copied — two copies of a path-traversal check are two things to keep right. Each route keeps its own containment re-check, because that check's value is being a *second* opinion.

No CSP change and no new Tauri capability were needed: `img-src` already carries `http:`, and the picker is opened inside the Rust command so no renderer-supplied path ever crosses the IPC boundary.

## Lifecycle

Persist-then-sweep: the record is written before the predecessor's files are collected, so a crash leaks a file rather than leaving a live record pointing at a deleted one. The boot sweep refuses to delete anything when the settings document was unreadable or quarantined — the same fail-safe `prune_album_art` documents, since "the document did not load" and "nothing is referenced" are indistinguishable at the deletion site and one of them costs the user their wallpaper.

## Also in here

- **Fit mode** (cover/contain), scoped to `[data-theme='custom']` so a choice made for a wallpaper cannot follow the user onto a bundled photo composed for `cover`.
- **The four ingest refusals reach the user** as distinct toasts, not a swallowed log line.
- **The settings preview is honest** — it resolves the imported image and applies all three sliders, rather than showing a raw thumbnail that reflects none of them.
- `custom` takes summer's heavier scrim, since a user's photo is unvetted and the shared default already proved insufficient for the one bright bundled image.
- `theme-init` and `applyTheme` both withhold `data-theme="custom"` until the record is confirmed, so the translucent topbar/sidebar/hero chrome never paints over a bare `--background`.
- The theme tile grid's roving tabindex and arrow navigation now run over the *visible* tiles, fixing a keyboard trap when the selected tile is hidden (onboarding, which does not offer the custom tile).

## Counts and contracts

`COMMAND_COUNT` 152 → 155, `NON_V1_COMMANDS` 17 → 20 (three v2-born commands with no v1 channel). `MainStoreKey::ALL` 8 → 9. `useThemeBgStore` gains `bgFit` **without** a version bump — `createPersistedStore` passes no `migrate`, so a bump would hand `merge` an undefined state and silently reset every user's opacity/blur/dim; the presence-checked `sanitize` is the correct additive path, and there are tests pinning it.

## Verification

Green locally: `pnpm typecheck`, `pnpm lint`, `pnpm lint:meta`, `pnpm test` (424 files / 3186 tests), `cargo fmt --check`, `cargo clippy --workspace --all-targets`, and the `shiranami-metadata` / `shiranami-serve` suites. Manually exercised in the running app.

One caveat for review: `packages/contracts/src/generated/bindings.ts` could **not** be regenerated on the authoring machine — Windows Application Control refuses to execute the crate's build script (`os error 4551`), reproduced identically on the clean base SHA. The three command entries and the `CustomBackground` type were written in the generator's exact format and cross-checked against the Rust signatures. CI regenerates and diffs this file, so if anything is off, this PR fails rather than shipping it.
