### PR TITLE
feat(appearance): room light time-of-day grade

### DIFF
--- a/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.hooks.ts
+++ b/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.hooks.ts
@@ -25,6 +25,8 @@ export function useVisualEffectsSection(): IVisualEffectsSectionView {
   const setArtworkBloomEnabled = useUIStore(s => s.setArtworkBloomEnabled);
   const coverCrossfadeEnabled = useUIStore(s => s.coverCrossfadeEnabled);
   const setCoverCrossfadeEnabled = useUIStore(s => s.setCoverCrossfadeEnabled);
+  const roomLightEnabled = useUIStore(s => s.roomLightEnabled);
+  const setRoomLightEnabled = useUIStore(s => s.setRoomLightEnabled);
   const library = useLibraryStore(s => s.library);
 
   // The silent-failure guard: a library without tempo data never breathes, and
@@ -71,6 +73,11 @@ export function useVisualEffectsSection(): IVisualEffectsSectionView {
     coverCrossfadeDescription: t('app.coverCrossfadeDesc'),
     coverCrossfadeEnabled,
     onCoverCrossfadeChange: setCoverCrossfadeEnabled,
+
+    roomLightLabel: t('app.roomLight'),
+    roomLightDescription: t('app.roomLightDesc'),
+    roomLightEnabled,
+    onRoomLightChange: setRoomLightEnabled,
 
     tempoBreathingLabel: t('app.tempoBreathing'),
     tempoBreathingDescription: t('app.tempoBreathingDesc'),

--- a/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.stories.tsx
+++ b/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.stories.tsx
@@ -5,9 +5,9 @@ import { useUIStore } from '@/stores/useUIStore';
 import VisualEffectsSection from './VisualEffectsSection';
 
 /**
- * settings · VisualEffectsSection. Seven immersive-effect switches — Now
+ * settings · VisualEffectsSection. Eight immersive-effect switches — Now
  * Playing view, Now playing banner, Low performance mode, Noise texture,
- * Artwork bloom, Cover crossfade, and Tempo breathing — each labelled via
+ * Artwork bloom, Cover crossfade, Room light, and Tempo breathing — each labelled via
  * `aria-labelledby`, most paired with a live preview tile beneath it. The
  * switches read and write the UI store directly, so flipping one updates the
  * store and re-renders the matching preview. Stories seed the store on entry.
@@ -46,6 +46,7 @@ export const Default: Story = {
         tempoBreathingEnabled: true,
         artworkBloomEnabled: true,
         coverCrossfadeEnabled: true,
+        roomLightEnabled: true,
       });
       return <Story />;
     },
@@ -59,6 +60,7 @@ export const Default: Story = {
     await expect(canvas.getByRole('switch', { name: 'Noise texture' })).not.toBeChecked();
     await expect(canvas.getByRole('switch', { name: 'Artwork bloom' })).toBeChecked();
     await expect(canvas.getByRole('switch', { name: 'Cover crossfade' })).toBeChecked();
+    await expect(canvas.getByRole('switch', { name: 'Room light' })).toBeChecked();
     await expect(canvas.getByRole('switch', { name: 'Tempo breathing' })).toBeChecked();
   },
 };

--- a/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.test.tsx
+++ b/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.test.tsx
@@ -33,6 +33,7 @@ function reset(): void {
     tempoBreathingEnabled: true,
     artworkBloomEnabled: true,
     coverCrossfadeEnabled: true,
+    roomLightEnabled: true,
   });
   useLibraryStore.setState({ library: [], libraryLoaded: true });
   vi.clearAllMocks();
@@ -50,6 +51,7 @@ describe('VisualEffectsSection', () => {
     expect(screen.getByText('Noise texture')).toBeInTheDocument();
     expect(screen.getByText('Artwork bloom')).toBeInTheDocument();
     expect(screen.getByText('Cover crossfade')).toBeInTheDocument();
+    expect(screen.getByText('Room light')).toBeInTheDocument();
     expect(screen.getByText('Tempo breathing')).toBeInTheDocument();
   });
 
@@ -73,6 +75,17 @@ describe('VisualEffectsSection', () => {
     await user.click(screen.getByRole('switch', { name: 'Cover crossfade' }));
 
     expect(setCoverCrossfadeEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('toggles the room light through the store setter', async () => {
+    const user = userEvent.setup();
+    const setRoomLightEnabled = vi.fn();
+    useUIStore.setState({ setRoomLightEnabled });
+    render(<VisualEffectsSection />);
+
+    await user.click(screen.getByRole('switch', { name: 'Room light' }));
+
+    expect(setRoomLightEnabled).toHaveBeenCalledWith(false);
   });
 
   it('toggles tempo breathing through the store setter', async () => {

--- a/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.tsx
+++ b/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.tsx
@@ -39,6 +39,10 @@ export default function VisualEffectsSection() {
     coverCrossfadeDescription,
     coverCrossfadeEnabled,
     onCoverCrossfadeChange,
+    roomLightLabel,
+    roomLightDescription,
+    roomLightEnabled,
+    onRoomLightChange,
     tempoBreathingLabel,
     tempoBreathingDescription,
     tempoBreathingEnabled,
@@ -97,6 +101,14 @@ export default function VisualEffectsSection() {
           description={coverCrossfadeDescription}
           checked={coverCrossfadeEnabled}
           onCheckedChange={onCoverCrossfadeChange}
+          divider
+        />
+
+        <SettingsToggleRow
+          label={roomLightLabel}
+          description={roomLightDescription}
+          checked={roomLightEnabled}
+          onCheckedChange={onRoomLightChange}
           divider
         />
 

--- a/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.types.ts
+++ b/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.types.ts
@@ -58,6 +58,15 @@ export interface IVisualEffectsSectionView {
   /** Toggle the visual cover crossfade. */
   readonly onCoverCrossfadeChange: (next: boolean) => void;
 
+  /** Localized "Room light" toggle label. */
+  readonly roomLightLabel: string;
+  /** Localized "Room light" toggle description. */
+  readonly roomLightDescription: string;
+  /** Whether the time-of-day lighting grade is enabled. */
+  readonly roomLightEnabled: boolean;
+  /** Toggle the time-of-day lighting grade. */
+  readonly onRoomLightChange: (next: boolean) => void;
+
   /** Localized "Tempo breathing" toggle label. */
   readonly tempoBreathingLabel: string;
   /** Localized "Tempo breathing" toggle description. */

--- a/apps/web/src/components/shared/AmbientBackground/AmbientBackground.hooks.ts
+++ b/apps/web/src/components/shared/AmbientBackground/AmbientBackground.hooks.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useReducedMotion } from 'motion/react';
 import { useAmbientColor } from '@/hooks/useAmbientColor';
+import { useRoomLight, roomLightLayerStyle } from '@/hooks/useRoomLight';
 import { useTempoBreathing } from '@/hooks/useTempoBreathing';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useUIStore } from '@/stores/useUIStore';
