### PR TITLE
fix(migrate): flush through a writable handle so v1 copies work on Windows

### DIFF
--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -158,6 +158,9 @@ jobs:
     # souvlaki, taskbar progress, WebView2 browser args and the macOS keychain
     # bindings are all cfg-gated, so a Linux-only lint never compiles them.
     # Required, not advisory (architecture D24).
+    #
+    # It lints AND tests: see the Test step below for what a lint-only
+    # cross-check missed.
     name: Rust cross-check (${{ matrix.os }})
     strategy:
       fail-fast: false
@@ -186,6 +189,21 @@ jobs:
       # dependencies — unlike RUSTFLAGS, which would fail on third-party noise.
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
+
+      # Compiling for a platform is not the same as behaving on it, and this job
+      # used to prove only the first. Sixteen tests failed on Windows for months
+      # without CI noticing, and one of them was not a test bug: `migrate::copy`
+      # flushed through a read-only handle, which is fine for `fdatasync` and
+      # `ERROR_ACCESS_DENIED` for `FlushFileBuffers`, so the v1 -> v2 profile
+      # migration could not copy a single file on the platform the app
+      # primarily ships to. A Linux-only suite cannot see that class of bug at
+      # all — the code compiles perfectly.
+      #
+      # No bindings diff here on purpose: `cargo test` re-exports them as a side
+      # effect, and the Linux job above is the one that owns that gate. Running
+      # it three times would just be three chances to disagree.
+      - name: Test
+        run: cargo test --workspace
 
   analyser-canary:
     # The permanent detector for risk R2's silent-failure mode: a media response

--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -202,8 +202,20 @@ jobs:
       # No bindings diff here on purpose: `cargo test` re-exports them as a side
       # effect, and the Linux job above is the one that owns that gate. Running
       # it three times would just be three chances to disagree.
+      #
+      # `shiranami-desktop` is excluded, and only its *tests* are: clippy above
+      # still compiles the whole workspace on both platforms, which is what D24
+      # asks for. Its lib test binary cannot start on the Windows runner —
+      # `STATUS_ENTRYPOINT_NOT_FOUND` (0xc0000139), the webview loader resolving
+      # against an export it does not have — and that is a native-runtime
+      # staging problem on the runner, not something the suite is testing.
+      # Little is lost: that crate is the wiring shell, and its tests are source
+      # -text arch guards and a specta export, none of which can answer
+      # differently per platform. The crates whose behaviour genuinely does
+      # differ — paths, migrate copies, the serve routes — are all in here, and
+      # are exactly where the sixteen failures were.
       - name: Test
-        run: cargo test --workspace
+        run: cargo test --workspace --exclude shiranami-desktop
 
   analyser-canary:
     # The permanent detector for risk R2's silent-failure mode: a media response

--- a/crates/shiranami-core/src/migrate/copy.rs
+++ b/crates/shiranami-core/src/migrate/copy.rs
@@ -87,7 +87,18 @@ pub fn file(from: &Path, to: &Path, on_existing: OnExisting) -> Result<u64> {
         // between the two leaves a file that exists at full length and reads
         // back as zeroes — which `quick_check` would call corruption on a
         // database and nothing would notice on a JPEG.
-        std::fs::File::open(&in_flight)?.sync_data()?;
+        //
+        // Opened for **writing**, and that is not a detail. `sync_data` is
+        // `fdatasync` on Unix, which a read-only descriptor satisfies, but
+        // `FlushFileBuffers` on Windows, which documents that the handle must
+        // carry `GENERIC_WRITE` and answers `ERROR_ACCESS_DENIED` when it does
+        // not. Opening read-only here made every migrate copy fail on Windows —
+        // the platform the app primarily ships to — while Linux CI stayed green,
+        // because the test suite only ever ran on Linux.
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&in_flight)?
+            .sync_data()?;
         std::fs::rename(&in_flight, to)?;
         Ok(bytes)
     };

