### PR TITLE
feat(vinyl): spinning vinyl display with reactive ring for now playing and sanctuary

### DIFF
--- a/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.hooks.ts
+++ b/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.hooks.ts
@@ -67,6 +67,7 @@ export function useNowPlayingView(): INowPlayingViewView {
   const panel = useUIStore(s => s.nowPlayingPanel);
   const togglePanel = useUIStore(s => s.toggleNowPlayingPanel);
   const lowPerformanceMode = useUIStore(s => s.lowPerformanceMode);
+  const vinylDisplayEnabled = useUIStore(s => s.vinylDisplayEnabled);
   const albumArtTiltEnabled = useDecorativeMotion();
   const lyricsPlainOpacity = useLyricsAppearanceStore(s => s.lyricsPlainOpacity);
   const lyricsPlainFontSize = useLyricsAppearanceStore(s => s.lyricsPlainFontSize);
@@ -148,6 +149,7 @@ export function useNowPlayingView(): INowPlayingViewView {
     panelButtons,
     panelGroupLabel: t('panelGroup'),
     lowPerformanceMode,
+    vinylDisplayEnabled,
     albumArtTiltEnabled,
     lyricsClasses,
     lyrics,

--- a/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.test.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.test.tsx
@@ -66,7 +66,7 @@ function renderView(ui: ReactElement): RenderResult {
 
 function reset(): void {
   usePlaybackStore.setState({ currentTrack: null, duration: 0, isPlaying: false });
-  useUIStore.setState({ nowPlayingPanel: 'lyrics' });
+  useUIStore.setState({ nowPlayingPanel: 'lyrics', vinylDisplayEnabled: false });
   useViewStore.setState({ activeView: 'now-playing', previousView: 'library' });
 }
 
@@ -108,6 +108,28 @@ describe('NowPlayingView', () => {
     renderView(<NowPlayingView />);
 
     expect(screen.queryByText(/BPM/)).not.toBeInTheDocument();
+  });
+
+  it('swaps the album-art card for the vinyl record when the display is enabled', () => {
+    usePlaybackStore.setState({ currentTrack: makeTrack(), duration: 215 });
+    useUIStore.setState({ vinylDisplayEnabled: true });
+
+    renderView(<NowPlayingView />);
+
+    expect(document.querySelector('[data-slot="vinyl-record"]')).toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: 'Late Nights' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the album-art card when the vinyl display is off', () => {
+    usePlaybackStore.setState({
+      currentTrack: makeTrack({ albumArt: 'art://cover.jpg' }),
+      duration: 215,
+    });
+
+    renderView(<NowPlayingView />);
+
+    expect(document.querySelector('[data-slot="vinyl-record"]')).not.toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Late Nights' })).toBeInTheDocument();
   });
 
   it('switches the active panel when a toggle is pressed', () => {

--- a/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.tsx
@@ -13,6 +13,7 @@ import { VolumeControl } from '@/components/player/VolumeControl';
 import { TimeDisplay } from '@/components/player/TimeDisplay';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { IconButton } from '@/components/ui/icon-button';
+import { VinylRecord } from '@/components/shared/VinylRecord';
 import { useNowPlayingView } from './NowPlayingView.hooks';
 
 export default function NowPlayingView() {
@@ -31,6 +32,7 @@ export default function NowPlayingView() {
     panelButtons,
     panelGroupLabel,
     lowPerformanceMode,
+    vinylDisplayEnabled,
     albumArtTiltEnabled,
     lyricsClasses,
     lyrics,
@@ -151,42 +153,50 @@ export default function NowPlayingView() {
                 : 'w-full max-w-[min(calc(100vh_-_30rem),clamp(300px,24vw,440px))]'
             )}
           >
-            <AnimatePresence mode="wait">
-              <motion.div
-                key={currentTrack.id}
-                initial={
-                  albumArtTiltEnabled
-                    ? { scale: 0.9, opacity: 0, rotate: -3 }
-                    : { scale: 0.9, opacity: 0 }
-                }
-                animate={
-                  albumArtTiltEnabled
-                    ? { scale: 1, opacity: 1, rotate: 0 }
-                    : { scale: 1, opacity: 1 }
-                }
-                exit={
-                  albumArtTiltEnabled
-                    ? { scale: 0.9, opacity: 0, rotate: 3 }
-                    : { scale: 0.9, opacity: 0 }
-                }
-                transition={{ type: 'spring', damping: 22, stiffness: 250 }}
-                className={cn(
-                  'w-full h-full rounded-2xl @5xl:rounded-3xl overflow-hidden',
-                  'shadow-2xl shadow-black/40 bg-muted flex items-center justify-center'
-                )}
-              >
-                {currentTrack.albumArt ? (
-                  <img
-                    src={currentTrack.albumArt}
-                    alt={currentTrack.album}
-                    className="w-full h-full object-cover"
-                    decoding="async"
-                  />
-                ) : (
-                  <Music className="w-16 h-16 text-muted-foreground/30" />
-                )}
-              </motion.div>
-            </AnimatePresence>
+            {vinylDisplayEnabled ? (
+              <VinylRecord
+                albumArt={currentTrack.albumArt}
+                albumAlt={currentTrack.album}
+                className="absolute inset-0"
+              />
+            ) : (
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={currentTrack.id}
+                  initial={
+                    albumArtTiltEnabled
+                      ? { scale: 0.9, opacity: 0, rotate: -3 }
+                      : { scale: 0.9, opacity: 0 }
+                  }
+                  animate={
+                    albumArtTiltEnabled
+                      ? { scale: 1, opacity: 1, rotate: 0 }
+                      : { scale: 1, opacity: 1 }
+                  }
+                  exit={
+                    albumArtTiltEnabled
+                      ? { scale: 0.9, opacity: 0, rotate: 3 }
+                      : { scale: 0.9, opacity: 0 }
+                  }
+                  transition={{ type: 'spring', damping: 22, stiffness: 250 }}
+                  className={cn(
+                    'w-full h-full rounded-2xl @5xl:rounded-3xl overflow-hidden',
+                    'shadow-2xl shadow-black/40 bg-muted flex items-center justify-center'
+                  )}
+                >
+                  {currentTrack.albumArt ? (
+                    <img
+                      src={currentTrack.albumArt}
+                      alt={currentTrack.album}
+                      className="w-full h-full object-cover"
+                      decoding="async"
+                    />
+                  ) : (
+                    <Music className="w-16 h-16 text-muted-foreground/30" />
+                  )}
+                </motion.div>
+              </AnimatePresence>
+            )}
 
             {/* The resident, half overlapping the frame edge (display-only:
                 interactions stay on the player-bar perch). */}

--- a/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.types.ts
+++ b/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.types.ts
@@ -74,6 +74,8 @@ export interface INowPlayingViewView {
   readonly panelGroupLabel: string;
   /** Whether low-performance mode is on — softens panel-switch animation. */
   readonly lowPerformanceMode: boolean;
+  /** Render the spinning vinyl record in place of the album-art card. */
+  readonly vinylDisplayEnabled: boolean;
   /** Whether the album art plays the ±3° track-change tilt (off under reduced
    *  motion / low-performance mode). */
   readonly albumArtTiltEnabled: boolean;

--- a/apps/web/src/components/sanctuary/SanctuaryView/SanctuaryView.hooks.ts
+++ b/apps/web/src/components/sanctuary/SanctuaryView/SanctuaryView.hooks.ts
@@ -1,10 +1,15 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Clock3, Disc3, Image, type LucideIcon } from 'lucide-react';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useInterfaceStore } from '@/stores/useInterfaceStore';
 import { useLyricsAppearanceStore } from '@/stores/useLyricsAppearanceStore';
 import { useWeatherStore } from '@/stores/useWeatherStore';
-import { useSanctuaryStore, SANCTUARY_CHROME_TIMEOUT_MS } from '@/stores/useSanctuaryStore';
+import {
+  useSanctuaryStore,
+  SANCTUARY_CHROME_TIMEOUT_MS,
+  type SanctuaryVariant,
+} from '@/stores/useSanctuaryStore';
 import { useCompanionStore } from '@/stores/useCompanionStore';
 import { useWeatherQuery } from '@/hooks/queries/useWeather';
 import { useCompanionPresence } from '@/hooks/useCompanionPresence';
@@ -18,6 +23,16 @@ import type { ISanctuaryViewView } from './SanctuaryView.types';
  * `F` would exit here *and* toggle there — re-entering the mode it just left.
  */
 const GLOBAL_SANCTUARY_KEYS = new Set(['f', 'F', 'Escape']);
+
+/** The in-view toggle walks the three center stages in this order. */
+const VARIANT_CYCLE: SanctuaryVariant[] = ['cover', 'clock', 'vinyl'];
+
+/** Toggle chrome per upcoming variant: its localized label key and icon. */
+const NEXT_VARIANT_META: Record<SanctuaryVariant, { labelKey: string; icon: LucideIcon }> = {
+  cover: { labelKey: 'showCover', icon: Image },
+  clock: { labelKey: 'showClock', icon: Clock3 },
+  vinyl: { labelKey: 'showVinyl', icon: Disc3 },
+};
 
 export function useSanctuaryView(): ISanctuaryViewView {
   const { t, i18n } = useTranslation('sanctuary');
@@ -104,6 +119,9 @@ export function useSanctuaryView(): ISanctuaryViewView {
   // view agrees with the player bar instead of showing a second answer.
   const titleText = useTrackTitle(currentTrack);
 
+  const nextVariant = VARIANT_CYCLE[(VARIANT_CYCLE.indexOf(variant) + 1) % VARIANT_CYCLE.length];
+  const nextMeta = NEXT_VARIANT_META[nextVariant];
+
   return {
     hasTrack: Boolean(currentTrack),
     currentTrack,
@@ -126,8 +144,9 @@ export function useSanctuaryView(): ISanctuaryViewView {
     companion,
     companionKeepsWatch,
     exitLabel: t('exit'),
-    variantToggleLabel: variant === 'cover' ? t('showClock') : t('showCover'),
+    variantToggleLabel: t(nextMeta.labelKey),
+    variantToggleIcon: nextMeta.icon,
     onExit: exitSanctuary,
-    onToggleVariant: () => setVariant(variant === 'cover' ? 'clock' : 'cover'),
+    onToggleVariant: () => setVariant(nextVariant),
   };
 }

--- a/apps/web/src/components/sanctuary/SanctuaryView/SanctuaryView.stories.tsx
+++ b/apps/web/src/components/sanctuary/SanctuaryView/SanctuaryView.stories.tsx
@@ -87,7 +87,7 @@ export const Clock: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByRole('button', { name: 'Show the cover' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Show the record' })).toBeInTheDocument();
     await expect(canvas.getByText(/Midnight Tapes/)).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/sanctuary/SanctuaryView/SanctuaryView.test.tsx
+++ b/apps/web/src/components/sanctuary/SanctuaryView/SanctuaryView.test.tsx
@@ -85,16 +85,31 @@ describe('SanctuaryView', () => {
     expect(screen.getByRole('button', { name: 'Leave Sanctuary' })).toBeInTheDocument();
   });
 
-  it('flips to the clock variant through the toggle', () => {
+  it('cycles cover → clock → vinyl → cover through the toggle', () => {
     usePlaybackStore.setState({ currentTrack: makeTrack(), duration: 215 });
     useSanctuaryStore.setState({ sanctuaryActive: true });
 
     renderView(<SanctuaryView />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Show the clock' }));
-
     expect(useSanctuaryStore.getState().sanctuaryVariant).toBe('clock');
-    expect(screen.getByRole('button', { name: 'Show the cover' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show the record' }));
+    expect(useSanctuaryStore.getState().sanctuaryVariant).toBe('vinyl');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show the cover' }));
+    expect(useSanctuaryStore.getState().sanctuaryVariant).toBe('cover');
+  });
+
+  it('renders the vinyl center stage with the track info', () => {
+    usePlaybackStore.setState({ currentTrack: makeTrack(), duration: 215 });
+    useSanctuaryStore.setState({ sanctuaryActive: true, sanctuaryVariant: 'vinyl' });
+
+    renderView(<SanctuaryView />);
+
+    expect(document.querySelector('[data-slot="vinyl-record"]')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Midnight Tapes' })).toBeInTheDocument();
+    expect(screen.getByText('the active line')).toBeInTheDocument();
   });
 
   it('exits through the leave button', () => {

--- a/apps/web/src/components/sanctuary/SanctuaryView/SanctuaryView.tsx
+++ b/apps/web/src/components/sanctuary/SanctuaryView/SanctuaryView.tsx
@@ -1,6 +1,7 @@
-import { Music, Clock3, Disc3, Minimize2 } from 'lucide-react';
+import { Music, Minimize2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Companion } from '@/components/companion/Companion';
+import { VinylRecord } from '@/components/shared/VinylRecord';
 import { LyricsFocus } from '@/components/lyrics/LyricsFocus';
 import { PlayerControls } from '@/components/player/PlayerControls';
 import { SeekBar } from '@/components/player/SeekBar';
@@ -36,13 +37,12 @@ export default function SanctuaryView() {
     companionKeepsWatch,
     exitLabel,
     variantToggleLabel,
+    variantToggleIcon: VariantIcon,
     onExit,
     onToggleVariant,
   } = useSanctuaryView();
 
   if (!hasTrack || !currentTrack) return null;
-
-  const VariantIcon = variant === 'cover' ? Clock3 : Disc3;
 
   const chromeClass = cn(
     'transition-opacity duration-500',
@@ -71,6 +71,16 @@ export default function SanctuaryView() {
       />
     </div>
   ) : null;
+
+  // Shared by the cover and vinyl stages — the title + artist/album lines.
+  const trackInfo = (
+    <div className="text-center max-w-[70vw]">
+      <h1 className="font-serif italic text-3xl @5xl:text-4xl text-foreground truncate">
+        {titleText}
+      </h1>
+      <p className="text-sm text-muted-foreground mt-1.5 truncate">{trackLine}</p>
+    </div>
+  );
 
   // Built above JSX render position (declarative-JSX rule): the ±1 focus
   // stage, or nothing for tracks without synced lyrics.
@@ -126,7 +136,7 @@ export default function SanctuaryView() {
 
       {/* Center stage */}
       <div className="flex-1 min-h-0 flex flex-col items-center justify-center gap-6 px-8">
-        {variant === 'cover' ? (
+        {variant === 'cover' && (
           <>
             <div
               className={cn(
@@ -147,16 +157,25 @@ export default function SanctuaryView() {
               )}
             </div>
 
-            <div className="text-center max-w-[70vw]">
-              <h1 className="font-serif italic text-3xl @5xl:text-4xl text-foreground truncate">
-                {titleText}
-              </h1>
-              <p className="text-sm text-muted-foreground mt-1.5 truncate">{trackLine}</p>
-            </div>
+            {trackInfo}
 
             {lyricStage}
           </>
-        ) : (
+        )}
+
+        {variant === 'vinyl' && (
+          <>
+            <div className="shrink-0 w-[min(48vh,44vw,34rem)]">
+              <VinylRecord albumArt={currentTrack.albumArt} albumAlt={currentTrack.album} />
+            </div>
+
+            {trackInfo}
+
+            {lyricStage}
+          </>
+        )}
+
+        {variant === 'clock' && (
           <>
             <div className="font-display text-[clamp(4rem,16vw,11rem)] leading-none tabular-nums tracking-tight text-foreground">
               {timeLabel}

--- a/apps/web/src/components/sanctuary/SanctuaryView/SanctuaryView.types.ts
+++ b/apps/web/src/components/sanctuary/SanctuaryView/SanctuaryView.types.ts
@@ -1,3 +1,4 @@
+import type { LucideIcon } from 'lucide-react';
 import type { Track } from '@/stores/types';
 import type { SanctuaryVariant } from '@/stores/useSanctuaryStore';
 import type { useLyricsView } from '@/hooks/useLyricsView';
@@ -41,8 +42,10 @@ export interface ISanctuaryViewView {
   /** Localized labels for the two chrome buttons. */
   readonly exitLabel: string;
   readonly variantToggleLabel: string;
+  /** Icon for the variant toggle — always previews the NEXT center stage. */
+  readonly variantToggleIcon: LucideIcon;
   /** Leave the sanctuary (Esc, the exit button, or auto-exit). */
   readonly onExit: () => void;
-  /** Flip between the cover and clock center stages. */
+  /** Advance the center stage: cover → clock → vinyl → cover. */
   readonly onToggleVariant: () => void;
 }

--- a/apps/web/src/components/settings/SanctuarySection/SanctuarySection.hooks.ts
+++ b/apps/web/src/components/settings/SanctuarySection/SanctuarySection.hooks.ts
@@ -7,7 +7,7 @@ import {
 } from '@/stores/useSanctuaryStore';
 import type { ISanctuarySectionView } from './SanctuarySection.types';
 
-const VARIANT_ORDER: SanctuaryVariant[] = ['cover', 'clock'];
+const VARIANT_ORDER: SanctuaryVariant[] = ['cover', 'clock', 'vinyl'];
 
 export function useSanctuarySection(): ISanctuarySectionView {
   const { t } = useTranslation('settings');

--- a/apps/web/src/components/settings/SanctuarySection/SanctuarySection.test.tsx
+++ b/apps/web/src/components/settings/SanctuarySection/SanctuarySection.test.tsx
@@ -25,6 +25,15 @@ describe('SanctuarySection', () => {
     expect(screen.getByText('Sanctuary Mode')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Cover' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByRole('button', { name: 'Clock' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: 'Vinyl' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('selects the vinyl variant through its chip', () => {
+    render(<SanctuarySection />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Vinyl' }));
+
+    expect(useSanctuaryStore.getState().sanctuaryVariant).toBe('vinyl');
   });
 
   it('selects the clock variant through its chip', () => {

--- a/apps/web/src/components/settings/SanctuarySection/SanctuarySection.types.ts
+++ b/apps/web/src/components/settings/SanctuarySection/SanctuarySection.types.ts
@@ -10,7 +10,7 @@ export interface ISanctuarySectionView {
   readonly title: string;
   readonly subtitle: string;
 
-  /** Center-stage picker (cover / clock). */
+  /** Center-stage picker (cover / clock / vinyl). */
   readonly variantTitle: string;
   readonly variantDescription: string;
   readonly variantOptions: readonly ISanctuaryVariantOption[];

--- a/apps/web/src/components/settings/VinylPreview/VinylPreview.hooks.ts
+++ b/apps/web/src/components/settings/VinylPreview/VinylPreview.hooks.ts
@@ -1,0 +1,16 @@
+import { useTranslation } from 'react-i18next';
+import type { IVinylPreviewProps, IVinylPreviewView } from './VinylPreview.types';
+
+/**
+ * VinylPreview shows a live miniature of the actual VinylRecord component; the
+ * hook resolves the localized caption and forwards the toggle so the shell
+ * stays a thin render.
+ */
+export function useVinylPreview({ enabled }: IVinylPreviewProps): IVinylPreviewView {
+  const { t } = useTranslation('settings');
+
+  return {
+    title: t('app.effectPreview.vinyl'),
+    enabled,
+  };
+}

--- a/apps/web/src/components/settings/VinylPreview/VinylPreview.stories.tsx
+++ b/apps/web/src/components/settings/VinylPreview/VinylPreview.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
+
+import VinylPreview from './VinylPreview';
+
+/**
+ * settings · VinylPreview. The live preview for the vinyl record display in
+ * Visual effects settings: a miniature of the real VinylRecord component that
+ * drops to a quarter opacity when the effect is turned off. The mock is
+ * exposed as a labelled `role="img"`.
+ */
+const meta: Meta<typeof VinylPreview> = {
+  title: 'settings/VinylPreview',
+  component: VinylPreview,
+  parameters: {
+    // A single labelled role="img" over aria-hidden decorative disc layers —
+    // axe clean.
+    a11y: { test: 'error' },
+  },
+  decorators: [
+    Story => (
+      <div className="max-w-[420px] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof VinylPreview>;
+
+/** Effect on — the record miniature renders at full strength. */
+export const Enabled: Story = {
+  args: { enabled: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('img', { name: 'Vinyl preview' })).toBeInTheDocument();
+    await expect(canvasElement.querySelector('[data-slot="vinyl-record"]')).toBeInTheDocument();
+  },
+};
+
+/** Effect off — the record dims to a quarter opacity. */
+export const Disabled: Story = {
+  args: { enabled: false },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector('.opacity-25')).toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/settings/VinylPreview/VinylPreview.test.tsx
+++ b/apps/web/src/components/settings/VinylPreview/VinylPreview.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useUIStore } from '@/stores/useUIStore';
+
+import VinylPreview from './VinylPreview';
+
+/** The dimmable wrapper around the live record miniature. */
+const DISC_WRAP = '.size-\\[104px\\]';
+
+function reset(): void {
+  useUIStore.setState({
+    vinylLabelSource: 'artwork',
+    vinylRingStyle: 'glow',
+    lowPerformanceMode: false,
+  });
+}
+
+beforeEach(reset);
+afterEach(reset);
+
+describe('VinylPreview', () => {
+  it('labels the mock with the localized preview caption', () => {
+    render(<VinylPreview enabled />);
+
+    expect(screen.getByRole('img', { name: 'Vinyl preview' })).toBeInTheDocument();
+  });
+
+  it('renders the live record miniature at full strength when enabled', () => {
+    const { container } = render(<VinylPreview enabled />);
+
+    expect(container.querySelector('[data-slot="vinyl-record"]')).toBeInTheDocument();
+    expect(container.querySelector(DISC_WRAP)).toHaveClass('opacity-100');
+  });
+
+  it('dims the record when the display is disabled', () => {
+    const { container } = render(<VinylPreview enabled={false} />);
+
+    const wrap = container.querySelector(DISC_WRAP);
+    expect(wrap).toHaveClass('opacity-25');
+    expect(wrap).not.toHaveClass('opacity-100');
+  });
+});

--- a/apps/web/src/components/settings/VinylPreview/VinylPreview.tsx
+++ b/apps/web/src/components/settings/VinylPreview/VinylPreview.tsx
@@ -1,0 +1,30 @@
+import { cn } from '@/lib/utils';
+import { SettingsPreview } from '@/components/settings/SettingsPreview';
+import { VinylRecord } from '@/components/shared/VinylRecord';
+import { useVinylPreview } from './VinylPreview.hooks';
+import type { IVinylPreviewProps } from './VinylPreview.types';
+
+export default function VinylPreview(props: IVinylPreviewProps) {
+  const { title, enabled } = useVinylPreview(props);
+
+  return (
+    <SettingsPreview title={title}>
+      <div
+        className="rounded-xl border border-border/30 bg-background/40 p-3"
+        role="img"
+        aria-label={title}
+      >
+        <div className="relative mx-auto flex h-[140px] max-w-[340px] items-center justify-center overflow-hidden rounded-xl border border-border/25 bg-surface/60 p-3">
+          <div
+            className={cn(
+              'size-[104px] transition-opacity',
+              enabled ? 'opacity-100' : 'opacity-25'
+            )}
+          >
+            <VinylRecord albumArt={null} albumAlt={title} />
+          </div>
+        </div>
+      </div>
+    </SettingsPreview>
+  );
+}

--- a/apps/web/src/components/settings/VinylPreview/VinylPreview.types.ts
+++ b/apps/web/src/components/settings/VinylPreview/VinylPreview.types.ts
@@ -1,0 +1,11 @@
+export interface IVinylPreviewProps {
+  /** Whether the vinyl record display is enabled. */
+  readonly enabled: boolean;
+}
+
+export interface IVinylPreviewView {
+  /** Localized preview panel title (also used as the aria-label). */
+  readonly title: string;
+  /** Whether the vinyl record display is enabled. */
+  readonly enabled: boolean;
+}

--- a/apps/web/src/components/settings/VinylPreview/index.ts
+++ b/apps/web/src/components/settings/VinylPreview/index.ts
@@ -1,0 +1,2 @@
+export { default as VinylPreview } from './VinylPreview';
+export * from './VinylPreview.types';

--- a/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.hooks.ts
+++ b/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.hooks.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useUIStore } from '@/stores/useUIStore';
+import { useUIStore, VINYL_LABEL_SOURCES, VINYL_RING_STYLES } from '@/stores/useUIStore';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { pendingAnalysisInput } from '@/hooks/useAnalysis';
 import { isRadioTrack } from '@/lib/utils';
@@ -25,7 +25,25 @@ export function useVisualEffectsSection(): IVisualEffectsSectionView {
   const setArtworkBloomEnabled = useUIStore(s => s.setArtworkBloomEnabled);
   const coverCrossfadeEnabled = useUIStore(s => s.coverCrossfadeEnabled);
   const setCoverCrossfadeEnabled = useUIStore(s => s.setCoverCrossfadeEnabled);
+  const vinylDisplayEnabled = useUIStore(s => s.vinylDisplayEnabled);
+  const setVinylDisplayEnabled = useUIStore(s => s.setVinylDisplayEnabled);
+  const vinylLabelSource = useUIStore(s => s.vinylLabelSource);
+  const setVinylLabelSource = useUIStore(s => s.setVinylLabelSource);
+  const vinylRingStyle = useUIStore(s => s.vinylRingStyle);
+  const setVinylRingStyle = useUIStore(s => s.setVinylRingStyle);
   const library = useLibraryStore(s => s.library);
+
+  const vinylLabelOptions = VINYL_LABEL_SOURCES.map(value => ({
+    value,
+    label: t(`app.vinylDisplayLabel.${value}`),
+    isActive: vinylLabelSource === value,
+  }));
+
+  const vinylRingOptions = VINYL_RING_STYLES.map(value => ({
+    value,
+    label: t(`app.vinylRing.${value}`),
+    isActive: vinylRingStyle === value,
+  }));
 
   // The silent-failure guard: a library without tempo data never breathes, and
   // nothing on this card would say why. Below half coverage, point at the one
@@ -46,6 +64,21 @@ export function useVisualEffectsSection(): IVisualEffectsSectionView {
     nowPlayingDescription: t('app.nowPlayingViewDesc'),
     nowPlayingViewEnabled,
     onNowPlayingChange: setNowPlayingViewEnabled,
+
+    vinylDisplayLabel: t('app.vinylDisplay'),
+    vinylDisplayDescription: t('app.vinylDisplayDesc'),
+    vinylDisplayEnabled,
+    onVinylDisplayChange: setVinylDisplayEnabled,
+
+    vinylLabelTitle: t('app.vinylDisplayLabelTitle'),
+    vinylLabelDescription: t('app.vinylDisplayLabelDesc'),
+    vinylLabelOptions,
+    onSelectVinylLabelSource: setVinylLabelSource,
+
+    vinylRingTitle: t('app.vinylRingTitle'),
+    vinylRingDescription: t('app.vinylRingDesc'),
+    vinylRingOptions,
+    onSelectVinylRingStyle: setVinylRingStyle,
 
     libraryHeroLabel: t('app.libraryHeroCard'),
     libraryHeroDescription: t('app.libraryHeroCardDesc'),

--- a/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.test.tsx
+++ b/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.test.tsx
@@ -33,6 +33,9 @@ function reset(): void {
     tempoBreathingEnabled: true,
     artworkBloomEnabled: true,
     coverCrossfadeEnabled: true,
+    vinylDisplayEnabled: false,
+    vinylLabelSource: 'artwork',
+    vinylRingStyle: 'glow',
   });
   useLibraryStore.setState({ library: [], libraryLoaded: true });
   vi.clearAllMocks();
@@ -46,11 +49,42 @@ describe('VisualEffectsSection', () => {
     render(<VisualEffectsSection />);
 
     expect(screen.getByText('Now Playing view')).toBeInTheDocument();
+    expect(screen.getByText('Vinyl record display')).toBeInTheDocument();
     expect(screen.getByText('Low performance mode')).toBeInTheDocument();
     expect(screen.getByText('Noise texture')).toBeInTheDocument();
     expect(screen.getByText('Artwork bloom')).toBeInTheDocument();
     expect(screen.getByText('Cover crossfade')).toBeInTheDocument();
     expect(screen.getByText('Tempo breathing')).toBeInTheDocument();
+  });
+
+  it('toggles the vinyl display through the store setter', async () => {
+    const user = userEvent.setup();
+    const setVinylDisplayEnabled = vi.fn();
+    useUIStore.setState({ setVinylDisplayEnabled });
+    render(<VisualEffectsSection />);
+
+    await user.click(screen.getByRole('switch', { name: 'Vinyl record display' }));
+
+    expect(setVinylDisplayEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it('shows the label and ring pickers only while the vinyl display is on', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<VisualEffectsSection />);
+
+    expect(screen.queryByText('Record label')).not.toBeInTheDocument();
+
+    useUIStore.setState({ vinylDisplayEnabled: true });
+    rerender(<VisualEffectsSection />);
+
+    expect(screen.getByText('Record label')).toBeInTheDocument();
+    expect(screen.getByText('Reactive ring')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Spectrum' }));
+    expect(useUIStore.getState().vinylRingStyle).toBe('spectrum');
+
+    await user.click(screen.getByRole('button', { name: 'Brand mark' }));
+    expect(useUIStore.getState().vinylLabelSource).toBe('logo');
   });
 
   it('toggles the artwork bloom through the store setter', async () => {

--- a/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.tsx
+++ b/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.tsx
@@ -1,4 +1,5 @@
 import { AudioLines, Sparkles } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import {
   SettingsCard,
   SettingsInfoCallout,
@@ -9,7 +10,12 @@ import { LowPerformancePreview } from '@/components/settings/LowPerformancePrevi
 import { NoiseOverlayPreview } from '@/components/settings/NoiseOverlayPreview';
 import { NowPlayingViewPreview } from '@/components/settings/NowPlayingViewPreview';
 import { SanctuarySection } from '@/components/settings/SanctuarySection';
+import { VinylPreview } from '@/components/settings/VinylPreview';
 import { useVisualEffectsSection } from './VisualEffectsSection.hooks';
+
+const CHIP_ACTIVE = 'border border-primary/40 bg-primary/15 text-primary';
+const CHIP_IDLE =
+  'border border-transparent text-muted-foreground hover:bg-accent/50 hover:text-foreground';
 
 export default function VisualEffectsSection() {
   const {
@@ -19,6 +25,18 @@ export default function VisualEffectsSection() {
     nowPlayingDescription,
     nowPlayingViewEnabled,
     onNowPlayingChange,
+    vinylDisplayLabel,
+    vinylDisplayDescription,
+    vinylDisplayEnabled,
+    onVinylDisplayChange,
+    vinylLabelTitle,
+    vinylLabelDescription,
+    vinylLabelOptions,
+    onSelectVinylLabelSource,
+    vinylRingTitle,
+    vinylRingDescription,
+    vinylRingOptions,
+    onSelectVinylRingStyle,
     libraryHeroLabel,
     libraryHeroDescription,
     libraryHeroCardEnabled,
@@ -46,6 +64,34 @@ export default function VisualEffectsSection() {
     tempoBreathingHint,
   } = useVisualEffectsSection();
 
+  const vinylLabelChips = vinylLabelOptions.map(option => (
+    <button
+      key={option.value}
+      onClick={() => onSelectVinylLabelSource(option.value)}
+      aria-pressed={option.isActive}
+      className={cn(
+        'rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+        option.isActive ? CHIP_ACTIVE : CHIP_IDLE
+      )}
+    >
+      {option.label}
+    </button>
+  ));
+
+  const vinylRingChips = vinylRingOptions.map(option => (
+    <button
+      key={option.value}
+      onClick={() => onSelectVinylRingStyle(option.value)}
+      aria-pressed={option.isActive}
+      className={cn(
+        'rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+        option.isActive ? CHIP_ACTIVE : CHIP_IDLE
+      )}
+    >
+      {option.label}
+    </button>
+  ));
+
   return (
     <div className="space-y-4">
       <SettingsCard icon={Sparkles} title={title} subtitle={subtitle}>
@@ -56,6 +102,30 @@ export default function VisualEffectsSection() {
           onCheckedChange={onNowPlayingChange}
         />
         <NowPlayingViewPreview enabled={nowPlayingViewEnabled} />
+
+        <SettingsToggleRow
+          label={vinylDisplayLabel}
+          description={vinylDisplayDescription}
+          checked={vinylDisplayEnabled}
+          onCheckedChange={onVinylDisplayChange}
+          divider
+        />
+        <VinylPreview enabled={vinylDisplayEnabled} />
+
+        {vinylDisplayEnabled && (
+          <div className="space-y-4 px-3" data-slot="vinyl-display-options">
+            <div>
+              <p className="mb-1 text-sm font-medium text-foreground">{vinylLabelTitle}</p>
+              <p className="mb-3 text-xs text-muted-foreground">{vinylLabelDescription}</p>
+              <div className="flex items-center gap-1.5">{vinylLabelChips}</div>
+            </div>
+            <div>
+              <p className="mb-1 text-sm font-medium text-foreground">{vinylRingTitle}</p>
+              <p className="mb-3 text-xs text-muted-foreground">{vinylRingDescription}</p>
+              <div className="flex items-center gap-1.5">{vinylRingChips}</div>
+            </div>
+          </div>
+        )}
 
         <SettingsToggleRow
           label={libraryHeroLabel}

--- a/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.types.ts
+++ b/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.types.ts
@@ -1,3 +1,25 @@
+import type { VinylLabelSource, VinylRingStyle } from '@/stores/useUIStore';
+
+/** One render-ready chip in the vinyl label-source picker. */
+export interface IVinylLabelOption {
+  /** The label source this chip selects. */
+  readonly value: VinylLabelSource;
+  /** Localized chip label. */
+  readonly label: string;
+  /** Whether this source is the active one. */
+  readonly isActive: boolean;
+}
+
+/** One render-ready chip in the vinyl ring-style picker. */
+export interface IVinylRingOption {
+  /** The ring style this chip selects. */
+  readonly value: VinylRingStyle;
+  /** Localized chip label. */
+  readonly label: string;
+  /** Whether this style is the active one. */
+  readonly isActive: boolean;
+}
+
 export interface IVisualEffectsSectionView {
   /** Localized card title. */
   readonly title: string;
@@ -12,6 +34,33 @@ export interface IVisualEffectsSectionView {
   readonly nowPlayingViewEnabled: boolean;
   /** Toggle the Now Playing view. */
   readonly onNowPlayingChange: (next: boolean) => void;
+
+  /** Localized "Vinyl record display" toggle label. */
+  readonly vinylDisplayLabel: string;
+  /** Localized "Vinyl record display" toggle description. */
+  readonly vinylDisplayDescription: string;
+  /** Whether the vinyl record display is enabled. */
+  readonly vinylDisplayEnabled: boolean;
+  /** Toggle the vinyl record display. */
+  readonly onVinylDisplayChange: (next: boolean) => void;
+
+  /** Localized title for the record-label picker. */
+  readonly vinylLabelTitle: string;
+  /** Localized description for the record-label picker. */
+  readonly vinylLabelDescription: string;
+  /** Render-ready chips for the record-label picker. */
+  readonly vinylLabelOptions: readonly IVinylLabelOption[];
+  /** Select the record-label source. */
+  readonly onSelectVinylLabelSource: (source: VinylLabelSource) => void;
+
+  /** Localized title for the reactive-ring picker. */
+  readonly vinylRingTitle: string;
+  /** Localized description for the reactive-ring picker. */
+  readonly vinylRingDescription: string;
+  /** Render-ready chips for the reactive-ring picker. */
+  readonly vinylRingOptions: readonly IVinylRingOption[];
+  /** Select the reactive-ring style. */
+  readonly onSelectVinylRingStyle: (style: VinylRingStyle) => void;
 
   /** Localized "Now playing banner" toggle label. */
   readonly libraryHeroLabel: string;

--- a/apps/web/src/components/shared/VinylRecord/VinylRecord.hooks.ts
+++ b/apps/web/src/components/shared/VinylRecord/VinylRecord.hooks.ts
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { useUIStore } from '@/stores/useUIStore';
+import { useDecorativeMotion } from '@/hooks/useDecorativeMotion';
+import { useVisualizerFrame, type VisualizerFrame } from '@/hooks/useVisualizerFrame';
+import type { IVinylRecordProps, IVinylRecordView } from './VinylRecord.types';
+
+/** Spin-up to full speed — a motor reaching 33⅓ RPM. */
+const SPIN_UP_MS = 700;
+/** Coast-down to rest — the platter keeps its momentum a little longer. */
+const COAST_DOWN_MS = 1200;
+
+/** Bar count for the 'spectrum' ring. */
+const SPECTRUM_BARS = 56;
+/**
+ * The ring canvas overhangs the disc (`-inset-[15%]` → 130% of the wrapper),
+ * so the disc's radius inside the canvas is the half-extent divided by 1.3.
+ */
+const DISC_RADIUS_FRACTION = 1 / 1.3;
+
+interface IRingState {
+  /** Heavily-smoothed bass amplitude driving the glow halo. */
+  glow: number;
+  /** Per-bar peak-hold levels for the spectrum ring. */
+  bars: Float32Array;
+}
+
+interface IRingGradientCache {
+  key: string;
+  ctx: CanvasRenderingContext2D | null;
+  glow: CanvasGradient | null;
+}
+
+function findSpinAnimation(el: HTMLElement): Animation | null {
+  if (typeof el.getAnimations !== 'function') return null;
+  return (
+    el
+      .getAnimations()
+      .find(a => 'animationName' in a && (a as CSSAnimation).animationName === 'vinyl-spin') ?? null
+  );
+}
+
+function applyPlaybackRate(animation: Animation, rate: number): void {
+  if (typeof animation.updatePlaybackRate === 'function') {
+    animation.updatePlaybackRate(rate);
+  } else {
+    animation.playbackRate = rate;
+  }
+}
+
+export function useVinylRecord({
+  albumArt,
+  albumAlt,
+  source,
+  className,
+}: IVinylRecordProps): IVinylRecordView {
+  const isPlaying = usePlaybackStore(s => s.isPlaying);
+  const currentTrack = usePlaybackStore(s => s.currentTrack);
+  const labelSource = useUIStore(s => s.vinylLabelSource);
+  const ringStyle = useUIStore(s => s.vinylRingStyle);
+  const decorativeMotion = useDecorativeMotion();
+
+  const discRef = useRef<HTMLDivElement>(null);
+  const spinInitializedRef = useRef(false);
+  const ringStateRef = useRef<IRingState>({ glow: 0, bars: new Float32Array(SPECTRUM_BARS) });
+  const gradientCacheRef = useRef<IRingGradientCache>({ key: '', ctx: null, glow: null });
+
+  // Inertia: the CSS animation always runs (kill-lists aside); play/pause only
+  // eases its playback rate between 0 and 1, so the groove angle never resets.
+  useEffect(() => {
+    const el = discRef.current;
+    if (!el || !decorativeMotion) return;
+    const animation = findSpinAnimation(el);
+    if (!animation) return;
+
+    const target = isPlaying ? 1 : 0;
+    // First run lands on the target directly, so a paused track mounts at rest
+    // instead of coasting down from the stylesheet's default rate.
+    if (!spinInitializedRef.current) {
+      spinInitializedRef.current = true;
+      applyPlaybackRate(animation, target);
+      return;
+    }
+
+    const from = animation.playbackRate;
+    if (from === target) return;
+    const duration = target > from ? SPIN_UP_MS : COAST_DOWN_MS;
+    const start = performance.now();
+    let raf = requestAnimationFrame(function step(now: number) {
+      const t = Math.min(1, (now - start) / duration);
+      const eased = 1 - (1 - t) * (1 - t);
+      applyPlaybackRate(animation, from + (target - from) * eased);
+      if (t < 1) raf = requestAnimationFrame(step);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [isPlaying, decorativeMotion]);
+
+  const draw = useCallback(
+    ({ ctx, w, h, raw, binCount, rgb }: VisualizerFrame) => {
+      const state = ringStateRef.current;
+      const cx = w / 2;
+      const cy = h / 2;
+      const discR = (Math.min(w, h) / 2) * DISC_RADIUS_FRACTION;
+      const [pr, pg, pb] = rgb;
+
+      let bass = 0;
+      for (let i = 0; i < 6; i++) bass += raw[i];
+      bass = bass / 6 / 255;
+
+      if (ringStyle === 'glow') {
+        // Calm halo: quick-ish attack, slow decay, and a cached ring gradient
+        // (rebuilt only on resize / theme change) whose strength is amplitude.
+        state.glow += (bass - state.glow) * (bass > state.glow ? 0.12 : 0.03);
+
+        const cache = gradientCacheRef.current;
+        const key = `${Math.round(discR)}|${pr},${pg},${pb}`;
+        if (cache.key !== key || cache.ctx !== ctx) {
+          const glow = ctx.createRadialGradient(0, 0, discR * 0.96, 0, 0, discR * 1.3);
+          glow.addColorStop(0, `rgba(${pr}, ${pg}, ${pb}, 0)`);
+          glow.addColorStop(0.22, `rgba(${pr}, ${pg}, ${pb}, 0.5)`);
+          glow.addColorStop(1, `rgba(${pr}, ${pg}, ${pb}, 0)`);
+          cache.glow = glow;
+          cache.key = key;
+          cache.ctx = ctx;
+        }
+
+        ctx.save();
+        ctx.translate(cx, cy);
+        const swell = 1 + state.glow * 0.04;
+        ctx.scale(swell, swell);
+        ctx.globalAlpha = 0.15 + state.glow * 0.85;
+        ctx.fillStyle = cache.glow!;
+        ctx.beginPath();
+        ctx.arc(0, 0, discR * 1.3, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+        return;
+      }
+
+      // Spectrum: radial bars around the rim with per-bar peak hold + decay.
+      let mid = 0;
+      for (let i = 8; i < 32 && i < binCount; i++) mid += raw[i];
+      mid = mid / 24 / 255;
+
+      ctx.save();
+      ctx.translate(cx, cy);
+      ctx.lineWidth = Math.max(1.5, discR * 0.016);
+      ctx.lineCap = 'round';
+      const r0 = discR * 1.02;
+      for (let i = 0; i < SPECTRUM_BARS; i++) {
+        const idx = 2 + Math.floor((i / SPECTRUM_BARS) * binCount * 0.55);
+        const v = raw[Math.min(idx, binCount - 1)] / 255;
+        state.bars[i] = Math.max(v, state.bars[i] * 0.86);
+        const level = state.bars[i];
+        const angle = (i / SPECTRUM_BARS) * Math.PI * 2 - Math.PI / 2;
+        const r1 = r0 + 1 + level * discR * 0.2;
+        ctx.strokeStyle = `rgba(${pr}, ${pg}, ${pb}, ${0.18 + level * 0.55 + mid * 0.1})`;
+        ctx.beginPath();
+        ctx.moveTo(Math.cos(angle) * r0, Math.sin(angle) * r0);
+        ctx.lineTo(Math.cos(angle) * r1, Math.sin(angle) * r1);
+        ctx.stroke();
+      }
+      ctx.restore();
+    },
+    [ringStyle]
+  );
+
+  const ringVisible = ringStyle !== 'off' && decorativeMotion;
+  const ringActive = ringVisible && (source !== undefined || (isPlaying && Boolean(currentTrack)));
+  const ringCanvasRef = useVisualizerFrame({ draw, source, active: ringActive });
+
+  return {
+    discRef,
+    ringCanvasRef,
+    ringVisible,
+    staticRingVisible: ringStyle !== 'off' && !decorativeMotion,
+    labelSource,
+    ringStyle,
+    albumArt,
+    albumAlt,
+    className,
+  };
+}

--- a/apps/web/src/components/shared/VinylRecord/VinylRecord.stories.tsx
+++ b/apps/web/src/components/shared/VinylRecord/VinylRecord.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
+
+import { useUIStore } from '@/stores/useUIStore';
+import { createSyntheticSource } from '@/components/player/visualizerStorySource';
+import VinylRecord from './VinylRecord';
+
+/**
+ * shared · VinylRecord. The spinning vinyl artwork display: a CSS-only disc
+ * (grooves, wobble, static sheen) whose center label shows the album artwork
+ * or the 白波 brand mark, plus an optional audio-reactive ring canvas driven
+ * by a `FrequencySource`. The disc and ring are decorative (`aria-hidden`);
+ * only the artwork label contributes an accessible image.
+ */
+const meta: Meta<typeof VinylRecord> = {
+  title: 'shared/VinylRecord',
+  component: VinylRecord,
+  // Decorative disc layers are aria-hidden and the artwork label is a real
+  // <img alt> — axe clean at the error level.
+  parameters: { a11y: { test: 'error' } },
+  decorators: [
+    Story => (
+      <div className="size-[20rem] bg-background p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof VinylRecord>;
+
+/**
+ * Glow ring + brand-mark label. With no artwork the label falls back to the
+ * live-text 白波 mark; the synthetic source drives the halo draw path.
+ */
+export const BrandMarkGlow: Story = {
+  render: () => {
+    useUIStore.setState({ vinylLabelSource: 'logo', vinylRingStyle: 'glow' });
+    return <VinylRecord albumArt={null} albumAlt="Late Nights" source={createSyntheticSource()} />;
+  },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector('[data-slot="vinyl-record"]')).toBeInTheDocument();
+    await expect(canvasElement.querySelector('.vinyl-label')).toHaveTextContent('白波');
+    await expect(canvasElement.querySelector('canvas')).toBeInTheDocument();
+  },
+};
+
+/**
+ * Spectrum ring — ~56 radial bars around the rim, drawn from the same
+ * synthetic source through the shared visualizer frame hook.
+ */
+export const SpectrumRing: Story = {
+  render: () => {
+    useUIStore.setState({ vinylLabelSource: 'logo', vinylRingStyle: 'spectrum' });
+    return <VinylRecord albumArt={null} albumAlt="Late Nights" source={createSyntheticSource()} />;
+  },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector('canvas')).toBeInTheDocument();
+  },
+};
+
+/** Ring off — only the disc, sheen, and label render; no canvas mounts. */
+export const RingOff: Story = {
+  render: () => {
+    useUIStore.setState({ vinylLabelSource: 'logo', vinylRingStyle: 'off' });
+    return <VinylRecord albumArt={null} albumAlt="Late Nights" />;
+  },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector('canvas')).not.toBeInTheDocument();
+    await expect(canvasElement.querySelector('.vinyl-disc')).toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/shared/VinylRecord/VinylRecord.test.tsx
+++ b/apps/web/src/components/shared/VinylRecord/VinylRecord.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { useUIStore } from '@/stores/useUIStore';
+
+import VinylRecord from './VinylRecord';
+
+function reset(): void {
+  usePlaybackStore.setState({ currentTrack: null, isPlaying: false });
+  useUIStore.setState({
+    vinylLabelSource: 'artwork',
+    vinylRingStyle: 'glow',
+    lowPerformanceMode: false,
+  });
+}
+
+beforeEach(reset);
+afterEach(reset);
+
+describe('VinylRecord', () => {
+  it('renders the disc with the artwork label when art is available', () => {
+    render(<VinylRecord albumArt="art://cover.jpg" albumAlt="Late Nights" />);
+
+    expect(document.querySelector('[data-slot="vinyl-record"]')).toBeInTheDocument();
+    expect(screen.getByAltText('Late Nights')).toHaveAttribute('src', 'art://cover.jpg');
+  });
+
+  it('falls back to the brand mark when the track has no artwork', () => {
+    render(<VinylRecord albumArt={null} albumAlt="Late Nights" />);
+
+    expect(screen.queryByAltText('Late Nights')).not.toBeInTheDocument();
+    expect(document.querySelector('.vinyl-label')).toHaveTextContent('白波');
+  });
+
+  it('shows the brand mark instead of artwork under the logo label source', () => {
+    useUIStore.setState({ vinylLabelSource: 'logo' });
+
+    render(<VinylRecord albumArt="art://cover.jpg" albumAlt="Late Nights" />);
+
+    expect(screen.queryByAltText('Late Nights')).not.toBeInTheDocument();
+    expect(document.querySelector('.vinyl-label')).toHaveTextContent('白波');
+  });
+
+  it('mounts the reactive ring canvas while a ring style is on', () => {
+    const { container } = render(<VinylRecord albumArt={null} albumAlt="Late Nights" />);
+
+    expect(container.querySelector('canvas')).toBeInTheDocument();
+    expect(container.querySelector('.vinyl-static-ring')).not.toBeInTheDocument();
+  });
+
+  it('omits the ring entirely when the style is off', () => {
+    useUIStore.setState({ vinylRingStyle: 'off' });
+
+    const { container } = render(<VinylRecord albumArt={null} albumAlt="Late Nights" />);
+
+    expect(container.querySelector('canvas')).not.toBeInTheDocument();
+    expect(container.querySelector('.vinyl-static-ring')).not.toBeInTheDocument();
+  });
+
+  it('swaps the canvas for the static halo when decorative motion is suppressed', () => {
+    useUIStore.setState({ lowPerformanceMode: true });
+
+    const { container } = render(<VinylRecord albumArt={null} albumAlt="Late Nights" />);
+
+    expect(container.querySelector('canvas')).not.toBeInTheDocument();
+    expect(container.querySelector('.vinyl-static-ring')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/shared/VinylRecord/VinylRecord.tsx
+++ b/apps/web/src/components/shared/VinylRecord/VinylRecord.tsx
@@ -1,0 +1,79 @@
+import { cn } from '@/lib/utils';
+import { TrackThumbnail } from '@/components/shared/TrackThumbnail';
+import { useVinylRecord } from './VinylRecord.hooks';
+import type { IVinylRecordProps } from './VinylRecord.types';
+
+/**
+ * A spinning vinyl record — the alternative artwork display for the Now
+ * Playing view and the Sanctuary's vinyl variant.
+ *
+ * The disc is pure CSS (grooves via repeating-radial-gradient, 33⅓ RPM spin,
+ * 1px-off-center wobble); play/pause eases the animation's playback rate so
+ * the groove angle never resets. The static conic sheen sits above the disc
+ * and does not rotate. The center label shows the album artwork or the 白波
+ * brand mark, and an optional audio-reactive ring (glow / spectrum) is drawn
+ * on one absolutely-positioned canvas. All motion collapses under
+ * reduced-motion / low-performance mode: frozen disc, no wobble, static halo.
+ */
+export default function VinylRecord(props: IVinylRecordProps) {
+  const {
+    discRef,
+    ringCanvasRef,
+    ringVisible,
+    staticRingVisible,
+    labelSource,
+    albumArt,
+    albumAlt,
+    className,
+  } = useVinylRecord(props);
+
+  const brandMark = (
+    <span
+      className="select-none text-[34cqw] leading-none text-primary-foreground"
+      style={{
+        fontFamily: "'Shippori Mincho', 'Noto Sans JP', 'Hiragino Sans', serif",
+        fontWeight: 800,
+      }}
+      aria-hidden="true"
+    >
+      白波
+    </span>
+  );
+
+  const labelContent =
+    labelSource === 'artwork' ? (
+      <TrackThumbnail albumArt={albumArt} alt={albumAlt} fill fallback={brandMark} />
+    ) : (
+      brandMark
+    );
+
+  return (
+    <div data-slot="vinyl-record" className={cn('relative aspect-square', className)}>
+      {ringVisible && (
+        <canvas
+          ref={ringCanvasRef}
+          className="pointer-events-none absolute -inset-[15%]"
+          aria-hidden="true"
+        />
+      )}
+      {staticRingVisible && (
+        <div className="vinyl-static-ring absolute inset-0 rounded-full" aria-hidden="true" />
+      )}
+
+      <div ref={discRef} className="vinyl-disc vinyl-spin absolute inset-0 rounded-full">
+        <div className="vinyl-label @container absolute inset-[31%] flex items-center justify-center overflow-hidden rounded-full">
+          {labelContent}
+        </div>
+      </div>
+
+      <div
+        className="vinyl-sheen pointer-events-none absolute inset-0 rounded-full"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute left-1/2 top-1/2 size-[3%] -translate-x-1/2 -translate-y-1/2 rounded-full bg-black/80"
+        aria-hidden="true"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/shared/VinylRecord/VinylRecord.types.ts
+++ b/apps/web/src/components/shared/VinylRecord/VinylRecord.types.ts
@@ -1,0 +1,38 @@
+import type { RefObject } from 'react';
+import type { FrequencySource } from '@/components/player/visualizer-source';
+import type { VinylLabelSource, VinylRingStyle } from '@/stores/useUIStore';
+
+export interface IVinylRecordProps {
+  /** Album artwork URL for the 'artwork' label; the brand mark fills in when absent. */
+  readonly albumArt?: string | null;
+  /** `alt` for the artwork label image. */
+  readonly albumAlt: string;
+  /**
+   * Optional external frequency source for the reactive ring (stories /
+   * previews). The global audio-engine analyser is used when omitted.
+   */
+  readonly source?: FrequencySource;
+  /** Extra classes for the outer square wrapper (sizing/position). */
+  readonly className?: string;
+}
+
+export interface IVinylRecordView {
+  /** The rotating disc element — the hook eases its spin playback rate. */
+  readonly discRef: RefObject<HTMLDivElement | null>;
+  /** Canvas for the audio-reactive ring (mounted only while `ringVisible`). */
+  readonly ringCanvasRef: RefObject<HTMLCanvasElement | null>;
+  /** Render the reactive ring canvas (ring on and decorative motion allowed). */
+  readonly ringVisible: boolean;
+  /** Render the calm fixed halo instead (ring on but motion suppressed). */
+  readonly staticRingVisible: boolean;
+  /** The user's label preference, resolved from settings. */
+  readonly labelSource: VinylLabelSource;
+  /** Ring style, resolved from settings (drives the draw callback). */
+  readonly ringStyle: VinylRingStyle;
+  /** Album artwork URL for the artwork label (prop passthrough). */
+  readonly albumArt: string | null | undefined;
+  /** `alt` for the artwork label image (prop passthrough). */
+  readonly albumAlt: string;
+  /** Extra wrapper classes (prop passthrough). */
+  readonly className: string | undefined;
+}

--- a/apps/web/src/components/shared/VinylRecord/index.ts
+++ b/apps/web/src/components/shared/VinylRecord/index.ts
@@ -1,0 +1,2 @@
+export { default as VinylRecord } from './VinylRecord';
+export * from './VinylRecord.types';

--- a/apps/web/src/locales/en/sanctuary.json
+++ b/apps/web/src/locales/en/sanctuary.json
@@ -1,5 +1,6 @@
 {
   "exit": "Leave Sanctuary",
   "showClock": "Show the clock",
-  "showCover": "Show the cover"
+  "showCover": "Show the cover",
+  "showVinyl": "Show the record"
 }

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -455,6 +455,21 @@
     "sidebarResetDesc": "Restore the default order and item visibility",
     "nowPlayingView": "Now Playing view",
     "nowPlayingViewDesc": "Double-click album art in the player bar or now-playing card, or press Ctrl+Shift+P, to open an immersive full view",
+    "vinylDisplay": "Vinyl record display",
+    "vinylDisplayDesc": "Swap the album art in the Now Playing view for a slowly spinning vinyl record. Sanctuary Mode also gains a vinyl center stage.",
+    "vinylDisplayLabelTitle": "Record label",
+    "vinylDisplayLabelDesc": "What the record's center label shows: the album artwork, or the 白波 brand mark.",
+    "vinylDisplayLabel": {
+      "artwork": "Artwork",
+      "logo": "Brand mark"
+    },
+    "vinylRingTitle": "Reactive ring",
+    "vinylRingDesc": "A light ring around the disc that follows the music: a calm glow, a bar spectrum, or nothing at all.",
+    "vinylRing": {
+      "off": "Off",
+      "glow": "Glow",
+      "spectrum": "Spectrum"
+    },
     "libraryHeroCard": "Now playing banner",
     "libraryHeroCardDesc": "Show the large now-playing card above Library and Favorites. Turn off to give albums more room. The player bar still shows track info.",
     "lowPerfMode": "Low performance mode",
@@ -476,10 +491,11 @@
       "title": "Sanctuary Mode",
       "desc": "Press F while music plays: the app dissolves into a fullscreen player — the cover, the lyric, and the light.",
       "variantTitle": "Center stage",
-      "variantDesc": "What fills the screen: the record's cover, or a large clock with the track underneath.",
+      "variantDesc": "What fills the screen: the record's cover, a spinning vinyl, or a large clock with the track underneath.",
       "variant": {
         "cover": "Cover",
-        "clock": "Clock"
+        "clock": "Clock",
+        "vinyl": "Vinyl"
       },
       "autoEnter": "Enter on its own",
       "autoEnterDesc": "After a stretch of stillness while music plays, your desk quietly becomes a lofi display. Any key or pointer move brings the app right back.",
@@ -497,7 +513,8 @@
       "full": "Full",
       "noise": "Noise preview",
       "noiseOn": "Texture enabled",
-      "noiseOff": "Texture disabled"
+      "noiseOff": "Texture disabled",
+      "vinyl": "Vinyl preview"
     },
     "sectionsAriaLabel": "Settings sections",
     "theme": {

--- a/apps/web/src/locales/pl/sanctuary.json
+++ b/apps/web/src/locales/pl/sanctuary.json
@@ -1,5 +1,6 @@
 {
   "exit": "Opuść sanktuarium",
   "showClock": "Pokaż zegar",
-  "showCover": "Pokaż okładkę"
+  "showCover": "Pokaż okładkę",
+  "showVinyl": "Pokaż płytę"
 }

--- a/apps/web/src/locales/pl/settings.json
+++ b/apps/web/src/locales/pl/settings.json
@@ -477,6 +477,21 @@
     "sidebarResetDesc": "Przywróć domyślną kolejność i widoczność elementów",
     "nowPlayingView": "Widok Teraz odtwarzane",
     "nowPlayingViewDesc": "Kliknij dwukrotnie okładkę na pasku odtwarzacza lub karcie 'Teraz odtwarzane', albo naciśnij Ctrl+Shift+P, aby otworzyć widok pełnoekranowy",
+    "vinylDisplay": "Płyta winylowa",
+    "vinylDisplayDesc": "Zamienia okładkę w widoku Teraz odtwarzane na wolno wirującą płytę winylową. Tryb sanktuarium zyskuje też scenę z winylem.",
+    "vinylDisplayLabelTitle": "Etykieta płyty",
+    "vinylDisplayLabelDesc": "Co pokazuje środkowa etykieta płyty: okładkę albumu albo znak 白波.",
+    "vinylDisplayLabel": {
+      "artwork": "Okładka",
+      "logo": "Znak marki"
+    },
+    "vinylRingTitle": "Reaktywny pierścień",
+    "vinylRingDesc": "Świetlny pierścień wokół płyty podążający za muzyką: spokojna poświata, widmo słupków albo nic.",
+    "vinylRing": {
+      "off": "Wyłączony",
+      "glow": "Poświata",
+      "spectrum": "Widmo"
+    },
     "libraryHeroCard": "Baner odtwarzanego utworu",
     "libraryHeroCardDesc": "Pokazuj dużą kartę nad Biblioteką i Ulubionymi. Wyłącz, aby zyskać więcej miejsca na albumy. Pasek odtwarzacza i tak pokazuje informacje o utworze.",
     "lowPerfMode": "Tryb niskiej wydajności",
@@ -498,10 +513,11 @@
       "title": "Tryb sanktuarium",
       "desc": "Naciśnij F podczas odtwarzania: aplikacja rozpływa się w pełnoekranowy odtwarzacz — okładka, tekst i światło.",
       "variantTitle": "Na środku sceny",
-      "variantDesc": "Co wypełnia ekran: okładka płyty albo duży zegar z utworem poniżej.",
+      "variantDesc": "Co wypełnia ekran: okładka płyty, wirujący winyl albo duży zegar z utworem poniżej.",
       "variant": {
         "cover": "Okładka",
-        "clock": "Zegar"
+        "clock": "Zegar",
+        "vinyl": "Winyl"
       },
       "autoEnter": "Uruchamiaj samoczynnie",
       "autoEnterDesc": "Po chwili bezruchu podczas odtwarzania biurko cicho zamienia się w lofi ekran. Dowolny klawisz lub ruch myszy natychmiast przywraca aplikację.",
@@ -519,7 +535,8 @@
       "full": "Pełne",
       "noise": "Podgląd szumu",
       "noiseOn": "Tekstura włączona",
-      "noiseOff": "Tekstura wyłączona"
+      "noiseOff": "Tekstura wyłączona",
+      "vinyl": "Podgląd winylu"
     },
     "sectionsAriaLabel": "Sekcje ustawień",
     "theme": {

--- a/apps/web/src/stores/useSanctuaryStore.test.ts
+++ b/apps/web/src/stores/useSanctuaryStore.test.ts
@@ -80,6 +80,12 @@ describe('useSanctuaryStore', () => {
     );
   });
 
+  it('accepts and persists the vinyl variant', () => {
+    useSanctuaryStore.getState().setSanctuaryVariant('vinyl');
+    expect(useSanctuaryStore.getState().sanctuaryVariant).toBe('vinyl');
+    expect(readPersisted().sanctuaryVariant).toBe('vinyl');
+  });
+
   it('coerces a malformed variant back to the default', () => {
     useSanctuaryStore.getState().setSanctuaryVariant('spiral' as never);
     expect(useSanctuaryStore.getState().sanctuaryVariant).toBe('cover');

--- a/apps/web/src/stores/useSanctuaryStore.ts
+++ b/apps/web/src/stores/useSanctuaryStore.ts
@@ -4,7 +4,7 @@ import { commands } from '@/lib/bridge/commands';
 import { logger } from '@/lib/logger';
 
 /** What the sanctuary shows center-stage. */
-export type SanctuaryVariant = 'cover' | 'clock';
+export type SanctuaryVariant = 'cover' | 'clock' | 'vinyl';
 
 export const SANCTUARY_AUTO_ENTER_MIN_MINUTES = 1;
 export const SANCTUARY_AUTO_ENTER_MAX_MINUTES = 60;
@@ -17,7 +17,7 @@ export const SANCTUARY_CHROME_TIMEOUT_MS = 4000;
 const STORE_KEY = 'shiranami.sanctuary-store';
 
 function coerceVariant(v: unknown): SanctuaryVariant {
-  return v === 'cover' || v === 'clock' ? v : SANCTUARY_VARIANT_DEFAULT;
+  return v === 'cover' || v === 'clock' || v === 'vinyl' ? v : SANCTUARY_VARIANT_DEFAULT;
 }
 
 function coerceAutoEnterMinutes(v: unknown): number {

--- a/apps/web/src/stores/useUIStore.test.ts
+++ b/apps/web/src/stores/useUIStore.test.ts
@@ -240,6 +240,67 @@ describe('visual-effect gates (artworkBloomEnabled / coverCrossfadeEnabled)', ()
   });
 });
 
+describe('vinyl display settings (vinylDisplayEnabled / vinylLabelSource / vinylRingStyle)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it('defaults to a disabled display with artwork label and glow ring', async () => {
+    const { useUIStore: store } = await import('./useUIStore');
+    expect(store.getState().vinylDisplayEnabled).toBe(false);
+    expect(store.getState().vinylLabelSource).toBe('artwork');
+    expect(store.getState().vinylRingStyle).toBe('glow');
+  });
+
+  it('persists all three setters to localStorage', async () => {
+    const { useUIStore: store } = await import('./useUIStore');
+    store.getState().setVinylDisplayEnabled(true);
+    store.getState().setVinylLabelSource('logo');
+    store.getState().setVinylRingStyle('spectrum');
+
+    expect(readPersisted().vinylDisplayEnabled).toBe(true);
+    expect(readPersisted().vinylLabelSource).toBe('logo');
+    expect(readPersisted().vinylRingStyle).toBe('spectrum');
+  });
+
+  it('round-trips persisted values through the sanitize path', async () => {
+    localStorage.setItem(
+      STORE_KEY,
+      JSON.stringify({
+        state: { vinylDisplayEnabled: true, vinylLabelSource: 'logo', vinylRingStyle: 'off' },
+        version: 1,
+      })
+    );
+    const { useUIStore: store } = await import('./useUIStore');
+    expect(store.getState().vinylDisplayEnabled).toBe(true);
+    expect(store.getState().vinylLabelSource).toBe('logo');
+    expect(store.getState().vinylRingStyle).toBe('off');
+  });
+
+  it('coerces garbage back to the defaults on load', async () => {
+    localStorage.setItem(
+      STORE_KEY,
+      JSON.stringify({
+        state: { vinylDisplayEnabled: 'yes', vinylLabelSource: 'hologram', vinylRingStyle: 42 },
+        version: 1,
+      })
+    );
+    const { useUIStore: store } = await import('./useUIStore');
+    expect(store.getState().vinylDisplayEnabled).toBe(false);
+    expect(store.getState().vinylLabelSource).toBe('artwork');
+    expect(store.getState().vinylRingStyle).toBe('glow');
+  });
+
+  it('setters reject unknown enum values', async () => {
+    const { useUIStore: store } = await import('./useUIStore');
+    store.getState().setVinylLabelSource('hologram' as never);
+    store.getState().setVinylRingStyle('laser' as never);
+    expect(store.getState().vinylLabelSource).toBe('artwork');
+    expect(store.getState().vinylRingStyle).toBe('glow');
+  });
+});
+
 describe('coerceVisualizerStyle (persist merge path)', () => {
   const ALL_STYLES = [
     'bars',

--- a/apps/web/src/stores/useUIStore.ts
+++ b/apps/web/src/stores/useUIStore.ts
@@ -1,6 +1,6 @@
 import { clamp } from '@shiranami/shared';
 import { arrayMove } from '@/lib/array';
-import { createPersistedStore, acceptStoreHmr } from '@/lib/createPersistedStore';
+import { createPersistedStore, coerceEnum, acceptStoreHmr } from '@/lib/createPersistedStore';
 import { useViewStore, type AppView, type PlayerSidePanel } from '@/stores/useViewStore';
 import {
   ALWAYS_VISIBLE_SIDEBAR_ITEMS,
@@ -42,6 +42,24 @@ export const VISUALIZER_STYLE_VALUES = [
   'vu',
   'kanji',
 ] as const satisfies readonly VisualizerStyle[];
+
+/** What the vinyl record's center label shows. */
+export type VinylLabelSource = 'artwork' | 'logo';
+/** The audio-reactive ring drawn around the vinyl disc. */
+export type VinylRingStyle = 'off' | 'glow' | 'spectrum';
+
+export const VINYL_LABEL_SOURCES = [
+  'artwork',
+  'logo',
+] as const satisfies readonly VinylLabelSource[];
+export const VINYL_RING_STYLES = [
+  'off',
+  'glow',
+  'spectrum',
+] as const satisfies readonly VinylRingStyle[];
+
+export const VINYL_LABEL_SOURCE_DEFAULT: VinylLabelSource = 'artwork';
+export const VINYL_RING_STYLE_DEFAULT: VinylRingStyle = 'glow';
 
 export type LibraryViewMode = 'tracks' | 'albums';
 export type AlbumGridSize = 'small' | 'medium' | 'large';
@@ -157,6 +175,9 @@ interface PersistedUIState {
   tempoBreathingEnabled: boolean;
   artworkBloomEnabled: boolean;
   coverCrossfadeEnabled: boolean;
+  vinylDisplayEnabled: boolean;
+  vinylLabelSource: VinylLabelSource;
+  vinylRingStyle: VinylRingStyle;
   landingView: LandingView;
 }
 
@@ -218,6 +239,20 @@ function sanitize(persisted: LegacyPersistedUIState | undefined): Partial<Persis
     out.artworkBloomEnabled = persisted.artworkBloomEnabled;
   if (typeof persisted.coverCrossfadeEnabled === 'boolean')
     out.coverCrossfadeEnabled = persisted.coverCrossfadeEnabled;
+  if (typeof persisted.vinylDisplayEnabled === 'boolean')
+    out.vinylDisplayEnabled = persisted.vinylDisplayEnabled;
+  if (persisted.vinylLabelSource !== undefined)
+    out.vinylLabelSource = coerceEnum(
+      persisted.vinylLabelSource,
+      VINYL_LABEL_SOURCES,
+      VINYL_LABEL_SOURCE_DEFAULT
+    );
+  if (persisted.vinylRingStyle !== undefined)
+    out.vinylRingStyle = coerceEnum(
+      persisted.vinylRingStyle,
+      VINYL_RING_STYLES,
+      VINYL_RING_STYLE_DEFAULT
+    );
   if (persisted.landingView !== undefined)
     out.landingView = coerceLandingView(persisted.landingView);
   return out;
@@ -250,6 +285,9 @@ const UI_KEYS: ReadonlySet<string> = new Set([
   'tempoBreathingEnabled',
   'artworkBloomEnabled',
   'coverCrossfadeEnabled',
+  'vinylDisplayEnabled',
+  'vinylLabelSource',
+  'vinylRingStyle',
   'landingView',
 ]);
 
@@ -393,6 +431,14 @@ interface UIState {
   tempoBreathingEnabled: boolean;
   artworkBloomEnabled: boolean;
   coverCrossfadeEnabled: boolean;
+  /**
+   * Vinyl record display: swap the Now Playing artwork card for a spinning
+   * vinyl disc. The label source and reactive ring below only matter while
+   * this master gate is on (the Sanctuary vinyl variant also honors them).
+   */
+  vinylDisplayEnabled: boolean;
+  vinylLabelSource: VinylLabelSource;
+  vinylRingStyle: VinylRingStyle;
   landingView: LandingView;
 }
 
@@ -407,6 +453,9 @@ interface UIActions {
   setTempoBreathingEnabled: (enabled: boolean) => void;
   setArtworkBloomEnabled: (enabled: boolean) => void;
   setCoverCrossfadeEnabled: (enabled: boolean) => void;
+  setVinylDisplayEnabled: (enabled: boolean) => void;
+  setVinylLabelSource: (source: VinylLabelSource) => void;
+  setVinylRingStyle: (style: VinylRingStyle) => void;
   setLandingView: (view: LandingView) => void;
   setSidebarCollapsed: (sidebarCollapsed: boolean) => void;
   toggleSidebarCollapsed: () => void;
@@ -453,6 +502,9 @@ export const useUIStore = createPersistedStore<UIState & UIActions>(
     tempoBreathingEnabled: true,
     artworkBloomEnabled: true,
     coverCrossfadeEnabled: true,
+    vinylDisplayEnabled: false,
+    vinylLabelSource: VINYL_LABEL_SOURCE_DEFAULT,
+    vinylRingStyle: VINYL_RING_STYLE_DEFAULT,
     landingView: LANDING_VIEW_DEFAULT,
 
     setNowPlayingViewEnabled: enabled => {
@@ -486,6 +538,17 @@ export const useUIStore = createPersistedStore<UIState & UIActions>(
     },
     setCoverCrossfadeEnabled: enabled => {
       set({ coverCrossfadeEnabled: enabled });
+    },
+    setVinylDisplayEnabled: enabled => {
+      set({ vinylDisplayEnabled: enabled });
+    },
+    setVinylLabelSource: source => {
+      set({
+        vinylLabelSource: coerceEnum(source, VINYL_LABEL_SOURCES, VINYL_LABEL_SOURCE_DEFAULT),
+      });
+    },
+    setVinylRingStyle: style => {
+      set({ vinylRingStyle: coerceEnum(style, VINYL_RING_STYLES, VINYL_RING_STYLE_DEFAULT) });
     },
     setLandingView: view => {
       set({ landingView: view });
@@ -582,6 +645,9 @@ export const useUIStore = createPersistedStore<UIState & UIActions>(
         tempoBreathingEnabled: s.tempoBreathingEnabled,
         artworkBloomEnabled: s.artworkBloomEnabled,
         coverCrossfadeEnabled: s.coverCrossfadeEnabled,
+        vinylDisplayEnabled: s.vinylDisplayEnabled,
+        vinylLabelSource: s.vinylLabelSource,
+        vinylRingStyle: s.vinylRingStyle,
         landingView: s.landingView,
       }) as PersistedUIState,
     sanitize: (persisted, current) => ({

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -353,6 +353,67 @@
   animation: splash-sweep 1.4s ease-in-out infinite;
 }
 
+/* Vinyl record display — the disc revolves once per 1.8s (33⅓ RPM) on a
+   composited transform layer. The 1px transform-origin offset gives the
+   pressing a subtle wobble for free. Pausing eases the animation's playback
+   rate to zero instead of removing it, so the groove angle never resets.
+   Decorative — killed under reduced-motion / low-perf below. */
+@keyframes vinyl-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.vinyl-spin {
+  transform-origin: calc(50% + 1px) calc(50% - 1px);
+  animation: vinyl-spin 1.8s linear infinite;
+  will-change: transform;
+}
+
+/* The pressing itself: a dark disc with grooves cut by a repeating radial
+   gradient over a soft edge-darkened base, plus an off-center pressing gleam. */
+.vinyl-disc {
+  background:
+    radial-gradient(circle at 32% 28%, oklch(1 0 0 / 0.05), transparent 46%),
+    repeating-radial-gradient(
+      circle at 50% 50%,
+      oklch(0.17 0.02 285) 0px,
+      oklch(0.11 0.015 285) 2px,
+      oklch(0.16 0.02 285) 4px
+    ),
+    radial-gradient(circle, oklch(0.19 0.03 290) 28%, oklch(0.09 0.02 290) 100%);
+  box-shadow:
+    inset 0 0 18px oklch(0 0 0 / 0.55),
+    0 10px 36px oklch(0 0 0 / 0.45);
+}
+
+/* Static (non-rotating) light sheen over the disc — the room's reflection
+   stays put while the record turns underneath it. */
+.vinyl-sheen {
+  background: conic-gradient(
+    from 205deg,
+    transparent 0deg,
+    oklch(1 0 0 / 0.07) 24deg,
+    transparent 58deg,
+    transparent 172deg,
+    oklch(1 0 0 / 0.045) 205deg,
+    transparent 242deg
+  );
+}
+
+/* The center label backing — a pressed paper disc tinted by the accent. */
+.vinyl-label {
+  background: radial-gradient(
+    circle at 38% 32%,
+    oklch(from var(--primary) calc(l + 0.08) c h),
+    oklch(from var(--primary) calc(l - 0.18) c h)
+  );
+}
+
+/* Reduced-motion / low-perf stand-in for the reactive ring: a calm fixed halo. */
+.vinyl-static-ring {
+  box-shadow: 0 0 28px 6px oklch(from var(--primary) l c h / 0.28);
+}
+
 /* Splash degradation — collapse every animated scene layer to a static still
    under reduced-motion OR low-performance mode. Steam + streaks have no
    meaningful static state → hidden; lights / LED / sweep go static; the loader
@@ -401,7 +462,8 @@
   .companion-sleep-breathe,
   .companion-idle-float,
   .companion-idle-blink,
-  .companion-bub-drift {
+  .companion-bub-drift,
+  .vinyl-spin {
     animation: none !important;
   }
   .animate-marquee {
@@ -430,6 +492,10 @@
 /* Drop the cup drop-shadow filter under low-perf (compositor cost). */
 [data-perf-mode='low'] .splash-cup-shadow {
   filter: none !important;
+}
+/* Freeze the vinyl disc under low-perf (mirrors the reduced-motion kill). */
+[data-perf-mode='low'] .vinyl-spin {
+  animation: none !important;
 }
 
 /* Midnight Lofi Cafe Theme */


### PR DESCRIPTION
## What

A spinning vinyl record as an alternative artwork display, available in the Now Playing view and as a third Sanctuary center stage.

- **Shared component** `shared/VinylRecord` (6-file layout): CSS-only disc — grooves via `repeating-radial-gradient`, 33 1/3 RPM rotation (1.8s/rev, linear infinite) on a composited transform layer, 1px transform-origin wobble, and a static (non-rotating) conic sheen. Spin-up (~700ms) and coast-down (~1.2s) inertia by easing the CSS animation's playback rate, so the groove angle never resets on pause.
- **Record label**: `vinylLabelSource` setting — circular-clipped album artwork (via `TrackThumbnail` fill) or the live-text 白波 brand mark in the Shippori Mincho stack.
- **Reactive ring**: `vinylRingStyle` setting — `glow` (default; heavily-smoothed bass halo with slow decay), `spectrum` (56 radial bars with peak hold), or `off`. One absolutely-positioned canvas drawn through the existing `useVisualizerFrame` hook; band reduction and gradient-cache idioms copied from `VinylVisualizer`. Renderer-side Web Audio only — no IPC, no Rust changes.
- **Now Playing**: when `vinylDisplayEnabled` is on, the inline art card yields to the record while the outer sizing wrapper stays untouched, so the companion cameo keeps its corner perch.
- **Sanctuary**: `vinyl` joins `cover`/`clock` as a third variant; the in-view toggle cycles all three, its icon/label always previewing the next stage; settings variant picker gains the chip.
- **Settings**: new toggle + live `VinylPreview` miniature + label/ring chip pickers in Visual effects. All three settings persist in `useUIStore` (sanitized with `coerceEnum`, default off / artwork / glow) with round-trip tests.
- **Motion discipline**: `.vinyl-spin` added to both kill-lists (reduced-motion and `[data-perf-mode='low']`); under suppressed motion the disc freezes, the wobble goes with it, and the ring falls back to a static halo.
- **i18n**: identical key trees in `en` and `pl` (`app.vinylDisplay*`, `app.vinylRing*`, `app.effectPreview.vinyl`, `app.sanctuary.variant.vinyl`, `sanctuary.showVinyl`).

## Verification

- `pnpm --filter @shiranami/web typecheck` — clean
- `pnpm --filter @shiranami/web test` — 325 files, 1980 tests, all green
- `pnpm lint` — clean; `pnpm lint:meta` — no blocking violations