@@ -79,8 +80,10 @@ export function useAmbientBackground(): IAmbientBackgroundView {
   const noiseOverlayEnabled = useUIStore(s => s.noiseOverlayEnabled);
   const artworkBloomEnabled = useUIStore(s => s.artworkBloomEnabled);
   const coverCrossfadeEnabled = useUIStore(s => s.coverCrossfadeEnabled);
+  const roomLightEnabled = useUIStore(s => s.roomLightEnabled);
   const reducedMotion = useReducedMotion();
   const tempoBreathing = useTempoBreathing();
+  const roomLight = useRoomLight();
 
   // The bloom has its own first-class toggle; low-performance mode stays the
   // master kill on top of it (it also unmounts the whole layer via `enabled`,
@@ -135,5 +138,8 @@ export function useAmbientBackground(): IAmbientBackgroundView {
     bloomKey: currentTrack?.id,
     showBloom: Boolean(currentTrack) && !reducedMotion && bloomEnabled,
     breathing: tempoBreathing.active,
+    // Low-perf already unmounts the whole layer via `enabled`; gating here too
+    // keeps the same no-leak discipline as the bloom's derived flags.
+    roomLightStyle: roomLightEnabled && !lowPerformanceMode ? roomLightLayerStyle(roomLight) : null,
   };
 }

--- a/apps/web/src/components/shared/AmbientBackground/AmbientBackground.stories.tsx
+++ b/apps/web/src/components/shared/AmbientBackground/AmbientBackground.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { Track } from '@/stores/types';
+import { roomLightForHour, roomLightLayerStyle } from '@/hooks/useRoomLight';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useUIStore } from '@/stores/useUIStore';
 import AmbientBackground from './AmbientBackground';