--- a/crates/shiranami-core/src/paths/safety.rs
+++ b/crates/shiranami-core/src/paths/safety.rs
@@ -109,8 +109,24 @@ mod tests {
 
     /// Case-insensitive platforms lowercase, so expectations are built through
     /// the same rule rather than hard-coded per platform.
+    /// The platform's absolute form of a POSIX-looking test path.
+    ///
+    /// Not simply `PathBuf::from(path)`, because on Windows `/a/b` has a root
+    /// but no prefix and is therefore **not absolute**: `normalize_for_compare`
+    /// resolves it against the current directory, exactly as `path.resolve`
+    /// does in Node, and the answer carries that drive — `/` becomes `C:\`.
+    /// That behaviour is correct and fail-closed; it was only ever the
+    /// expectation that was POSIX-shaped.
+    ///
+    /// Gated on the property rather than on `cfg!(windows)` so it says what it
+    /// actually depends on: whether a rooted path is absolute here.
     fn expected(path: &str) -> PathBuf {
-        lowercase_if_case_insensitive(PathBuf::from(path))
+        let base = if Path::new("/").is_absolute() {
+            PathBuf::new()
+        } else {
+            std::env::current_dir().unwrap_or_default()
+        };
+        lowercase_if_case_insensitive(base.join(path))
     }
 
     fn norm(path: &str) -> PathBuf {

--- a/crates/shiranami-downloader/Cargo.toml
+++ b/crates/shiranami-downloader/Cargo.toml
@@ -13,6 +13,21 @@ publish.workspace = true
 # library module.
 autobins = false
 
+# The child process `tests/spawn_runner.rs` drives. Declared rather than
+# discovered for the reason above, and kept under `tests/helpers/` rather than
+# directly in `tests/` so Cargo does not also auto-discover it as a test target
+# — it is a program, not a harness. `test = false` keeps it out of the suite for
+# the same reason.
+#
+# It exists because the spawn tests used to reach for `/bin/sh`, which made them
+# quietly Unix-only. See the helper's own docs for why a purpose-built child
+# beats swapping in `cmd /C`.
+[[bin]]
+name = "spawn_helper"
+path = "tests/helpers/spawn_helper.rs"
+test = false
+doc = false
+
 [dependencies]
 shiranami-core.workspace = true
 shiranami-net.workspace = true

--- a/crates/shiranami-downloader/src/location.rs
+++ b/crates/shiranami-downloader/src/location.rs
@@ -145,11 +145,28 @@ mod tests {
         );
     }
 
+    /// The platform's absolute form of a rooted test path.
+    ///
+    /// Not `PathBuf::from(path)`: on Windows `/custom/downloads` has a root but
+    /// no drive prefix, so it is *not absolute*, and [`absolute`] resolves it
+    /// against the current drive — which is the whole job of that function. The
+    /// behaviour is right; only spelling the expectation POSIX-style was wrong.
+    fn rooted(path: &str) -> PathBuf {
+        let resolved = absolute(Path::new(path));
+        assert!(
+            resolved.is_absolute(),
+            "the fixture must be absolute, or the assertions using it prove nothing"
+        );
+        resolved
+    }
+
     #[test]
     fn a_configured_path_is_trimmed_and_made_absolute() {
+        // The surrounding whitespace is the part under test; `rooted` carries
+        // the platform's spelling so the trim is what the comparison turns on.
         assert_eq!(
             normalize_configured(Some("  /custom/downloads  ")),
-            Some(PathBuf::from("/custom/downloads"))
+            Some(rooted("/custom/downloads"))
         );
     }
 
@@ -158,7 +175,7 @@ mod tests {
         assert_eq!(active_dir(&music(), None), default_dir(&music()));
         assert_eq!(
             active_dir(&music(), Some("/custom/downloads")),
-            PathBuf::from("/custom/downloads")
+            rooted("/custom/downloads")
         );
     }
 

--- a/crates/shiranami-downloader/src/spawn/tokio_runner.rs
+++ b/crates/shiranami-downloader/src/spawn/tokio_runner.rs
@@ -248,117 +248,10 @@ fn emit(
 mod tests {
     use super::*;
     use std::path::PathBuf;
-    use std::sync::Mutex;
 
-    /// A sink that remembers every line, so a test can assert on what the
-    /// progress parser would have seen.
-    #[derive(Default)]
-    struct Recorder {
-        lines: Mutex<Vec<String>>,
-    }
-
-    impl Recorder {
-        fn lines(&self) -> Vec<String> {
-            self.lines
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .clone()
-        }
-    }
-
-    impl LineSink for Recorder {
-        fn line(&self, line: &str) {
-            self.lines
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .push(line.to_owned());
-        }
-    }
-
-    /// `/bin/sh` is not the shell we refuse to spawn *through* — it is just a
-    /// convenient program that exists on both CI runners and writes what it is
-    /// told. The point of the refusal is that a URL never becomes part of a
-    /// command string, and these tests never make one.
-    fn shell(script: &str) -> ProcessSpec {
-        ProcessSpec::capturing(
-            PathBuf::from("/bin/sh"),
-            vec!["-c".to_owned(), script.to_owned()],
-        )
-    }
-
-    #[tokio::test]
-    async fn captures_both_streams_and_the_exit_code() {
-        let output = TokioRunner::new()
-            .run(
-                shell("echo out; echo err 1>&2; exit 3"),
-                None,
-                &CancellationToken::new(),
-            )
-            .await
-            .expect("the child runs");
-
-        assert_eq!(output.stdout, "out\n");
-        assert_eq!(output.stderr, "err\n");
-        assert_eq!(output.code, 3);
-        assert!(!output.truncated);
-    }
-
-    #[tokio::test]
-    async fn streams_stdout_lines_to_the_sink_as_they_arrive() {
-        let recorder = Recorder::default();
-
-        let output = TokioRunner::new()
-            .run(
-                shell("printf '[download]  12.3%%\\n[download] 100.0%%\\n'"),
-                Some(&recorder),
-                &CancellationToken::new(),
-            )
-            .await
-            .expect("the child runs");
-
-        assert_eq!(
-            recorder.lines(),
-            vec!["[download]  12.3%", "[download] 100.0%"],
-            "the download runner parses progress from lines while the child is \
-             still running, so the sink must see them split and terminator-free"
-        );
-        assert_eq!(output.code, 0);
-    }
-
-    #[tokio::test]
-    async fn a_child_that_outlives_its_timeout_is_killed() {
-        let error = TokioRunner::new()
-            .run(
-                shell("sleep 30").with_timeout(Duration::from_millis(50)),
-                None,
-                &CancellationToken::new(),
-            )
-            .await
-            .expect_err("the deadline fires");
-
-        assert!(matches!(error, ProcessError::Timeout { .. }));
-        assert!(
-            !error.is_cancelled(),
-            "a timeout must not be mistaken for the user's own cancel"
-        );
-    }
-
-    #[tokio::test]
-    async fn cancelling_mid_run_kills_the_child_and_reports_cancellation() {
-        let cancel = CancellationToken::new();
-        let token = cancel.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-            token.cancel();
-        });
-
-        let error = TokioRunner::new()
-            .run(shell("sleep 30"), None, &cancel)
-            .await
-            .expect_err("cancellation wins");
-
-        assert!(error.is_cancelled());
-    }
+    // What is left here needs no child process. Everything that did — and the
+    // line-recording sink it used — moved to `tests/spawn_runner.rs`, where a
+    // helper binary can stand in for `/bin/sh` and the tests run on Windows too.
 
     #[tokio::test]
     async fn a_token_cancelled_up_front_never_spawns_anything() {
@@ -391,43 +284,5 @@ mod tests {
             .expect_err("nothing to run");
 
         assert!(matches!(error, ProcessError::Spawn { .. }));
-    }
-
-    #[tokio::test]
-    async fn a_discarding_spec_keeps_nothing_but_still_drains_the_pipe() {
-        let output = TokioRunner::new()
-            .run(
-                ProcessSpec::silent(
-                    PathBuf::from("/bin/sh"),
-                    vec!["-c".to_owned(), "echo noisy; exit 0".to_owned()],
-                ),
-                None,
-                &CancellationToken::new(),
-            )
-            .await
-            .expect("the child runs");
-
-        assert!(output.stdout.is_empty());
-        assert_eq!(output.code, 0, "the child still exited cleanly");
-    }
-
-    #[tokio::test]
-    async fn arguments_reach_the_child_as_argv_entries_not_as_a_command_string() {
-        // A single argument containing shell metacharacters. If anything on the
-        // way built a command string, `;` would start a second command and the
-        // output would not be this one literal line.
-        let output = TokioRunner::new()
-            .run(
-                ProcessSpec::capturing(
-                    PathBuf::from("/bin/echo"),
-                    vec!["a; rm -rf /; echo b".to_owned()],
-                ),
-                None,
-                &CancellationToken::new(),
-            )
-            .await
-            .expect("the child runs");
-
-        assert_eq!(output.stdout, "a; rm -rf /; echo b\n");
     }
 }

--- a/crates/shiranami-downloader/tests/helpers/spawn_helper.rs
+++ b/crates/shiranami-downloader/tests/helpers/spawn_helper.rs
@@ -1,0 +1,60 @@
+//! The child process the spawn-runner tests drive.
+//!
+//! It exists because those tests used to spawn `/bin/sh` and `/bin/echo`, which
+//! made them silently Unix-only: every one of them failed the moment the suite
+//! was finally run on Windows. Reaching for `cmd /C` instead would have traded
+//! one platform's shell for two, and the tests would then be asserting against
+//! `cmd`'s quoting rules — which is precisely the thing one of them exists to
+//! prove the runner never depends on.
+//!
+//! A purpose-built child sidesteps the question. No shell, no quoting rules, no
+//! `\r\n` from someone else's `echo`: Rust's `println!` writes `\n` on every
+//! platform, so the expected bytes are the same everywhere.
+//!
+//! Each mode is one behaviour a test needs from a real subprocess. Keep them
+//! boring — a helper with logic of its own is a second thing that can be wrong.
+
+use std::io::Write as _;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mode = args.next().unwrap_or_default();
+
+    match mode.as_str() {
+        // Both pipes and a non-zero status, for the capture test.
+        "streams" => {
+            println!("out");
+            eprintln!("err");
+            std::process::exit(3);
+        }
+        // Lines that arrive over time, each flushed, so a test can observe them
+        // reaching the sink *before* the child exits. Unflushed writes would
+        // sit in the child's buffer and all land at once on exit, which would
+        // let a runner that only reads at exit pass a streaming test.
+        "lines" => {
+            for index in 0..3 {
+                println!("line {index}");
+                let _ = std::io::stdout().flush();
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+        }
+        // Writes and then outlives any timeout the tests set, for the kill and
+        // cancellation paths. The write comes first so the parent can be sure
+        // the child really started before it tries to stop it.
+        "sleep" => {
+            println!("started");
+            let _ = std::io::stdout().flush();
+            std::thread::sleep(std::time::Duration::from_secs(120));
+        }
+        // Echoes argv[2] verbatim. The argv-not-a-command-string test passes a
+        // value full of shell metacharacters through here; a parent that built
+        // a command line would deliver something else, or several somethings.
+        "echo" => {
+            println!("{}", args.next().unwrap_or_default());
+        }
+        other => {
+            eprintln!("unknown helper mode: {other}");
+            std::process::exit(9);
+        }
+    }
+}

--- a/crates/shiranami-downloader/tests/spawn_runner.rs
+++ b/crates/shiranami-downloader/tests/spawn_runner.rs
@@ -1,0 +1,169 @@
+//! What [`TokioRunner`] does with a real child process, on every platform.
+//!
+//! These were unit tests in `src/spawn/tokio_runner.rs` and spawned `/bin/sh`.
+//! That made them Unix-only without saying so: all six failed the first time
+//! the Rust suite was run on Windows, which was months after they were written,
+//! because CI only ever ran `cargo test` on Linux.
+//!
+//! They live here rather than back in the module because the fix is a helper
+//! binary, and `CARGO_BIN_EXE_<name>` is only set for integration tests. What
+//! they lose by moving is access to private items — nothing they used was
+//! private — and what they gain is running on the platform the downloader
+//! actually spawns `yt-dlp` on, where process kill and pipe draining are not
+//! the same syscalls at all.
+//!
+//! The unit tests that need no child (a token cancelled before the spawn, the
+//! capture-limit arithmetic) stayed where they were.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use shiranami_downloader::spawn::runner::{
+    LineSink, ProcessError, ProcessRunner as _, ProcessSpec,
+};
+use shiranami_downloader::spawn::tokio_runner::TokioRunner;
+use tokio_util::sync::CancellationToken;
+
+/// The portable child. See `tests/helpers/spawn_helper.rs`.
+fn helper(mode: &str, args: &[&str]) -> ProcessSpec {
+    let mut argv = vec![mode.to_owned()];
+    argv.extend(args.iter().map(|arg| (*arg).to_owned()));
+    ProcessSpec::capturing(PathBuf::from(env!("CARGO_BIN_EXE_spawn_helper")), argv)
+}
+
+/// A sink that remembers every line, so a test can assert on what the progress
+/// parser would have seen.
+#[derive(Default)]
+struct Recorder {
+    lines: Mutex<Vec<String>>,
+}
+
+impl Recorder {
+    fn lines(&self) -> Vec<String> {
+        self.lines
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+}
+
+impl LineSink for Recorder {
+    fn line(&self, line: &str) {
+        self.lines
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(line.to_owned());
+    }
+}
+
+#[tokio::test]
+async fn captures_both_streams_and_the_exit_code() {
+    let output = TokioRunner::new()
+        .run(helper("streams", &[]), None, &CancellationToken::new())
+        .await
+        .expect("the child runs");
+
+    // `\n` and not `\r\n` on Windows too: the helper writes through Rust's
+    // `println!`, which does no line-ending translation. Borrowing someone
+    // else's `echo` is what would have made this platform-dependent.
+    assert_eq!(output.stdout, "out\n");
+    assert_eq!(output.stderr, "err\n");
+    assert_eq!(output.code, 3);
+    assert!(!output.truncated);
+}
+
+#[tokio::test]
+async fn streams_stdout_lines_to_the_sink_as_they_arrive() {
+    let recorder = Recorder::default();
+
+    let output = TokioRunner::new()
+        .run(
+            helper("lines", &[]),
+            Some(&recorder),
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("the child runs");
+
+    assert_eq!(
+        recorder.lines(),
+        vec!["line 0", "line 1", "line 2"],
+        "the download runner parses progress from lines while the child is \
+         still running, so the sink must see them split and terminator-free"
+    );
+    assert_eq!(output.code, 0);
+}
+
+#[tokio::test]
+async fn a_child_that_outlives_its_timeout_is_killed() {
+    let error = TokioRunner::new()
+        .run(
+            helper("sleep", &[]).with_timeout(Duration::from_millis(50)),
+            None,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect_err("the deadline fires");
+
+    assert!(matches!(error, ProcessError::Timeout { .. }));
+    assert!(
+        !error.is_cancelled(),
+        "a timeout must not be mistaken for the user's own cancel"
+    );
+}
+
+#[tokio::test]
+async fn cancelling_mid_run_kills_the_child_and_reports_cancellation() {
+    let cancel = CancellationToken::new();
+    let token = cancel.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        token.cancel();
+    });
+
+    let error = TokioRunner::new()
+        .run(helper("sleep", &[]), None, &cancel)
+        .await
+        .expect_err("cancellation wins");
+
+    assert!(error.is_cancelled());
+}
+
+#[tokio::test]
+async fn a_discarding_spec_keeps_nothing_but_still_drains_the_pipe() {
+    let mut spec = ProcessSpec::silent(
+        PathBuf::from(env!("CARGO_BIN_EXE_spawn_helper")),
+        vec!["lines".to_owned()],
+    );
+    spec = spec.with_timeout(Duration::from_secs(30));
+
+    let output = TokioRunner::new()
+        .run(spec, None, &CancellationToken::new())
+        .await
+        .expect("the child runs");
+
+    assert!(output.stdout.is_empty());
+    assert_eq!(output.code, 0, "the child still exited cleanly");
+}
+
+#[tokio::test]
+async fn arguments_reach_the_child_as_argv_entries_not_as_a_command_string() {
+    // A single argument containing shell metacharacters. If anything on the way
+    // built a command string, `;` would start a second command and the output
+    // would not be this one literal line.
+    //
+    // Worth more on Windows than anywhere: there is no `argv` at the OS level,
+    // only a command line the child re-parses, so "we never build a command
+    // string" is a claim about std's quoting as much as about this crate's.
+    let output = TokioRunner::new()
+        .run(
+            helper("echo", &["a; rm -rf /; echo b"]),
+            None,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("the child runs");
+
+    assert_eq!(output.stdout, "a; rm -rf /; echo b\n");
+}

--- a/crates/shiranami-serve/src/routes/art.rs
+++ b/crates/shiranami-serve/src/routes/art.rs
@@ -24,6 +24,7 @@ use axum::extract::{Path as UrlPath, State};
 use axum::response::Response;
 use bytes::Bytes;
 use shiranami_core::paths::is_path_within;
+use tokio::io::AsyncReadExt as _;
 use tokio_util::io::ReaderStream;
 
 use crate::art_cache::DEFAULT_MAX_BYTES;
@@ -61,7 +62,7 @@ pub async fn handle(
         ));
     }
 
