### PR TITLE
feat(companion): weather-dressed outfits for shio and hotaru

### DIFF
--- a/apps/web/src/components/companion/Companion/Companion.stories.tsx
+++ b/apps/web/src/components/companion/Companion/Companion.stories.tsx
@@ -28,6 +28,10 @@ const meta: Meta<typeof Companion> = {
       control: 'select',
       options: ['idle', 'listening', 'grooving', 'drowsy', 'sleeping', 'waking', 'hiding'],
     },
+    outfit: {
+      control: 'select',
+      options: [null, 'umbrella', 'scarf', 'sun', 'lantern', 'sakura', 'maple', 'snow'],
+    },
   },
   parameters: {
     // Pure aria-hidden decoration — axe must find nothing to flag.
@@ -119,3 +123,63 @@ export const StaticFirstFrame: Story = {
     await expect(rig).not.toHaveClass('companion-sway');
   },
 };
+
+/* ── Weather fits ─────────────────────────────────────────────────────────
+   One story per outfit per species (`data-outfit` reveal on the sprite
+   root). Rain and storms bring the leaf umbrella; below ~5 °C the scarf;
+   above ~28 °C the sweat droplet; night and fog light the lantern; the
+   sakura / maple / snow trio is the calendar fallback when weather is off. */
+
+/** Shio under the leaf umbrella — raining outside. */
+export const ShioUmbrella: Story = {
+  args: { outfit: 'umbrella' },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector('svg')).toHaveAttribute('data-outfit', 'umbrella');
+    await expect(canvasElement.querySelectorAll('.companion-outfit')).toHaveLength(1);
+  },
+};
+
+/** Shio wrapped in the scarf — below ~5 °C. */
+export const ShioScarf: Story = { args: { outfit: 'scarf' } };
+
+/** Shio with the sweat droplet — above ~28 °C. */
+export const ShioSun: Story = { args: { outfit: 'sun' } };
+
+/** Shio by the soft lantern glow — night or fog. */
+export const ShioLantern: Story = { args: { outfit: 'lantern' } };
+
+/** Shio with a sakura petal — the spring fallback. */
+export const ShioSakura: Story = { args: { outfit: 'sakura' } };
+
+/** Shio under a maple leaf — the autumn fallback. */
+export const ShioMaple: Story = { args: { outfit: 'maple' } };
+
+/** Shio dusted with snow — snowfall, or the winter fallback. */
+export const ShioSnow: Story = { args: { outfit: 'snow' } };
+
+/** Hotaru under the leaf umbrella — raining outside. */
+export const HotaruUmbrella: Story = {
+  args: { species: 'hotaru', outfit: 'umbrella' },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector('svg')).toHaveAttribute('data-outfit', 'umbrella');
+    await expect(canvasElement.querySelectorAll('.companion-outfit')).toHaveLength(1);
+  },
+};
+
+/** Hotaru wrapped in the scarf — below ~5 °C. */
+export const HotaruScarf: Story = { args: { species: 'hotaru', outfit: 'scarf' } };
+
+/** Hotaru with the sweat droplet — above ~28 °C. */
+export const HotaruSun: Story = { args: { species: 'hotaru', outfit: 'sun' } };
+
+/** Hotaru by the soft lantern glow — night or fog. */
+export const HotaruLantern: Story = { args: { species: 'hotaru', outfit: 'lantern' } };
+
+/** Hotaru with a sakura petal — the spring fallback. */
+export const HotaruSakura: Story = { args: { species: 'hotaru', outfit: 'sakura' } };
+
+/** Hotaru under a maple leaf — the autumn fallback. */
+export const HotaruMaple: Story = { args: { species: 'hotaru', outfit: 'maple' } };
+
+/** Hotaru dusted with snow — snowfall, or the winter fallback. */
+export const HotaruSnow: Story = { args: { species: 'hotaru', outfit: 'snow' } };

--- a/apps/web/src/components/companion/Companion/Companion.test.tsx
+++ b/apps/web/src/components/companion/Companion/Companion.test.tsx
@@ -79,6 +79,41 @@ describe('Companion', () => {
     expect(container.querySelectorAll('.companion-lvbub')).toHaveLength(5);
   });
 