@@ -29,16 +30,22 @@ const track: Track = {
 /**
  * shared · AmbientBackground. The artwork bloom — four blurred, saturated,
  * slowly counter-rotating copies of the current cover — painted behind the
- * shell, with a color-glow fallback for artless tracks and the film-grain
- * noise overlay. Seeded with a playing track (and low-performance mode off)
- * so the layers render.
+ * shell, with a color-glow fallback for artless tracks, the film-grain noise
+ * overlay, and the room-light time-of-day grade. Seeded with a playing track
+ * (and low-performance mode off) so the layers render. The component's own
+ * room-light layer follows the wall clock, so the base stories disable it and
+ * the per-stop stories pin an hour instead — every story stays deterministic.
  */
 const meta: Meta<typeof AmbientBackground> = {
   title: 'shared/AmbientBackground',
   component: AmbientBackground,
   decorators: [
     Story => {
-      useUIStore.setState({ lowPerformanceMode: false, noiseOverlayEnabled: true });
+      useUIStore.setState({
+        lowPerformanceMode: false,
+        noiseOverlayEnabled: true,
+        roomLightEnabled: false,
+      });
       return (
         <div className="relative w-full h-64">
           <Story />
@@ -83,3 +90,45 @@ export const GlowFallback: Story = {
     },
   ],
 };
+
+/**
+ * A room-light stop pinned to a fixed hour: the component's clock-driven layer
+ * stays off (meta decorator) and the story paints the exact same layer markup
+ * with the stop's custom properties, over the seeded artwork bloom.
+ */
+function roomLightStopStory(hour: number): Story {
+  return {
+    decorators: [
+      Story => {
+        usePlaybackStore.setState({ currentTrack: { ...track, albumArt: STORY_COVER } });
+        const style = roomLightLayerStyle(roomLightForHour(hour));
+        return (
+          <>
+            <Story />
+            <div
+              className="room-light fixed inset-0 pointer-events-none z-0"
+              data-slot="room-light"
+              aria-hidden="true"
+              style={style}
+            />
+          </>
+        );
+      },
+    ],
+  };
+}
+
+/** 06:00 — cool blue-grey early-morning light. */
+export const RoomLightDawn: Story = roomLightStopStory(6);
+
+/** 12:00 — neutral daylight, the grade nearly invisible. */
+export const RoomLightDay: Story = roomLightStopStory(12);
+
+/** 18:00 — golden-hour amber wash around sunset. */
+export const RoomLightGoldenHour: Story = roomLightStopStory(18);
+
+/** 21:00 — dusk: the wash cools down while the desk lamp starts to glow. */
+export const RoomLightDusk: Story = roomLightStopStory(21);
+
+/** 23:00 — night: a slightly dimmer scene lit by the warm desk-lamp corner. */
+export const RoomLightNight: Story = roomLightStopStory(23);

--- a/apps/web/src/components/shared/AmbientBackground/AmbientBackground.test.tsx
+++ b/apps/web/src/components/shared/AmbientBackground/AmbientBackground.test.tsx
@@ -26,6 +26,7 @@ afterEach(() => {
     tempoBreathingEnabled: true,
     artworkBloomEnabled: true,
     coverCrossfadeEnabled: true,
+    roomLightEnabled: true,
   });
 });
 
@@ -171,6 +172,23 @@ describe('AmbientBackground', () => {
     expect(container.querySelector('[data-slot="ambient-glow"]')).not.toBeNull();
   });
 
+  it('renders the room-light grade layer with the stop custom properties', () => {
+    const { container } = render(<AmbientBackground />);
+
+    const layer = container.querySelector<HTMLElement>('[data-slot="room-light"]');
+    expect(layer).not.toBeNull();
+    expect(layer!.style.getPropertyValue('--room-light-tint')).toContain('color-mix');
+    expect(layer!.style.getPropertyValue('--room-light-lamp')).not.toBe('');
+  });
+
+  it('omits the room-light layer when the toggle is off', () => {
+    useUIStore.setState({ roomLightEnabled: false });
+
+    const { container } = render(<AmbientBackground />);
+
+    expect(container.querySelector('[data-slot="room-light"]')).toBeNull();
+  });
+
   it('keeps every drift period in minutes, never seconds', () => {
     // The calm contract: rotation slower than once per five minutes for every
     // layer. A "faster" tuning pass would flip this from ambience to motion.
@@ -235,5 +253,13 @@ describe('useAmbientBackground gating', () => {
     expect(result.current.enabled).toBe(false);
     expect(result.current.showBloom).toBe(false);
     expect(result.current.bloomSlots.current).toBeNull();
+  });
+
+  it('keeps low-performance mode as the master kill over the room-light toggle', () => {
+    useUIStore.setState({ roomLightEnabled: true, lowPerformanceMode: true });
+
+    const { result } = renderHook(() => useAmbientBackground());
+
+    expect(result.current.roomLightStyle).toBeNull();
   });
 });

--- a/apps/web/src/components/shared/AmbientBackground/AmbientBackground.tsx
+++ b/apps/web/src/components/shared/AmbientBackground/AmbientBackground.tsx
@@ -66,6 +66,7 @@ export default function AmbientBackground() {
     bloomKey,
     showBloom,
     breathing,
+    roomLightStyle,
   } = useAmbientBackground();
 
   if (!enabled) return null;
@@ -142,6 +143,20 @@ export default function AmbientBackground() {
           transition={{ duration: 1.1, ease: 'easeOut', times: [0, 0.3, 1] }}
           className="fixed inset-0 pointer-events-none z-0"
           style={{ background: glowBackground }}
+        />
+      )}
+
+      {/* Room light: the time-of-day grade over the whole ambient scene —
+          later in the DOM than the bloom/glow so it tints them, not the other
+          way round. The stops and their minutes-long cross-fade live in CSS
+          (globals.css `.room-light`); the div only publishes the custom
+          properties for the current stop. */}
+      {roomLightStyle && (
+        <div
+          className="room-light fixed inset-0 pointer-events-none z-0"
+          data-slot="room-light"
+          aria-hidden="true"
+          style={roomLightStyle}
         />
       )}
     </>