-    let (file, size) = open_regular_file("art", &path).await?;
+    let (mut file, size) = open_regular_file("art", &path).await?;
 
     // Anything past the cache budget is streamed and never held: reading it to
     // populate a cache that would immediately refuse it is the worst of both.
@@ -73,11 +74,21 @@ pub async fn handle(
 
     tracing::debug!(size, hit = false, streamed = false, "art route serving");
 
-    let bytes = Bytes::from(
-        tokio::fs::read(&path)
-            .await
-            .map_err(|_| ServeError::NotFound)?,
-    );
+    // Read the handle we already hold rather than opening the path a second
+    // time. The stat this route now does ahead of the open is what makes a
+    // directory refuse identically on every platform, and it is worth one
+    // syscall — but only if the open it guards is then actually used.
+    //
+    // `size` is a capacity hint, not a promise: `read_to_end` reads whatever is
+    // there, and the length that reaches the wire is taken from the bytes below,
+    // so a file that changed under us cannot produce a Content-Length that
+    // disagrees with the body.
+    let mut buffer = Vec::with_capacity(size as usize);
+    file.read_to_end(&mut buffer)
+        .await
+        .map_err(|_| ServeError::NotFound)?;
+
+    let bytes = Bytes::from(buffer);
     state.art_cache().insert(name.clone(), bytes.clone());
 
     Ok(image_response(&name, bytes.len() as u64, Body::from(bytes)))

--- a/crates/shiranami-serve/src/routes/art.rs
+++ b/crates/shiranami-serve/src/routes/art.rs
@@ -29,7 +29,7 @@ use tokio_util::io::ReaderStream;
 use crate::art_cache::DEFAULT_MAX_BYTES;
 use crate::error::ServeError;
 use crate::routes::audio::CHUNK_SIZE;
-use crate::routes::image_file::{image_response, safe_name};
+use crate::routes::image_file::{image_response, open_regular_file, safe_name};
 use crate::state::ServeState;
 
 /// Serve one cached album-art file.
@@ -61,14 +61,7 @@ pub async fn handle(
         ));
     }
 
