### PR TITLE
refactor(web): status tokens, unified focus ring, primitive defaults and PageHeader actions

### DIFF
--- a/apps/web/src/components/debug/DebugOverlay/DebugOverlay.tsx
+++ b/apps/web/src/components/debug/DebugOverlay/DebugOverlay.tsx
@@ -45,7 +45,7 @@ function Stat({ label, value, warn }: { label: string; value: string; warn?: boo
   return (
     <div className="flex items-baseline justify-between gap-3">
       <span className="text-white/50">{label}</span>
-      <span className={cn('font-mono tabular-nums', warn ? 'text-amber-400' : 'text-white/90')}>
+      <span className={cn('font-mono tabular-nums', warn ? 'text-warning' : 'text-white/90')}>
         {value}
       </span>
     </div>
@@ -58,7 +58,7 @@ export default function DebugOverlay() {
   const procRows = main?.procs.map(p => (
     <tr
       key={p.pid}
-      className={cn(p.kind === 'main' && 'text-cyan-300', p.cpu >= 25 && 'text-amber-400')}
+      className={cn(p.kind === 'main' && 'text-cyan-300', p.cpu >= 25 && 'text-warning')}
     >
       <td className="text-left">{p.kind}</td>
       <td className="text-right">{p.pid}</td>
@@ -68,7 +68,7 @@ export default function DebugOverlay() {
   ));
 
   const commitRows = renderer.renderStats.map(s => (
-    <tr key={s.id} className={cn(s.commits >= 30 && 'text-amber-400')}>
+    <tr key={s.id} className={cn(s.commits >= 30 && 'text-warning')}>
       <td className="text-left">{s.id}</td>
       <td className="text-right">{s.commits}</td>
       <td className="text-right">{s.totalDuration.toFixed(1)}</td>
@@ -92,7 +92,7 @@ export default function DebugOverlay() {
       key={`${t.ts}-${i}`}
       className={cn(
         'flex justify-between gap-2',
-        t.duration >= 100 ? 'text-red-400' : 'text-amber-400'
+        t.duration >= 100 ? 'text-destructive' : 'text-warning'
       )}
     >
       <span className="truncate">

--- a/apps/web/src/components/debug/DebugOverlay/DebugOverlay.tsx
+++ b/apps/web/src/components/debug/DebugOverlay/DebugOverlay.tsx
@@ -116,7 +116,7 @@ export default function DebugOverlay() {
         <button
           type="button"
           onClick={close}
-          className="rounded px-1.5 text-white/50 hover:bg-white/10 hover:text-white"
+          className="focus-ring rounded px-1.5 text-white/50 hover:bg-white/10 hover:text-white"
           aria-label="Close debug panel"
         >
           esc

--- a/apps/web/src/components/downloads/DownloadQueueRow/DownloadQueueRow.hooks.ts
+++ b/apps/web/src/components/downloads/DownloadQueueRow/DownloadQueueRow.hooks.ts
@@ -33,7 +33,7 @@ export function useDownloadQueueRow({ item }: IDownloadQueueRowProps): IDownload
   const statusLabel = t(`status.${item.status}`);
 
   const statusClass = cn(
-    item.status === 'done' && 'text-emerald-400/80',
+    item.status === 'done' && 'text-success/80',
     item.status === 'error' && 'text-destructive/80',
     item.status === 'canceled' && 'text-muted-foreground/60',
     isActive && 'text-primary/70',

--- a/apps/web/src/components/history/HistoryHeroSection/HistoryHeroSection.tsx
+++ b/apps/web/src/components/history/HistoryHeroSection/HistoryHeroSection.tsx
@@ -11,7 +11,7 @@ export default function HistoryHeroSection(props: IHistoryHeroSectionProps) {
       type="button"
       onClick={() => onSelectRange(range.id)}
       className={cn(
-        'rounded-full border px-4 py-2 text-xs font-medium transition-colors',
+        'focus-ring rounded-full border px-4 py-2 text-xs font-medium transition-colors',
         range.isActive
           ? 'border-primary/60 bg-primary/15 text-primary'
           : 'border-border/20 bg-background/30 text-muted-foreground hover:border-border/35 hover:text-foreground'

--- a/apps/web/src/components/history/HistoryTopTrackRow/HistoryTopTrackRow.tsx
+++ b/apps/web/src/components/history/HistoryTopTrackRow/HistoryTopTrackRow.tsx
@@ -9,7 +9,7 @@ export default function HistoryTopTrackRow(props: IHistoryTopTrackRowProps) {
     <button
       type="button"
       onClick={onPlay}
-      className="flex w-full items-center gap-3 rounded-2xl border border-border/20 bg-background/25 px-3 py-3 text-left transition-colors hover:border-border/35 hover:bg-accent/35"
+      className="focus-ring flex w-full items-center gap-3 rounded-2xl border border-border/20 bg-background/25 px-3 py-3 text-left transition-colors hover:border-border/35 hover:bg-accent/35"
     >
       <HistoryTrackArtwork albumArt={track.albumArt} title={track.title} />
       <div className="min-w-0 flex-1">

--- a/apps/web/src/components/library/ScanProgressCard/ScanProgressCard.tsx
+++ b/apps/web/src/components/library/ScanProgressCard/ScanProgressCard.tsx
@@ -34,7 +34,7 @@ export default function ScanProgressCard() {
         size="sm"
         onClick={onCancel}
         disabled={isCancelling}
-        className="rounded-lg [&_svg]:size-3.5"
+        className="[&_svg]:size-3.5"
       >
         {isCancelling ? <Loader2 className="animate-spin" /> : <Ban />}
         {cancelLabel}

--- a/apps/web/src/components/library/ViewModeButton/ViewModeButton.hooks.ts
+++ b/apps/web/src/components/library/ViewModeButton/ViewModeButton.hooks.ts
@@ -4,7 +4,7 @@ import type { IViewModeButtonProps, IViewModeButtonView } from './ViewModeButton
 export function useViewModeButton({ active }: IViewModeButtonProps): IViewModeButtonView {
   return {
     className: cn(
-      'p-2 rounded-lg transition-colors',
+      'focus-ring p-2 rounded-lg transition-colors',
       active ? 'bg-primary/15 text-primary' : 'text-muted-foreground/50 hover:text-foreground'
     ),
   };

--- a/apps/web/src/components/onboarding/steps/FoldersStep/FoldersStep.tsx
+++ b/apps/web/src/components/onboarding/steps/FoldersStep/FoldersStep.tsx
@@ -78,7 +78,7 @@ export default function FoldersStep() {
             onClick={onAddFolder}
             disabled={addDisabled}
             aria-label={t('folders.addFolder')}
-            className="h-auto w-full rounded-xl border-dashed border-border/40 bg-transparent py-2.5 text-primary shadow-none hover:border-primary/30 hover:bg-primary/10 hover:text-primary"
+            className="h-auto w-full border-dashed border-border/40 bg-transparent py-2.5 text-primary shadow-none hover:border-primary/30 hover:bg-primary/10 hover:text-primary"
           >
             {isScanning ? <Loader2 className="animate-spin" /> : <Plus />}
             {isScanning ? t('folders.scanning') : t('folders.addFolder')}

--- a/apps/web/src/components/onboarding/steps/ToolsStep/ToolsStep.tsx
+++ b/apps/web/src/components/onboarding/steps/ToolsStep/ToolsStep.tsx
@@ -58,7 +58,7 @@ export default function ToolsStep() {
           <ToolsInstaller affordance={installAffordance} installLabel={t('tools.installAll')} />
         ) : (
           <div className="flex items-start gap-2.5 rounded-xl border border-primary/25 bg-primary/[0.06] px-3 py-2.5">
-            <Check aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-green-400" />
+            <Check aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-success" />
             <p className="text-sm leading-snug text-foreground">{t('tools.allSet')}</p>
           </div>
         )}

--- a/apps/web/src/components/onboarding/steps/ToolsStep/ToolsStep.tsx
+++ b/apps/web/src/components/onboarding/steps/ToolsStep/ToolsStep.tsx
@@ -111,11 +111,7 @@ function ToolsInstaller({
     );
   }
   return (
-    <Button
-      type="button"
-      onClick={affordance.onInstall}
-      className="w-full rounded-xl [&_svg]:size-3.5"
-    >
+    <Button type="button" onClick={affordance.onInstall} className="w-full [&_svg]:size-3.5">
       <ArrowDownToLine />
       {installLabel}
     </Button>

--- a/apps/web/src/components/overview/RecommendationsShelf/RecommendationsShelf.tsx
+++ b/apps/web/src/components/overview/RecommendationsShelf/RecommendationsShelf.tsx
@@ -171,7 +171,7 @@ function DiscoverRow({
     subtitleClass = 'truncate text-xs text-primary/70';
   } else if (isDone) {
     subtitleText = t('addedToLibrary');
-    subtitleClass = 'truncate text-xs text-emerald-400/80';
+    subtitleClass = 'truncate text-xs text-success/80';
   } else if (isError) {
     subtitleText = t('downloadError');
     subtitleClass = 'truncate text-xs text-destructive/80';
@@ -183,7 +183,7 @@ function DiscoverRow({
   let cardExtra = '';
   if (isDownloading) cardExtra = 'bg-primary/[0.04]';
   if (isDone)
-    cardExtra = 'border-emerald-400/15 motion-safe:transition-colors motion-safe:duration-200';
+    cardExtra = 'border-success/15 motion-safe:transition-colors motion-safe:duration-200';
 
   const previewAriaLabel = isPreviewing
     ? t('pausePreviewAria', { title: item.title })

--- a/apps/web/src/components/overview/StatTile/StatTile.hooks.ts
+++ b/apps/web/src/components/overview/StatTile/StatTile.hooks.ts
@@ -1,7 +1,7 @@
 import type { IStatTileProps, IStatTileView, StatTrendDirection } from './StatTile.types';
 
 function hintClassFor(trend: StatTrendDirection): string {
-  if (trend === 'up') return 'text-emerald-400/90';
+  if (trend === 'up') return 'text-success/90';
   if (trend === 'down') return 'text-muted-foreground/70';
   return 'text-muted-foreground/55';
 }

--- a/apps/web/src/components/overview/StatTile/StatTile.stories.tsx
+++ b/apps/web/src/components/overview/StatTile/StatTile.stories.tsx
@@ -60,7 +60,7 @@ export const TrendUp: Story = {
     const canvas = within(canvasElement);
     const hint = canvas.getByText('+2h 18m vs. last week');
     await expect(hint).toBeInTheDocument();
-    await expect(hint).toHaveClass('text-emerald-400/90');
+    await expect(hint).toHaveClass('text-success/90');
   },
 };
 
@@ -77,6 +77,6 @@ export const TrendDown: Story = {
     const canvas = within(canvasElement);
     const hint = canvas.getByText('−45m vs. last week');
     await expect(hint).toBeInTheDocument();
-    await expect(hint).not.toHaveClass('text-emerald-400/90');
+    await expect(hint).not.toHaveClass('text-success/90');
   },
 };

--- a/apps/web/src/components/overview/StatTile/StatTile.test.tsx
+++ b/apps/web/src/components/overview/StatTile/StatTile.test.tsx
@@ -29,6 +29,6 @@ describe('StatTile', () => {
     );
 
     const hint = screen.getByText('+2h 18m vs. last week');
-    expect(hint).toHaveClass('text-emerald-400/90');
+    expect(hint).toHaveClass('text-success/90');
   });
 });

--- a/apps/web/src/components/player/EqualizerPanel/EqualizerPanel.tsx
+++ b/apps/web/src/components/player/EqualizerPanel/EqualizerPanel.tsx
@@ -209,7 +209,7 @@ export default function EqualizerPanel(props: IEqualizerPanelProps) {
         <button
           type="button"
           onClick={onReset}
-          className="text-xs px-3 py-1.5 rounded-lg text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+          className="focus-ring text-xs px-3 py-1.5 rounded-lg text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
         >
           {t('reset')}
         </button>

--- a/apps/web/src/components/player/PlayerBar/PlayerBar.tsx
+++ b/apps/web/src/components/player/PlayerBar/PlayerBar.tsx
@@ -127,8 +127,8 @@ export default function PlayerBar() {
                 <div className="flex items-center gap-2 min-w-0">
                   <p className="text-sm font-medium text-foreground truncate">{titleText}</p>
                   {isRadioTrack(currentTrack.filePath) && (
-                    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-red-500/15 text-red-400 text-[9px] font-semibold uppercase tracking-wider shrink-0">
-                      <span className="w-1.5 h-1.5 rounded-full bg-red-400 animate-pulse" />
+                    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-destructive/15 text-destructive text-[9px] font-semibold uppercase tracking-wider shrink-0">
+                      <span className="w-1.5 h-1.5 rounded-full bg-destructive animate-pulse" />
                       {t('live')}
                     </span>
                   )}

--- a/apps/web/src/components/player/QueuePanel/QueuePanel.tsx
+++ b/apps/web/src/components/player/QueuePanel/QueuePanel.tsx
@@ -49,7 +49,7 @@ export default function QueuePanel(props: IQueuePanelProps) {
           {hasQueue && (
             <button
               onClick={onClear}
-              className="flex items-center gap-1 text-[10px] font-medium text-muted-foreground/40 hover:text-destructive transition-colors"
+              className="focus-ring rounded-sm flex items-center gap-1 text-[10px] font-medium text-muted-foreground/40 hover:text-destructive transition-colors"
             >
               <Trash2 className="w-3 h-3" />
               {t('clear')}

--- a/apps/web/src/components/player/QueueRow/QueueRow.tsx
+++ b/apps/web/src/components/player/QueueRow/QueueRow.tsx
@@ -83,7 +83,7 @@ export default function SortableQueueRow(props: ISortableQueueRowProps) {
       onClick={onPlay}
     >
       <button
-        className="shrink-0 p-0.5 rounded text-muted-foreground/20 opacity-0 group-hover:opacity-100 hover:text-muted-foreground/60 transition-all duration-150 cursor-grab active:cursor-grabbing touch-none"
+        className="focus-ring shrink-0 p-0.5 rounded text-muted-foreground/20 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-muted-foreground/60 transition-all duration-150 cursor-grab active:cursor-grabbing touch-none"
         aria-label={labels.dragToReorder}
         {...attributes}
         {...listeners}

--- a/apps/web/src/components/player/SleepTimer/SleepTimer.tsx
+++ b/apps/web/src/components/player/SleepTimer/SleepTimer.tsx
@@ -132,7 +132,9 @@ export default function SleepTimer() {
                 aria-label={t('customLabel')}
                 className="h-8 rounded-lg bg-accent/40 border-border/50 px-2.5 placeholder:text-muted-foreground/50 focus-visible:ring-primary/40"
               />
-              {customError && <p className="text-[10px] text-red-400 px-1">{t('customError')}</p>}
+              {customError && (
+                <p className="text-[10px] text-destructive px-1">{t('customError')}</p>
+              )}
               <div className="flex gap-1.5">
                 <button
                   onClick={onCustomSubmit}
@@ -153,7 +155,7 @@ export default function SleepTimer() {
           {isActive && (
             <button
               onClick={onCancel}
-              className="w-full text-left px-2.5 py-1.5 rounded-lg text-sm text-red-400 hover:bg-red-500/10 transition-colors"
+              className="w-full text-left px-2.5 py-1.5 rounded-lg text-sm text-destructive hover:bg-destructive/10 transition-colors"
             >
               {t('cancelTimer')}
             </button>

--- a/apps/web/src/components/player/SleepTimer/SleepTimer.tsx
+++ b/apps/web/src/components/player/SleepTimer/SleepTimer.tsx
@@ -38,7 +38,7 @@ export default function SleepTimer() {
       key={minutes}
       onClick={() => onSelectPreset(minutes)}
       className={cn(
-        'w-full text-left px-2.5 py-1.5 rounded-lg text-sm transition-colors',
+        'focus-ring w-full text-left px-2.5 py-1.5 rounded-lg text-sm transition-colors',
         'hover:bg-accent/50 hover:text-foreground',
         'text-muted-foreground'
       )}
@@ -88,7 +88,7 @@ export default function SleepTimer() {
               <button
                 onClick={onShowCustom}
                 className={cn(
-                  'w-full text-left px-2.5 py-1.5 rounded-lg text-sm transition-colors',
+                  'focus-ring w-full text-left px-2.5 py-1.5 rounded-lg text-sm transition-colors',
                   'hover:bg-accent/50 hover:text-foreground',
                   'text-muted-foreground'
                 )}
@@ -101,7 +101,7 @@ export default function SleepTimer() {
               <button
                 onClick={onSelectWindDown}
                 className={cn(
-                  'w-full text-left px-2.5 py-1.5 rounded-lg transition-colors',
+                  'focus-ring w-full text-left px-2.5 py-1.5 rounded-lg transition-colors',
                   'hover:bg-accent/50',
                   'text-muted-foreground hover:text-foreground'
                 )}
@@ -138,13 +138,13 @@ export default function SleepTimer() {
               <div className="flex gap-1.5">
                 <button
                   onClick={onCustomSubmit}
-                  className="flex-1 px-2.5 py-1.5 rounded-lg text-sm bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+                  className="focus-ring flex-1 px-2.5 py-1.5 rounded-lg text-sm bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
                 >
                   {t('customStart')}
                 </button>
                 <button
                   onClick={onShowPresets}
-                  className="flex-1 px-2.5 py-1.5 rounded-lg text-sm text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+                  className="focus-ring flex-1 px-2.5 py-1.5 rounded-lg text-sm text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
                 >
                   {t('customBack')}
                 </button>
@@ -155,7 +155,7 @@ export default function SleepTimer() {
           {isActive && (
             <button
               onClick={onCancel}
-              className="w-full text-left px-2.5 py-1.5 rounded-lg text-sm text-destructive hover:bg-destructive/10 transition-colors"
+              className="focus-ring w-full text-left px-2.5 py-1.5 rounded-lg text-sm text-destructive hover:bg-destructive/10 transition-colors"
             >
               {t('cancelTimer')}
             </button>

--- a/apps/web/src/components/player/VolumeControl/VolumeControl.tsx
+++ b/apps/web/src/components/player/VolumeControl/VolumeControl.tsx
@@ -33,7 +33,7 @@ function VolumeControl({ sliderClassName = 'w-24' }: IVolumeControlProps) {
         <TooltipTrigger asChild>
           <button
             onClick={onToggleMute}
-            className="w-8 h-8 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
+            className="focus-ring rounded-md w-8 h-8 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
             aria-label={buttonLabel}
           >
             <VolumeIcon className="w-4 h-4" />

--- a/apps/web/src/components/playlist-import/PlaylistImportView/PlaylistImportView.tsx
+++ b/apps/web/src/components/playlist-import/PlaylistImportView/PlaylistImportView.tsx
@@ -46,12 +46,7 @@ export default function PlaylistImportView() {
               <Loader2 className="w-4 h-4 text-muted-foreground animate-spin" />
             )}
             {view.showExtractButton && (
-              <Button
-                size="sm"
-                onClick={view.handleExtract}
-                disabled={view.extractDisabled}
-                className="rounded-lg"
-              >
+              <Button size="sm" onClick={view.handleExtract} disabled={view.extractDisabled}>
                 {view.t('extract')}
               </Button>
             )}
@@ -95,7 +90,7 @@ export default function PlaylistImportView() {
         {view.hasResults && (
           <div className="mt-3 max-w-2xl flex items-center gap-3">
             {view.showDownloadButton && (
-              <Button onClick={view.onDownloadClick} className="rounded-xl">
+              <Button onClick={view.onDownloadClick}>
                 <Download />
                 {view.hasSelection
                   ? view.t('downloadSelected', { count: view.selectedPendingCount })
@@ -105,7 +100,7 @@ export default function PlaylistImportView() {
             {view.showCancelButton && (
               <Button
                 onClick={view.handleCancel}
-                className="rounded-xl bg-destructive/10 text-destructive shadow-none hover:bg-destructive/20 hover:text-destructive"
+                className="bg-destructive/10 text-destructive shadow-none hover:bg-destructive/20 hover:text-destructive"
               >
                 <X />
                 {view.t('cancel')}
@@ -126,7 +121,7 @@ export default function PlaylistImportView() {
               variant="ghost"
               size="sm"
               onClick={view.handleReset}
-              className="rounded-xl text-muted-foreground"
+              className="text-muted-foreground"
               title={view.t('startOver')}
             >
               {view.t('newImport')}

--- a/apps/web/src/components/playlist-import/PlaylistRow/PlaylistRow.hooks.ts
+++ b/apps/web/src/components/playlist-import/PlaylistRow/PlaylistRow.hooks.ts
@@ -63,7 +63,7 @@ export function usePlaylistRow(props: RowComponentProps<IPlaylistRowProps>): IPl
   const errorSuffix = status === 'error' && track?.error ? `: ${track.error}` : '';
 
   const statusBadgeClass = cn(
-    status === 'done' && 'text-green-400',
+    status === 'done' && 'text-success',
     status === 'error' && 'text-destructive',
     status === 'skipped' && 'text-muted-foreground/50',
     isActive && 'text-primary'

--- a/apps/web/src/components/playlist-import/PlaylistRow/PlaylistRow.tsx
+++ b/apps/web/src/components/playlist-import/PlaylistRow/PlaylistRow.tsx
@@ -104,7 +104,7 @@ export default function PlaylistRow(props: RowComponentProps<IPlaylistRowProps>)
             <p className="text-xs text-muted-foreground truncate">{result.uploader}</p>
             {isLowConfidence && (
               <span
-                className="flex items-center gap-1 text-[10px] font-medium text-amber-500 shrink-0"
+                className="flex items-center gap-1 text-[10px] font-medium text-warning shrink-0"
                 title={lowConfidenceHint}
               >
                 <AlertTriangle className="w-3 h-3" />

--- a/apps/web/src/components/playlist-import/PlaylistRow/PlaylistRow.tsx
+++ b/apps/web/src/components/playlist-import/PlaylistRow/PlaylistRow.tsx
@@ -140,7 +140,7 @@ export default function PlaylistRow(props: RowComponentProps<IPlaylistRowProps>)
               event.stopPropagation();
               onRemove();
             }}
-            className="shrink-0 relative z-10 w-7 h-7 rounded-lg flex items-center justify-center text-muted-foreground/30 hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100"
+            className="focus-ring shrink-0 relative z-10 w-7 h-7 rounded-lg flex items-center justify-center text-muted-foreground/30 hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
             title={removeLabel}
             aria-label={removeLabel}
           >

--- a/apps/web/src/components/playlists/PlaylistDetailHeader/PlaylistDetailHeader.tsx
+++ b/apps/web/src/components/playlists/PlaylistDetailHeader/PlaylistDetailHeader.tsx
@@ -110,13 +110,13 @@ export default function PlaylistDetailHeader(props: IPlaylistDetailHeaderProps) 
                 <div className="flex items-center gap-2">
                   <button
                     onClick={onDelete}
-                    className="flex-1 px-2 py-1 rounded-lg text-xs font-medium bg-destructive/15 text-destructive hover:bg-destructive/25 transition-colors"
+                    className="focus-ring flex-1 px-2 py-1 rounded-lg text-xs font-medium bg-destructive/15 text-destructive hover:bg-destructive/25 transition-colors"
                   >
                     {tCommon('delete')}
                   </button>
                   <button
                     onClick={() => setShowDeleteConfirm(false)}
-                    className="flex-1 px-2 py-1 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                    className="focus-ring flex-1 px-2 py-1 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
                   >
                     {tCommon('cancel')}
                   </button>
@@ -132,7 +132,7 @@ export default function PlaylistDetailHeader(props: IPlaylistDetailHeaderProps) 
         <div ref={coverMenuRef} className="relative shrink-0">
           <button
             onClick={() => setShowCoverMenu(open => !open)}
-            className="group/cover relative w-16 h-16 rounded-xl bg-surface border border-border/30 flex items-center justify-center overflow-hidden"
+            className="focus-ring group/cover relative w-16 h-16 rounded-xl bg-surface border border-border/30 flex items-center justify-center overflow-hidden"
             disabled={isUpdatingCover}
             title={t('editCover')}
           >
@@ -176,7 +176,7 @@ export default function PlaylistDetailHeader(props: IPlaylistDetailHeaderProps) 
               >
                 <button
                   onClick={handlePickCustomCover}
-                  className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
+                  className="focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
                 >
                   <ImagePlus className="w-4 h-4 text-muted-foreground/60" />
                   {t('uploadCustomImage')}
@@ -185,7 +185,7 @@ export default function PlaylistDetailHeader(props: IPlaylistDetailHeaderProps) 
                 {suggestedCoverArt && (
                   <button
                     onClick={handleUseSuggestedCover}
-                    className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
+                    className="focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
                   >
                     <Sparkles className="w-4 h-4 text-muted-foreground/60" />
                     {t('useTrackArtwork')}
@@ -195,7 +195,7 @@ export default function PlaylistDetailHeader(props: IPlaylistDetailHeaderProps) 
                 {playlist.coverArt && (
                   <button
                     onClick={handleClearCover}
-                    className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left text-destructive hover:bg-destructive/10 transition-colors"
+                    className="focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left text-destructive hover:bg-destructive/10 transition-colors"
                   >
                     <XCircle className="w-4 h-4" />
                     {t('removeCover')}
@@ -219,7 +219,7 @@ export default function PlaylistDetailHeader(props: IPlaylistDetailHeaderProps) 
           ) : (
             <button
               onClick={onStartEdit}
-              className="font-display text-lg font-semibold text-foreground truncate block text-left hover:text-primary transition-colors"
+              className="focus-ring rounded-sm font-display text-lg font-semibold text-foreground truncate block text-left hover:text-primary transition-colors"
               title={t('clickToRename')}
             >
               {playlist.name}

--- a/apps/web/src/components/playlists/PlaylistDetailView/PlaylistDetailView.tsx
+++ b/apps/web/src/components/playlists/PlaylistDetailView/PlaylistDetailView.tsx
@@ -75,7 +75,10 @@ export default function PlaylistDetailView() {
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-4 text-center px-6">
         <p className="text-sm text-muted-foreground">{t('notFound')}</p>
-        <button onClick={onBack} className="text-xs text-primary hover:underline">
+        <button
+          onClick={onBack}
+          className="focus-ring rounded-sm text-xs text-primary hover:underline"
+        >
           {t('goBack')}
         </button>
       </div>

--- a/apps/web/src/components/playlists/PlaylistsView/PlaylistsView.tsx
+++ b/apps/web/src/components/playlists/PlaylistsView/PlaylistsView.tsx
@@ -143,7 +143,7 @@ export default function PlaylistsView() {
                 size="sm"
                 onClick={onCreate}
                 disabled={!canCreate}
-                className="h-7 rounded-lg bg-primary/20 px-3 text-primary shadow-none hover:bg-primary/30 [&_svg]:size-3.5"
+                className="h-7 bg-primary/20 px-3 text-primary shadow-none hover:bg-primary/30 [&_svg]:size-3.5"
               >
                 {isCreating && <Loader2 className="animate-spin" />}
                 {isCreating ? t('creating') : t('create')}
@@ -152,7 +152,7 @@ export default function PlaylistsView() {
                 variant="ghost"
                 size="sm"
                 onClick={closeNewForm}
-                className="h-7 rounded-lg px-2 text-muted-foreground"
+                className="h-7 px-2 text-muted-foreground"
               >
                 {tCommon('cancel')}
               </Button>

--- a/apps/web/src/components/radio/RadioView/RadioView.tsx
+++ b/apps/web/src/components/radio/RadioView/RadioView.tsx
@@ -218,13 +218,7 @@ export default function RadioView() {
         </div>
         {showLoadMore && (
           <div className="shrink-0 flex justify-center">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={isLoadingMore}
-              onClick={onLoadMore}
-              className="rounded-xl"
-            >
+            <Button variant="outline" size="sm" disabled={isLoadingMore} onClick={onLoadMore}>
               {isLoadingMore && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
               {t('loadMore')}
             </Button>

--- a/apps/web/src/components/radio/RadioView/RadioView.tsx
+++ b/apps/web/src/components/radio/RadioView/RadioView.tsx
@@ -359,7 +359,7 @@ export default function RadioView() {
             {showClearAll && (
               <button
                 onClick={onClearAll}
-                className="text-xs font-medium text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+                className="focus-ring rounded-sm text-xs font-medium text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
               >
                 {t('clearFilters')}
               </button>

--- a/apps/web/src/components/search/DependencyInstallCard/DependencyInstallCard.tsx
+++ b/apps/web/src/components/search/DependencyInstallCard/DependencyInstallCard.tsx
@@ -30,7 +30,7 @@ export default function DependencyInstallCard(props: IDependencyInstallCardProps
         )}
 
         {showSuccess && (
-          <div className="flex items-center justify-center gap-2 text-green-400">
+          <div className="flex items-center justify-center gap-2 text-success">
             <Check className="w-4 h-4" />
             <p className="text-sm font-medium">{installedLabel}</p>
           </div>

--- a/apps/web/src/components/search/DependencyInstallCard/DependencyInstallCard.tsx
+++ b/apps/web/src/components/search/DependencyInstallCard/DependencyInstallCard.tsx
@@ -38,7 +38,7 @@ export default function DependencyInstallCard(props: IDependencyInstallCardProps
 
         {showInstallButton && (
           <>
-            <Button onClick={onInstall} className="h-auto w-full rounded-xl py-2.5">
+            <Button onClick={onInstall} className="h-auto w-full py-2.5">
               <ArrowDownToLine />
               {installButtonLabel}
             </Button>

--- a/apps/web/src/components/search/SearchResultRow/SearchResultRow.tsx
+++ b/apps/web/src/components/search/SearchResultRow/SearchResultRow.tsx
@@ -39,7 +39,7 @@ export default function SearchResultRow(props: ISearchResultRowProps) {
         isDownloading
           ? 'bg-primary/[0.04]'
           : isDone
-            ? 'border border-emerald-400/15'
+            ? 'border border-success/15'
             : 'hover:bg-accent/50'
       )}
     >
@@ -82,7 +82,7 @@ export default function SearchResultRow(props: ISearchResultRowProps) {
         {isDownloading ? (
           <p className="text-xs text-primary/70 truncate mt-0.5">{downloadingLabel}</p>
         ) : isDone ? (
-          <p className="text-xs text-emerald-400/80 truncate mt-0.5">{addedLabel}</p>
+          <p className="text-xs text-success/80 truncate mt-0.5">{addedLabel}</p>
         ) : isError ? (
           <p className="text-xs text-destructive/80 truncate mt-0.5">{errorLabel}</p>
         ) : (

--- a/apps/web/src/components/search/SearchResultRow/SearchResultRow.tsx
+++ b/apps/web/src/components/search/SearchResultRow/SearchResultRow.tsx
@@ -45,7 +45,7 @@ export default function SearchResultRow(props: ISearchResultRowProps) {
     >
       <button
         onClick={onPreviewClick}
-        className="w-11 h-11 rounded-lg overflow-hidden bg-muted shrink-0 relative z-10 group/thumb"
+        className="focus-ring w-11 h-11 rounded-lg overflow-hidden bg-muted shrink-0 relative z-10 group/thumb"
         title={previewLabel}
         aria-label={previewLabel}
       >

--- a/apps/web/src/components/search/SearchView/SearchView.tsx
+++ b/apps/web/src/components/search/SearchView/SearchView.tsx
@@ -115,7 +115,7 @@ export default function SearchView() {
               <button
                 type="button"
                 onClick={onClearQuery}
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 w-6 h-6 rounded-md flex items-center justify-center text-muted-foreground/50 hover:text-foreground hover:bg-accent transition-colors"
+                className="focus-ring absolute right-2.5 top-1/2 -translate-y-1/2 w-6 h-6 rounded-md flex items-center justify-center text-muted-foreground/50 hover:text-foreground hover:bg-accent transition-colors"
               >
                 <X className="w-3.5 h-3.5" />
               </button>

--- a/apps/web/src/components/settings/AppearanceSection/AppearanceSection.tsx
+++ b/apps/web/src/components/settings/AppearanceSection/AppearanceSection.tsx
@@ -68,7 +68,7 @@ export default function AppearanceSection() {
       key={lang.code}
       onClick={() => onSelectLanguage(lang.code)}
       className={cn(
-        'px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
+        'focus-ring px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
         lang.isActive
           ? 'bg-primary/15 text-primary border border-primary/40'
           : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground border border-transparent'
@@ -83,7 +83,7 @@ export default function AppearanceSection() {
       key={preset.value}
       onClick={() => onSetUiScale(preset.value)}
       className={cn(
-        'px-2 py-1 rounded-md text-xs font-medium transition-colors',
+        'focus-ring px-2 py-1 rounded-md text-xs font-medium transition-colors',
         preset.isActive
           ? 'bg-primary/15 text-primary border border-primary/40'
           : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground border border-transparent'
@@ -116,8 +116,7 @@ export default function AppearanceSection() {
       tabIndex={bgFit === option ? 0 : -1}
       onClick={() => onSetBgFit(option)}
       className={cn(
-        'rounded-lg border px-2.5 py-1.5 text-xs font-medium transition-colors',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+        'focus-ring rounded-lg border px-2.5 py-1.5 text-xs font-medium transition-colors',
         bgFit === option
           ? 'border-primary/60 bg-primary/10 text-foreground'
           : 'border-border/50 text-muted-foreground hover:text-foreground'
@@ -161,7 +160,7 @@ export default function AppearanceSection() {
               {isScaleModified && (
                 <button
                   onClick={onResetUiScale}
-                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  className="focus-ring rounded-sm text-xs text-muted-foreground hover:text-foreground transition-colors"
                 >
                   {resetLabel}
                 </button>
@@ -191,7 +190,7 @@ export default function AppearanceSection() {
               aria-disabled={isPickingBackground}
               aria-busy={isPickingBackground}
               aria-describedby="bg-format-hint"
-              className="flex items-center gap-1.5 rounded-lg border border-border/50 px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-disabled:pointer-events-none aria-disabled:opacity-60"
+              className="focus-ring flex items-center gap-1.5 rounded-lg border border-border/50 px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:border-border aria-disabled:pointer-events-none aria-disabled:opacity-60"
             >
               <ImagePlus className="size-3.5" />
               {hasCustomBackground ? t('app.background.replace') : t('app.background.choose')}
@@ -200,7 +199,7 @@ export default function AppearanceSection() {
               <button
                 type="button"
                 onClick={onClearBackground}
-                className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="focus-ring flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
               >
                 <Trash2 className="size-3.5" />
                 {t('app.background.remove')}
@@ -218,7 +217,7 @@ export default function AppearanceSection() {
             <button
               type="button"
               onClick={onRetryCustomBackground}
-              className="rounded-lg px-2 py-1 text-[11px] font-medium text-foreground underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="focus-ring rounded-lg px-2 py-1 text-[11px] font-medium text-foreground underline-offset-2 hover:underline"
             >
               {t('app.background.retry')}
             </button>
@@ -232,7 +231,7 @@ export default function AppearanceSection() {
               {isBgModified && (
                 <button
                   onClick={onResetBg}
-                  className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  className="focus-ring rounded-sm flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
                   aria-label={t('app.bgAdjust.reset')}
                 >
                   <RotateCcw className="size-3" />
@@ -330,7 +329,7 @@ export default function AppearanceSection() {
           hasAccentOverride ? (
             <button
               onClick={onResetAccent}
-              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              className="focus-ring rounded-sm flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
               aria-label={t('app.accent.reset')}
             >
               <RotateCcw className="size-3" />

--- a/apps/web/src/components/settings/CompactSection/CompactSection.tsx
+++ b/apps/web/src/components/settings/CompactSection/CompactSection.tsx
@@ -44,7 +44,7 @@ function PresetControl<T extends string>({
       key={option.value}
       onClick={() => onChange(option.value)}
       className={cn(
-        'rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+        'focus-ring rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
         option.isActive
           ? 'border border-primary/40 bg-primary/15 text-primary'
           : 'border border-transparent text-muted-foreground hover:bg-accent/50 hover:text-foreground'
@@ -178,7 +178,7 @@ export default function CompactSection() {
           <div className="px-3">
             <button
               onClick={onReset}
-              className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+              className="focus-ring rounded-sm text-xs text-muted-foreground transition-colors hover:text-foreground"
             >
               {resetLabel}
             </button>

--- a/apps/web/src/components/settings/DiscordSection/DiscordSection.tsx
+++ b/apps/web/src/components/settings/DiscordSection/DiscordSection.tsx
@@ -39,7 +39,7 @@ export default function DiscordSection() {
       onClick={() => onSelectActivity(chip.value)}
       aria-pressed={chip.isActive}
       className={cn(
-        'rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors',
+        'focus-ring rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors',
         chip.isActive
           ? 'bg-sky-500/20 text-sky-600 dark:text-sky-400'
           : 'bg-muted/40 text-muted-foreground hover:bg-muted/60'

--- a/apps/web/src/components/settings/DiskUsageSection/DiskUsageSection.tsx
+++ b/apps/web/src/components/settings/DiskUsageSection/DiskUsageSection.tsx
@@ -71,12 +71,7 @@ export default function DiskUsageSection() {
             <AlertTriangle className="w-4 h-4 text-destructive shrink-0" aria-hidden="true" />
             <span>{t('diskUsage.error')}</span>
           </div>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={onRefresh}
-            className="rounded-lg [&_svg]:size-3.5"
-          >
+          <Button variant="secondary" size="sm" onClick={onRefresh} className="[&_svg]:size-3.5">
             <RefreshCw />
             {t('diskUsage.retry')}
           </Button>

--- a/apps/web/src/components/settings/EnrichConfidenceBadge/EnrichConfidenceBadge.hooks.ts
+++ b/apps/web/src/components/settings/EnrichConfidenceBadge/EnrichConfidenceBadge.hooks.ts
@@ -7,8 +7,8 @@ import type {
 
 // Token-backed colors — High = success green, Med = warning amber, Low = danger red.
 const LEVEL_CLASSES: Record<ConfidenceLevel, string> = {
-  high: 'bg-[rgba(var(--status-success-rgb),0.12)] text-emerald-300 border-emerald-400/25',
-  med: 'bg-[rgba(var(--status-warning-rgb),0.12)] text-amber-300 border-amber-400/25',
+  high: 'bg-success/10 text-success border-success/25',
+  med: 'bg-warning/10 text-warning border-warning/25',
   low: 'bg-destructive/10 text-destructive border-destructive/25',
 };
 

--- a/apps/web/src/components/settings/EnrichLastRunPanel/EnrichLastRunPanel.tsx
+++ b/apps/web/src/components/settings/EnrichLastRunPanel/EnrichLastRunPanel.tsx
@@ -120,7 +120,7 @@ export default function EnrichLastRunPanel() {
         type="button"
         onClick={onToggle}
         aria-expanded={open}
-        className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-foreground hover:bg-accent/30 rounded-xl transition-colors"
+        className="focus-ring flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-foreground hover:bg-accent/30 rounded-xl transition-colors"
       >
         {open ? (
           <ChevronDown className="w-4 h-4 text-muted-foreground shrink-0" aria-hidden="true" />

--- a/apps/web/src/components/settings/EnrichLastRunPanel/EnrichLastRunPanel.tsx
+++ b/apps/web/src/components/settings/EnrichLastRunPanel/EnrichLastRunPanel.tsx
@@ -70,7 +70,7 @@ function RunEntryItem({ entry, t, tDialog }: IRunEntryItemProps) {
     <li className="px-3 py-2.5 space-y-1.5">
       <div className="flex items-center gap-2 min-w-0">
         {hasChanges ? (
-          <Check className="w-3.5 h-3.5 text-green-500 shrink-0" aria-hidden="true" />
+          <Check className="w-3.5 h-3.5 text-success shrink-0" aria-hidden="true" />
         ) : entry.success ? (
           <Check className="w-3.5 h-3.5 text-muted-foreground shrink-0" aria-hidden="true" />
         ) : (

--- a/apps/web/src/components/settings/EnrichProgressBar/EnrichProgressBar.tsx
+++ b/apps/web/src/components/settings/EnrichProgressBar/EnrichProgressBar.tsx
@@ -31,7 +31,7 @@ export default function EnrichProgressBar() {
         {progress.status === 'writing' && t('lib.enrichWriting')}
         {progress.status === 'done' && (
           <span className="flex items-center gap-1.5 min-w-0">
-            <Check className="w-3 h-3 text-green-500 shrink-0" aria-hidden="true" />
+            <Check className="w-3 h-3 text-success shrink-0" aria-hidden="true" />
             <span className="truncate">{progress.trackName}</span>
             <EnrichConfidenceBadge confidence={progress.confidence} />
           </span>

--- a/apps/web/src/components/settings/EqualizerSection/EqualizerSection.tsx
+++ b/apps/web/src/components/settings/EqualizerSection/EqualizerSection.tsx
@@ -112,7 +112,7 @@ export default function EqualizerSection() {
       type="button"
       onClick={() => onApplyPreset(tile.id)}
       className={cn(
-        'px-3 py-2 rounded-lg border text-center text-xs font-medium transition-all',
+        'focus-ring px-3 py-2 rounded-lg border text-center text-xs font-medium transition-all',
         tile.selected
           ? 'border-primary/40 bg-primary/10 text-foreground'
           : 'border-border/30 text-muted-foreground hover:border-border/50 hover:bg-accent/30 hover:text-foreground/80'
@@ -219,7 +219,7 @@ export default function EqualizerSection() {
           <button
             type="button"
             onClick={onReset}
-            className="text-xs px-3 py-1.5 rounded-lg border border-border/30 text-muted-foreground hover:bg-accent/50 hover:text-foreground hover:border-border/50 transition-colors"
+            className="focus-ring text-xs px-3 py-1.5 rounded-lg border border-border/30 text-muted-foreground hover:bg-accent/50 hover:text-foreground hover:border-border/50 transition-colors"
           >
             {resetLabel}
           </button>

--- a/apps/web/src/components/settings/InterfaceSection/InterfaceSection.tsx
+++ b/apps/web/src/components/settings/InterfaceSection/InterfaceSection.tsx
@@ -87,7 +87,7 @@ export default function InterfaceSection() {
           isModified ? (
             <button
               onClick={onResetInterface}
-              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              className="focus-ring rounded-sm flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
               aria-label={t('app.interface.reset')}
             >
               <RotateCcw className="size-3" />

--- a/apps/web/src/components/settings/LibraryAnalysisCard/LibraryAnalysisCard.tsx
+++ b/apps/web/src/components/settings/LibraryAnalysisCard/LibraryAnalysisCard.tsx
@@ -32,7 +32,7 @@ export default function LibraryAnalysisCard() {
           <div
             className={cn(
               'flex items-center gap-2',
-              allAnalyzed ? 'text-emerald-300' : 'text-muted-foreground'
+              allAnalyzed ? 'text-success' : 'text-muted-foreground'
             )}
           >
             {allAnalyzed && <CheckCircle2 className="w-4 h-4 shrink-0" />}

--- a/apps/web/src/components/settings/LibraryDoctorCard/LibraryDoctorCard.tsx
+++ b/apps/web/src/components/settings/LibraryDoctorCard/LibraryDoctorCard.tsx
@@ -7,7 +7,7 @@ import { useLibraryDoctorCard } from './LibraryDoctorCard.hooks';
 
 const SEVERITY_DOT: Record<DoctorSeverity, string> = {
   error: 'bg-destructive',
-  warning: 'bg-amber-400',
+  warning: 'bg-warning',
   info: 'bg-muted-foreground/60',
 };
 
@@ -80,7 +80,7 @@ export default function LibraryDoctorCard() {
           <div
             className={cn(
               'flex items-center gap-2 px-3 py-2.5 rounded-xl bg-background/50 border border-border/20',
-              allHealthy && 'text-emerald-300'
+              allHealthy && 'text-success'
             )}
           >
             {allHealthy && <CheckCircle2 className="w-4 h-4 shrink-0" />}

--- a/apps/web/src/components/settings/LibrarySection/LibrarySection.tsx
+++ b/apps/web/src/components/settings/LibrarySection/LibrarySection.tsx
@@ -61,7 +61,7 @@ export default function LibrarySection() {
               variant="secondary"
               onClick={onRescan}
               disabled={isRescanDisabled}
-              className="rounded-xl [&_svg]:size-3.5"
+              className="[&_svg]:size-3.5"
             >
               {isScanning ? <Loader2 className="animate-spin" /> : <RefreshCw />}
               {isScanning ? t('lib.scanning') : t('lib.rescan')}
@@ -89,7 +89,7 @@ export default function LibrarySection() {
               variant="secondary"
               onClick={onExport}
               disabled={isBackupBusy}
-              className="rounded-xl [&_svg]:size-3.5"
+              className="[&_svg]:size-3.5"
             >
               {isBackupBusy ? <Loader2 className="animate-spin" /> : <Download />}
               {t('lib.backupExport')}
@@ -98,7 +98,7 @@ export default function LibrarySection() {
               variant="secondary"
               onClick={onImport}
               disabled={isBackupBusy}
-              className="rounded-xl [&_svg]:size-3.5"
+              className="[&_svg]:size-3.5"
             >
               {isBackupBusy ? <Loader2 className="animate-spin" /> : <Upload />}
               {t('lib.backupImport')}
@@ -118,7 +118,7 @@ export default function LibrarySection() {
             <Button
               variant="destructiveGhost"
               onClick={() => onSetConfirmClear(true)}
-              className="rounded-xl [&_svg]:size-3.5"
+              className="[&_svg]:size-3.5"
             >
               <Trash2 />
               {t('lib.clearLibrary')}
@@ -132,7 +132,7 @@ export default function LibrarySection() {
                   size="sm"
                   onClick={onClearLibrary}
                   disabled={isClearing}
-                  className="gap-2 rounded-lg text-sm [&_svg]:size-3.5"
+                  className="gap-2 text-sm [&_svg]:size-3.5"
                 >
                   {isClearing ? <Loader2 className="animate-spin" /> : <Trash2 />}
                   {isClearing ? t('lib.clearing') : t('lib.yesClear')}
@@ -141,7 +141,7 @@ export default function LibrarySection() {
                   variant="ghost"
                   size="sm"
                   onClick={() => onSetConfirmClear(false)}
-                  className="rounded-lg text-sm text-muted-foreground"
+                  className="text-sm text-muted-foreground"
                 >
                   {tc('cancel')}
                 </Button>

--- a/apps/web/src/components/settings/LowPerformancePreview/LowPerformancePreview.stories.tsx
+++ b/apps/web/src/components/settings/LowPerformancePreview/LowPerformancePreview.stories.tsx
@@ -48,7 +48,7 @@ export const ReducedRendering: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByText('Reduced rendering')).toBeInTheDocument();
-    await expect(canvas.getByText('Reduced')).toHaveClass('bg-amber-500/15');
+    await expect(canvas.getByText('Reduced')).toHaveClass('bg-warning/15');
     await expect(canvasElement.querySelector('.grid')).toHaveClass('opacity-35');
   },
 };

--- a/apps/web/src/components/settings/LowPerformancePreview/LowPerformancePreview.test.tsx
+++ b/apps/web/src/components/settings/LowPerformancePreview/LowPerformancePreview.test.tsx
@@ -37,6 +37,6 @@ describe('LowPerformancePreview', () => {
   it('recolors the badge to amber while the mode is on', () => {
     render(<LowPerformancePreview enabled />);
 
-    expect(screen.getByText('Reduced')).toHaveClass('bg-amber-500/15', 'text-amber-200');
+    expect(screen.getByText('Reduced')).toHaveClass('bg-warning/15', 'text-warning');
   });
 });

--- a/apps/web/src/components/settings/LowPerformancePreview/LowPerformancePreview.tsx
+++ b/apps/web/src/components/settings/LowPerformancePreview/LowPerformancePreview.tsx
@@ -21,13 +21,13 @@ export default function LowPerformancePreview(props: ILowPerformancePreviewProps
         <div className="mx-auto max-w-[340px] rounded-xl border border-border/25 bg-surface/60 p-3">
           <div className="mb-3 flex items-center justify-between">
             <div className="flex items-center gap-2 text-xs text-foreground">
-              <Zap className={cn('size-3.5', enabled ? 'text-amber-300' : 'text-primary')} />
+              <Zap className={cn('size-3.5', enabled ? 'text-warning' : 'text-primary')} />
               <span>{statusLabel}</span>
             </div>
             <div
               className={cn(
                 'rounded-full px-2 py-0.5 text-[10px]',
-                enabled ? 'bg-amber-500/15 text-amber-200' : 'bg-primary/15 text-primary'
+                enabled ? 'bg-warning/15 text-warning' : 'bg-primary/15 text-primary'
               )}
             >
               {badgeLabel}

--- a/apps/web/src/components/settings/LyricsSection/LyricsSection.tsx
+++ b/apps/web/src/components/settings/LyricsSection/LyricsSection.tsx
@@ -153,7 +153,7 @@ export default function LyricsSection() {
           <div className="px-3">
             <button
               onClick={onReset}
-              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              className="focus-ring rounded-sm text-xs text-muted-foreground hover:text-foreground transition-colors"
             >
               {resetLabel}
             </button>
@@ -323,7 +323,7 @@ function FontSizeControl({ title, description, value, onChange }: IFontSizeContr
       aria-checked={value === size}
       onClick={() => onChange(size)}
       className={cn(
-        'px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
+        'focus-ring px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
         value === size
           ? 'bg-primary/15 text-primary border border-primary/40'
           : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground border border-transparent'
@@ -361,7 +361,7 @@ function PresentationControl({ title, description, value, onChange }: IPresentat
       aria-checked={value === presentation}
       onClick={() => onChange(presentation)}
       className={cn(
-        'px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
+        'focus-ring px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
         value === presentation
           ? 'bg-primary/15 text-primary border border-primary/40'
           : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground border border-transparent'

--- a/apps/web/src/components/settings/MetadataEnrichSection/MetadataEnrichSection.tsx
+++ b/apps/web/src/components/settings/MetadataEnrichSection/MetadataEnrichSection.tsx
@@ -115,11 +115,11 @@ export default function MetadataEnrichSection() {
               aria-labelledby="enrich-confirm-title"
               aria-describedby="enrich-confirm-body"
               onKeyDown={e => e.key === 'Escape' && onDismissConfirm()}
-              className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-3 space-y-3"
+              className="rounded-xl border border-warning/30 bg-warning/5 p-3 space-y-3"
             >
               <div className="flex items-start gap-2">
                 <AlertTriangle
-                  className="w-4 h-4 text-amber-500 mt-0.5 shrink-0"
+                  className="w-4 h-4 text-warning mt-0.5 shrink-0"
                   aria-hidden="true"
                 />
                 <div className="space-y-1">
@@ -136,7 +136,7 @@ export default function MetadataEnrichSection() {
                   ref={confirmYesRef}
                   size="sm"
                   onClick={onConfirmedEnrich}
-                  className="gap-2 rounded-lg bg-amber-500 text-sm text-black shadow-none hover:bg-amber-500/90 [&_svg]:size-3.5"
+                  className="gap-2 rounded-lg bg-warning text-sm text-warning-foreground shadow-none hover:bg-warning/90 [&_svg]:size-3.5"
                 >
                   <Search />
                   {t('lib.enrichYesWrite')}

--- a/apps/web/src/components/settings/MetadataEnrichSection/MetadataEnrichSection.tsx
+++ b/apps/web/src/components/settings/MetadataEnrichSection/MetadataEnrichSection.tsx
@@ -136,7 +136,7 @@ export default function MetadataEnrichSection() {
                   ref={confirmYesRef}
                   size="sm"
                   onClick={onConfirmedEnrich}
-                  className="gap-2 rounded-lg bg-warning text-sm text-warning-foreground shadow-none hover:bg-warning/90 [&_svg]:size-3.5"
+                  className="gap-2 bg-warning text-sm text-warning-foreground shadow-none hover:bg-warning/90 [&_svg]:size-3.5"
                 >
                   <Search />
                   {t('lib.enrichYesWrite')}
@@ -145,7 +145,7 @@ export default function MetadataEnrichSection() {
                   variant="ghost"
                   size="sm"
                   onClick={onDismissConfirm}
-                  className="rounded-lg text-sm text-muted-foreground"
+                  className="text-sm text-muted-foreground"
                 >
                   {tc('cancel')}
                 </Button>
@@ -158,7 +158,7 @@ export default function MetadataEnrichSection() {
                 onClick={onEnrich}
                 disabled={enrichDisabled}
                 aria-busy={isEnriching}
-                className="rounded-xl bg-primary/15 text-primary shadow-none hover:bg-primary/25 [&_svg]:size-3.5"
+                className="bg-primary/15 text-primary shadow-none hover:bg-primary/25 [&_svg]:size-3.5"
               >
                 {isEnriching ? (
                   <Loader2 className="animate-spin" aria-hidden="true" />
@@ -173,7 +173,7 @@ export default function MetadataEnrichSection() {
                   onClick={onCancel}
                   disabled={isCancelling}
                   aria-busy={isCancelling}
-                  className="rounded-xl [&_svg]:size-3.5"
+                  className="[&_svg]:size-3.5"
                 >
                   {isCancelling ? (
                     <Loader2 className="animate-spin" aria-hidden="true" />

--- a/apps/web/src/components/settings/MusicFoldersSection/MusicFoldersSection.tsx
+++ b/apps/web/src/components/settings/MusicFoldersSection/MusicFoldersSection.tsx
@@ -63,7 +63,7 @@ export default function MusicFoldersSection() {
               variant="outline"
               onClick={onAddFolder}
               disabled={isAddDisabled}
-              className="h-auto w-full rounded-xl border-dashed border-border/40 bg-transparent py-2.5 text-primary shadow-none hover:border-primary/30 hover:bg-primary/10 hover:text-primary"
+              className="h-auto w-full border-dashed border-border/40 bg-transparent py-2.5 text-primary shadow-none hover:border-primary/30 hover:bg-primary/10 hover:text-primary"
             >
               {isScanning ? <Loader2 className="animate-spin" /> : <Plus />}
               {isScanning ? t('folders.scanning') : t('folders.addFolder')}

--- a/apps/web/src/components/settings/SanctuarySection/SanctuarySection.tsx
+++ b/apps/web/src/components/settings/SanctuarySection/SanctuarySection.tsx
@@ -36,7 +36,7 @@ export default function SanctuarySection() {
       onClick={() => onSelectVariant(option.value)}
       aria-pressed={option.isActive}
       className={cn(
-        'rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+        'focus-ring rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
         option.isActive
           ? 'border border-primary/40 bg-primary/15 text-primary'
           : 'border border-transparent text-muted-foreground hover:bg-accent/50 hover:text-foreground'

--- a/apps/web/src/components/settings/SettingsCard/SettingsCard.hooks.ts
+++ b/apps/web/src/components/settings/SettingsCard/SettingsCard.hooks.ts
@@ -3,15 +3,15 @@ import type { ISettingsCardProps, ISettingsCardTone } from './SettingsCard.types
 const TONE_TILE: Record<ISettingsCardTone, { bg: string; icon: string }> = {
   default: { bg: 'bg-primary/10', icon: 'text-primary' },
   destructive: { bg: 'bg-destructive/15', icon: 'text-destructive' },
-  warning: { bg: 'bg-amber-500/15', icon: 'text-amber-500' },
-  info: { bg: 'bg-sky-500/15', icon: 'text-sky-500' },
+  warning: { bg: 'bg-warning/15', icon: 'text-warning' },
+  info: { bg: 'bg-info/15', icon: 'text-info' },
 };
 
 const TONE_SURFACE: Record<ISettingsCardTone, string> = {
   default: 'bg-surface/50 border-border/30',
   destructive: 'border-destructive/25 bg-destructive/[0.06]',
-  warning: 'border-amber-500/25 bg-amber-500/[0.05]',
-  info: 'border-sky-500/25 bg-sky-500/[0.04]',
+  warning: 'border-warning/25 bg-warning/5',
+  info: 'border-info/25 bg-info/[0.04]',
 };
 
 const TONE_TITLE: Record<ISettingsCardTone, string> = {

--- a/apps/web/src/components/settings/SubfolderPlaylistDialog/SubfolderPlaylistDialog.tsx
+++ b/apps/web/src/components/settings/SubfolderPlaylistDialog/SubfolderPlaylistDialog.tsx
@@ -78,7 +78,7 @@ export default function SubfolderPlaylistDialog(props: ISubfolderPlaylistDialogP
           {showSelectAll && (
             <button
               onClick={onToggleAll}
-              className="text-xs text-primary hover:text-primary/80 transition-colors px-1 mb-2"
+              className="focus-ring rounded-sm text-xs text-primary hover:text-primary/80 transition-colors px-1 mb-2"
             >
               {allSelected ? t('folders.deselectAll') : t('folders.selectAll')}
             </button>

--- a/apps/web/src/components/settings/UpdatesSection/UpdatesSection.tsx
+++ b/apps/web/src/components/settings/UpdatesSection/UpdatesSection.tsx
@@ -90,7 +90,7 @@ export default function UpdatesSection() {
             )}
           </div>
 
-          <p className={cn('text-xs', isError ? 'text-red-400' : 'text-muted-foreground')}>
+          <p className={cn('text-xs', isError ? 'text-destructive' : 'text-muted-foreground')}>
             {statusMessage}
           </p>
 

--- a/apps/web/src/components/settings/UpdatesSection/UpdatesSection.tsx
+++ b/apps/web/src/components/settings/UpdatesSection/UpdatesSection.tsx
@@ -49,29 +49,21 @@ export default function UpdatesSection() {
               size="sm"
               onClick={onCheckForUpdates}
               disabled={isCheckDisabled}
-              className="gap-1.5 rounded-lg [&_svg]:size-3.5"
+              className="gap-1.5 [&_svg]:size-3.5"
             >
               {isCheckDisabled ? <Loader2 className="animate-spin" /> : <RefreshCcw />}
               {t('upd.check')}
             </Button>
 
             {isUpdateAvailable && (
-              <Button
-                size="sm"
-                onClick={onDownloadUpdate}
-                className="gap-1.5 rounded-lg [&_svg]:size-3.5"
-              >
+              <Button size="sm" onClick={onDownloadUpdate} className="gap-1.5 [&_svg]:size-3.5">
                 <Download />
                 {t('upd.downloadVersion', { version })}
               </Button>
             )}
 
             {isUpdateReady && (
-              <Button
-                size="sm"
-                onClick={onInstallUpdate}
-                className="gap-1.5 rounded-lg [&_svg]:size-3.5"
-              >
+              <Button size="sm" onClick={onInstallUpdate} className="gap-1.5 [&_svg]:size-3.5">
                 <Check />
                 {t('upd.installRestart')}
               </Button>

--- a/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.tsx
+++ b/apps/web/src/components/settings/VisualEffectsSection/VisualEffectsSection.tsx
@@ -74,7 +74,7 @@ export default function VisualEffectsSection() {
       onClick={() => onSelectVinylLabelSource(option.value)}
       aria-pressed={option.isActive}
       className={cn(
-        'rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+        'focus-ring rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
         option.isActive ? CHIP_ACTIVE : CHIP_IDLE
       )}
     >
@@ -88,7 +88,7 @@ export default function VisualEffectsSection() {
       onClick={() => onSelectVinylRingStyle(option.value)}
       aria-pressed={option.isActive}
       className={cn(
-        'rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+        'focus-ring rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
         option.isActive ? CHIP_ACTIVE : CHIP_IDLE
       )}
     >

--- a/apps/web/src/components/settings/downloads/DownloadLocationPanel/DownloadLocationPanel.tsx
+++ b/apps/web/src/components/settings/downloads/DownloadLocationPanel/DownloadLocationPanel.tsx
@@ -37,7 +37,7 @@ export default function DownloadLocationPanel(props: IDownloadLocationPanelProps
           size="sm"
           onClick={onChange}
           disabled={updating}
-          className="gap-2 rounded-lg text-sm [&_svg]:size-3.5"
+          className="gap-2 text-sm [&_svg]:size-3.5"
         >
           {updating ? <Loader2 className="animate-spin" /> : <FolderOpen />}
           {changeLabel}
@@ -50,7 +50,7 @@ export default function DownloadLocationPanel(props: IDownloadLocationPanelProps
             size="sm"
             onClick={onReset}
             disabled={updating}
-            className="rounded-lg text-sm text-muted-foreground"
+            className="text-sm text-muted-foreground"
           >
             {resetLabel}
           </Button>

--- a/apps/web/src/components/settings/downloads/DownloadsSection/DownloadsSection.tsx
+++ b/apps/web/src/components/settings/downloads/DownloadsSection/DownloadsSection.tsx
@@ -38,11 +38,7 @@ export default function DownloadsSection() {
               caption={s.dependencyInstallCaption}
             />
           ) : (
-            <Button
-              type="button"
-              onClick={s.onInstallMissingTools}
-              className="rounded-xl [&_svg]:size-3.5"
-            >
+            <Button type="button" onClick={s.onInstallMissingTools} className="[&_svg]:size-3.5">
               <ArrowDownToLine />
               {s.installMissingLabel}
             </Button>
@@ -99,7 +95,7 @@ export default function DownloadsSection() {
                   type="button"
                   variant="secondary"
                   onClick={s.onInstallYtDlp}
-                  className="rounded-xl [&_svg]:size-3.5"
+                  className="[&_svg]:size-3.5"
                 >
                   <Download />
                   {s.updateYtdlpLabel}
@@ -138,7 +134,7 @@ export default function DownloadsSection() {
                   type="button"
                   variant="secondary"
                   onClick={s.onInstallFfmpeg}
-                  className="rounded-xl [&_svg]:size-3.5"
+                  className="[&_svg]:size-3.5"
                 >
                   <Download />
                   {s.updateFfmpegLabel}

--- a/apps/web/src/components/settings/downloads/ToolStatusRow/ToolStatusRow.tsx
+++ b/apps/web/src/components/settings/downloads/ToolStatusRow/ToolStatusRow.tsx
@@ -17,10 +17,10 @@ export default function ToolStatusRow(props: IToolStatusRowProps) {
     <div className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-background/50 border border-border/20">
       {installed ? (
         <>
-          <Check className="w-4 h-4 text-green-400" />
+          <Check className="w-4 h-4 text-success" />
           <span className="text-sm text-foreground">{installedTitle}</span>
           {updateAvailable ? (
-            <span className="ml-auto text-[10px] font-medium uppercase tracking-wider text-amber-300">
+            <span className="ml-auto text-[10px] font-medium uppercase tracking-wider text-warning">
               {updateAvailableLabel}
             </span>
           ) : (

--- a/apps/web/src/components/shared/AlbumSortControl/AlbumSortControl.tsx
+++ b/apps/web/src/components/shared/AlbumSortControl/AlbumSortControl.tsx
@@ -13,7 +13,7 @@ export default function AlbumSortControl(props: IAlbumSortControlProps) {
       key={option.mode}
       onClick={() => onModeChange(option.mode)}
       className={cn(
-        'text-left px-2 py-1.5 rounded-md text-xs transition-colors',
+        'focus-ring text-left px-2 py-1.5 rounded-md text-xs transition-colors',
         option.active ? 'bg-primary/15 text-primary' : 'text-foreground/80 hover:bg-accent'
       )}
     >
@@ -25,7 +25,7 @@ export default function AlbumSortControl(props: IAlbumSortControlProps) {
     <Popover>
       <PopoverTrigger asChild>
         <button
-          className="flex items-center gap-1.5 rounded-xl border border-border/50 bg-card px-3 py-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          className="focus-ring flex items-center gap-1.5 rounded-xl border border-border/50 bg-card px-3 py-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
           aria-label={labels.button}
           title={labels.button}
         >
@@ -44,7 +44,7 @@ export default function AlbumSortControl(props: IAlbumSortControlProps) {
             <button
               onClick={() => onOrderChange('asc')}
               className={cn(
-                'flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-xs transition-colors',
+                'focus-ring flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-xs transition-colors',
                 order === 'asc'
                   ? 'bg-primary/15 text-primary'
                   : 'text-foreground/80 hover:bg-accent'
@@ -58,7 +58,7 @@ export default function AlbumSortControl(props: IAlbumSortControlProps) {
             <button
               onClick={() => onOrderChange('desc')}
               className={cn(
-                'flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-xs transition-colors',
+                'focus-ring flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-xs transition-colors',
                 order === 'desc'
                   ? 'bg-primary/15 text-primary'
                   : 'text-foreground/80 hover:bg-accent'

--- a/apps/web/src/components/shared/DownloadProgressButton/DownloadProgressButton.hooks.ts
+++ b/apps/web/src/components/shared/DownloadProgressButton/DownloadProgressButton.hooks.ts
@@ -50,8 +50,8 @@ export function useDownloadProgressButton({
     return {
       Icon: Check,
       spin: false,
-      colorClass: 'text-emerald-400/90',
-      borderClass: 'border-emerald-400/15 motion-safe:transition-colors motion-safe:duration-200',
+      colorClass: 'text-success/90',
+      borderClass: 'border-success/15 motion-safe:transition-colors motion-safe:duration-200',
       isDisabled,
       isBusy,
     };

--- a/apps/web/src/components/shared/EditTagsDialog/EditTagsDialog.tsx
+++ b/apps/web/src/components/shared/EditTagsDialog/EditTagsDialog.tsx
@@ -56,20 +56,14 @@ export default function EditTagsDialog(props: IEditTagsDialogProps) {
           <p className="text-xs text-muted-foreground">{t('writeWarning')}</p>
 
           <div className="flex justify-end gap-2 pt-1">
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={onClose}
-              disabled={saving}
-              className="rounded-lg"
-            >
+            <Button type="button" variant="ghost" onClick={onClose} disabled={saving}>
               {t('cancel')}
             </Button>
             <Button
               type="submit"
               disabled={saving}
               aria-busy={saving}
-              className="rounded-lg gap-2 [&_svg]:size-3.5"
+              className="gap-2 [&_svg]:size-3.5"
             >
               {saving ? (
                 <Loader2 className="animate-spin" aria-hidden="true" />

--- a/apps/web/src/components/shared/GridSizeToggle/GridSizeToggle.tsx
+++ b/apps/web/src/components/shared/GridSizeToggle/GridSizeToggle.tsx
@@ -11,7 +11,7 @@ export default function GridSizeToggle(props: IGridSizeToggleProps) {
       key={itemSize}
       onClick={() => onSizeChange(itemSize)}
       className={cn(
-        'p-2 rounded-lg transition-colors',
+        'focus-ring p-2 rounded-lg transition-colors',
         active ? 'bg-primary/15 text-primary' : 'text-muted-foreground/50 hover:text-foreground'
       )}
       aria-label={label}

--- a/apps/web/src/components/shared/ImportDialog/ImportDialog.tsx
+++ b/apps/web/src/components/shared/ImportDialog/ImportDialog.tsx
@@ -152,7 +152,7 @@ export default function ImportDialog(props: IImportDialogProps) {
 
               {/* Actions */}
               {state === 'ready' && (
-                <Button onClick={startImport} className="h-auto w-full rounded-xl py-2.5">
+                <Button onClick={startImport} className="h-auto w-full py-2.5">
                   <Download />
                   {t('downloadAll', { count: tracks.length })}
                 </Button>

--- a/apps/web/src/components/shared/ImportDialog/ImportDialog.tsx
+++ b/apps/web/src/components/shared/ImportDialog/ImportDialog.tsx
@@ -44,13 +44,13 @@ export default function ImportDialog(props: IImportDialogProps) {
           isActive
             ? 'bg-primary/10 border border-primary/20'
             : isCompleted
-              ? 'bg-green-500/5'
+              ? 'bg-success/5'
               : 'bg-accent/30'
         }`}
       >
         <span
           className={`text-xs w-5 text-center shrink-0 transition-colors duration-300 ${
-            isCompleted ? 'text-green-400' : isActive ? 'text-primary' : 'text-muted-foreground/50'
+            isCompleted ? 'text-success' : isActive ? 'text-primary' : 'text-muted-foreground/50'
           }`}
         >
           {isCompleted ? (
@@ -64,7 +64,7 @@ export default function ImportDialog(props: IImportDialogProps) {
         <Music
           className={`w-4 h-4 shrink-0 transition-colors duration-300 ${
             isCompleted
-              ? 'text-green-400/50'
+              ? 'text-success/50'
               : isActive
                 ? 'text-primary/60'
                 : 'text-muted-foreground/40'
@@ -160,10 +160,10 @@ export default function ImportDialog(props: IImportDialogProps) {
 
               {state === 'done' && (
                 <div className="flex flex-col items-center gap-2 py-2">
-                  <div className="w-10 h-10 rounded-full bg-green-500/10 flex items-center justify-center">
-                    <Check className="w-5 h-5 text-green-400" />
+                  <div className="w-10 h-10 rounded-full bg-success/10 flex items-center justify-center">
+                    <Check className="w-5 h-5 text-success" />
                   </div>
-                  <p className="text-sm text-green-400 font-medium">{t('downloadComplete')}</p>
+                  <p className="text-sm text-success font-medium">{t('downloadComplete')}</p>
                   {playlistData && (
                     <p className="text-xs text-muted-foreground">
                       {t('playlistCreated', {

--- a/apps/web/src/components/shared/NowPlayingHero/NowPlayingHero.test.tsx
+++ b/apps/web/src/components/shared/NowPlayingHero/NowPlayingHero.test.tsx
@@ -39,6 +39,20 @@ describe('NowPlayingHero', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it('positions the artwork wrapper so the frosted surface cannot paint over it', () => {
+    usePlaybackStore.setState({
+      currentTrack: makeTrack({ albumArt: 'file:///covers/late-nights.jpg' }),
+    });
+    render(<NowPlayingHero />);
+
+    // The hero's two overlays (.now-playing-hero-surface and the blurred
+    // backdrop) are absolutely positioned, so they outrank any in-flow
+    // sibling in paint order. Without `relative` here the artwork renders
+    // behind them once the entrance spring settles — dark and blurred.
+    const artwork = screen.getByRole('img', { name: 'Midnight study session' });
+    expect(artwork.parentElement?.className).toContain('relative');
+  });
+
   it('honors the show predicate — collapses when it returns false', () => {
     usePlaybackStore.setState({ currentTrack: makeTrack({ title: 'Hidden track' }) });
     render(<NowPlayingHero show={() => false} />);

--- a/apps/web/src/components/shared/NowPlayingHero/NowPlayingHero.tsx
+++ b/apps/web/src/components/shared/NowPlayingHero/NowPlayingHero.tsx
@@ -57,7 +57,16 @@ export default function NowPlayingHero(props: INowPlayingHeroProps) {
                 transition={{ type: 'spring', damping: 20, stiffness: 250 }}
                 onDoubleClick={nowPlayingViewEnabled ? onEnterNowPlaying : undefined}
                 className={cn(
-                  'w-24 h-24 rounded-xl overflow-hidden shadow-2xl shadow-black/30 shrink-0 bg-muted flex items-center justify-center',
+                  // `relative` is load-bearing, not cosmetic: the two overlays
+                  // above are absolutely positioned, so they paint above any
+                  // in-flow sibling. Motion only lifts this wrapper out of the
+                  // in-flow paint phase while the entrance spring is running
+                  // (a live transform creates a stacking context); once it
+                  // settles at scale 1 motion writes `transform: none` and the
+                  // artwork would drop behind the frosted surface — picking up
+                  // its 70% dark fill and blur(10px) backdrop-filter under
+                  // image themes. Positioning it keeps it on top for good.
+                  'relative w-24 h-24 rounded-xl overflow-hidden shadow-2xl shadow-black/30 shrink-0 bg-muted flex items-center justify-center',
                   nowPlayingViewEnabled && 'cursor-pointer transition-transform hover:scale-[1.02]'
                 )}
               >

--- a/apps/web/src/components/shared/PageHeader/PageHeader.hooks.ts
+++ b/apps/web/src/components/shared/PageHeader/PageHeader.hooks.ts
@@ -10,6 +10,7 @@ export function usePageHeader({
   icon,
   subtitle,
   variant = 'page',
+  actions,
 }: IPageHeaderProps): IPageHeaderView {
-  return { title, icon, subtitle, variant };
+  return { title, icon, subtitle, variant, actions };
 }

--- a/apps/web/src/components/shared/PageHeader/PageHeader.stories.tsx
+++ b/apps/web/src/components/shared/PageHeader/PageHeader.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Library } from 'lucide-react';
+import { Library, Plus } from 'lucide-react';
 
+import { Button } from '@/components/ui/button';
 import PageHeader from './PageHeader';
 
 /**
@@ -30,5 +31,21 @@ export const Section: Story = {
     icon: Library,
     title: 'Albums',
     subtitle: '24 albums',
+  },
+};
+
+/** Trailing action controls (e.g. a create button) via the `actions` slot. */
+export const SectionWithActions: Story = {
+  args: {
+    variant: 'section',
+    icon: Library,
+    title: 'Albums',
+    subtitle: '24 albums',
+    actions: (
+      <Button size="sm" className="gap-1.5">
+        <Plus className="size-4" />
+        New album
+      </Button>
+    ),
   },
 };

--- a/apps/web/src/components/shared/PageHeader/PageHeader.test.tsx
+++ b/apps/web/src/components/shared/PageHeader/PageHeader.test.tsx
@@ -17,4 +17,23 @@ describe('PageHeader', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Albums' })).toBeInTheDocument();
     expect(screen.getByText('24 albums')).toBeInTheDocument();
   });
+
+  it('renders the actions slot on the trailing edge in both variants', () => {
+    const { rerender } = render(
+      <PageHeader title="Library" actions={<button type="button">New</button>} />
+    );
+
+    expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument();
+
+    rerender(
+      <PageHeader
+        variant="section"
+        icon={Library}
+        title="Albums"
+        actions={<button type="button">Import</button>}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Import' })).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/shared/PageHeader/PageHeader.tsx
+++ b/apps/web/src/components/shared/PageHeader/PageHeader.tsx
@@ -2,7 +2,7 @@ import { usePageHeader } from './PageHeader.hooks';
 import type { IPageHeaderProps } from './PageHeader.types';
 
 export default function PageHeader(props: IPageHeaderProps) {
-  const { title, icon: Icon, subtitle, variant } = usePageHeader(props);
+  const { title, icon: Icon, subtitle, variant, actions } = usePageHeader(props);
 
   if (variant === 'section') {
     return (
@@ -12,7 +12,7 @@ export default function PageHeader(props: IPageHeaderProps) {
             <Icon className="w-4 h-4 text-primary" aria-hidden="true" focusable="false" />
           </div>
         )}
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <h2 className="font-serif italic text-xl leading-tight text-foreground truncate">
             {title}
           </h2>
@@ -22,13 +22,17 @@ export default function PageHeader(props: IPageHeaderProps) {
             </p>
           )}
         </div>
+        {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}
       </div>
     );
   }
 
   return (
-    <div className="px-6 pt-5 pb-1 shrink-0">
-      <h1 className="font-serif italic text-3xl leading-tight text-foreground truncate">{title}</h1>
+    <div className="flex items-center gap-3 px-6 pt-5 pb-1 shrink-0">
+      <h1 className="font-serif italic text-3xl leading-tight text-foreground truncate min-w-0 flex-1">
+        {title}
+      </h1>
+      {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}
     </div>
   );
 }

--- a/apps/web/src/components/shared/PageHeader/PageHeader.types.ts
+++ b/apps/web/src/components/shared/PageHeader/PageHeader.types.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import type { LucideIcon } from 'lucide-react';
 
 export interface IPageHeaderProps {
@@ -9,6 +10,8 @@ export interface IPageHeaderProps {
   readonly subtitle?: string;
   /** `'page'` renders a top-level `<h1>`; `'section'` an icon + `<h2>` row. */
   readonly variant?: 'page' | 'section';
+  /** Optional action controls rendered on the trailing edge of the header. */
+  readonly actions?: ReactNode;
 }
 
 export interface IPageHeaderView {
@@ -20,4 +23,6 @@ export interface IPageHeaderView {
   readonly subtitle?: string;
   /** Resolved variant (defaults to `'page'`). */
   readonly variant: 'page' | 'section';
+  /** Optional action controls rendered on the trailing edge of the header. */
+  readonly actions?: ReactNode;
 }

--- a/apps/web/src/components/shared/PlaylistContextMenu/PlaylistContextMenu.tsx
+++ b/apps/web/src/components/shared/PlaylistContextMenu/PlaylistContextMenu.tsx
@@ -16,7 +16,7 @@ function MenuItem({
   return (
     <button
       onClick={onClick}
-      className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
+      className="focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
     >
       <span className="shrink-0 w-4 h-4 flex items-center justify-center text-muted-foreground/60">
         {icon}

--- a/apps/web/src/components/shared/PlaylistPickerContent/PlaylistPickerContent.tsx
+++ b/apps/web/src/components/shared/PlaylistPickerContent/PlaylistPickerContent.tsx
@@ -39,7 +39,7 @@ export default function PlaylistPickerContent(props: IPlaylistPickerContentProps
           onToggle(pl);
         }}
         disabled={isMutating}
-        className={`w-full flex items-center gap-2 px-3 py-1.5 text-xs transition-colors text-left disabled:pointer-events-none ${
+        className={`focus-ring w-full flex items-center gap-2 px-3 py-1.5 text-xs transition-colors text-left disabled:pointer-events-none ${
           isInPlaylist
             ? 'text-primary/80 hover:text-primary hover:bg-accent'
             : 'text-foreground/80 hover:text-foreground hover:bg-accent'
@@ -98,7 +98,7 @@ export default function PlaylistPickerContent(props: IPlaylistPickerContentProps
               e.stopPropagation();
               onShowNewForm();
             }}
-            className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-primary/80 hover:text-primary hover:bg-accent transition-colors"
+            className="focus-ring w-full flex items-center gap-2 px-3 py-1.5 text-xs text-primary/80 hover:text-primary hover:bg-accent transition-colors"
           >
             <Plus className="w-3 h-3" />
             {tCommon('newPlaylist')}

--- a/apps/web/src/components/shared/ShareDialog/ShareDialog.tsx
+++ b/apps/web/src/components/shared/ShareDialog/ShareDialog.tsx
@@ -48,7 +48,7 @@ export default function ShareDialog(props: IShareDialogProps) {
               </div>
               <button
                 onClick={handleCopy}
-                className="shrink-0 w-10 h-10 rounded-xl bg-primary text-primary-foreground flex items-center justify-center hover:bg-primary/90 transition-colors"
+                className="focus-ring shrink-0 w-10 h-10 rounded-xl bg-primary text-primary-foreground flex items-center justify-center hover:bg-primary/90 transition-colors"
                 aria-label={t('copyLink')}
               >
                 {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}

--- a/apps/web/src/components/shared/SidePanel/SidePanel.tsx
+++ b/apps/web/src/components/shared/SidePanel/SidePanel.tsx
@@ -38,7 +38,7 @@ export default function SidePanel(props: ISidePanelProps) {
         <button
           onClick={onFlip}
           aria-label={flipLabel}
-          className="text-muted-foreground/40 hover:text-foreground transition-colors"
+          className="focus-ring rounded-sm text-muted-foreground/40 hover:text-foreground transition-colors"
         >
           <FlipIcon className="w-3.5 h-3.5" />
         </button>

--- a/apps/web/src/components/shared/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar/Sidebar.tsx
@@ -164,7 +164,7 @@ export default function Sidebar() {
         <button
           onClick={onOpenHome}
           className={cn(
-            'no-drag flex items-center rounded-xl text-left transition-colors',
+            'focus-ring no-drag flex items-center rounded-xl text-left transition-colors',
             sidebarCollapsed ? 'justify-center w-9 h-9' : 'gap-2.5 min-w-0 flex-1'
           )}
           title={sidebarCollapsed ? t('shiranami', { ns: 'common' }) : undefined}
@@ -214,7 +214,7 @@ export default function Sidebar() {
                   </p>
                   <button
                     onClick={() => navigateTo('playlists')}
-                    className="text-[10px] text-primary/70 hover:text-primary transition-colors uppercase tracking-wider"
+                    className="focus-ring rounded-sm text-[10px] text-primary/70 hover:text-primary transition-colors uppercase tracking-wider"
                   >
                     {t('all')}
                   </button>

--- a/apps/web/src/components/shared/TopBar/TopBar.tsx
+++ b/apps/web/src/components/shared/TopBar/TopBar.tsx
@@ -32,7 +32,7 @@ export default function TopBar(props: ITopBarProps) {
       onClick={() => onLanguageChange(lang.code)}
       aria-label={t(`language.${lang.code}`)}
       className={cn(
-        'px-2 py-1 rounded-md text-xs font-medium transition-colors',
+        'focus-ring px-2 py-1 rounded-md text-xs font-medium transition-colors',
         currentLanguage === lang.code
           ? 'bg-primary/15 text-primary'
           : 'text-muted-foreground/60 hover:text-foreground hover:bg-accent'
@@ -64,7 +64,7 @@ export default function TopBar(props: ITopBarProps) {
             onClick={toggleDropdown}
             disabled={scanBlocked}
             className={cn(
-              'flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-colors',
+              'focus-ring flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-colors',
               dropdownOpen
                 ? 'bg-accent text-foreground'
                 : 'text-muted-foreground hover:text-foreground hover:bg-accent'
@@ -78,14 +78,14 @@ export default function TopBar(props: ITopBarProps) {
             <div className="absolute right-0 top-full mt-1 w-44 py-1 rounded-xl bg-card border border-border/50 shadow-xl shadow-black/20 z-50">
               <button
                 onClick={onAddFolder}
-                className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
+                className="focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
               >
                 <FolderOpen className="w-4 h-4 text-muted-foreground" />
                 {t('addFolder')}
               </button>
               <button
                 onClick={onAddFile}
-                className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
+                className="focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
               >
                 <File className="w-4 h-4 text-muted-foreground" />
                 {t('addFile')}
@@ -94,7 +94,7 @@ export default function TopBar(props: ITopBarProps) {
               <button
                 onClick={onRescan}
                 disabled={rescanDisabled}
-                className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-foreground/80 hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50 disabled:pointer-events-none"
+                className="focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm text-foreground/80 hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50 disabled:pointer-events-none"
               >
                 {isRescanning ? (
                   <Loader2 className="w-4 h-4 text-muted-foreground animate-spin" />

--- a/apps/web/src/components/shared/TrackContextMenu/TrackContextMenu.tsx
+++ b/apps/web/src/components/shared/TrackContextMenu/TrackContextMenu.tsx
@@ -42,7 +42,7 @@ function MenuItem({
       title={title}
       aria-disabled={disabled || undefined}
       className={cn(
-        'w-full flex items-center gap-2.5 px-3 py-2 text-sm transition-colors text-left',
+        'focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm transition-colors text-left',
         disabled
           ? 'text-muted-foreground/50 cursor-not-allowed'
           : variant === 'destructive'

--- a/apps/web/src/components/shared/TrackEnrichDialog/TrackEnrichDialog.tsx
+++ b/apps/web/src/components/shared/TrackEnrichDialog/TrackEnrichDialog.tsx
@@ -177,36 +177,31 @@ export default function TrackEnrichDialog(props: ITrackEnrichDialogProps) {
         <div className="flex justify-end gap-2">
           {showRetryFooter && (
             <>
-              <Button variant="ghost" onClick={handleClose} className="rounded-lg">
+              <Button variant="ghost" onClick={handleClose}>
                 {t('close')}
               </Button>
-              <Button onClick={runPreview} className="rounded-lg gap-2 [&_svg]:size-3.5">
+              <Button onClick={runPreview} className="gap-2 [&_svg]:size-3.5">
                 <RotateCw aria-hidden="true" />
                 {t('retry')}
               </Button>
             </>
           )}
           {state.kind === 'applied' && (
-            <Button onClick={handleClose} className="rounded-lg gap-2 [&_svg]:size-3.5">
+            <Button onClick={handleClose} className="gap-2 [&_svg]:size-3.5">
               <Check aria-hidden="true" />
               {t('done')}
             </Button>
           )}
           {state.kind === 'found' && (
             <>
-              <Button
-                variant="ghost"
-                onClick={handleClose}
-                disabled={applying}
-                className="rounded-lg"
-              >
+              <Button variant="ghost" onClick={handleClose} disabled={applying}>
                 {t('discard')}
               </Button>
               <Button
                 onClick={handleApply}
                 disabled={applying}
                 aria-busy={applying}
-                className="rounded-lg gap-2 [&_svg]:size-3.5"
+                className="gap-2 [&_svg]:size-3.5"
               >
                 {applying ? (
                   <Loader2 className="animate-spin" aria-hidden="true" />

--- a/apps/web/src/components/shared/ViewEmptyState/ViewEmptyState.tsx
+++ b/apps/web/src/components/shared/ViewEmptyState/ViewEmptyState.tsx
@@ -19,7 +19,7 @@ export default function ViewEmptyState(props: IViewEmptyStateProps) {
             </p>
           </div>
           {action && (
-            <Button size="sm" onClick={action.onClick} className="rounded-xl px-4 py-2">
+            <Button size="sm" onClick={action.onClick} className="px-4 py-2">
               {action.label}
             </Button>
           )}
@@ -84,7 +84,7 @@ export default function ViewEmptyState(props: IViewEmptyStateProps) {
         {hasHints && <div className="flex items-center gap-3">{hintChips}</div>}
 
         {action && (
-          <Button size="sm" onClick={action.onClick} className="rounded-xl px-4 py-2">
+          <Button size="sm" onClick={action.onClick} className="px-4 py-2">
             {action.label}
           </Button>
         )}

--- a/apps/web/src/components/shared/WindowControls/WindowControls.tsx
+++ b/apps/web/src/components/shared/WindowControls/WindowControls.tsx
@@ -20,7 +20,7 @@ export default function WindowControls({ className }: IWindowControlsProps) {
       <button
         type="button"
         onClick={minimize}
-        className="flex h-8 w-10 items-center justify-center rounded-md text-muted-foreground/55 transition-colors hover:bg-accent hover:text-foreground"
+        className="focus-ring flex h-8 w-10 items-center justify-center rounded-md text-muted-foreground/55 transition-colors hover:bg-accent hover:text-foreground"
         aria-label={t('minimize')}
       >
         <Minus className="h-3.5 w-3.5" />
@@ -28,7 +28,7 @@ export default function WindowControls({ className }: IWindowControlsProps) {
       <button
         type="button"
         onClick={maximize}
-        className="flex h-8 w-10 items-center justify-center rounded-md text-muted-foreground/55 transition-colors hover:bg-accent hover:text-foreground"
+        className="focus-ring flex h-8 w-10 items-center justify-center rounded-md text-muted-foreground/55 transition-colors hover:bg-accent hover:text-foreground"
         aria-label={isMaximized ? t('restore') : t('maximize')}
       >
         {isMaximized ? <Copy className="h-3.5 w-3.5" /> : <Square className="h-3.5 w-3.5" />}
@@ -37,7 +37,7 @@ export default function WindowControls({ className }: IWindowControlsProps) {
         type="button"
         onClick={close}
         className={cn(
-          'flex h-8 w-10 items-center justify-center rounded-md',
+          'focus-ring flex h-8 w-10 items-center justify-center rounded-md',
           'text-muted-foreground/55 transition-colors',
           'hover:bg-destructive/85 hover:text-destructive-foreground'
         )}

--- a/apps/web/src/components/shared/WindowControls/WindowControls.tsx
+++ b/apps/web/src/components/shared/WindowControls/WindowControls.tsx
@@ -39,7 +39,7 @@ export default function WindowControls({ className }: IWindowControlsProps) {
         className={cn(
           'flex h-8 w-10 items-center justify-center rounded-md',
           'text-muted-foreground/55 transition-colors',
-          'hover:bg-red-500/85 hover:text-white'
+          'hover:bg-destructive/85 hover:text-destructive-foreground'
         )}
         aria-label={t('close')}
       >

--- a/apps/web/src/components/smart-playlists/SmartPlaylistsView/SmartPlaylistCard/SmartPlaylistCard.tsx
+++ b/apps/web/src/components/smart-playlists/SmartPlaylistsView/SmartPlaylistCard/SmartPlaylistCard.tsx
@@ -8,7 +8,7 @@ export default function SmartPlaylistCard(props: ISmartPlaylistCardProps) {
   return (
     <button
       onClick={onOpen}
-      className="flex items-center gap-3 w-full rounded-xl border border-border/40 bg-card/50 p-3 text-left transition-colors hover:bg-accent"
+      className="focus-ring flex items-center gap-3 w-full rounded-xl border border-border/40 bg-card/50 p-3 text-left transition-colors hover:bg-accent"
     >
       <div className="w-10 h-10 rounded-lg bg-primary/15 border border-primary/25 flex items-center justify-center shrink-0">
         <Sparkles className="w-4 h-4 text-primary" aria-hidden="true" />

--- a/apps/web/src/components/smart-playlists/SmartPlaylistsView/SmartPlaylistDetail/SmartPlaylistDetail.tsx
+++ b/apps/web/src/components/smart-playlists/SmartPlaylistsView/SmartPlaylistDetail/SmartPlaylistDetail.tsx
@@ -43,7 +43,10 @@ export default function SmartPlaylistDetail(props: ISmartPlaylistDetailProps) {
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-4 text-center px-6">
         <p className="text-sm text-muted-foreground">{t('notFound')}</p>
-        <button onClick={onBack} className="text-xs text-primary hover:underline">
+        <button
+          onClick={onBack}
+          className="focus-ring rounded-sm text-xs text-primary hover:underline"
+        >
           {t('goBack')}
         </button>
       </div>
@@ -91,13 +94,13 @@ export default function SmartPlaylistDetail(props: ISmartPlaylistDetailProps) {
                   <button
                     onClick={onDelete}
                     disabled={isDeleting}
-                    className="flex-1 px-2 py-1 rounded-lg text-xs font-medium bg-destructive/15 text-destructive hover:bg-destructive/25 transition-colors disabled:opacity-50"
+                    className="focus-ring flex-1 px-2 py-1 rounded-lg text-xs font-medium bg-destructive/15 text-destructive hover:bg-destructive/25 transition-colors disabled:opacity-50"
                   >
                     {tCommon('delete')}
                   </button>
                   <button
                     onClick={onCancelDelete}
-                    className="flex-1 px-2 py-1 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                    className="focus-ring flex-1 px-2 py-1 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
                   >
                     {tCommon('cancel')}
                   </button>

--- a/apps/web/src/components/smart-playlists/SmartPlaylistsView/SmartPlaylistsView.tsx
+++ b/apps/web/src/components/smart-playlists/SmartPlaylistsView/SmartPlaylistsView.tsx
@@ -48,14 +48,17 @@ export default function SmartPlaylistsView() {
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
-      <PageHeader title={t('title')} icon={Sparkles} variant="section" />
-
-      <div className="flex items-center justify-end px-6 py-3 shrink-0">
-        <Button size="sm" onClick={onCreate} className="gap-1.5">
-          <Plus className="size-4" />
-          {t('newSmartPlaylist')}
-        </Button>
-      </div>
+      <PageHeader
+        title={t('title')}
+        icon={Sparkles}
+        variant="section"
+        actions={
+          <Button size="sm" onClick={onCreate} className="gap-1.5">
+            <Plus className="size-4" />
+            {t('newSmartPlaylist')}
+          </Button>
+        }
+      />
 
       {isEmpty ? (
         <ViewEmptyState
@@ -65,7 +68,7 @@ export default function SmartPlaylistsView() {
           action={{ label: t('newSmartPlaylist'), onClick: onCreate }}
         />
       ) : (
-        <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin px-6 pb-6">
+        <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin px-6 pt-4 pb-6">
           <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">{cards}</div>
         </div>
       )}

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'focus-ring inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[background-color,border-color,color,box-shadow,transform] active:scale-[0.97] motion-reduce:transition-none motion-reduce:active:scale-100 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'focus-ring inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-[background-color,border-color,color,box-shadow,transform] active:scale-[0.97] motion-reduce:transition-none motion-reduce:active:scale-100 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -19,8 +19,8 @@ const buttonVariants = cva(
       },
       size: {
         default: 'h-9 px-4 py-2',
-        sm: 'h-8 rounded-md px-3 text-xs',
-        lg: 'h-10 rounded-md px-8',
+        sm: 'h-8 px-3 text-xs',
+        lg: 'h-10 px-8',
         icon: 'h-9 w-9',
       },
     },

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[background-color,border-color,color,box-shadow,transform] active:scale-[0.97] motion-reduce:transition-none motion-reduce:active:scale-100 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'focus-ring inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[background-color,border-color,color,box-shadow,transform] active:scale-[0.97] motion-reduce:transition-none motion-reduce:active:scale-100 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {

--- a/apps/web/src/components/ui/icon-button.tsx
+++ b/apps/web/src/components/ui/icon-button.tsx
@@ -5,7 +5,7 @@ import { motion } from 'motion/react';
 import { cn } from '@/lib/utils';
 
 const iconButtonVariants = cva(
-  'inline-flex items-center justify-center rounded-lg text-muted-foreground/75 transition-[background-color,border-color,color,box-shadow,transform] active:scale-95 motion-reduce:transition-none motion-reduce:active:scale-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0',
+  'focus-ring inline-flex items-center justify-center rounded-lg text-muted-foreground/75 transition-[background-color,border-color,color,box-shadow,transform] active:scale-95 motion-reduce:transition-none motion-reduce:active:scale-100 disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0',
   {
     variants: {
       variant: {

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -1,12 +1,23 @@
 import { Toaster as Sonner } from 'sonner';
+import { PLAYER_BAR_HEIGHT } from '@/lib/layout';
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
+/**
+ * App toast surface. Colors, radius and close-button chrome come entirely from
+ * the app's theme tokens (see the [data-sonner-toaster] block in globals.css),
+ * so toasts follow the active app theme rather than one of sonner's built-in
+ * palettes — no hardcoded theme prop. Bottom-right, lifted above the player
+ * bar so a toast never covers the transport controls.
+ */
 const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
-      theme="dark"
       className="toaster group"
+      position="bottom-right"
+      offset={{ bottom: PLAYER_BAR_HEIGHT + 12 }}
+      duration={4000}
+      closeButton
       toastOptions={{
         classNames: {
           toast:

--- a/apps/web/src/components/ui/status-badge.tsx
+++ b/apps/web/src/components/ui/status-badge.tsx
@@ -17,9 +17,9 @@ interface VariantStyle {
 const VARIANTS: Record<StatusBadgeVariant, VariantStyle> = {
   experimental: {
     icon: Sparkles,
-    // Amber — caution, "may change or be removed"
+    // Warning amber — caution, "may change or be removed"
     classes:
-      'bg-amber-500/10 border-amber-400/25 text-amber-300 shadow-[inset_0_1px_0_rgba(var(--status-warning-rgb),0.12)]',
+      'bg-warning/10 border-warning/25 text-warning shadow-[inset_0_1px_0_rgba(var(--status-warning-rgb),0.12)]',
   },
   beta: {
     icon: FlaskConical,
@@ -29,9 +29,9 @@ const VARIANTS: Record<StatusBadgeVariant, VariantStyle> = {
   },
   new: {
     icon: Zap,
-    // Emerald — "shipped recently, check it out"
+    // Success green — "shipped recently, check it out"
     classes:
-      'bg-emerald-500/10 border-emerald-400/25 text-emerald-300 shadow-[inset_0_1px_0_rgba(var(--status-success-rgb),0.12)]',
+      'bg-success/10 border-success/25 text-success shadow-[inset_0_1px_0_rgba(var(--status-success-rgb),0.12)]',
   },
 };
 

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -16,7 +16,7 @@ function Switch({
         'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full transition-colors duration-200',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
         'disabled:cursor-not-allowed disabled:opacity-50',
-        'data-[state=checked]:bg-primary data-[state=unchecked]:bg-[oklch(0.32_0.02_280)]',
+        'data-[state=checked]:bg-primary data-[state=unchecked]:bg-switch-track',
         'data-[state=checked]:shadow-[0_0_10px_-2px_rgba(var(--primary-rgb),0.6)]',
         className
       )}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -30,6 +30,7 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-switch-track: var(--switch-track);
   --color-brand-600: var(--brand-600);
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
@@ -588,6 +589,10 @@
   --input: oklch(0.12 0.02 280);
   --ring: oklch(0.72 0.12 280);
 
+  /* Unchecked switch track — lighter than --muted so the control still reads
+     as interactive against card surfaces. */
+  --switch-track: oklch(0.32 0.02 280);
+
   --radius: 0.75rem;
 
   --sidebar: oklch(0.06 0.02 280);
@@ -649,11 +654,21 @@
   --ring: var(--primary);
 }
 
-/* Sonner toast – override default dark-theme colors with app tokens */
-[data-sonner-toaster][data-sonner-theme='dark'] {
+/* Sonner toast — the surface, radius and close-button chrome all read the app
+   tokens whatever sonner theme is active (the attribute selector matches any
+   value at the same specificity sonner's own :where()-wrapped rules avoid),
+   so toasts follow the active app theme instead of a sonner built-in palette.
+   The --gray* vars are what sonner's close button reads. */
+[data-sonner-toaster][data-sonner-theme] {
   --normal-bg: var(--card);
   --normal-border: var(--border);
   --normal-text: var(--foreground);
+  --border-radius: var(--radius);
+  --gray1: var(--card);
+  --gray2: var(--muted);
+  --gray4: var(--border-strong);
+  --gray5: var(--border-strong);
+  --gray12: var(--foreground);
 }
 
 /* Utility classes */

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -657,6 +657,15 @@
 }
 
 /* Utility classes */
+
+/* Unified keyboard-focus treatment — THE focus-visible recipe for every
+   interactive element. Button/IconButton bake it into their variants; raw
+   <button>/<a> sites add the class directly. outline-hidden (not outline-none)
+   keeps the outline in forced-colors mode where box-shadow rings vanish. */
+@utility focus-ring {
+  @apply focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring;
+}
+
 @utility drag {
   -webkit-app-region: drag;
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -23,6 +23,10 @@
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-info: var(--info);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -573,6 +577,14 @@
   --border-strong: oklch(1 0 0 / 0.18);
   --destructive: oklch(0.55 0.22 25);
   --destructive-foreground: oklch(1 0 0);
+
+  /* Semantic status accents — success / warning / info. Deliberately fixed
+     across every theme (theme blocks restyle only the primary accent), so a
+     status color always reads the same no matter which theme is active. */
+  --success: oklch(0.765 0.177 163);
+  --warning: oklch(0.828 0.189 84);
+  --warning-foreground: oklch(0.1 0.02 280);
+  --info: oklch(0.746 0.16 233);
   --input: oklch(0.12 0.02 280);
   --ring: oklch(0.72 0.12 280);
 
@@ -589,9 +601,10 @@
   /* RGB triplet of --primary for canvas/inline usage */
   --primary-rgb: 155, 125, 235;
 
-  /* RGB triplets for semantic status accents (badge shadows, callouts) */
-  --status-warning-rgb: 252, 211, 77;
-  --status-success-rgb: 110, 231, 183;
+  /* RGB triplets mirroring --warning / --success for rgba() shadow usage
+     (inset badge highlights). Keep in sync with the status tokens above. */
+  --status-warning-rgb: 251, 191, 36;
+  --status-success-rgb: 52, 211, 153;
 }
 
 /* ── Theme image + per-theme accent ──────────────────────────────────────

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ overrides:
   '@xhmikosr/decompress': '>=11.1.3'
   valibot: '>=1.4.2'
   brace-expansion@1: 1.1.16
-  brace-expansion@2: 2.1.2
+  brace-expansion@2: ^2.1.3
   brace-expansion@5: '>=5.0.8'
 
 importers:
@@ -5591,8 +5591,8 @@ packages:
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -17112,7 +17112,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -20525,11 +20525,11 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,11 +39,13 @@ overrides:
   svgo: '>=4.0.2'
   '@xhmikosr/decompress': '>=11.1.3'
   valibot: '>=1.4.2'
-  # CVE-2026-14257 is only patched on the 5.x line. The @1/@2 pins just hold
-  # those lines at their newest release — they cannot clear the advisory, which
-  # needs the `minimatch` parents dragging them in to move to 5.x.
+  # CVE-2026-14257 (GHSA-mh99-v99m-4gvg): each major line has its own
+  # patched release. @2 clears Dependabot alert #117 (>=2.0.0 <2.1.3,
+  # patched at 2.1.3). @1 is left at 1.1.16 — its alert (#118, <1.1.17)
+  # is auto-dismissed by GitHub, so it's out of scope here; a patched
+  # 1.1.17+ is available if that line needs bumping later.
   'brace-expansion@1': 1.1.16
-  'brace-expansion@2': 2.1.2
+  'brace-expansion@2': '^2.1.3'
   'brace-expansion@5': '>=5.0.8'
 
 onlyBuiltDependencies:


### PR DESCRIPTION
## Summary

Foundation taste pass for `apps/web` — fixes systemic design drift in four focused commits:

1. **Semantic status tokens** — adds `--success` / `--warning` (+`--warning-foreground`) / `--info` to the theme (fixed across every app theme) and migrates ~30 drifted raw-palette sites (`green-400/500`, `emerald-300/400`, `amber-200..500`, and `red-400` where destructive belongs) to them. `ui/status-badge.tsx` and the `--status-*-rgb` shadow triplets now ride the same tokens.
2. **Unified focus treatment** — one `focus-ring` utility (`outline-hidden` + `ring-1 ring-ring`) shared by `Button`, `IconButton`, and ~35 raw `<button>` sites that previously had no focus-visible styling; divergent `ring-2` recipes normalized. Hover-revealed controls (queue drag handle, playlist-row remove) also surface on keyboard focus.
3. **Primitive fixes** — `Button` defaults to the token radius `rounded-lg` (0.75rem, what ~45 call sites were overriding to; redundant overrides dropped, zero visual change at those sites), `Switch`'s hardcoded oklch track becomes `--switch-track`, and the sonner `Toaster` is properly configured (bottom-right above the player bar, 4s, close button, colors/radius from app tokens for any sonner theme instead of hardcoded dark).
4. **PageHeader actions slot** — optional `actions` prop on both variants; `SmartPlaylistsView` adopts it in place of its ad-hoc `justify-end` bar.

Deliberately left alone (owned by other lanes): DownloadsView/HistoryView/OverviewView (incl. DownloadsView's amber banner at line 144), companion components, sanctuary variant logic, vinyl visuals. Skipped in the focus sweep on purpose: `AccentColorPicker` (intentional offset-ring for color swatches), `LyricLineButton` (parent-supplied soft lyric ring), `VirtualSortableTrackRow` handle (`tabIndex={-1}`).

## Test plan

- `pnpm --filter @shiranami/web typecheck` — clean
- `pnpm --filter @shiranami/web test` — 327 files / 2064 tests pass (includes a new PageHeader actions test; StatTile & LowPerformancePreview assertions updated to the token classes)
- `pnpm --filter @shiranami/web test:storybook` — 245 files / 555 tests pass (new `SectionWithActions` story)
- `pnpm lint`, `pnpm format:check` — clean
- `pnpm --filter @shiranami/web build` — verified the compiled CSS emits `.focus-ring:focus-visible` with the token ring plus the forced-colors outline fallback
- No Rust touched