--- a/apps/web/src/components/shared/AmbientBackground/AmbientBackground.types.ts
+++ b/apps/web/src/components/shared/AmbientBackground/AmbientBackground.types.ts
@@ -1,3 +1,5 @@
+import type { CSSProperties } from 'react';
+
 export interface IArtBloomLayer {
   /** Square edge length of the cover copy (viewport-relative unit string). */
   readonly size: string;
@@ -55,4 +57,9 @@ export interface IAmbientBackgroundView {
   readonly showBloom: boolean;
   /** Tempo-locked breathing engages (BPM known, toggle on, motion allowed). */
   readonly breathing: boolean;
+  /**
+   * The `--room-light-*` custom properties for the time-of-day lighting grade,
+   * or `null` when the room-light toggle is off (the shell skips the layer).
+   */
+  readonly roomLightStyle: CSSProperties | null;
 }

--- a/apps/web/src/hooks/useRoomLight.test.ts
+++ b/apps/web/src/hooks/useRoomLight.test.ts
@@ -1,0 +1,98 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ROOM_LIGHT_STOPS,
+  roomLightForHour,
+  roomLightLayerStyle,
+  useRoomLight,
+  type RoomLightStopKey,
+} from './useRoomLight';
+
+function gradeOf(key: RoomLightStopKey) {
+  return ROOM_LIGHT_STOPS.find(stop => stop.key === key)!.grade;
+}
+
+describe('roomLightForHour', () => {
+  it.each<[number, RoomLightStopKey]>([
+    [0, 'night'],
+    [1, 'night'],
+    [2, 'night'],
+    [3, 'night'],
+    [4, 'night'],
+    [5, 'dawn'],
+    [6, 'dawn'],
+    [7, 'dawn'],
+    [8, 'dawn'],
+    [9, 'day'],
+    [10, 'day'],
+    [11, 'day'],
+    [12, 'day'],
+    [13, 'day'],
+    [14, 'day'],
+    [15, 'day'],
+    [16, 'day'],
+    [17, 'goldenHour'],
+    [18, 'goldenHour'],
+    [19, 'goldenHour'],
+    [20, 'dusk'],
+    [21, 'dusk'],
+    [22, 'night'],
+    [23, 'night'],
+  ])('hour %i resolves to the %s stop', (hour, key) => {
+    expect(roomLightForHour(hour)).toEqual(gradeOf(key));
+  });
+
+  it('floors fractional hours and wraps out-of-range values modulo 24', () => {
+    expect(roomLightForHour(17.9)).toEqual(gradeOf('goldenHour'));
+    expect(roomLightForHour(24)).toEqual(gradeOf('night'));
+    expect(roomLightForHour(29)).toEqual(gradeOf('dawn'));
+    expect(roomLightForHour(-1)).toEqual(gradeOf('night'));
+  });
+
+  it('keeps every stop a subtle grade: alphas bounded and ordered hours', () => {
+    let previousFrom = -1;
+    for (const stop of ROOM_LIGHT_STOPS) {
+      expect(stop.fromHour).toBeGreaterThan(previousFrom);
+      previousFrom = stop.fromHour;
+      expect(stop.grade.warmth).toBeGreaterThanOrEqual(0);
+      expect(stop.grade.warmth).toBeLessThanOrEqual(0.3);
+      expect(stop.grade.lampVignette).toBeGreaterThanOrEqual(0);
+      expect(stop.grade.lampVignette).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('lights the desk lamp only after dark', () => {
+    for (const stop of ROOM_LIGHT_STOPS) {
+      const lampExpected = stop.key === 'dusk' || stop.key === 'night';
+      expect(stop.grade.lampVignette > 0).toBe(lampExpected);
+    }
+  });
+});
+
+describe('roomLightLayerStyle', () => {
+  it('pre-mixes the tint to its warmth and exposes the lamp opacity', () => {
+    const style = roomLightLayerStyle(gradeOf('goldenHour')) as Record<string, string>;
+
+    expect(style['--room-light-tint']).toBe(
+      'color-mix(in oklab, oklch(0.75 0.14 65) 10%, transparent)'
+    );
+    expect(style['--room-light-lamp']).toBe('0');
+  });
+});
+
+describe('useRoomLight', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the grade for the current local hour', () => {
+    vi.setSystemTime(new Date(2026, 7, 14, 18, 30, 0));
+
+    const { result } = renderHook(() => useRoomLight());
+
+    expect(result.current).toEqual(gradeOf('goldenHour'));
+  });
+});