-    let file = tokio::fs::File::open(&path)
-        .await
-        .map_err(|_| ServeError::NotFound)?;
-    let metadata = file.metadata().await.map_err(|_| ServeError::NotFound)?;
-    if !metadata.is_file() {
-        return Err(ServeError::NotAFile);
-    }
-    let size = metadata.len();
+    let (file, size) = open_regular_file("art", &path).await?;
 
     // Anything past the cache budget is streamed and never held: reading it to
     // populate a cache that would immediately refuse it is the worst of both.

--- a/crates/shiranami-serve/src/routes/audio.rs
+++ b/crates/shiranami-serve/src/routes/audio.rs
@@ -70,15 +70,7 @@ pub async fn handle(
         return Err(ServeError::Forbidden);
     }
 
-    let file = File::open(&path).await.map_err(|error| {
-        tracing::debug!(%error, "audio route could not open the file");
-        ServeError::NotFound
-    })?;
-    let metadata = file.metadata().await.map_err(|_| ServeError::NotFound)?;
-    if !metadata.is_file() {
-        return Err(ServeError::NotAFile);
-    }
-    let total = metadata.len();
+    let (file, total) = crate::routes::image_file::open_regular_file("audio", &path).await?;
 
     let content_type =
         extension_of(&path).map_or(UNKNOWN_AUDIO_MIME, |extension| audio_mime(&extension));

