### PR TITLE
test(appearance): restore the matchMedia stub in afterEach, not mid-test

### DIFF
--- a/apps/web/src/components/shared/ThemeBackground/ThemeBackground.test.tsx
+++ b/apps/web/src/components/shared/ThemeBackground/ThemeBackground.test.tsx
@@ -38,6 +38,11 @@ function renderWith(record: CustomBackground | null): HTMLElement {
 afterEach(() => {
   useThemeStore.setState({ theme: 'none' });
   useUIStore.setState({ lowPerformanceMode: false });
+  // Here rather than at the end of the one test that stubs `matchMedia`: a
+  // restore on the happy path only is no restore at all, and a leaked
+  // reduced-motion stub would quietly freeze every test that ran afterwards —
+  // failing whichever one happened to be next rather than the one at fault.
+  vi.restoreAllMocks();
 });
 
 describe('ThemeBackground', () => {
@@ -124,7 +129,6 @@ describe('ThemeBackground', () => {
     expect(container.querySelector('.theme-bg-image')).toHaveStyle({
       backgroundImage: 'url(http://127.0.0.1:1234/tok/background/bg-abc.still.jpg)',
     });
-    vi.restoreAllMocks();
   });
 
   it('keeps a static import animating-irrelevant under low-performance mode', () => {


### PR DESCRIPTION
Small follow-up to #381.

`ThemeBackground.test.tsx`'s reduced-motion test stubs `window.matchMedia` and called `vi.restoreAllMocks()` as its **last statement** — so the restore only ran when the test passed. Any failure or early throw would leak a stub that answers `matches: true` to every query, silently freezing every animation check that ran afterwards, and failing whichever test happened to come next rather than the one at fault.

Moved into the existing `afterEach`, beside the two store resets where the rest of the per-test cleanup already lives.

## Honesty about the cause

I noticed this while chasing an intermittent failure in the full suite on merged `v2` — one run reported `1 failed | 423 passed` and I lost the detail before I could attribute it. Six subsequent runs (three before this change, three after) were all clean, so I **cannot** claim this was the cause. A mock restored only on the happy path is worth fixing either way, and if the flake resurfaces it will now do so somewhere that points at itself.