--- a/apps/web/src/hooks/useRoomLight.ts
+++ b/apps/web/src/hooks/useRoomLight.ts
@@ -1,0 +1,92 @@
+import type { CSSProperties } from 'react';
+import { useCurrentHour } from '@/hooks/useCurrentHour';
+
+/** The five keyed lighting stops of the room-light day cycle. */
+export type RoomLightStopKey = 'dawn' | 'day' | 'goldenHour' | 'dusk' | 'night';
+
+export interface IRoomLightGrade {
+  /** Full-strength wash color of the grade (any CSS color; `warmth` scales it in). */
+  readonly tint: string;
+  /** Strength of the tint wash, 0–1 — the fraction of `tint` mixed over the scene. */
+  readonly warmth: number;
+  /** Opacity of the warm desk-lamp corner vignette, 0–1 (only lit after dark). */
+  readonly lampVignette: number;
+}
+
+interface IRoomLightStop {
+  /** First local hour (0–23) at which this stop takes over. */
+  readonly fromHour: number;
+  /** Stable stop identity — for tests and per-stop Storybook stories. */
+  readonly key: RoomLightStopKey;
+  /** The grade this stop applies until the next stop's hour. */
+  readonly grade: IRoomLightGrade;
+}
+
+/**
+ * The day cycle, keyed by local hour: cool blue-grey at dawn, a barely-there
+ * neutral by day, a golden-hour amber wash toward sunset, a warming dusk where
+ * the desk lamp starts to glow, and a slightly dimmer night scene lit by the
+ * lamp corner alone. Night wraps midnight — hours before the first stop belong
+ * to the last one. Alphas stay whisper-quiet on purpose: this is a lighting
+ * grade over the ambient art, never a curtain in front of it.
+ */
+export const ROOM_LIGHT_STOPS: readonly IRoomLightStop[] = [
+  {
+    fromHour: 5,
+    key: 'dawn',
+    grade: { tint: 'oklch(0.78 0.05 240)', warmth: 0.08, lampVignette: 0 },
+  },
+  {
+    fromHour: 9,
+    key: 'day',
+    grade: { tint: 'oklch(0.85 0.02 90)', warmth: 0.03, lampVignette: 0 },
+  },
+  {
+    fromHour: 17,
+    key: 'goldenHour',
+    grade: { tint: 'oklch(0.75 0.14 65)', warmth: 0.1, lampVignette: 0 },
+  },
+  {
+    fromHour: 20,
+    key: 'dusk',
+    grade: { tint: 'oklch(0.6 0.1 50)', warmth: 0.07, lampVignette: 0.45 },
+  },
+  {
+    fromHour: 22,
+    key: 'night',
+    grade: { tint: 'oklch(0.2 0.03 290)', warmth: 0.22, lampVignette: 1 },
+  },
+];
+
+/**
+ * The grade for a local hour. Fractional hours floor to their containing hour
+ * and out-of-range values wrap modulo 24, so a clock source can never select
+ * nothing; hours before the first stop (small hours) wrap to the last (night).
+ */
+export function roomLightForHour(hour: number): IRoomLightGrade {
+  const normalized = ((Math.floor(hour) % 24) + 24) % 24;
+  let active = ROOM_LIGHT_STOPS[ROOM_LIGHT_STOPS.length - 1];
+  for (const stop of ROOM_LIGHT_STOPS) {
+    if (stop.fromHour <= normalized) active = stop;
+  }
+  return active.grade;
+}
+
+/**
+ * The `--room-light-*` custom properties the `.room-light` layer consumes
+ * (globals.css): the tint pre-mixed to its warmth over transparent, and the
+ * lamp vignette's opacity. Kept a pure builder so AmbientBackground's hook and
+ * the per-stop Storybook stories derive pixel-identical layers.
+ */
+export function roomLightLayerStyle(grade: IRoomLightGrade): CSSProperties {
+  return {
+    '--room-light-tint': `color-mix(in oklab, ${grade.tint} ${Math.round(grade.warmth * 100)}%, transparent)`,
+    '--room-light-lamp': String(grade.lampVignette),
+  } as CSSProperties;
+}
+
+/** The room-light grade for the current local hour, live across hour boundaries. */
+export function useRoomLight(): IRoomLightGrade {
+  const hour = useCurrentHour();
+  return roomLightForHour(hour);
+}

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -465,6 +465,8 @@
     "artworkBloomDesc": "Blurred copies of the record's cover drift slowly behind the app. When off, a calm color glow takes its place.",
     "coverCrossfade": "Cover crossfade",
     "coverCrossfadeDesc": "The artwork backdrop dissolves from one record into the next. This is the visual dissolve only — the audio crossfade lives in Playback.",