+  it('stamps data-outfit and mounts exactly one accessory layer when dressed', () => {
+    const { container } = render(
+      <Companion species="shio" stage={2} mode="listening" motion={false} outfit="scarf" />
+    );
+    expect(container.querySelector('svg')).toHaveAttribute('data-outfit', 'scarf');
+    expect(container.querySelectorAll('.companion-outfit')).toHaveLength(1);
+    expect(container.querySelector('.companion-o-scarf')).not.toBeNull();
+  });
+
+  it('renders bare (no data-outfit, no accessory nodes) when outfit is null or omitted', () => {
+    const { container: omitted } = render(
+      <Companion species="shio" stage={2} mode="listening" motion={false} />
+    );
+    expect(omitted.querySelector('svg')).not.toHaveAttribute('data-outfit');
+    expect(omitted.querySelector('.companion-outfit')).toBeNull();
+
+    const { container: explicit } = render(
+      <Companion species="hotaru" stage={2} mode="listening" motion={false} outfit={null} />
+    );
+    expect(explicit.querySelector('svg')).not.toHaveAttribute('data-outfit');
+    expect(explicit.querySelector('.companion-outfit')).toBeNull();
+  });
+
+  it('renders outfit=null byte-identical to the outfit-less sprite', () => {
+    // The only per-render variance is the useId mask id — normalize it away.
+    const normalize = (html: string) => html.replace(/_r_[a-z0-9]+_/g, '_id_');
+    const { container: bare } = render(
+      <Companion species="shio" stage={3} mode="idle" motion={false} />
+    );
+    const { container: nullOutfit } = render(
+      <Companion species="shio" stage={3} mode="idle" motion={false} outfit={null} />
+    );
+    expect(normalize(nullOutfit.innerHTML)).toBe(normalize(bare.innerHTML));
+  });
+
   it('exposes peek as custom properties on the sprite root', () => {
     const { container } = render(
       <Companion species="shio" stage={1} mode="listening" motion peekOffset={{ x: 2, y: -1 }} />

--- a/apps/web/src/components/companion/Companion/Companion.tsx
+++ b/apps/web/src/components/companion/Companion/Companion.tsx
@@ -7,7 +7,7 @@ import type { ICompanionProps } from './Companion.types';
 /**
  * The resident sprite — one shell, two species. Renders the shared stage
  * (ripple pool, ripple ring, level-up foam bubbles) around the chosen rig,
- * stamps the state/stage/face data attributes the companion CSS keys off,
+ * stamps the state/stage/face/outfit data attributes the companion CSS keys off,
  * and runs the WAAPI one-shots. Purely presentational: the machine lives in
  * `useCompanionPresence`, interactions live on the surfaces (perch).
  *
@@ -15,7 +15,7 @@ import type { ICompanionProps } from './Companion.types';
  * never reaches the a11y tree; hit-testing is the surface's concern.
  */
 export default function Companion(props: ICompanionProps) {
-  const { species, stage, mode, size = 56, className } = props;
+  const { species, stage, mode, outfit, size = 56, className } = props;
   const { svgRef, face, rigClass, hopClass, height, rootStyle } = useCompanion(props);
 
   return (
@@ -30,6 +30,7 @@ export default function Companion(props: ICompanionProps) {
       data-stage={stage}
       data-state={mode}
       data-face={face}
+      data-outfit={outfit ?? undefined}
       style={rootStyle}
       aria-hidden="true"
       focusable="false"
@@ -41,9 +42,9 @@ export default function Companion(props: ICompanionProps) {
       <g className={hopClass}>
         <g className={cn('companion-rig', rigClass)}>
           {species === 'shio' ? (
-            <ShioRig stage={stage} mode={mode} motion={props.motion} />
+            <ShioRig stage={stage} mode={mode} motion={props.motion} outfit={outfit} />
           ) : (
-            <HotaruRig stage={stage} mode={mode} motion={props.motion} />
+            <HotaruRig stage={stage} mode={mode} motion={props.motion} outfit={outfit} />
           )}
         </g>
       </g>

--- a/apps/web/src/components/companion/Companion/Companion.types.ts
+++ b/apps/web/src/components/companion/Companion/Companion.types.ts
@@ -5,6 +5,7 @@ import type {
   CompanionSpecies,
   CompanionStage,
 } from '@/lib/companionMachine';
+import type { CompanionOutfit } from '@/lib/companionOutfit';
 
 /** Face variant shown by the sprite (drives the `data-face` attribute). */
 export type CompanionFace = 'open' | 'half' | 'closed';
@@ -19,6 +20,11 @@ export interface ICompanionProps {
   readonly overlaySeq?: number;
   /** Decorative motion allowed; false = static first frame of every state. */
   readonly motion: boolean;
+  /**
+   * Weather/seasonal accessory (drives the `data-outfit` attribute, mirror of
+   * `data-stage`). Null/omitted = bare — byte-identical to the outfit-less rig.
+   */
+  readonly outfit?: CompanionOutfit | null;
   /** Rendered width in px (56 = player perch, 64 = Now Playing). */
   readonly size?: number;
   readonly className?: string;

--- a/apps/web/src/components/companion/CompanionPerch/CompanionPerch.test.tsx
+++ b/apps/web/src/components/companion/CompanionPerch/CompanionPerch.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import CompanionPerch from './CompanionPerch';
@@ -22,6 +23,16 @@ const track: Track = {
   loudnessLufs: -15,
 };
 
+/* Presence now reads the cached weather query, so the perch needs a client. */
+function renderPerch() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <CompanionPerch />
+    </QueryClientProvider>
+  );
+}
+
 describe('CompanionPerch', () => {
   beforeEach(() => {
     useCompanionRuntimeStore.setState({ machine: createCompanionState(), suspended: false });
@@ -38,7 +49,7 @@ describe('CompanionPerch', () => {
   });
 
   it('renders the sprite, hidden from assistive tech, pointer-inert outside the hitbox', () => {
-    const { container } = render(<CompanionPerch />);
+    const { container } = renderPerch();
     const wrap = container.querySelector('[data-slot="companion-perch"]');
     expect(wrap).not.toBeNull();
     expect(wrap).toHaveAttribute('aria-hidden', 'true');
@@ -52,21 +63,21 @@ describe('CompanionPerch', () => {
 
   it('unmounts entirely when the master toggle turns the companion off', () => {
     useInterfaceStore.setState({ companion: false });
-    const { container } = render(<CompanionPerch />);
+    const { container } = renderPerch();
     expect(container.querySelector('[data-slot="companion-perch"]')).toBeNull();
   });
 
   it('slides behind the bar edge during lyric focus instead of unmounting', () => {
     useLyricsAppearanceStore.setState({ lyricsPresentation: 'focus' });
     useViewStore.setState({ rightPanel: 'lyrics' });
-    const { container } = render(<CompanionPerch />);
+    const { container } = renderPerch();
     const wrap = container.querySelector('[data-slot="companion-perch"]');
     expect(wrap).not.toBeNull();
     expect(wrap).toHaveClass('opacity-0');
   });
 
   it('overlaps the bar top edge so the resident sits on the border', () => {
-    const { container } = render(<CompanionPerch />);
+    const { container } = renderPerch();
     const wrap = container.querySelector('[data-slot="companion-perch"]') as HTMLElement;
     // The horizontal seat uses clamp() (dropped by jsdom's CSS parser), so
     // only the numeric parts are assertable here.

--- a/apps/web/src/components/companion/CompanionPerch/CompanionPerch.tsx
+++ b/apps/web/src/components/companion/CompanionPerch/CompanionPerch.tsx
@@ -55,6 +55,7 @@ export default function CompanionPerch() {
           overlay={presence.overlay}
           overlaySeq={presence.overlaySeq}
           motion={presence.motion}
+          outfit={presence.outfit}
           size={56}
           peekOffset={peekOffset}
           faceOverride={faceOverride}

--- a/apps/web/src/components/companion/HotaruRig/HotaruRig.hooks.ts
+++ b/apps/web/src/components/companion/HotaruRig/HotaruRig.hooks.ts
@@ -22,5 +22,6 @@ export function useHotaruRig({ stage, mode, motion }: IHotaruRigProps): IHotaruR
     bubClass: motion && (listening || grooving) ? 'companion-bub-drift' : undefined,
     blinkClass: motion && mode === 'idle' ? 'companion-idle-blink' : undefined,
     eyeRy: stage === 0 ? 4.2 : 3.4,
+    lanternClass: motion ? 'companion-lantern-glow' : undefined,
   };
 }

--- a/apps/web/src/components/companion/HotaruRig/HotaruRig.test.tsx
+++ b/apps/web/src/components/companion/HotaruRig/HotaruRig.test.tsx
@@ -45,4 +45,28 @@ describe('HotaruRig', () => {
     const { container } = renderRig(<HotaruRig stage={2} mode="listening" motion={false} />);
     expect(container.querySelectorAll('.companion-ink').length).toBeGreaterThan(0);
   });
+
+  it('mounts only the worn accessory layer, and none when bare', () => {
+    const { container: bare } = renderRig(<HotaruRig stage={2} mode="idle" motion={false} />);
+    expect(bare.querySelector('.companion-outfit')).toBeNull();
+
+    const { container: dressed } = renderRig(
+      <HotaruRig stage={2} mode="idle" motion={false} outfit="sakura" />
+    );
+    expect(dressed.querySelectorAll('.companion-outfit')).toHaveLength(1);
+    expect(dressed.querySelector('.companion-o-sakura')).not.toBeNull();
+    expect(dressed.querySelector('.companion-o-maple')).toBeNull();
+  });
+
+  it('pulses the lantern glow only when motion is allowed', () => {
+    const { container: moving } = renderRig(
+      <HotaruRig stage={2} mode="idle" motion outfit="lantern" />
+    );
+    expect(moving.querySelector('.companion-o-lantern')).toHaveClass('companion-lantern-glow');
+
+    const { container: still } = renderRig(
+      <HotaruRig stage={2} mode="idle" motion={false} outfit="lantern" />
+    );
+    expect(still.querySelector('.companion-o-lantern')).not.toHaveClass('companion-lantern-glow');
+  });
 });

--- a/apps/web/src/components/companion/HotaruRig/HotaruRig.tsx
+++ b/apps/web/src/components/companion/HotaruRig/HotaruRig.tsx
@@ -10,8 +10,12 @@ import type { IHotaruRigProps } from './HotaruRig.types';
  * Renders as a fragment inside the Companion sprite's rig group; stage layers
  * carry `companion-s*` classes revealed by the root's `data-stage`.
  */
-export default function HotaruRig({ stage, mode, motion }: IHotaruRigProps) {
-  const { maskId, beatClass, bubClass, blinkClass, eyeRy } = useHotaruRig({ stage, mode, motion });
+export default function HotaruRig({ stage, mode, motion, outfit }: IHotaruRigProps) {
+  const { maskId, beatClass, bubClass, blinkClass, eyeRy, lanternClass } = useHotaruRig({
+    stage,
+    mode,
+    motion,
+  });
 
   return (
     <g data-slot="hotaru-rig" transform="translate(0,-3)">
@@ -91,6 +95,74 @@ export default function HotaruRig({ stage, mode, motion }: IHotaruRigProps) {
         <circle className="companion-bub companion-s4" cx="28" cy="40" r="1.5" opacity={0.7} />
         <circle className="companion-bub companion-s4" cx="93" cy="34" r="1.6" opacity={0.7} />
       </g>
+
+      {/* Weather fit — at most one accessory mounts, so a bare Hotaru (outfit
+          null) renders byte-identical to the outfit-less rig. */}
+      {outfit === 'umbrella' && (
+        <g className="companion-outfit companion-o-umbrella">
+          <path
+            className="companion-ink-s"
+            d="M 80 30 Q 87 46 80 60"
+            style={{ strokeWidth: 1.6, opacity: 0.7 }}
+          />
+          <path
+            className="companion-o-canopy"
+            d="M 32 30 Q 60 8 88 28 Q 73 22 60 23 Q 46 25 32 30 Z"
+          />
+          <path
+            className="companion-ink-s"
+            d="M 38 27 Q 60 14 83 26"
+            style={{ strokeWidth: 1, opacity: 0.45 }}
+          />
+        </g>
+      )}
+      {outfit === 'scarf' && (
+        <g className="companion-outfit companion-o-scarf">
+          <path
+            className="companion-o-accent"
+            d="M 40 55 Q 60 65 80 55 Q 81 59 80 61 Q 60 71 40 61 Q 39 59 40 55 Z"
+          />
+          <path className="companion-o-accent" d="M 71 60 L 76 74 Q 71 77 66 73 Z" />
+        </g>
+      )}
+      {outfit === 'sun' && (
+        <g className="companion-outfit companion-o-sun">
+          <path className="companion-o-drop" d="M 85 32 Q 91 41 85 45 Q 79 41 85 32 Z" />
+          <path className="companion-o-drop" d="M 92 42 Q 95 46 92 48 Q 89 46 92 42 Z" />
+        </g>
+      )}
+      {outfit === 'lantern' && (
+        <g className={cn('companion-outfit companion-o-lantern', lanternClass)}>
+          <circle className="companion-o-halo" cx="28" cy="52" r="7.5" />
+          <circle className="companion-o-glowcore" cx="28" cy="52" r="3" />
+        </g>
+      )}
+      {outfit === 'sakura' && (
+        <g className="companion-outfit companion-o-sakura">
+          <path className="companion-o-petal" d="M 56 21 Q 60 16 64 21 Q 60 27 56 21 Z" />
+          <path
+            className="companion-o-petal"
+            d="M 90 48 Q 93 45 95 48 Q 93 52 90 48 Z"
+            opacity={0.7}
+          />
+        </g>
+      )}
+      {outfit === 'maple' && (
+        <g className="companion-outfit companion-o-maple" transform="rotate(14 61 23)">
+          <path
+            className="companion-o-accent"
+            d="M 61 15 L 64 21 L 70 19 L 66 24 L 70 28 L 63 27 L 61 33 L 59 27 L 52 28 L 56 24 L 52 19 L 58 21 Z"
+          />
+        </g>
+      )}
+      {outfit === 'snow' && (
+        <g className="companion-outfit companion-o-snow">
+          <circle className="companion-o-snowflake" cx="48" cy="26" r="1.7" />
+          <circle className="companion-o-snowflake" cx="60" cy="21" r="2" />
+          <circle className="companion-o-snowflake" cx="72" cy="27" r="1.5" />
+          <circle className="companion-o-snowflake" cx="88" cy="52" r="1.3" />
+        </g>
+      )}
     </g>
   );
 }

--- a/apps/web/src/components/companion/HotaruRig/HotaruRig.types.ts
+++ b/apps/web/src/components/companion/HotaruRig/HotaruRig.types.ts
@@ -1,4 +1,5 @@
 import type { CompanionMode, CompanionStage } from '@/lib/companionMachine';
+import type { CompanionOutfit } from '@/lib/companionOutfit';
 
 export interface IHotaruRigProps {
   /** Evolution stage index (0–4); reveals the additive layer groups. */
@@ -7,6 +8,11 @@ export interface IHotaruRigProps {
   readonly mode: CompanionMode;
   /** Decorative motion allowed; false renders the static first frame. */
   readonly motion: boolean;
+  /**
+   * Weather/seasonal accessory layer. Null/omitted mounts nothing — the bare
+   * rig stays byte-identical to the outfit-less render.
+   */
+  readonly outfit?: CompanionOutfit | null;
 }
 
 export interface IHotaruRigView {
@@ -20,4 +26,6 @@ export interface IHotaruRigView {
   readonly blinkClass: string | undefined;
   /** Hatchling eyes are bigger — the endearingly unfinished look. */
   readonly eyeRy: number;
+  /** Soft pulse for the lantern-glow outfit (undefined = static glow). */
+  readonly lanternClass: string | undefined;
 }

--- a/apps/web/src/components/companion/ShioRig/ShioRig.hooks.ts
+++ b/apps/web/src/components/companion/ShioRig/ShioRig.hooks.ts
@@ -22,5 +22,6 @@ export function useShioRig({ stage, mode, motion }: IShioRigProps): IShioRigView
     bubClass: motion && (listening || grooving) ? 'companion-bub-drift' : undefined,
     blinkClass: motion && mode === 'idle' ? 'companion-idle-blink' : undefined,
     eyeRy: stage === 0 ? 3.8 : 3,
+    lanternClass: motion ? 'companion-lantern-glow' : undefined,
   };
 }

--- a/apps/web/src/components/companion/ShioRig/ShioRig.test.tsx
+++ b/apps/web/src/components/companion/ShioRig/ShioRig.test.tsx
@@ -49,4 +49,28 @@ describe('ShioRig', () => {
     const eye = container.querySelector('.companion-f-open .companion-ink');
     expect(eye?.getAttribute('ry')).toBe('3.8');
   });
+
+  it('mounts only the worn accessory layer, and none when bare', () => {
+    const { container: bare } = renderRig(<ShioRig stage={2} mode="idle" motion={false} />);
+    expect(bare.querySelector('.companion-outfit')).toBeNull();
+
+    const { container: dressed } = renderRig(
+      <ShioRig stage={2} mode="idle" motion={false} outfit="umbrella" />
+    );
+    expect(dressed.querySelectorAll('.companion-outfit')).toHaveLength(1);
+    expect(dressed.querySelector('.companion-o-umbrella')).not.toBeNull();
+    expect(dressed.querySelector('.companion-o-scarf')).toBeNull();
+  });
+
+  it('pulses the lantern glow only when motion is allowed', () => {
+    const { container: moving } = renderRig(
+      <ShioRig stage={2} mode="idle" motion outfit="lantern" />
+    );
+    expect(moving.querySelector('.companion-o-lantern')).toHaveClass('companion-lantern-glow');
+
+    const { container: still } = renderRig(
+      <ShioRig stage={2} mode="idle" motion={false} outfit="lantern" />
+    );
+    expect(still.querySelector('.companion-o-lantern')).not.toHaveClass('companion-lantern-glow');
+  });
 });

--- a/apps/web/src/components/companion/ShioRig/ShioRig.tsx
+++ b/apps/web/src/components/companion/ShioRig/ShioRig.tsx
@@ -10,8 +10,12 @@ import type { IShioRigProps } from './ShioRig.types';
  * layers carry `companion-s*` classes and are revealed by the root's
  * `data-stage` (see globals.css "Companion sprite").
  */
-export default function ShioRig({ stage, mode, motion }: IShioRigProps) {
-  const { maskId, beatClass, bubClass, blinkClass, eyeRy } = useShioRig({ stage, mode, motion });
+export default function ShioRig({ stage, mode, motion, outfit }: IShioRigProps) {
+  const { maskId, beatClass, bubClass, blinkClass, eyeRy, lanternClass } = useShioRig({
+    stage,
+    mode,
+    motion,
+  });
 
   return (
     <g data-slot="shio-rig">
@@ -113,6 +117,74 @@ export default function ShioRig({ stage, mode, motion }: IShioRigProps) {
         <circle className="companion-bub" cx="72" cy="90.5" r="2" />
         <circle className="companion-bub companion-s2" cx="41" cy="91" r="1.7" />
       </g>
+
+      {/* Weather fit — at most one accessory mounts, so a bare Shio (outfit
+          null) renders byte-identical to the outfit-less rig. */}
+      {outfit === 'umbrella' && (
+        <g className="companion-outfit companion-o-umbrella">
+          <path
+            className="companion-ink-s"
+            d="M 72 44 Q 78 64 74 82"
+            style={{ strokeWidth: 1.6, opacity: 0.7 }}
+          />
+          <path
+            className="companion-o-canopy"
+            d="M 34 36 Q 58 14 86 34 Q 72 29 58 30 Q 44 31 34 36 Z"
+          />
+          <path
+            className="companion-ink-s"
+            d="M 40 33 Q 58 21 81 32"
+            style={{ strokeWidth: 1, opacity: 0.45 }}
+          />
+        </g>
+      )}
+      {outfit === 'scarf' && (
+        <g className="companion-outfit companion-o-scarf">
+          <path
+            className="companion-o-accent"
+            d="M 42 62 Q 58 71 74 62 Q 75 66 74 68 Q 58 77 42 68 Q 41 66 42 62 Z"
+          />
+          <path className="companion-o-accent" d="M 66 67 L 71 81 Q 66 84 61 80 Z" />
+        </g>
+      )}
+      {outfit === 'sun' && (
+        <g className="companion-outfit companion-o-sun">
+          <path className="companion-o-drop" d="M 80 34 Q 86 43 80 47 Q 74 43 80 34 Z" />
+          <path className="companion-o-drop" d="M 88 44 Q 91 48 88 50 Q 85 48 88 44 Z" />
+        </g>
+      )}
+      {outfit === 'lantern' && (
+        <g className={cn('companion-outfit companion-o-lantern', lanternClass)}>
+          <circle className="companion-o-halo" cx="29" cy="40" r="7.5" />
+          <circle className="companion-o-glowcore" cx="29" cy="40" r="3" />
+        </g>
+      )}
+      {outfit === 'sakura' && (
+        <g className="companion-outfit companion-o-sakura">
+          <path className="companion-o-petal" d="M 56 27 Q 60 22 64 27 Q 60 33 56 27 Z" />
+          <path
+            className="companion-o-petal"
+            d="M 88 52 Q 91 49 93 52 Q 91 56 88 52 Z"
+            opacity={0.7}
+          />
+        </g>
+      )}
+      {outfit === 'maple' && (
+        <g className="companion-outfit companion-o-maple" transform="rotate(14 61 29)">
+          <path
+            className="companion-o-accent"
+            d="M 61 21 L 64 27 L 70 25 L 66 30 L 70 34 L 63 33 L 61 39 L 59 33 L 52 34 L 56 30 L 52 25 L 58 27 Z"
+          />
+        </g>
+      )}
+      {outfit === 'snow' && (
+        <g className="companion-outfit companion-o-snow">
+          <circle className="companion-o-snowflake" cx="48" cy="31" r="1.7" />
+          <circle className="companion-o-snowflake" cx="59" cy="27" r="2" />
+          <circle className="companion-o-snowflake" cx="69" cy="32" r="1.5" />
+          <circle className="companion-o-snowflake" cx="84" cy="63" r="1.3" />
+        </g>
+      )}
     </g>
   );
 }

--- a/apps/web/src/components/companion/ShioRig/ShioRig.types.ts
+++ b/apps/web/src/components/companion/ShioRig/ShioRig.types.ts
@@ -1,4 +1,5 @@
 import type { CompanionMode, CompanionStage } from '@/lib/companionMachine';
+import type { CompanionOutfit } from '@/lib/companionOutfit';
 
 export interface IShioRigProps {
   /** Evolution stage index (0–4); reveals the additive layer groups. */
@@ -7,6 +8,11 @@ export interface IShioRigProps {
   readonly mode: CompanionMode;
   /** Decorative motion allowed; false renders the static first frame. */
   readonly motion: boolean;
+  /**
+   * Weather/seasonal accessory layer. Null/omitted mounts nothing — the bare
+   * rig stays byte-identical to the outfit-less render.
+   */
+  readonly outfit?: CompanionOutfit | null;
 }
 
 export interface IShioRigView {
@@ -20,4 +26,6 @@ export interface IShioRigView {
   readonly blinkClass: string | undefined;
   /** Hatchling eyes are bigger — the endearingly unfinished look. */
   readonly eyeRy: number;
+  /** Soft pulse for the lantern-glow outfit (undefined = static glow). */
+  readonly lanternClass: string | undefined;
 }

--- a/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.tsx
@@ -206,6 +206,7 @@ export default function NowPlayingView() {
                   overlay={companion.overlay}
                   overlaySeq={companion.overlaySeq}
                   motion={companion.motion}
+                  outfit={companion.outfit}
                   size={64}
                 />
               </div>

--- a/apps/web/src/components/player/PlayerBar/PlayerBar.test.tsx
+++ b/apps/web/src/components/player/PlayerBar/PlayerBar.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Track } from '@/stores/types';
@@ -36,10 +37,14 @@ function makeTrack(overrides: Partial<Track> = {}): Track {
 }
 
 function renderBar() {
+  // The perch's presence read now includes the cached weather query.
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <TooltipProvider>
-      <PlayerBar />
-    </TooltipProvider>
+    <QueryClientProvider client={client}>
+      <TooltipProvider>
+        <PlayerBar />
+      </TooltipProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/apps/web/src/components/sanctuary/SanctuaryView/SanctuaryView.tsx
+++ b/apps/web/src/components/sanctuary/SanctuaryView/SanctuaryView.tsx
@@ -67,6 +67,7 @@ export default function SanctuaryView() {
         stage={companion.stage}
         mode={chromeVisible ? companion.mode : 'sleeping'}
         motion={companion.motion}
+        outfit={companion.outfit}
         size={72}
       />
     </div>

--- a/apps/web/src/components/settings/CompanionSection/CompanionSection.hooks.ts
+++ b/apps/web/src/components/settings/CompanionSection/CompanionSection.hooks.ts
@@ -17,6 +17,8 @@ export function useCompanionSection(): ICompanionSectionView {
   const setVisible = useInterfaceStore(s => s.setVisible);
   const keepsWatch = useCompanionStore(s => s.sanctuaryKeepsWatch);
   const setKeepsWatch = useCompanionStore(s => s.setSanctuaryKeepsWatch);
+  const dressForWeather = useCompanionStore(s => s.dressForWeather);
+  const setDressForWeather = useCompanionStore(s => s.setDressForWeather);
   const ledger = useCompanionLedger();
   const motion = useDecorativeMotion();
 
@@ -45,6 +47,8 @@ export function useCompanionSection(): ICompanionSectionView {
     onSelectSpecies: ledger.setSpecies,
     keepsWatch,
     onToggleKeepsWatch: setKeepsWatch,
+    dressForWeather,
+    onToggleDressForWeather: setDressForWeather,
     stage: ledger.stage,
     motion,
     stageLine,

--- a/apps/web/src/components/settings/CompanionSection/CompanionSection.test.tsx
+++ b/apps/web/src/components/settings/CompanionSection/CompanionSection.test.tsx
@@ -10,7 +10,11 @@ import { useInterfaceStore } from '@/stores/useInterfaceStore';
 
 function reset(): void {
   useInterfaceStore.setState({ companion: true });
-  useCompanionStore.setState({ species: 'shio', sanctuaryKeepsWatch: false });
+  useCompanionStore.setState({
+    species: 'shio',
+    sanctuaryKeepsWatch: false,
+    dressForWeather: true,
+  });
   useCompanionRuntimeStore.setState({
     ledger: { name: null, xpHours: null, hasBackend: false },
   });
@@ -47,6 +51,14 @@ describe('CompanionSection', () => {
     const switches = screen.getAllByRole('switch');
     await user.click(switches[0]);
     expect(useInterfaceStore.getState().companion).toBe(false);
+  });
+
+  it('toggles the weather-fits preference from its own row', async () => {
+    const user = userEvent.setup();
+    render(<CompanionSection />);
+
+    await user.click(screen.getByRole('switch', { name: /Dresses for the weather/ }));
+    expect(useCompanionStore.getState().dressForWeather).toBe(false);
   });
 
   it('keeps numbers out of sight until the ledger answers, then prose only', () => {

--- a/apps/web/src/components/settings/CompanionSection/CompanionSection.tsx
+++ b/apps/web/src/components/settings/CompanionSection/CompanionSection.tsx
@@ -20,6 +20,8 @@ export default function CompanionSection() {
     onSelectSpecies,
     keepsWatch,
     onToggleKeepsWatch,
+    dressForWeather,
+    onToggleDressForWeather,
     stage,
     motion,
     stageLine,
@@ -82,6 +84,15 @@ export default function CompanionSection() {
         description={t('app.interface.companion.keepsWatchDesc')}
         checked={keepsWatch}
         onCheckedChange={onToggleKeepsWatch}
+        disabled={!enabled}
+        divider
+      />
+
+      <SettingsToggleRow
+        label={t('app.interface.companion.dressForWeather')}
+        description={t('app.interface.companion.dressForWeatherDesc')}
+        checked={dressForWeather}
+        onCheckedChange={onToggleDressForWeather}
         disabled={!enabled}
         divider
       />

--- a/apps/web/src/components/settings/CompanionSection/CompanionSection.types.ts
+++ b/apps/web/src/components/settings/CompanionSection/CompanionSection.types.ts
@@ -26,6 +26,9 @@ export interface ICompanionSectionView {
   /** "Keeps watch in Sanctuary" sub-toggle. */
   readonly keepsWatch: boolean;
   readonly onToggleKeepsWatch: (keepsWatch: boolean) => void;
+  /** "Dresses for the weather" sub-toggle (weather fits + seasonal accents). */
+  readonly dressForWeather: boolean;
+  readonly onToggleDressForWeather: (dress: boolean) => void;
   /** Current stage — the previews render the pet as it actually is today. */
   readonly stage: CompanionStage;
   /** Decorative motion allowed — previews sway only when the app itself may. */

--- a/apps/web/src/hooks/useCompanionPresence.ts
+++ b/apps/web/src/hooks/useCompanionPresence.ts
@@ -1,15 +1,19 @@
 import { useCallback, useEffect } from 'react';
 import { ensureCompanionDriver } from '@/lib/companionDriver';
 import { getCompanionApi } from '@/lib/companionBackend';
+import { outfitFor } from '@/lib/companionOutfit';
 import { useCompanionRuntimeStore } from '@/stores/useCompanionRuntimeStore';
 import { useCompanionStore } from '@/stores/useCompanionStore';
+import { useWeatherStore } from '@/stores/useWeatherStore';
 import { useDecorativeMotion } from '@/hooks/useDecorativeMotion';
+import { useWeatherQuery } from '@/hooks/queries/useWeather';
 import type {
   CompanionMode,
   CompanionOverlay,
   CompanionSpecies,
   CompanionStage,
 } from '@/lib/companionMachine';
+import type { CompanionOutfit } from '@/lib/companionOutfit';
 
 /** What a surface needs to render the resident. */
 export interface ICompanionPresence {
@@ -22,6 +26,25 @@ export interface ICompanionPresence {
   readonly motion: boolean;
   /** False only when the master toggle is off — surfaces unmount entirely. */
   readonly enabled: boolean;
+  /** Weather/seasonal accessory the resident wears; null = bare. */
+  readonly outfit: CompanionOutfit | null;
+}
+
+/**
+ * Weather-fit derivation shared by every presence read: the resident dresses
+ * from the same cached weather query the Overview clock card uses (same key,
+ * same 15-min staleness — deduped, never a parallel request), falling back to
+ * the calendar season when weather is off or unavailable. The master
+ * `dressForWeather` toggle gates both the query and the derivation.
+ */
+function useCompanionOutfit(): CompanionOutfit | null {
+  const dressForWeather = useCompanionStore(s => s.dressForWeather);
+  const weatherEnabled = useWeatherStore(s => s.enabled);
+  const weatherCoords = useWeatherStore(s => s.coords);
+  const { data: weather } = useWeatherQuery(weatherEnabled && dressForWeather, weatherCoords);
+
+  if (!dressForWeather) return null;
+  return outfitFor(weather ?? null, new Date());
 }
 
 /**
@@ -38,6 +61,7 @@ export function useCompanionPresence(): ICompanionPresence {
   const suspended = useCompanionRuntimeStore(s => s.suspended);
   const species = useCompanionStore(s => s.species);
   const decorativeMotion = useDecorativeMotion();
+  const outfit = useCompanionOutfit();
 
   return {
     species,
@@ -47,6 +71,7 @@ export function useCompanionPresence(): ICompanionPresence {
     overlaySeq: machine.overlaySeq,
     motion: decorativeMotion && !suspended,
     enabled: machine.mode !== 'hidden',
+    outfit,
   };
 }
 

--- a/apps/web/src/lib/companionOutfit.test.ts
+++ b/apps/web/src/lib/companionOutfit.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { WeatherCurrent } from '@shiranami/contracts';
+import {
+  COMPANION_OUTFITS,
+  COMPANION_SCARF_BELOW_C,
+  COMPANION_SWEAT_ABOVE_C,
+  isCompanionNightHour,
+  outfitFor,
+  seasonalOutfitFor,
+  type CompanionOutfit,
+} from './companionOutfit';
+
+function weather(overrides: Partial<WeatherCurrent> = {}): WeatherCurrent {
+  return { tempC: 15, condition: 'clear', label: 'Clear sky', ...overrides };
+}
+
+/** A mild spring afternoon — no live-weather rule fires. */
+const NOON = new Date(2026, 3, 15, 12, 0, 0);
+const MIDNIGHT = new Date(2026, 3, 15, 0, 30, 0);
+
+describe('outfitFor with live weather', () => {
+  it.each<[Partial<WeatherCurrent>, CompanionOutfit | null]>([
+    [{ condition: 'rain' }, 'umbrella'],
+    [{ condition: 'thunderstorm' }, 'umbrella'],
+    [{ condition: 'snow', tempC: -2 }, 'snow'],
+    [{ condition: 'clear', tempC: COMPANION_SCARF_BELOW_C - 1 }, 'scarf'],
+    [{ condition: 'clear', tempC: COMPANION_SWEAT_ABOVE_C + 4 }, 'sun'],
+    [{ condition: 'fog' }, 'lantern'],
+    [{ condition: 'clear', tempC: 18 }, null],
+    [{ condition: 'partly_cloudy', tempC: 18 }, null],
+    [{ condition: 'cloudy', tempC: 18 }, null],
+    [{ condition: 'unknown', tempC: 18 }, null],
+  ])('derives %o → %s at noon', (overrides, expected) => {
+    expect(outfitFor(weather(overrides), NOON)).toBe(expected);
+  });
+
+  it('lights the lantern for clear night skies', () => {
+    expect(outfitFor(weather({ condition: 'clear' }), MIDNIGHT)).toBe('lantern');
+  });
+
+  it('lets the rain umbrella win over cold, heat, and night', () => {
+    expect(outfitFor(weather({ condition: 'rain', tempC: -4 }), MIDNIGHT)).toBe('umbrella');
+    expect(outfitFor(weather({ condition: 'thunderstorm', tempC: 33 }), NOON)).toBe('umbrella');
+  });
+
+  it('prefers the scarf over the lantern on a cold foggy morning', () => {
+    expect(outfitFor(weather({ condition: 'fog', tempC: 1 }), NOON)).toBe('scarf');
+  });
+
+  it('treats the thresholds as exclusive bounds', () => {
+    expect(outfitFor(weather({ tempC: COMPANION_SCARF_BELOW_C }), NOON)).toBeNull();
+    expect(outfitFor(weather({ tempC: COMPANION_SWEAT_ABOVE_C }), NOON)).toBeNull();
+  });
+});
+
+describe('outfitFor without weather (seasonal fallback)', () => {
+  it.each<[number, CompanionOutfit | null]>([
+    [0, 'snow'],
+    [1, 'snow'],
+    [2, 'sakura'],
+    [3, 'sakura'],
+    [4, 'sakura'],
+    [5, null],
+    [6, null],
+    [7, null],
+    [8, 'maple'],
+    [9, 'maple'],
+    [10, 'maple'],
+    [11, 'snow'],
+  ])('month index %i → %s', (month, expected) => {
+    const date = new Date(2026, month, 10, 12, 0, 0);
+    expect(outfitFor(null, date)).toBe(expected);
+    expect(seasonalOutfitFor(date)).toBe(expected);
+  });
+});
+
+describe('isCompanionNightHour', () => {
+  it.each<[number, boolean]>([
+    [0, true],
+    [4, true],
+    [5, false],
+    [12, false],
+    [21, false],
+    [22, true],
+    [23, true],
+  ])('hour %i → %s', (hour, expected) => {
+    expect(isCompanionNightHour(hour)).toBe(expected);
+  });
+});
+
+describe('COMPANION_OUTFITS', () => {
+  it('lists every accessory exactly once', () => {
+    expect(new Set(COMPANION_OUTFITS).size).toBe(COMPANION_OUTFITS.length);
+    expect(COMPANION_OUTFITS).toHaveLength(7);
+  });
+});

--- a/apps/web/src/lib/companionOutfit.ts
+++ b/apps/web/src/lib/companionOutfit.ts
@@ -1,0 +1,80 @@
+import type { WeatherCurrent } from '@shiranami/contracts';
+
+/**
+ * Weather fits — the pure deriver behind the companion's accessory.
+ *
+ * When the opt-in weather integration has data, the resident dresses for the
+ * sky outside: a leaf umbrella in the rain, a scarf on cold days, a sweat
+ * droplet in the heat, a soft lantern glow at night or in fog. Without
+ * weather the calendar takes over with a quiet seasonal accent — sakura in
+ * spring, a maple leaf in autumn, snow dusting in winter, nothing in summer.
+ *
+ * Pure on purpose (weather + date in, outfit out): the caller owns *when* to
+ * derive; this module only owns *what* the resident wears. Null means bare —
+ * the rigs render exactly as they do today.
+ */
+
+/** Accessory the resident wears; keys the `data-outfit` CSS reveal. */
+export type CompanionOutfit =
+  | 'umbrella'
+  | 'scarf'
+  | 'sun'
+  | 'lantern'
+  | 'sakura'
+  | 'maple'
+  | 'snow';
+
+export const COMPANION_OUTFITS: readonly CompanionOutfit[] = [
+  'umbrella',
+  'scarf',
+  'sun',
+  'lantern',
+  'sakura',
+  'maple',
+  'snow',
+] as const;
+
+/** Below this °C the resident wraps up in the scarf. */
+export const COMPANION_SCARF_BELOW_C = 5;
+
+/** Above this °C the sweat droplet appears. */
+export const COMPANION_SWEAT_ABOVE_C = 28;
+
+/**
+ * Night bucket for the lantern glow — mirrors the Overview greeting's
+ * time-of-day windows (night = 22:00–04:59) so the app tells one story about
+ * when the day ends.
+ */
+export function isCompanionNightHour(hour: number): boolean {
+  return hour >= 22 || hour < 5;
+}
+
+/**
+ * The calendar fallback (northern-hemisphere seasons by month): sakura in
+ * Mar–May, maple in Sep–Nov, snow in Dec–Feb, bare in summer.
+ */
+export function seasonalOutfitFor(date: Date): CompanionOutfit | null {
+  const month = date.getMonth();
+  if (month >= 2 && month <= 4) return 'sakura';
+  if (month >= 8 && month <= 10) return 'maple';
+  if (month === 11 || month <= 1) return 'snow';
+  return null;
+}
+
+/**
+ * What the resident wears right now. Live weather wins over the calendar;
+ * within live weather, precipitation beats temperature beats light: rain and
+ * storms call for the leaf umbrella, snowfall dusts the fur, then the cold
+ * scarf / heat droplet thresholds, then the lantern for fog or night. Mild
+ * clear daytime weather means bare — the accessory should stay an event, not
+ * a uniform.
+ */
+export function outfitFor(weather: WeatherCurrent | null, date: Date): CompanionOutfit | null {
+  if (!weather) return seasonalOutfitFor(date);
+  if (weather.condition === 'rain' || weather.condition === 'thunderstorm') return 'umbrella';
+  if (weather.condition === 'snow') return 'snow';
+  if (weather.tempC < COMPANION_SCARF_BELOW_C) return 'scarf';
+  if (weather.tempC > COMPANION_SWEAT_ABOVE_C) return 'sun';
+  if (weather.condition === 'fog' || isCompanionNightHour(date.getHours())) return 'lantern';
+  return null;
+}

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -558,6 +558,8 @@
         "hotaruEpithet": "the star jelly",
         "keepsWatch": "Keeps watch in Sanctuary",
         "keepsWatchDesc": "Stays asleep in a corner, lights low, while the sanctuary plays",
+        "dressForWeather": "Dresses for the weather",
+        "dressForWeatherDesc": "A tiny accessory for the sky outside — a leaf umbrella in the rain, a scarf on cold days. Follows the seasons when weather is off.",
         "stageLineNew": "{{name}} · just hatched — it grows as you listen",
         "stageLine_one": "{{name}} · grown from {{count}} hour of listening",
         "stageLine_other": "{{name}} · grown from {{count}} hours of listening"

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -580,6 +580,8 @@
         "hotaruEpithet": "meduza-gwiazda",
         "keepsWatch": "Czuwa w Sanktuarium",
         "keepsWatchDesc": "Śpi w rogu przy przygaszonym świetle, gdy sanktuarium gra",
+        "dressForWeather": "Ubiera się na pogodę",
+        "dressForWeatherDesc": "Drobny dodatek pod niebo za oknem — liściasty parasol w deszczu, szalik w chłodne dni. Gdy pogoda jest wyłączona, podąża za porami roku.",
         "stageLineNew": "{{name}} · jeszcze maleństwo — rośnie, gdy słuchasz",
         "stageLine_one": "{{name}} · {{count}} godzina wspólnego słuchania",
         "stageLine_few": "{{name}} · {{count}} godziny wspólnego słuchania",

--- a/apps/web/src/stores/useCompanionStore.test.ts
+++ b/apps/web/src/stores/useCompanionStore.test.ts
@@ -1,9 +1,11 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   COMPANION_DEFAULT_PERCH_FRACTION,
   isCompanionSpecies,
   useCompanionStore,
 } from './useCompanionStore';
+
+const STORE_KEY = 'shiranami.companion-store';
 
 describe('useCompanionStore', () => {
   beforeEach(() => {
@@ -12,14 +14,16 @@ describe('useCompanionStore', () => {
       species: 'shio',
       perchFraction: COMPANION_DEFAULT_PERCH_FRACTION,
       sanctuaryKeepsWatch: false,
+      dressForWeather: true,
     });
   });
 
-  it('defaults to Shio, the default perch seat, and no sanctuary watch', () => {
+  it('defaults to Shio, the default perch seat, no sanctuary watch, weather fits on', () => {
     const s = useCompanionStore.getState();
     expect(s.species).toBe('shio');
     expect(s.perchFraction).toBe(COMPANION_DEFAULT_PERCH_FRACTION);
     expect(s.sanctuaryKeepsWatch).toBe(false);
+    expect(s.dressForWeather).toBe(true);
   });
 
   it('switches species between the two residents only', () => {
@@ -45,10 +49,43 @@ describe('useCompanionStore', () => {
     expect(useCompanionStore.getState().sanctuaryKeepsWatch).toBe(true);
   });
 
+  it('toggles the weather-fits preference', () => {
+    useCompanionStore.getState().setDressForWeather(false);
+    expect(useCompanionStore.getState().dressForWeather).toBe(false);
+    useCompanionStore.getState().setDressForWeather(true);
+    expect(useCompanionStore.getState().dressForWeather).toBe(true);
+  });
+
   it('narrows species values', () => {
     expect(isCompanionSpecies('shio')).toBe(true);
     expect(isCompanionSpecies('hotaru')).toBe(true);
     expect(isCompanionSpecies('awa')).toBe(false);
     expect(isCompanionSpecies(null)).toBe(false);
+  });
+});
+
+describe('useCompanionStore rehydration sanitizing', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it('round-trips a persisted dressForWeather=false on load', async () => {
+    localStorage.setItem(
+      STORE_KEY,
+      JSON.stringify({ state: { species: 'hotaru', dressForWeather: false }, version: 1 })
+    );
+    const mod = await import('./useCompanionStore');
+    expect(mod.useCompanionStore.getState().species).toBe('hotaru');
+    expect(mod.useCompanionStore.getState().dressForWeather).toBe(false);
+  });
+
+  it('falls back to weather fits on for garbage or absent persisted values', async () => {
+    localStorage.setItem(
+      STORE_KEY,
+      JSON.stringify({ state: { species: 'shio', dressForWeather: 'maybe' }, version: 1 })
+    );
+    const mod = await import('./useCompanionStore');
+    expect(mod.useCompanionStore.getState().dressForWeather).toBe(true);
   });
 });

--- a/apps/web/src/stores/useCompanionStore.ts
+++ b/apps/web/src/stores/useCompanionStore.ts
@@ -29,12 +29,14 @@ interface PersistedCompanionState {
   species: CompanionSpecies;
   perchFraction: number;
   sanctuaryKeepsWatch: boolean;
+  dressForWeather: boolean;
 }
 
 const COMPANION_DEFAULTS: PersistedCompanionState = {
   species: 'shio',
   perchFraction: COMPANION_DEFAULT_PERCH_FRACTION,
   sanctuaryKeepsWatch: false,
+  dressForWeather: true,
 };
 
 function clampFraction(v: unknown): number {
@@ -53,6 +55,8 @@ function sanitize(
     out.perchFraction = clampFraction(persisted.perchFraction);
   if (typeof persisted.sanctuaryKeepsWatch === 'boolean')
     out.sanctuaryKeepsWatch = persisted.sanctuaryKeepsWatch;
+  if (typeof persisted.dressForWeather === 'boolean')
+    out.dressForWeather = persisted.dressForWeather;
   return out;
 }
 
@@ -60,6 +64,7 @@ interface CompanionActions {
   setSpecies: (species: CompanionSpecies) => void;
   setPerchFraction: (fraction: number) => void;
   setSanctuaryKeepsWatch: (keepsWatch: boolean) => void;
+  setDressForWeather: (dress: boolean) => void;
 }
 
 export const useCompanionStore = createPersistedStore<PersistedCompanionState & CompanionActions>(
@@ -74,6 +79,9 @@ export const useCompanionStore = createPersistedStore<PersistedCompanionState & 
     setSanctuaryKeepsWatch: keepsWatch => {
       set({ sanctuaryKeepsWatch: keepsWatch });
     },
+    setDressForWeather: dress => {
+      set({ dressForWeather: dress });
+    },
   }),
   {
     name: STORE_KEY,
@@ -82,6 +90,7 @@ export const useCompanionStore = createPersistedStore<PersistedCompanionState & 
       species: s.species,
       perchFraction: s.perchFraction,
       sanctuaryKeepsWatch: s.sanctuaryKeepsWatch,
+      dressForWeather: s.dressForWeather,
     }),
     sanitize: (persisted, current) => ({
       ...current,

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -401,7 +401,8 @@
   .companion-sleep-breathe,
   .companion-idle-float,
   .companion-idle-blink,
-  .companion-bub-drift {
+  .companion-bub-drift,
+  .companion-lantern-glow {
     animation: none !important;
   }
   .animate-marquee {
@@ -430,6 +431,11 @@
 /* Drop the cup drop-shadow filter under low-perf (compositor cost). */
 [data-perf-mode='low'] .splash-cup-shadow {
   filter: none !important;
+}
+/* Companion loops are already gated app-side (useDecorativeMotion); the
+   lantern pulse also degrades here as a CSS-level belt. */
+[data-perf-mode='low'] .companion-lantern-glow {
+  animation: none !important;
 }
 
 /* Midnight Lofi Cafe Theme */
@@ -742,6 +748,20 @@
 /* Foam bubbles drift while listening. */
 @utility companion-bub-drift {
   animation: companion-drift 3.4s ease-in-out infinite alternate;
+}
+
+/* Lantern-glow outfit: a slow warm pulse at a fixed calm period — ambient
+   light, never the beat. */
+@keyframes companion-lantern-pulse {
+  from {
+    opacity: 0.7;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@utility companion-lantern-glow {
+  animation: companion-lantern-pulse 4s ease-in-out infinite alternate;
 }
 
 @utility eq-bar-1 {
@@ -1170,4 +1190,57 @@
 }
 .companion-svg:is([data-state='sleeping'], [data-state='drowsy']) .companion-pool {
   scale: 0.85;
+}
+
+/* ── Weather fits ────────────────────────────────────────────────────────
+   Outfit accessory layers (one <g> per outfit per rig), revealed by the
+   root's data-outfit exactly like stages ride data-stage. Fills route
+   through the same --companion-* / --primary-rgb / --art-* plumbing as the
+   rig, so accessories recolor with the theme and the playing record. */
+.companion-svg .companion-outfit {
+  display: none;
+}
+.companion-svg[data-outfit='umbrella'] .companion-o-umbrella,
+.companion-svg[data-outfit='scarf'] .companion-o-scarf,
+.companion-svg[data-outfit='sun'] .companion-o-sun,
+.companion-svg[data-outfit='lantern'] .companion-o-lantern,
+.companion-svg[data-outfit='sakura'] .companion-o-sakura,
+.companion-svg[data-outfit='maple'] .companion-o-maple,
+.companion-svg[data-outfit='snow'] .companion-o-snow {
+  display: inline;
+}
+
+/* Outfit paints. Canopy = the leaf umbrella's blade; accent = scarf/maple
+   (strong primary, like the headphones); petal = sakura's soft primary;
+   drop = the sweat droplet on the bubble tint; snowflake = the body foam
+   constant; glow/halo = the lantern's accent-warmed light. */
+.companion-svg .companion-o-canopy {
+  fill: color-mix(in srgb, var(--art-2, rgb(var(--primary-rgb))) 55%, var(--companion-foam));
+  transition: fill 1.2s ease;
+}
+.companion-svg .companion-o-accent {
+  fill: rgb(var(--primary-rgb) / 0.7);
+  transition: fill 1.2s ease;
+}
+.companion-svg .companion-o-petal {
+  fill: rgb(var(--primary-rgb) / 0.45);
+  transition: fill 1.2s ease;
+}
+.companion-svg .companion-o-drop {
+  fill: color-mix(in srgb, var(--art-3, oklch(0.55 0.08 285)) 75%, transparent);
+  transition: fill 1.2s ease;
+}
+.companion-svg .companion-o-snowflake {
+  fill: var(--companion-foam);
+  stroke: oklch(0.3 0.04 285 / 0.16);
+  stroke-width: 0.6;
+}
+.companion-svg .companion-o-glowcore {
+  fill: color-mix(in srgb, rgb(var(--primary-rgb)) 65%, var(--companion-foam));
+  transition: fill 1.2s ease;
+}
+.companion-svg .companion-o-halo {
+  fill: color-mix(in srgb, rgb(var(--primary-rgb)) 50%, transparent);
+  opacity: 0.35;
+  transition: fill 1.2s ease;
 }


### PR DESCRIPTION
## What

The companion now dresses for the weather. When the opt-in weather integration has data, the resident wears a small condition-keyed SVG accessory; when weather is off or unavailable, it falls back to a quiet seasonal accent by calendar month. A master **Dresses for the weather** toggle (default on) sits in the companion settings card.

| Signal | Fit |
| --- | --- |
| Rain / thunderstorm | Leaf umbrella |
| Snowfall | Snow dusting |
| Below ~5 °C | Scarf |
| Above ~28 °C | Sweat droplet |
| Night or fog | Soft lantern glow |
| No weather: Mar–May / Sep–Nov / Dec–Feb | Sakura petal / maple leaf / snow dusting (bare in summer) |

## How

- **Pure deriver** `apps/web/src/lib/companionOutfit.ts` — `outfitFor(weather, date)` → `CompanionOutfit | null`, table-driven unit tests. Precipitation beats temperature beats light; night hours mirror the Overview time-of-day buckets (22:00–04:59).
- **Rigs**: one `<g>` accessory layer per outfit per rig, revealed by a `data-outfit` attribute on the sprite root (mirror of `data-stage`). Only the worn accessory mounts, so `outfit=null` renders the rigs **byte-identical** to before (asserted in tests). Fills route through the existing `--companion-*` / `--primary-rgb` / `--art-*` plumbing, so accessories recolor with themes and the playing record.
- **Motion**: the lantern pulse is a fixed-period compositor-only loop, gated app-side by `useDecorativeMotion()` and neutralized in both the reduced-motion and low-perf CSS degradation blocks.
- **Wiring**: `useCompanionPresence` derives the outfit once and every perch surface (player perch, Now Playing cameo, Sanctuary cameo) inherits it. It reads the same cached weather query as the Overview clock card (same key, 15-min staleness — deduped, no parallel requests); the query is additionally gated by the new toggle.
- **Setting**: `dressForWeather` persisted in `useCompanionStore` next to `sanctuaryKeepsWatch` (partialize + sanitize + rehydration round-trip tests), with identical en/pl key trees.
- **Stories**: one per outfit per species.

## Verification

- `pnpm test` (web project): 324 files, 2004 tests — green
- `eslint apps/web/src` — clean
- `tsc --noEmit` (web) — clean