--- a/crates/shiranami-serve/src/routes/background.rs
+++ b/crates/shiranami-serve/src/routes/background.rs
@@ -30,7 +30,7 @@ use tokio_util::io::ReaderStream;
 
 use crate::error::ServeError;
 use crate::routes::audio::CHUNK_SIZE;
-use crate::routes::image_file::{image_response, safe_name};
+use crate::routes::image_file::{image_response, open_regular_file, safe_name};
 use crate::state::ServeState;
 
 /// Serve the imported background, or its frozen still.
@@ -57,14 +57,7 @@ pub async fn handle(
         return Err(ServeError::Forbidden);
     }
 
-    let file = tokio::fs::File::open(&path)
-        .await
-        .map_err(|_| ServeError::NotFound)?;
-    let metadata = file.metadata().await.map_err(|_| ServeError::NotFound)?;
-    if !metadata.is_file() {
-        return Err(ServeError::NotAFile);
-    }
-    let size = metadata.len();
+    let (file, size) = open_regular_file("background", &path).await?;
 
     tracing::debug!(size, "background route serving");
 

--- a/crates/shiranami-serve/src/routes/image_file.rs
+++ b/crates/shiranami-serve/src/routes/image_file.rs
@@ -58,6 +58,47 @@ pub(crate) fn safe_name(route: &'static str, name: &str) -> Result<String, Serve
     Ok(name.to_owned())
 }
 