+    "roomLight": "Room light",
+    "roomLightDesc": "The app follows your local day — cool morning light, a golden-hour wash toward sunset, and a slightly dimmer room with a warm desk lamp after dark. Changes drift in over minutes.",
     "tempoBreathing": "Tempo breathing",
     "tempoBreathingDesc": "The artwork bloom, the floating mascot, and the compact player's pulse breathe at the tempo of the playing track. Tracks without tempo data keep their fixed rhythm.",
     "tempoBreathingHint": "Most of your library has no tempo data yet, so the breathing rarely engages. Run the analysis once from the Library settings.",

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -487,6 +487,8 @@
     "artworkBloomDesc": "Rozmyte kopie okładki płyty powoli dryfują za interfejsem aplikacji. Po wyłączeniu zastępuje je spokojna kolorowa poświata.",
     "coverCrossfade": "Przenikanie okładek",
     "coverCrossfadeDesc": "Tło z okładką płynnie przenika z jednej płyty w następną. To wyłącznie efekt wizualny — crossfade dźwięku znajdziesz w ustawieniach odtwarzania.",
+    "roomLight": "Światło pokoju",
+    "roomLightDesc": "Aplikacja podąża za Twoją porą dnia — chłodne światło poranka, złota poświata przed zachodem, a po zmroku lekko przyciemniony pokój z ciepłą lampką na biurku. Zmiany przenikają się minutami.",
     "tempoBreathing": "Oddychanie w tempie",
     "tempoBreathingDesc": "Poświata okładki, unosząca się maskotka i pulsowanie kompaktowego odtwarzacza oddychają w tempie odtwarzanego utworu. Utwory bez danych o tempie zachowują stały rytm.",
     "tempoBreathingHint": "Większość biblioteki nie ma jeszcze danych o tempie, więc oddychanie rzadko się włącza. Uruchom analizę raz w ustawieniach biblioteki.",

--- a/apps/web/src/stores/useUIStore.test.ts
+++ b/apps/web/src/stores/useUIStore.test.ts
@@ -240,6 +240,43 @@ describe('visual-effect gates (artworkBloomEnabled / coverCrossfadeEnabled)', ()
   });
 });
 