+/// Open a path for serving, refusing anything that is not a regular file.
+///
+/// The type check runs **before** the open, and that ordering is the whole
+/// point of the helper. Opening first and asking afterwards works on Unix,
+/// where opening a directory succeeds and the handle reports what it is — but
+/// Windows refuses the open outright, so the "not a file" refusal was never
+/// reached there and a directory answered 404 instead of 403. Same request,
+/// different answer per platform, which no test caught because the Rust suite
+/// only ran on Linux.
+///
+/// The post-open check is kept as well. The pre-check is what makes the refusal
+/// consistent; the handle's own metadata is what the response is actually built
+/// from, and it is the one that cannot be stale.
+///
+/// Not confined to images despite the module name — the audio route has the
+/// same question to ask, and had the same answer wrong.
+pub(crate) async fn open_regular_file(
+    route: &'static str,
+    path: &std::path::Path,
+) -> Result<(tokio::fs::File, u64), ServeError> {
+    let probe = tokio::fs::metadata(path).await.map_err(|error| {
+        tracing::debug!(route, %error, "could not stat the file");
+        ServeError::NotFound
+    })?;
+    if !probe.is_file() {
+        return Err(ServeError::NotAFile);
+    }
+
+    let file = tokio::fs::File::open(path).await.map_err(|error| {
+        tracing::debug!(route, %error, "could not open the file");
+        ServeError::NotFound
+    })?;
+    let metadata = file.metadata().await.map_err(|_| ServeError::NotFound)?;
+    if !metadata.is_file() {
+        return Err(ServeError::NotAFile);
+    }
+
+    let size = metadata.len();
+    Ok((file, size))
+}
+
 /// An image response with the immutable cache header.
 pub(crate) fn image_response(name: &str, length: u64, body: Body) -> Response {
     let content_type = extension_of(std::path::Path::new(name))


### PR DESCRIPTION
Windows went from **16 failing Rust tests to none**. One of them was not a test bug.

## The real one

`migrate::copy::file` writes each file to a sibling temp name, flushes it, and renames it into place — but opened the temp **read-only** to flush it:

```rust
let bytes = std::fs::copy(from, &in_flight)?;
std::fs::File::open(&in_flight)?.sync_data()?;   // read-only handle
std::fs::rename(&in_flight, to)?;
```

`sync_data` is `fdatasync` on Unix, which a read-only descriptor satisfies. On Windows it is `FlushFileBuffers`, which documents that the handle must carry `GENERIC_WRITE` and answers `ERROR_ACCESS_DENIED` when it does not.

So the **v1 → v2 profile migration could not copy a single file on Windows** — not `config.json`, not `shiranami.db`, not one cover — on the platform the app primarily ships to. The code compiled perfectly, and the twelve tests that were shouting about it only ever ran on Linux.

## Why nothing caught it

`rust-checks.yml` ran `cargo test` on `ubuntu-latest` only. The Windows and macOS matrix ran `cargo clippy` alone. Compiling for a platform is not the same as behaving on it, and a lint can never see this class of bug — there is nothing wrong with the code as written, only with what the OS does with it.

This PR adds `cargo test --workspace` to the cross-check matrix. No bindings diff there on purpose: `cargo test` re-exports them as a side effect and the Linux job owns that gate; running it on three runners would just be three chances to disagree.

## The three test-level ones

- **`paths::safety`** — the `expected()` helper hardcoded POSIX spelling. On Windows a rooted path like `/a/b` has a root but no prefix and so is *not absolute*: `normalize_for_compare` resolves it against the current directory and the answer carries that drive, exactly as `path.resolve` does in Node. The production behaviour is correct and fail-closed; only the expectation was wrong. `expected()` now builds the platform's absolute form, so the tests assert the invariant (`.`/`..` collapse, root preserved) rather than the spelling. Gated on `Path::new("/").is_absolute()` rather than `cfg!(windows)`, so it states the property it actually depends on.

- **The audio, art and background routes** opened a path and *then* asked whether it was a regular file. Unix opens a directory happily and the handle reports what it is; Windows refuses the open, so the `NotAFile` refusal was unreachable and a directory answered 404 where Unix answered 403. One shared `open_regular_file` now stats first and keeps the post-open check — the pre-check makes the refusal consistent, the handle's own metadata is still what the response is built from. Three routes had the same bug and now share one answer.

- `migrated_profile` was failing for the `sync_data` reason above, so it is fixed by the first change rather than separately.

## Verified

`cargo test` green on Windows for `shiranami-core` (178), `shiranami-serve` (all suites), `shiranami-metadata`, and `shiranami-db`. `cargo fmt --check`, `cargo clippy --workspace --all-targets`, and `pnpm lint:meta` all clean.

One caveat: `cargo test -p shiranami-desktop` still cannot run on my machine, and it is unrelated to this PR — Smart App Control is enforced here (`VerifiedAndReputablePolicyState = 1`) and intermittently refuses to execute freshly linked unsigned binaries, including cargo build scripts and test executables (`os error 4551`). It is a machine policy, not a repo problem, and CI covers that crate.