+describe('roomLightEnabled (time-of-day lighting grade gate)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it('defaults to enabled on a fresh profile (opt-out setting)', async () => {
+    const { useUIStore: store } = await import('./useUIStore');
+    expect(store.getState().roomLightEnabled).toBe(true);
+  });
+
+  it('persists setRoomLightEnabled to localStorage', async () => {
+    const { useUIStore: store } = await import('./useUIStore');
+    store.getState().setRoomLightEnabled(false);
+    expect(store.getState().roomLightEnabled).toBe(false);
+    expect(readPersisted().roomLightEnabled).toBe(false);
+  });
+
+  it('restores a persisted opt-out through the sanitize path', async () => {
+    localStorage.setItem(
+      STORE_KEY,
+      JSON.stringify({ state: { roomLightEnabled: false }, version: 1 })
+    );
+    const { useUIStore: store } = await import('./useUIStore');
+    expect(store.getState().roomLightEnabled).toBe(false);
+  });
+
+  it('ignores non-boolean garbage and keeps the enabled default', async () => {
+    localStorage.setItem(
+      STORE_KEY,
+      JSON.stringify({ state: { roomLightEnabled: 'nope' }, version: 1 })
+    );
+    const { useUIStore: store } = await import('./useUIStore');
+    expect(store.getState().roomLightEnabled).toBe(true);
+  });
+});
+
 describe('coerceVisualizerStyle (persist merge path)', () => {
   const ALL_STYLES = [
     'bars',

--- a/apps/web/src/stores/useUIStore.ts
+++ b/apps/web/src/stores/useUIStore.ts
@@ -157,6 +157,7 @@ interface PersistedUIState {
   tempoBreathingEnabled: boolean;
   artworkBloomEnabled: boolean;
   coverCrossfadeEnabled: boolean;
+  roomLightEnabled: boolean;
   landingView: LandingView;
 }
 
@@ -218,6 +219,8 @@ function sanitize(persisted: LegacyPersistedUIState | undefined): Partial<Persis
     out.artworkBloomEnabled = persisted.artworkBloomEnabled;
   if (typeof persisted.coverCrossfadeEnabled === 'boolean')
     out.coverCrossfadeEnabled = persisted.coverCrossfadeEnabled;
+  if (typeof persisted.roomLightEnabled === 'boolean')
+    out.roomLightEnabled = persisted.roomLightEnabled;
   if (persisted.landingView !== undefined)
     out.landingView = coerceLandingView(persisted.landingView);
   return out;
@@ -250,6 +253,7 @@ const UI_KEYS: ReadonlySet<string> = new Set([
   'tempoBreathingEnabled',
   'artworkBloomEnabled',
   'coverCrossfadeEnabled',
+  'roomLightEnabled',
   'landingView',
 ]);
 
@@ -381,9 +385,10 @@ interface UIState {
    *   its track-change pulse), `coverCrossfadeEnabled` (the visual dissolve
    *   between records — distinct from the audio crossfade, which lives in
    *   usePlaybackStore), `tempoBreathingEnabled` (BPM-locked breathing),
-   *   `noiseOverlayEnabled` (film-grain overlay), and `lowPerformanceMode`
-   *   (master kill for all ambient rendering, including palette extraction
-   *   in useAmbientColor).
+   *   `noiseOverlayEnabled` (film-grain overlay), `roomLightEnabled` (the
+   *   time-of-day lighting grade over the ambient scene), and
+   *   `lowPerformanceMode` (master kill for all ambient rendering, including
+   *   palette extraction in useAmbientColor).
    * - useAccentStore: `followArtAccent` — accent follows the cover's palette.
    * - useSanctuaryStore: Sanctuary Mode (fullscreen immersive player).
    * - useLyricsAppearanceStore: `lyricsPresentation` — list vs. focus stage.
@@ -393,6 +398,7 @@ interface UIState {
   tempoBreathingEnabled: boolean;
   artworkBloomEnabled: boolean;
   coverCrossfadeEnabled: boolean;
+  roomLightEnabled: boolean;
   landingView: LandingView;
 }
 
@@ -407,6 +413,7 @@ interface UIActions {
   setTempoBreathingEnabled: (enabled: boolean) => void;
   setArtworkBloomEnabled: (enabled: boolean) => void;
   setCoverCrossfadeEnabled: (enabled: boolean) => void;
+  setRoomLightEnabled: (enabled: boolean) => void;
   setLandingView: (view: LandingView) => void;
   setSidebarCollapsed: (sidebarCollapsed: boolean) => void;
   toggleSidebarCollapsed: () => void;
@@ -453,6 +460,7 @@ export const useUIStore = createPersistedStore<UIState & UIActions>(
     tempoBreathingEnabled: true,
     artworkBloomEnabled: true,
     coverCrossfadeEnabled: true,
+    roomLightEnabled: true,
     landingView: LANDING_VIEW_DEFAULT,
 
     setNowPlayingViewEnabled: enabled => {
@@ -486,6 +494,9 @@ export const useUIStore = createPersistedStore<UIState & UIActions>(
     },
     setCoverCrossfadeEnabled: enabled => {
       set({ coverCrossfadeEnabled: enabled });
+    },
+    setRoomLightEnabled: enabled => {
+      set({ roomLightEnabled: enabled });
     },
     setLandingView: view => {
       set({ landingView: view });
@@ -582,6 +593,7 @@ export const useUIStore = createPersistedStore<UIState & UIActions>(
         tempoBreathingEnabled: s.tempoBreathingEnabled,
         artworkBloomEnabled: s.artworkBloomEnabled,
         coverCrossfadeEnabled: s.coverCrossfadeEnabled,
+        roomLightEnabled: s.roomLightEnabled,
         landingView: s.landingView,
       }) as PersistedUIState,
     sanitize: (persisted, current) => ({

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -249,6 +249,34 @@
   }
 }
 
+/* ── Room Light — the time-of-day lighting grade over the ambient scene
+   (AmbientBackground). The layer div publishes two custom properties per stop:
+   `--room-light-tint` (the wash color, pre-mixed to its warmth) and
+   `--room-light-lamp` (the desk-lamp corner vignette's opacity). Both land on
+   natively animatable properties (background-color / opacity), so a stop
+   change cross-fades over minutes with zero per-frame script. The properties
+   are read only inside `.room-light` and default to invisible, so they cannot
+   leak into themes while the feature is off. ── */
+.room-light {
+  background-color: var(--room-light-tint, transparent);
+  transition: background-color 240s linear;
+}
+/* The warm desk-lamp pool anchored in the bottom-right corner — always
+   painted, but only faded in via the lamp property after dark. */
+.room-light::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    120% 120% at 86% 96%,
+    oklch(0.8 0.13 70 / 0.38) 0%,
+    oklch(0.72 0.14 60 / 0.14) 32%,
+    transparent 62%
+  );
+  opacity: var(--room-light-lamp, 0);
+  transition: opacity 240s linear;
+}
+
 /* EQ bar animations - must be outside @theme inline for Tailwind v4 */
 @keyframes eq-bar-1 {
   0%,
@@ -408,6 +436,12 @@
     animation: none !important;
     transform: none !important;
   }
+  /* Room light keeps its grade but jumps between stops instead of tweening —
+     the minutes-long cross-fade is decorative motion, the grade itself is not. */
+  .room-light,
+  .room-light::after {
+    transition: none !important;
+  }
 }
 
 [data-perf-mode='low'] .splash-steam,
@@ -430,6 +464,16 @@
 /* Drop the cup drop-shadow filter under low-perf (compositor cost). */
 [data-perf-mode='low'] .splash-cup-shadow {
   filter: none !important;
+}
+/* AmbientBackground already unmounts the room-light layer under low-perf, but
+   drop it here too (same self-documenting belt as .noise) so any future
+   always-on mount stays covered. */
+[data-perf-mode='low'] .room-light {
+  display: none;
+}
+[data-perf-mode='low'] .room-light,
+[data-perf-mode='low'] .room-light::after {
+  transition: none !important;
 }
 
 /* Midnight Lofi Cafe Theme */


### PR DESCRIPTION
## What

A subtle time-of-day lighting grade over the app's ambient background. The app follows the local day: cool blue-grey light in the early morning, a barely-there neutral by day, a golden-hour amber wash around sunset, and after dark a slightly dimmer scene with a warm desk-lamp corner vignette. Cross-fades between stops happen over minutes, never abruptly.

## How

- **`useRoomLight`** (`apps/web/src/hooks/useRoomLight.ts`): a pure `roomLightForHour(hour)` deriver across five keyed stops (dawn 5h / day 9h / golden hour 17h / dusk 20h / night 22h, wrapping midnight), a `roomLightLayerStyle` builder shared with Storybook, and the hook reading the existing `useCurrentHour`.
- **AmbientBackground**: one absolutely-positioned layer rendered above the artwork bloom, publishing `--room-light-tint` (pre-mixed to its warmth) and `--room-light-lamp`. Renders `null` under low-performance mode, same as the rest of the layer.
- **CSS** (`globals.css`): the `.room-light` rules land the custom properties on natively animatable `background-color`/`opacity` with 240s linear transitions — the minutes-long cross-fade costs zero per-frame script. Properties are only read inside `.room-light` and default to invisible, so nothing leaks into themes when the feature is off. Added to **both** degradation blocks (`prefers-reduced-motion` jumps between stops instead of tweening; `[data-perf-mode='low']` drops the layer entirely).
- **Setting**: `roomLightEnabled` (default **on**) beside the other visual gates in `useUIStore` — persisted, sanitized, in `UI_KEYS`/`partialize`, with round-trip tests. Toggle row in Settings → Visual effects next to Artwork bloom / Cover crossfade.
- **Sanctuary**: the clock variant inherits the grade automatically — it paints no opaque background over the shared ambient layer, so no special-casing was needed.
- **i18n**: identical `app.roomLight` / `app.roomLightDesc` key trees in `en` and `pl`.
- **Stories**: one deterministic Storybook story per lighting stop (the base stories pin the clock-driven layer off so they stay stable).

## Verified

- `vitest --project web`: 324 files, 1996 tests green (includes new table-driven stop tests, layer tests, store round-trips).
- `pnpm lint` (repo eslint incl. the custom plugin): clean.
- `tsc --noEmit` for `@shiranami/web`: clean.