### PR TITLE
refactor(web): downloads + history view polish on the v2 foundation

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,7 +5,6 @@ import { motion, AnimatePresence } from 'motion/react';
 import { cn } from '@/lib/utils';
 import { VIEW_TRANSITION } from '@/lib/motion';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
-import { logger } from '@/lib/logger';
 import { IS_ELECTRON, IS_E2E } from '@/lib/platform';
 import { PLAYER_BAR_HEIGHT, VISUALIZER_HEIGHT, PLAYER_BAR_PLUS_VIZ } from '@/lib/layout';
 import { Sidebar } from '@/components/shared/Sidebar';
@@ -88,10 +87,7 @@ import { useLayoutStore } from '@/stores/useLayoutStore';
 import { useViewStore } from '@/stores/useViewStore';
 import { useDownloadStore } from '@/stores/useDownloadStore';
 import { useDownloadQueueStore } from '@/stores/useDownloadQueueStore';
-import {
-  useDownloadQueueImporter,
-  reconstructBatchesFromSnapshot,
-} from '@/hooks/useDownloadQueueImporter';
+import { useDownloadQueueImporter, hydrateDownloadQueue } from '@/hooks/useDownloadQueueImporter';
 import { useMetadataEnrichStore } from '@/stores/useMetadataEnrichStore';
 import { useLibraryStore } from '@/stores/useLibraryStore';
 import { useOnboardingStore } from '@/stores/useOnboardingStore';
@@ -228,22 +224,10 @@ function App() {
   // (mounted below) is the single owner of library import for queued downloads.
   useEffect(() => {
     if (!IS_ELECTRON) return;
-    const applySnapshot = useDownloadQueueStore.getState().applySnapshot;
-    window.electronAPI.downloader
-      .getDownloadQueue()
-      .then(snapshot => {
-        // Reconstruct any in-flight playlist-import batches from the restored
-        // queue BEFORE applying the snapshot, so the App-level importer sees each
-        // batch the instant it sees its items (zustand setState is synchronous).
-        reconstructBatchesFromSnapshot(snapshot.items);
-        applySnapshot(snapshot);
-      })
-      .catch((err: unknown) => {
-        // The persisted queue failed to load at boot. The next queue-state
-        // broadcast will recover the snapshot, but log so it's diagnosable.
-        logger.error('[downloads] initial queue hydration failed', err);
-      });
-    const cleanup = window.electronAPI.downloader.onQueueState(applySnapshot);
+    hydrateDownloadQueue();
+    const cleanup = window.electronAPI.downloader.onQueueState(
+      useDownloadQueueStore.getState().applySnapshot
+    );
     return cleanup;
   }, []);
 

--- a/apps/web/src/components/downloads/DownloadsView/DownloadsView.hooks.ts
+++ b/apps/web/src/components/downloads/DownloadsView/DownloadsView.hooks.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import { IS_ELECTRON } from '@/lib/platform';
 import i18n from '@/lib/i18n';
 import { logger } from '@/lib/logger';
+import { hydrateDownloadQueue } from '@/hooks/useDownloadQueueImporter';
 import { useDownloadQueueStore } from '@/stores/useDownloadQueueStore';
 import type { DownloadQueueItem } from '@shiranami/contracts';
 import type { IDownloadSection, IDownloadsViewView } from './DownloadsView.types';
@@ -51,9 +52,11 @@ function cancelAll() {
 
 export function useDownloadsView(): IDownloadsViewView {
   const { t } = useTranslation('downloads');
+  const { t: tCommon } = useTranslation('common');
   const items = useDownloadQueueStore(s => s.items);
   const paused = useDownloadQueueStore(s => s.paused);
   const hydrated = useDownloadQueueStore(s => s.hydrated);
+  const hydrationFailed = useDownloadQueueStore(s => s.hydrationFailed);
   const [showCancelAllConfirm, setShowCancelAllConfirm] = useState(false);
 
   const sections = useMemo<IDownloadSection[]>(() => {
@@ -84,6 +87,9 @@ export function useDownloadsView(): IDownloadsViewView {
     paused,
     isEmpty: items.length === 0,
     hydrated,
+    isError: !hydrated && hydrationFailed,
+    retryLabel: tCommon('retry'),
+    onRetryHydration: hydrateDownloadQueue,
     hasPendingWork,
     hasCompleted,
     showCancelAllConfirm,

--- a/apps/web/src/components/downloads/DownloadsView/DownloadsView.stories.tsx
+++ b/apps/web/src/components/downloads/DownloadsView/DownloadsView.stories.tsx
@@ -31,12 +31,13 @@ function seedQueue(items: DownloadQueueItem[], paused = false): void {
 }
 
 /**
- * downloads · DownloadsView. The Downloads screen: an `<h1>` title with
- * pause/resume, cancel-all (a confirm popover), and clear-completed actions,
- * then the queue grouped into Active / Queued / Completed `<h2>` sections of
- * `DownloadQueueRow`s. Reads the renderer-side `useDownloadQueueStore` mirror of
- * the main-process queue; holds a blank loading frame until the first snapshot
- * lands, then shows either the grouped sections or an empty state. Cancellation,
+ * downloads · DownloadsView. The Downloads screen: a `PageHeader` `<h1>` with
+ * pause/resume, cancel-all (a confirm popover), and clear-completed actions in
+ * its actions slot, then the queue grouped into Active / Queued / Completed
+ * `<h2>` sections of `DownloadQueueRow`s. Reads the renderer-side
+ * `useDownloadQueueStore` mirror of the main-process queue; holds a skeleton
+ * frame until the first snapshot lands, then shows the grouped sections, an
+ * empty state, or an error state with retry if hydration failed. Cancellation,
  * pause, and clear are IPC no-ops in the browser run. Stories seed the store.
  */
 const meta: Meta<typeof DownloadsView> = {
@@ -112,7 +113,33 @@ export const Empty: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByText('No downloads yet')).toBeInTheDocument();
-    // No queue chrome renders in the empty state.
-    await expect(canvas.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+    // The page header stays put; only the queue toolbar goes away.
+    await expect(canvas.getByRole('heading', { level: 1, name: 'Downloads' })).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Pause the download queue' })
+    ).not.toBeInTheDocument();
+  },
+};
+
+/** Initial hydration failed — the error state offers a retry. */
+export const LoadError: Story = {
+  beforeEach: () => {
+    // Reset to the pre-hydration shape, then flag the failed initial fetch.
+    useDownloadQueueStore.setState({
+      items: [],
+      byUrl: new Map(),
+      byYoutubeId: new Map(),
+      maxConcurrency: 0,
+      activeCount: 0,
+      paused: false,
+      hydrated: false,
+      hydrationFailed: false,
+    });
+    useDownloadQueueStore.getState().markHydrationFailed();
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Couldn't load the download queue")).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/downloads/DownloadsView/DownloadsView.test.tsx
+++ b/apps/web/src/components/downloads/DownloadsView/DownloadsView.test.tsx
@@ -27,8 +27,8 @@ function seedQueue(items: DownloadQueueItem[], paused = false): void {
   useDownloadQueueStore.getState().applySnapshot(snapshot);
 }
 
-beforeEach(() => {
-  // Reset to the store's initial (pre-hydration) shape before each test.
+function resetQueueStore(): void {
+  // Reset to the store's initial (pre-hydration) shape.
   useDownloadQueueStore.setState({
     items: [],
     byUrl: new Map(),
@@ -37,27 +37,38 @@ beforeEach(() => {
     activeCount: 0,
     paused: false,
     hydrated: false,
+    hydrationFailed: false,
   });
-});
+}
 
-afterEach(() => {
-  useDownloadQueueStore.setState({
-    items: [],
-    byUrl: new Map(),
-    byYoutubeId: new Map(),
-    maxConcurrency: 0,
-    activeCount: 0,
-    paused: false,
-    hydrated: false,
-  });
-});
+beforeEach(resetQueueStore);
+afterEach(resetQueueStore);
 
 describe('DownloadsView', () => {
-  it('holds a blank loading frame before the queue hydrates', () => {
+  it('holds a skeleton frame before the queue hydrates', () => {
     render(<DownloadsView />);
 
     expect(screen.getByRole('status')).toHaveTextContent('Loading downloads');
+    expect(document.querySelector('[aria-busy="true"]')).not.toBeNull();
     expect(screen.queryByText('No downloads yet')).toBeNull();
+  });
+
+  it('shows the error state with a retry action when hydration fails', () => {
+    useDownloadQueueStore.getState().markHydrationFailed();
+    render(<DownloadsView />);
+
+    expect(screen.getByText("Couldn't load the download queue")).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(screen.queryByText('No downloads yet')).toBeNull();
+  });
+
+  it('recovers from a failed hydration once a snapshot lands', () => {
+    useDownloadQueueStore.getState().markHydrationFailed();
+    seedQueue([]);
+    render(<DownloadsView />);
+
+    expect(screen.queryByText("Couldn't load the download queue")).toBeNull();
+    expect(screen.getByText('No downloads yet')).toBeInTheDocument();
   });
 
   it('shows the empty state once hydrated with no items', () => {
@@ -65,6 +76,9 @@ describe('DownloadsView', () => {
     render(<DownloadsView />);
 
     expect(screen.getByText('No downloads yet')).toBeInTheDocument();
+    // The page header stays put across states — only the toolbar goes away.
+    expect(screen.getByRole('heading', { level: 1, name: 'Downloads' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Pause the download queue' })).toBeNull();
   });
 
   it('renders grouped sections and their items', () => {

--- a/apps/web/src/components/downloads/DownloadsView/DownloadsView.tsx
+++ b/apps/web/src/components/downloads/DownloadsView/DownloadsView.tsx
@@ -1,8 +1,10 @@
-import { DownloadCloud, Trash2, Pause, Play, Ban } from 'lucide-react';
+import { AlertCircle, DownloadCloud, Trash2, Pause, Play, Ban } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import { PageHeader } from '@/components/shared/PageHeader';
 import { ViewEmptyState } from '@/components/shared/ViewEmptyState';
 import { DownloadQueueRow } from '@/components/downloads/DownloadQueueRow';
+import { DownloadsViewSkeleton } from './DownloadsViewSkeleton';
 import { useDownloadsView } from './DownloadsView.hooks';
 
 export default function DownloadsView() {
@@ -12,6 +14,9 @@ export default function DownloadsView() {
     paused,
     isEmpty,
     hydrated,
+    isError,
+    retryLabel,
+    onRetryHydration,
     hasPendingWork,
     hasCompleted,
     showCancelAllConfirm,
@@ -23,20 +28,39 @@ export default function DownloadsView() {
     onConfirmCancelAll,
   } = useDownloadsView();
 
-  if (isEmpty) {
-    // Hold a blank frame until the first snapshot lands so a persisted queue
-    // doesn't flash "No downloads yet" on launch before it hydrates.
-    if (!hydrated) {
-      return (
-        <div className="flex-1 flex flex-col min-h-0 overflow-y-auto px-6 py-6" aria-busy="true">
-          <span role="status" className="sr-only">
-            {t('loading')}
-          </span>
-        </div>
-      );
-    }
+  if (isError) {
     return (
-      <div className="flex-1 flex flex-col min-h-0 overflow-y-auto px-6 py-6">
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <PageHeader title={t('title')} />
+        <ViewEmptyState
+          variant="error"
+          title={t('loadError.title')}
+          subtitle={t('loadError.subtitle')}
+          icon={AlertCircle}
+          action={{ label: retryLabel, onClick: onRetryHydration }}
+        />
+      </div>
+    );
+  }
+
+  // Hold a skeleton frame until the first snapshot lands so a persisted queue
+  // doesn't flash "No downloads yet" on launch before it hydrates.
+  if (!hydrated) {
+    return (
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <PageHeader title={t('title')} />
+        <span role="status" className="sr-only">
+          {t('loading')}
+        </span>
+        <DownloadsViewSkeleton />
+      </div>
+    );
+  }
+
+  if (isEmpty) {
+    return (
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <PageHeader title={t('title')} />
         <ViewEmptyState
           title={t('empty.title')}
           subtitle={t('empty.description')}
@@ -62,91 +86,86 @@ export default function DownloadsView() {
     );
   });
 
-  return (
-    <div className="flex-1 flex flex-col min-h-0 overflow-y-auto px-6 py-6">
-      <header className="flex items-start justify-between gap-4 mb-5">
-        <div>
-          <h1 className="font-display text-2xl font-semibold text-foreground">{t('title')}</h1>
-          <p className="text-sm text-muted-foreground/70 mt-1">{t('subtitle')}</p>
-        </div>
-        <div className="flex items-center gap-2 shrink-0">
-          {paused ? (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onResumeQueue}
-              aria-label={t('a11y.resumeQueue')}
-              className="rounded-xl"
-            >
-              <Play className="size-4" />
-              {t('action.resume')}
-            </Button>
-          ) : (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onPauseQueue}
-              disabled={!hasPendingWork}
-              aria-label={t('a11y.pauseQueue')}
-              className="rounded-xl"
-            >
-              <Pause className="size-4" />
-              {t('action.pause')}
-            </Button>
-          )}
+  const headerActions = (
+    <>
+      {paused ? (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onResumeQueue}
+          aria-label={t('a11y.resumeQueue')}
+        >
+          <Play className="size-4" />
+          {t('action.resume')}
+        </Button>
+      ) : (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onPauseQueue}
+          disabled={!hasPendingWork}
+          aria-label={t('a11y.pauseQueue')}
+        >
+          <Pause className="size-4" />
+          {t('action.pause')}
+        </Button>
+      )}
 
-          <Popover open={showCancelAllConfirm} onOpenChange={setShowCancelAllConfirm}>
-            <PopoverTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!hasPendingWork}
-                aria-label={t('a11y.cancelAll')}
-                className="rounded-xl text-destructive hover:text-destructive"
-              >
-                <Ban className="size-4" />
-                {t('action.cancelAll')}
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent align="end" className="w-64">
-              <p className="text-xs text-foreground/80 mb-2">{t('action.cancelAllConfirm')}</p>
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={onConfirmCancelAll}
-                  className="flex-1 px-2 py-1 rounded-lg text-xs font-medium bg-destructive/15 text-destructive hover:bg-destructive/25 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                >
-                  {t('action.cancelAllConfirmAction')}
-                </button>
-                <button
-                  onClick={() => setShowCancelAllConfirm(false)}
-                  className="flex-1 px-2 py-1 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                >
-                  {t('action.keep')}
-                </button>
-              </div>
-            </PopoverContent>
-          </Popover>
-
+      <Popover open={showCancelAllConfirm} onOpenChange={setShowCancelAllConfirm}>
+        <PopoverTrigger asChild>
           <Button
             variant="outline"
             size="sm"
-            onClick={onClearCompleted}
-            disabled={!hasCompleted}
-            className="rounded-xl"
+            disabled={!hasPendingWork}
+            aria-label={t('a11y.cancelAll')}
+            className="text-destructive hover:text-destructive"
           >
-            <Trash2 className="size-4" />
-            {t('action.clearCompleted')}
+            <Ban className="size-4" />
+            {t('action.cancelAll')}
           </Button>
-        </div>
-      </header>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-64">
+          <p className="text-xs text-foreground/80 mb-2">{t('action.cancelAllConfirm')}</p>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onConfirmCancelAll}
+              className="focus-ring flex-1 px-2 py-1 rounded-lg text-xs font-medium bg-destructive/15 text-destructive hover:bg-destructive/25 transition-colors"
+            >
+              {t('action.cancelAllConfirmAction')}
+            </button>
+            <button
+              onClick={() => setShowCancelAllConfirm(false)}
+              className="focus-ring flex-1 px-2 py-1 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+            >
+              {t('action.keep')}
+            </button>
+          </div>
+        </PopoverContent>
+      </Popover>
 
-      {paused && (
-        <div className="mb-4 px-3 py-2 rounded-xl bg-amber-500/10 border border-amber-500/20 text-xs text-amber-500/90">
-          {t('paused.banner')}
-        </div>
-      )}
+      <Button variant="outline" size="sm" onClick={onClearCompleted} disabled={!hasCompleted}>
+        <Trash2 className="size-4" />
+        {t('action.clearCompleted')}
+      </Button>
+    </>
+  );
 
-      <div className="flex flex-col gap-6">{sectionBlocks}</div>
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <PageHeader title={t('title')} actions={headerActions} />
+
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin px-6 pt-4 pb-6">
+        {paused && (
+          <div
+            role="status"
+            className="mb-4 px-3 py-2 rounded-xl bg-warning/10 border border-warning/25 text-xs text-warning"
+          >
+            {t('paused.banner')}
+          </div>
+        )}
+
+        <div className="flex flex-col gap-6">{sectionBlocks}</div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/downloads/DownloadsView/DownloadsView.types.ts
+++ b/apps/web/src/components/downloads/DownloadsView/DownloadsView.types.ts
@@ -19,8 +19,14 @@ export interface IDownloadsViewView {
   readonly paused: boolean;
   /** No items at all (shows the empty/loading frame). */
   readonly isEmpty: boolean;
-  /** False until the first snapshot lands — holds a blank frame instead of the empty state. */
+  /** False until the first snapshot lands — holds a skeleton frame instead of the empty state. */
   readonly hydrated: boolean;
+  /** Initial hydration failed before any snapshot landed — shows the error state. */
+  readonly isError: boolean;
+  /** Label for the error-state retry action (common namespace). */
+  readonly retryLabel: string;
+  /** Re-attempt the initial queue hydration after a failure. */
+  readonly onRetryHydration: () => void;
   /** There is in-flight or pending work to pause / cancel. */
   readonly hasPendingWork: boolean;
   /** There are completed/terminal items to clear. */

--- a/apps/web/src/components/downloads/DownloadsView/DownloadsViewSkeleton/DownloadsViewSkeleton.hooks.ts
+++ b/apps/web/src/components/downloads/DownloadsView/DownloadsViewSkeleton/DownloadsViewSkeleton.hooks.ts
@@ -1,0 +1,30 @@
+import type {
+  IDownloadsViewSkeletonSection,
+  IDownloadsViewSkeletonView,
+} from './DownloadsViewSkeleton.types';
+
+/**
+ * Two lifecycle groups' worth of placeholder rows, echoing the Active / Queued
+ * sections a restored queue typically renders into.
+ */
+const SECTION_ROW_COUNTS: readonly number[] = [2, 3];
+
+// The frame is fixed, so the keys are built once at module scope rather than
+// on every render.
+const SECTIONS: readonly IDownloadsViewSkeletonSection[] = SECTION_ROW_COUNTS.map(
+  (rowCount, sectionIndex) => ({
+    key: `downloads-skeleton-section-${sectionIndex}`,
+    rowKeys: Array.from(
+      { length: rowCount },
+      (_, rowIndex) => `downloads-skeleton-row-${sectionIndex}-${rowIndex}`
+    ),
+  })
+);
+
+/**
+ * Owns the placeholder section list so the shell only maps ready-made keys into
+ * markup and stays a thin, logic-free render.
+ */
+export function useDownloadsViewSkeleton(): IDownloadsViewSkeletonView {
+  return { sections: SECTIONS };
+}

--- a/apps/web/src/components/downloads/DownloadsView/DownloadsViewSkeleton/DownloadsViewSkeleton.stories.tsx
+++ b/apps/web/src/components/downloads/DownloadsView/DownloadsViewSkeleton/DownloadsViewSkeleton.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
+
+import DownloadsViewSkeleton from './DownloadsViewSkeleton';
+
+/**
+ * downloads · DownloadsViewSkeleton. The loading state DownloadsView renders
+ * before the first main-process queue snapshot lands: two pulsing section
+ * groups on the same grid as `DownloadQueueRow` — heading bar, then rows of
+ * artwork square, title bar, status bar and status-button square — inside an
+ * `aria-busy` container, so a restored queue doesn't reflow once it hydrates.
+ *
+ * Non-interactive by design, so there is nothing to drive: it has exactly one
+ * appearance, and the single story asserts that structure rather than padding
+ * out variants that do not exist.
+ */
+const meta: Meta<typeof DownloadsViewSkeleton> = {
+  title: 'downloads/DownloadsViewSkeleton',
+  component: DownloadsViewSkeleton,
+  parameters: {
+    // Pulsing <div>s inside an aria-busy container — no roles, names, or text
+    // reach the a11y tree, so axe passes clean.
+    a11y: { test: 'error' },
+  },
+  decorators: [
+    Story => (
+      <div className="flex h-[36rem] w-[36rem] flex-col">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DownloadsViewSkeleton>;
+
+/** Two aria-busy placeholder section groups, five rows total, and no copy. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector('[aria-busy="true"]')).not.toBeNull();
+    await expect(canvasElement.querySelectorAll('.rounded-xl')).toHaveLength(5);
+    await expect(canvasElement.textContent).toBe('');
+  },
+};

--- a/apps/web/src/components/downloads/DownloadsView/DownloadsViewSkeleton/DownloadsViewSkeleton.test.tsx
+++ b/apps/web/src/components/downloads/DownloadsView/DownloadsViewSkeleton/DownloadsViewSkeleton.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import DownloadsViewSkeleton from './DownloadsViewSkeleton';
+
+const PLACEHOLDER_ROWS = 5;
+const BARS_PER_ROW = 4;
+const SECTION_HEADING_BARS = 2;
+
+describe('DownloadsViewSkeleton', () => {
+  it('marks its root aria-busy so assistive tech knows the queue is still loading', () => {
+    const { container } = render(<DownloadsViewSkeleton />);
+
+    expect(container.firstElementChild).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('renders two section groups of placeholder queue rows', () => {
+    const { container } = render(<DownloadsViewSkeleton />);
+
+    expect(container.querySelectorAll('.rounded-xl')).toHaveLength(PLACEHOLDER_ROWS);
+    expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(
+      PLACEHOLDER_ROWS * BARS_PER_ROW + SECTION_HEADING_BARS
+    );
+  });
+
+  it('pulses every placeholder so the queue reads as loading', () => {
+    const { container } = render(<DownloadsViewSkeleton />);
+
+    for (const placeholder of container.querySelectorAll('[data-slot="skeleton"]')) {
+      expect(placeholder.className).toContain('animate-pulse');
+    }
+  });
+
+  it('renders no copy, so no text flashes before the queue lands', () => {
+    const { container } = render(<DownloadsViewSkeleton />);
+
+    expect(container.textContent).toBe('');
+  });
+});

--- a/apps/web/src/components/downloads/DownloadsView/DownloadsViewSkeleton/DownloadsViewSkeleton.tsx
+++ b/apps/web/src/components/downloads/DownloadsView/DownloadsViewSkeleton/DownloadsViewSkeleton.tsx
@@ -1,0 +1,34 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { useDownloadsViewSkeleton } from './DownloadsViewSkeleton.hooks';
+
+export default function DownloadsViewSkeleton() {
+  const { sections } = useDownloadsViewSkeleton();
+
+  const sectionBlocks = sections.map(section => {
+    const rows = section.rowKeys.map(rowKey => (
+      <div key={rowKey} className="flex items-center gap-3 rounded-xl px-3 py-2.5">
+        <Skeleton className="h-10 w-10 rounded-lg" />
+        <div className="flex-1 space-y-1.5">
+          <Skeleton className="h-3.5 w-44 max-w-full" />
+          <Skeleton className="h-3 w-28" />
+        </div>
+        <Skeleton className="size-8 rounded-lg" />
+      </div>
+    ));
+    return (
+      <div key={section.key} className="flex flex-col gap-1.5">
+        <Skeleton className="mx-1 h-3 w-20" />
+        {rows}
+      </div>
+    );
+  });
+
+  return (
+    <div
+      className="flex-1 min-h-0 overflow-hidden px-6 pt-4 pb-6 flex flex-col gap-6"
+      aria-busy="true"
+    >
+      {sectionBlocks}
+    </div>
+  );
+}

--- a/apps/web/src/components/downloads/DownloadsView/DownloadsViewSkeleton/DownloadsViewSkeleton.types.ts
+++ b/apps/web/src/components/downloads/DownloadsView/DownloadsViewSkeleton/DownloadsViewSkeleton.types.ts
@@ -1,0 +1,19 @@
+/**
+ * DownloadsViewSkeleton takes no inputs — it is the fixed placeholder frame the
+ * downloads view shows before the first queue snapshot lands — so its props
+ * surface is intentionally empty and exists to keep the per-component contract
+ * consistent.
+ */
+export interface IDownloadsViewSkeletonProps {}
+
+export interface IDownloadsViewSkeletonSection {
+  /** Stable key for the placeholder section group. */
+  readonly key: string;
+  /** Stable key per placeholder queue row within the group. */
+  readonly rowKeys: readonly string[];
+}
+
+export interface IDownloadsViewSkeletonView {
+  /** Placeholder section groups mirroring the Active / Queued queue layout. */
+  readonly sections: readonly IDownloadsViewSkeletonSection[];
+}

--- a/apps/web/src/components/downloads/DownloadsView/DownloadsViewSkeleton/index.ts
+++ b/apps/web/src/components/downloads/DownloadsView/DownloadsViewSkeleton/index.ts
@@ -1,0 +1,2 @@
+export { default as DownloadsViewSkeleton } from './DownloadsViewSkeleton';
+export * from './DownloadsViewSkeleton.types';

--- a/apps/web/src/components/history/HistoryActivityGraph/HistoryActivityGraph.stories.tsx
+++ b/apps/web/src/components/history/HistoryActivityGraph/HistoryActivityGraph.stories.tsx
@@ -38,7 +38,7 @@ const meta: Meta<typeof HistoryActivityGraph> = {
   // a single summarizing `role="img"` label, asserted in `play`).
   decorators: [
     Story => (
-      <div className="w-[40rem] rounded-[24px] border border-border/25 p-4">
+      <div className="w-[40rem] rounded-panel border border-border/25 p-4">
         <Story />
       </div>
     ),

--- a/apps/web/src/components/history/HistoryRecentRow/HistoryRecentRow.tsx
+++ b/apps/web/src/components/history/HistoryRecentRow/HistoryRecentRow.tsx
@@ -12,7 +12,7 @@ export default function HistoryRecentRow(props: IHistoryRecentRowProps) {
       type="button"
       variants={STAGGER_ITEM}
       onClick={onPlay}
-      className="flex w-full items-center gap-3 rounded-2xl border border-border/20 bg-background/25 px-3 py-3 text-left transition-colors hover:border-border/35 hover:bg-accent/35"
+      className="focus-ring flex w-full items-center gap-3 rounded-2xl border border-border/20 bg-background/25 px-3 py-3 text-left transition-colors hover:border-border/35 hover:bg-accent/35"
     >
       <HistoryTrackArtwork albumArt={entry.albumArt} title={entry.title} />
       <div className="min-w-0 flex-1">

--- a/apps/web/src/components/history/HistoryView/HistoryView.test.tsx
+++ b/apps/web/src/components/history/HistoryView/HistoryView.test.tsx
@@ -104,6 +104,19 @@ describe('HistoryView', () => {
     expect(screen.getByText('Recent Plays')).toBeInTheDocument();
   });
 
+  it('exposes every panel as a region named by its heading', () => {
+    renderView({
+      ...EMPTY_DATA,
+      summary: { ...EMPTY_DATA.summary, topTracks: [makeTrack()], topArtists: [makeArtist()] },
+      recent: [makeEntry()],
+    });
+
+    expect(screen.getByRole('region', { name: 'Activity' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Top Tracks' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Top Artists' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Recent Plays' })).toBeInTheDocument();
+  });
+
   it('renders the row data inside their sections', () => {
     renderView({
       ...EMPTY_DATA,

--- a/apps/web/src/components/history/HistoryView/HistoryView.tsx
+++ b/apps/web/src/components/history/HistoryView/HistoryView.tsx
@@ -10,6 +10,7 @@ import { HistoryRecentRow } from '@/components/history/HistoryRecentRow';
 import { RecapShelf } from '@/components/history/RecapShelf';
 import { HistoryStatCard } from './HistoryStatCard';
 import { HistoryViewSkeleton } from './HistoryViewSkeleton';
+import { StatsSection } from './StatsSection';
 import { useHistoryView } from './HistoryView.hooks';
 
 export default function HistoryView() {
@@ -66,33 +67,27 @@ export default function HistoryView() {
       <div className="flex w-full flex-col gap-6 px-6 pb-10 pt-6">
         <HistoryHeroSection selectedRange={view.selectedRange} onRangeChange={view.onRangeChange} />
 
-        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">{statCards}</section>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">{statCards}</div>
 
-        <section className="rounded-[24px] border border-border/25 glass-panel p-4">
-          <div className="flex items-center gap-2">
-            <BarChart3 className="size-4 text-primary/80" />
-            <h2 className="font-display text-lg font-semibold text-foreground">
-              {view.activityTitle}
-            </h2>
-          </div>
-          <p className="mt-1 text-xs text-muted-foreground/65">{view.activityCaption}</p>
+        {/* The activity graph is the page's focal panel — the hero treatment
+            keeps the list panels below reading as supporting detail. */}
+        <StatsSection
+          variant="hero"
+          title={view.activityTitle}
+          caption={view.activityCaption}
+          icon={BarChart3}
+        >
           <div className="mt-5">
             <HistoryActivityGraph points={view.activitySeries} range={view.selectedRange} />
           </div>
-        </section>
+        </StatsSection>
 
         {/* Past weeks' recaps, derived on demand — where Overview's card folds
             away to, and reachable without waiting for one. */}
         <RecapShelf />
 
-        <section className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
-          <div className="rounded-[24px] border border-border/25 glass-panel p-4">
-            <div className="flex items-center gap-2">
-              <Disc3 className="size-4 text-primary/80" />
-              <h2 className="font-display text-lg font-semibold text-foreground">
-                {view.topTracksTitle}
-              </h2>
-            </div>
+        <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
+          <StatsSection title={view.topTracksTitle} icon={Disc3}>
             <div className="mt-4 space-y-3">
               {hasTopTracks ? (
                 topTrackRows
@@ -100,15 +95,9 @@ export default function HistoryView() {
                 <HistoryEmptyState title={view.noTopTracksTitle} copy={view.noTopTracksCopy} />
               )}
             </div>
-          </div>
+          </StatsSection>
 
-          <div className="rounded-[24px] border border-border/25 glass-panel p-4">
-            <div className="flex items-center gap-2">
-              <BarChart3 className="size-4 text-primary/80" />
-              <h2 className="font-display text-lg font-semibold text-foreground">
-                {view.topArtistsTitle}
-              </h2>
-            </div>
+          <StatsSection title={view.topArtistsTitle} icon={BarChart3}>
             <div className="mt-4 space-y-3">
               {hasTopArtists ? (
                 topArtistRows
@@ -119,16 +108,10 @@ export default function HistoryView() {
                 />
               )}
             </div>
-          </div>
-        </section>
+          </StatsSection>
+        </div>
 
-        <section className="rounded-[24px] border border-border/25 glass-panel p-4">
-          <div className="flex items-center gap-2">
-            <Clock3 className="size-4 text-primary/80" />
-            <h2 className="font-display text-lg font-semibold text-foreground">
-              {view.recentTitle}
-            </h2>
-          </div>
+        <StatsSection title={view.recentTitle} icon={Clock3}>
           <div className="mt-4">
             {!hasRecent ? (
               <HistoryEmptyState title={view.noRecentPlaysTitle} copy={view.noRecentPlaysCopy} />
@@ -136,7 +119,7 @@ export default function HistoryView() {
               <StaggerList className="space-y-3">{recentRows}</StaggerList>
             )}
           </div>
-        </section>
+        </StatsSection>
       </div>
     </div>
   );

--- a/apps/web/src/components/history/HistoryView/HistoryViewSkeleton/HistoryViewSkeleton.stories.tsx
+++ b/apps/web/src/components/history/HistoryView/HistoryViewSkeleton/HistoryViewSkeleton.stories.tsx
@@ -44,9 +44,9 @@ export const Default: Story = {
     await expect(canvasElement.querySelector('[aria-busy="true"]')).not.toBeNull();
     await expect(canvasElement.querySelectorAll('.rounded-full')).toHaveLength(3);
     await expect(canvasElement.querySelector('.md\\:grid-cols-4')?.children).toHaveLength(4);
-    await expect(canvasElement.querySelectorAll('.rounded-\\[24px\\]')).toHaveLength(4);
+    await expect(canvasElement.querySelectorAll('.rounded-panel')).toHaveLength(4);
     await expect(canvasElement.querySelectorAll('.border-border\\/20')).toHaveLength(14);
-    await expect(canvasElement.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(65);
+    await expect(canvasElement.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(67);
     await expect(canvasElement.textContent).toBe('');
   },
 };

--- a/apps/web/src/components/history/HistoryView/HistoryViewSkeleton/HistoryViewSkeleton.test.tsx
+++ b/apps/web/src/components/history/HistoryView/HistoryViewSkeleton/HistoryViewSkeleton.test.tsx
@@ -7,7 +7,7 @@ const HERO_PILLS = 3;
 const STAT_CARDS = 4;
 const PANELS = 4;
 const LIST_ROWS = 14;
-const TOTAL_PLACEHOLDERS = 65;
+const TOTAL_PLACEHOLDERS = 67;
 
 describe('HistoryViewSkeleton', () => {
   it('marks its root aria-busy so assistive tech knows the dashboard is still loading', () => {
@@ -33,7 +33,7 @@ describe('HistoryViewSkeleton', () => {
   it('reserves the activity, top-tracks, top-artists and recent panels', () => {
     const { container } = render(<HistoryViewSkeleton />);
 
-    expect(container.querySelectorAll('.rounded-\\[24px\\]')).toHaveLength(PANELS);
+    expect(container.querySelectorAll('.rounded-panel')).toHaveLength(PANELS);
   });
 
   it('reserves four rows in each list panel plus six recent-play rows', () => {

--- a/apps/web/src/components/history/HistoryView/HistoryViewSkeleton/HistoryViewSkeleton.tsx
+++ b/apps/web/src/components/history/HistoryView/HistoryViewSkeleton/HistoryViewSkeleton.tsx
@@ -28,7 +28,7 @@ export default function HistoryViewSkeleton() {
   ));
 
   const listPanels = listPanelKeys.map(key => (
-    <div key={key} className="rounded-[24px] border border-border/25 bg-surface/30 p-4">
+    <div key={key} className="rounded-panel border border-border/25 bg-surface/30 p-4">
       <Skeleton className="h-5 w-36" />
       <div className="mt-4 space-y-3">{panelRows}</div>
     </div>
@@ -53,12 +53,19 @@ export default function HistoryViewSkeleton() {
         <div className="mt-5 flex gap-2">{heroPills}</div>
       </div>
       <div className="grid gap-4 md:grid-cols-4">{statCards}</div>
-      <div className="rounded-[24px] border border-border/25 bg-surface/30 p-4">
-        <Skeleton className="h-5 w-40" />
+      {/* Mirrors the promoted activity panel so the page doesn't reflow. */}
+      <div className="rounded-panel border border-border/25 bg-surface/30 p-5 sm:p-6">
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-9 rounded-lg" />
+          <div className="space-y-1.5">
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-3 w-56" />
+          </div>
+        </div>
         <Skeleton className="mt-5 h-40 w-full rounded-2xl" />
       </div>
       <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">{listPanels}</div>
-      <div className="rounded-[24px] border border-border/25 bg-surface/30 p-4">
+      <div className="rounded-panel border border-border/25 bg-surface/30 p-4">
         <Skeleton className="h-5 w-40" />
         <div className="mt-4 space-y-3">{recentRows}</div>
       </div>

--- a/apps/web/src/components/history/HistoryView/StatsSection/StatsSection.hooks.ts
+++ b/apps/web/src/components/history/HistoryView/StatsSection/StatsSection.hooks.ts
@@ -1,0 +1,19 @@
+import { useId } from 'react';
+import type { IStatsSectionProps, IStatsSectionView } from './StatsSection.types';
+
+/**
+ * StatsSection is purely presentational — HistoryView's hook has already
+ * localized every string — so this hook only mints the heading id that wires
+ * the section's `aria-labelledby`, resolves the variant default, and renames
+ * `icon` to the capitalized `Icon` the shell renders.
+ */
+export function useStatsSection({
+  title,
+  icon: Icon,
+  caption,
+  variant = 'panel',
+  children,
+}: IStatsSectionProps): IStatsSectionView {
+  const headingId = useId();
+  return { headingId, title, Icon, caption, isHero: variant === 'hero', children };
+}

--- a/apps/web/src/components/history/HistoryView/StatsSection/StatsSection.stories.tsx
+++ b/apps/web/src/components/history/HistoryView/StatsSection/StatsSection.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
+import { BarChart3, Clock3 } from 'lucide-react';
+
+import StatsSection from './StatsSection';
+
+/**
+ * history · StatsSection. The section-card chrome every History panel shares:
+ * a `<section>` wired to its `<h2>` via `aria-labelledby`, a decorative icon,
+ * an optional caption, and the panel body as children. The default `panel`
+ * variant is the quiet glass card; the `hero` variant promotes one section —
+ * the activity graph — into the page's focal panel with a primary-tinted
+ * border, radial wash, icon chip, and a larger heading.
+ */
+const meta: Meta<typeof StatsSection> = {
+  title: 'history/StatsSection',
+  component: StatsSection,
+  parameters: {
+    // A labelled region with a real <h2> and a decorative icon — axe passes
+    // clean.
+    a11y: { test: 'error' },
+  },
+  decorators: [
+    Story => (
+      <div className="w-[36rem]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StatsSection>;
+
+/** The quiet section-card chrome shared by the list panels. */
+export const Panel: Story = {
+  args: {
+    title: 'Recent Plays',
+    icon: Clock3,
+    children: <p className="mt-4 text-sm text-muted-foreground">Rows render here.</p>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const region = canvas.getByRole('region', { name: 'Recent Plays' });
+    const heading = canvas.getByRole('heading', { level: 2, name: 'Recent Plays' });
+    await expect(region).toHaveAttribute('aria-labelledby', heading.id);
+  },
+};
+
+/** The promoted focal panel used by the activity graph. */
+export const Hero: Story = {
+  args: {
+    title: 'Activity',
+    icon: BarChart3,
+    caption: 'Plays per day across the selected range.',
+    variant: 'hero',
+    children: <div className="mt-5 h-32 rounded-2xl bg-background/30" />,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const region = canvas.getByRole('region', { name: 'Activity' });
+    await expect(region.className).toContain('border-primary/20');
+    await expect(canvas.getByText('Plays per day across the selected range.')).toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/history/HistoryView/StatsSection/StatsSection.test.tsx
+++ b/apps/web/src/components/history/HistoryView/StatsSection/StatsSection.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { BarChart3, Clock3 } from 'lucide-react';
+
+import StatsSection from './StatsSection';
+
+describe('StatsSection', () => {
+  it('renders a region named by its heading via aria-labelledby', () => {
+    render(
+      <StatsSection title="Recent Plays" icon={Clock3}>
+        <p>rows</p>
+      </StatsSection>
+    );
+
+    const region = screen.getByRole('region', { name: 'Recent Plays' });
+    const heading = screen.getByRole('heading', { level: 2, name: 'Recent Plays' });
+    expect(region).toHaveAttribute('aria-labelledby', heading.id);
+  });
+
+  it('renders the caption beneath the heading when provided', () => {
+    render(
+      <StatsSection title="Activity" icon={BarChart3} caption="Plays per day">
+        <div />
+      </StatsSection>
+    );
+
+    expect(screen.getByText('Plays per day')).toBeInTheDocument();
+  });
+
+  it('renders its children inside the section body', () => {
+    render(
+      <StatsSection title="Top Tracks" icon={BarChart3}>
+        <p>Midnight study session</p>
+      </StatsSection>
+    );
+
+    const region = screen.getByRole('region', { name: 'Top Tracks' });
+    expect(region).toContainElement(screen.getByText('Midnight study session'));
+  });
+
+  it('renders the supplied icon, decorative and sized by the section', () => {
+    const { container } = render(
+      <StatsSection title="Activity" icon={BarChart3}>
+        <div />
+      </StatsSection>
+    );
+
+    const icon = container.querySelector('svg') as SVGElement;
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+    expect(icon.getAttribute('class')).toContain('size-4');
+  });
+
+  it('promotes the hero variant with the primary-tinted chrome and icon chip', () => {
+    render(
+      <StatsSection title="Activity" icon={BarChart3} variant="hero" caption="Plays per day">
+        <div />
+      </StatsSection>
+    );
+
+    const region = screen.getByRole('region', { name: 'Activity' });
+    expect(region.className).toContain('border-primary/20');
+    expect(region.querySelector('.bg-primary\\/15')).not.toBeNull();
+  });
+
+  it('keeps the quiet panel chrome by default', () => {
+    render(
+      <StatsSection title="Top Artists" icon={BarChart3}>
+        <div />
+      </StatsSection>
+    );
+
+    const region = screen.getByRole('region', { name: 'Top Artists' });
+    expect(region.className).toContain('border-border/25');
+    expect(region.className).not.toContain('border-primary/20');
+  });
+});

--- a/apps/web/src/components/history/HistoryView/StatsSection/StatsSection.tsx
+++ b/apps/web/src/components/history/HistoryView/StatsSection/StatsSection.tsx
@@ -1,0 +1,47 @@
+import { useStatsSection } from './StatsSection.hooks';
+import type { IStatsSectionProps } from './StatsSection.types';
+
+export default function StatsSection(props: IStatsSectionProps) {
+  const { headingId, title, Icon, caption, isHero, children } = useStatsSection(props);
+
+  if (isHero) {
+    return (
+      <section
+        aria-labelledby={headingId}
+        className="relative overflow-hidden rounded-panel border border-primary/20 glass-panel p-5 sm:p-6"
+      >
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(var(--primary-rgb),0.14),transparent_50%)]" />
+        <div className="relative">
+          <div className="flex items-center gap-3">
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-primary/25 bg-primary/15">
+              <Icon className="size-4 text-primary" />
+            </div>
+            <div className="min-w-0">
+              <h2 id={headingId} className="font-display text-xl font-semibold text-foreground">
+                {title}
+              </h2>
+              {caption && <p className="mt-0.5 text-xs text-muted-foreground/65">{caption}</p>}
+            </div>
+          </div>
+          {children}
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="rounded-panel border border-border/25 glass-panel p-4"
+    >
+      <div className="flex items-center gap-2">
+        <Icon className="size-4 text-primary/80" />
+        <h2 id={headingId} className="font-display text-lg font-semibold text-foreground">
+          {title}
+        </h2>
+      </div>
+      {caption && <p className="mt-1 text-xs text-muted-foreground/65">{caption}</p>}
+      {children}
+    </section>
+  );
+}

--- a/apps/web/src/components/history/HistoryView/StatsSection/StatsSection.types.ts
+++ b/apps/web/src/components/history/HistoryView/StatsSection/StatsSection.types.ts
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+export interface IStatsSectionProps {
+  /** Section heading text, also the section's accessible name. */
+  readonly title: string;
+  /** Leading icon beside the heading (decorative). */
+  readonly icon: LucideIcon;
+  /** Optional supporting line beneath the heading row. */
+  readonly caption?: string;
+  /**
+   * `'hero'` promotes the section into the page's focal panel (primary tint,
+   * icon chip, larger heading); `'panel'` (the default) renders the quiet
+   * section-card chrome.
+   */
+  readonly variant?: 'panel' | 'hero';
+  /** Section body — brings its own top margin. */
+  readonly children: ReactNode;
+}
+
+export interface IStatsSectionView {
+  /** Unique id wiring the section's `aria-labelledby` to its heading. */
+  readonly headingId: string;
+  /** Section heading text, also the section's accessible name. */
+  readonly title: string;
+  /** Leading icon component, renamed for direct JSX use. */
+  readonly Icon: LucideIcon;
+  /** Optional supporting line beneath the heading row. */
+  readonly caption?: string;
+  /** Derived: whether the hero treatment applies. */
+  readonly isHero: boolean;
+  /** Section body — brings its own top margin. */
+  readonly children: ReactNode;
+}

--- a/apps/web/src/components/history/HistoryView/StatsSection/index.ts
+++ b/apps/web/src/components/history/HistoryView/StatsSection/index.ts
@@ -1,0 +1,2 @@
+export { default as StatsSection } from './StatsSection';
+export * from './StatsSection.types';

--- a/apps/web/src/components/history/RecapShelf/RecapShelf.hooks.ts
+++ b/apps/web/src/components/history/RecapShelf/RecapShelf.hooks.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useId, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RECAP_ARCHIVE_WEEKS, formatWeekRange, listCompletedWeeks } from '@/lib/recap';
 import { useWeeklyRecapQuery } from '@/hooks/queries/useRecap';
@@ -13,6 +13,7 @@ import type { IRecapShelfView } from './RecapShelf.types';
  */
 export function useRecapShelf(): IRecapShelfView {
   const { t, i18n } = useTranslation('history');
+  const headingId = useId();
 
   // The week list is stable for the whole mounted life of the view — computing
   // it once per mount keeps the chips from shifting under a click at midnight.
@@ -35,6 +36,7 @@ export function useRecapShelf(): IRecapShelfView {
   );
 
   return {
+    headingId,
     title: t('recaps.title'),
     caption: t('recaps.caption'),
     weeks,

--- a/apps/web/src/components/history/RecapShelf/RecapShelf.tsx
+++ b/apps/web/src/components/history/RecapShelf/RecapShelf.tsx
@@ -14,8 +14,17 @@ import { useRecapShelf } from './RecapShelf.hooks';
  * brings its own panel, exactly as it appears on Overview.
  */
 export default function RecapShelf() {
-  const { title, caption, weeks, onSelectWeek, recap, selectedLabel, isLoading, quietWeekCopy } =
-    useRecapShelf();
+  const {
+    headingId,
+    title,
+    caption,
+    weeks,
+    onSelectWeek,
+    recap,
+    selectedLabel,
+    isLoading,
+    quietWeekCopy,
+  } = useRecapShelf();
 
   const weekChips = weeks.map(week => (
     <button
@@ -24,8 +33,7 @@ export default function RecapShelf() {
       aria-pressed={week.selected}
       onClick={() => onSelectWeek(week.key)}
       className={cn(
-        'shrink-0 rounded-full border px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'focus-ring shrink-0 rounded-full border px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors',
         week.selected
           ? 'border-primary/40 bg-primary/10 text-primary'
           : 'border-border/25 text-muted-foreground hover:border-border/45 hover:text-foreground'
@@ -36,10 +44,12 @@ export default function RecapShelf() {
   ));
 
   return (
-    <section>
+    <section aria-labelledby={headingId}>
       <div className="flex items-center gap-2">
         <Feather className="size-4 text-primary/80" aria-hidden="true" />
-        <h2 className="font-display text-lg font-semibold text-foreground">{title}</h2>
+        <h2 id={headingId} className="font-display text-lg font-semibold text-foreground">
+          {title}
+        </h2>
       </div>
       <p className="mt-1 text-xs text-muted-foreground/65">{caption}</p>
 
@@ -47,11 +57,11 @@ export default function RecapShelf() {
 
       <div className="mt-3">
         {isLoading ? (
-          <div className="h-24 animate-pulse rounded-[24px] border border-border/20 bg-background/20" />
+          <div className="h-24 animate-pulse rounded-panel border border-border/20 bg-background/20" />
         ) : recap ? (
           <WeeklyRecapCard recap={recap} weekLabel={selectedLabel} />
         ) : (
-          <p className="rounded-[24px] border border-border/20 bg-background/20 px-4 py-8 text-center text-sm text-muted-foreground/60">
+          <p className="rounded-panel border border-border/20 bg-background/20 px-4 py-8 text-center text-sm text-muted-foreground/60">
             {quietWeekCopy}
           </p>
         )}

--- a/apps/web/src/components/history/RecapShelf/RecapShelf.types.ts
+++ b/apps/web/src/components/history/RecapShelf/RecapShelf.types.ts
@@ -18,6 +18,8 @@ export interface IRecapShelfWeek {
 }
 
 export interface IRecapShelfView {
+  /** Unique id wiring the shelf section's `aria-labelledby` to its heading. */
+  readonly headingId: string;
   /** Shelf heading ("Recaps"). */
   readonly title: string;
   /** Sub-caption under the heading. */

--- a/apps/web/src/components/shared/WeeklyRecapCard/WeeklyRecapCard.hooks.ts
+++ b/apps/web/src/components/shared/WeeklyRecapCard/WeeklyRecapCard.hooks.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useId, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { pad2 } from '@shiranami/shared';
 import { formatListeningDuration } from '@/lib/listeningDuration';
@@ -15,6 +15,7 @@ export function useWeeklyRecapCard({
   weekLabel,
 }: IWeeklyRecapCardProps): IWeeklyRecapCardView {
   const { t } = useTranslation('overview');
+  const headingId = useId();
 
   const lines = useMemo<string[]>(() => {
     const built: string[] = [];
@@ -41,6 +42,7 @@ export function useWeeklyRecapCard({
   }, [recap, t]);
 
   return {
+    headingId,
     title: t('recap.title'),
     titleEm: t('recap.titleEm'),
     weekLabel,

--- a/apps/web/src/components/shared/WeeklyRecapCard/WeeklyRecapCard.tsx
+++ b/apps/web/src/components/shared/WeeklyRecapCard/WeeklyRecapCard.tsx
@@ -12,7 +12,7 @@ import type { IWeeklyRecapCardProps } from './WeeklyRecapCard.types';
  */
 export default function WeeklyRecapCard(props: IWeeklyRecapCardProps) {
   const { onOpenArchive } = props;
-  const { title, titleEm, weekLabel, lines, archiveLabel } = useWeeklyRecapCard(props);
+  const { headingId, title, titleEm, weekLabel, lines, archiveLabel } = useWeeklyRecapCard(props);
 
   const lineNodes = lines.map(line => (
     <p key={line} className="text-sm leading-relaxed text-muted-foreground">
@@ -21,11 +21,14 @@ export default function WeeklyRecapCard(props: IWeeklyRecapCardProps) {
   ));
 
   return (
-    <section className="rounded-[24px] border border-border/25 glass-panel p-4">
+    <section
+      aria-labelledby={headingId}
+      className="rounded-panel border border-border/25 glass-panel p-4"
+    >
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <Feather className="size-4 text-primary/80" aria-hidden="true" />
-          <h2 className="font-display text-lg font-semibold text-foreground">
+          <h2 id={headingId} className="font-display text-lg font-semibold text-foreground">
             {title} <em className="text-primary/85">{titleEm}</em>
           </h2>
         </div>
@@ -33,7 +36,7 @@ export default function WeeklyRecapCard(props: IWeeklyRecapCardProps) {
           <button
             type="button"
             onClick={onOpenArchive}
-            className="rounded-lg px-2 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-primary/80 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="focus-ring rounded-lg px-2 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-primary/80 transition-colors hover:text-primary"
           >
             {archiveLabel} →
           </button>

--- a/apps/web/src/components/shared/WeeklyRecapCard/WeeklyRecapCard.types.ts
+++ b/apps/web/src/components/shared/WeeklyRecapCard/WeeklyRecapCard.types.ts
@@ -13,6 +13,8 @@ export interface IWeeklyRecapCardProps {
 }
 
 export interface IWeeklyRecapCardView {
+  /** Unique id wiring the card section's `aria-labelledby` to its heading. */
+  readonly headingId: string;
   /** Card heading ("The week, in short."). */
   readonly title: string;
   /** Emphasized tail of the heading. */

--- a/apps/web/src/hooks/useDownloadQueueImporter.ts
+++ b/apps/web/src/hooks/useDownloadQueueImporter.ts
@@ -50,6 +50,28 @@ export function reconstructBatchesFromSnapshot(items: DownloadQueueItem[]): void
   }
 }
 
+/**
+ * Fetch the persisted main-process queue and mirror it into the renderer
+ * stores: batches first (so the App-level importer sees each batch the instant
+ * it sees its items — zustand setState is synchronous), then the queue
+ * snapshot. On failure the queue store is flagged so the Downloads view can
+ * surface an error state with a retry; any later queue-state broadcast also
+ * recovers the snapshot.
+ */
+export function hydrateDownloadQueue(): void {
+  if (!IS_ELECTRON) return;
+  window.electronAPI.downloader
+    .getDownloadQueue()
+    .then(snapshot => {
+      reconstructBatchesFromSnapshot(snapshot.items);
+      useDownloadQueueStore.getState().applySnapshot(snapshot);
+    })
+    .catch((err: unknown) => {
+      logger.error('[downloads] queue hydration failed', err);
+      useDownloadQueueStore.getState().markHydrationFailed();
+    });
+}
+
 export interface BatchImportSummary {
   done: number;
   skipped: number;

--- a/apps/web/src/locales/en/downloads.json
+++ b/apps/web/src/locales/en/downloads.json
@@ -1,6 +1,5 @@
 {
   "title": "Downloads",
-  "subtitle": "Track and manage your active and completed downloads.",
   "section": {
     "active": "Active",
     "queued": "Queued",
@@ -35,6 +34,10 @@
     "cancelAllFailed": "Couldn't cancel the queue. Please try again."
   },
   "loading": "Loading downloads…",
+  "loadError": {
+    "title": "Couldn't load the download queue",
+    "subtitle": "Something went wrong. Try again."
+  },
   "empty": {
     "title": "No downloads yet",
     "description": "Tracks you download from search, recommendations, or playlist import will appear here."

--- a/apps/web/src/locales/pl/downloads.json
+++ b/apps/web/src/locales/pl/downloads.json
@@ -1,6 +1,5 @@
 {
   "title": "Pobierania",
-  "subtitle": "Śledź aktywne i zakończone pobierania oraz zarządzaj nimi.",
   "section": {
     "active": "Aktywne",
     "queued": "W kolejce",
@@ -35,6 +34,10 @@
     "cancelAllFailed": "Nie udało się anulować kolejki. Spróbuj ponownie."
   },
   "loading": "Ładowanie pobierań…",
+  "loadError": {
+    "title": "Nie udało się załadować kolejki pobierań",
+    "subtitle": "Coś poszło nie tak. Spróbuj ponownie."
+  },
   "empty": {
     "title": "Brak pobierań",
     "description": "Utwory pobrane z wyszukiwarki, rekomendacji lub importu playlisty pojawią się tutaj."

--- a/apps/web/src/stores/useDownloadQueueStore.ts
+++ b/apps/web/src/stores/useDownloadQueueStore.ts
@@ -23,10 +23,17 @@ interface DownloadQueueState {
    * doesn't flash the empty state on launch.
    */
   hydrated: boolean;
+  /**
+   * True when the initial queue fetch failed before any snapshot landed. Only
+   * meaningful while `hydrated` is false — any successful snapshot (retry or
+   * queue-state broadcast) clears it and the queue is live again.
+   */
+  hydrationFailed: boolean;
 }
 
 interface DownloadQueueActions {
   applySnapshot: (snapshot: DownloadQueueSnapshot) => void;
+  markHydrationFailed: () => void;
   getById: (id: string) => DownloadQueueItem | undefined;
   getByUrl: (url: string) => DownloadQueueItem | undefined;
   getByYoutubeId: (youtubeId: string) => DownloadQueueItem | undefined;
@@ -55,6 +62,7 @@ export const useDownloadQueueStore = create<DownloadQueueState & DownloadQueueAc
     activeCount: 0,
     paused: false,
     hydrated: false,
+    hydrationFailed: false,
 
     applySnapshot: snapshot => {
       const { byUrl, byYoutubeId } = buildIndices(snapshot.items);
@@ -66,8 +74,11 @@ export const useDownloadQueueStore = create<DownloadQueueState & DownloadQueueAc
         activeCount: snapshot.activeCount,
         paused: snapshot.paused,
         hydrated: true,
+        hydrationFailed: false,
       });
     },
+
+    markHydrationFailed: () => set({ hydrationFailed: true }),
 
     getById: id => get().items.find(item => item.id === id),
     getByUrl: url => get().byUrl.get(url),

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -41,6 +41,9 @@
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
+  /* Section-card panels (the 24px `rounded-panel` chrome), tied to the app
+     radius so the whole family scales together. */
+  --radius-panel: calc(var(--radius) * 2);
 
   --font-sans: 'DM Sans', system-ui, sans-serif;
   --font-display: 'Sora', 'DM Sans', system-ui, sans-serif;


### PR DESCRIPTION
## Summary

Polish pass over the Downloads and History views, building on the v2 foundation sweep (PageHeader actions slot, status tokens, unified focus ring).

**Downloads (`DownloadsView`)**
- Replaces the bespoke `<h1>` header with the house `PageHeader` (serif italic title), moving pause/resume, cancel-all, and clear-completed into its actions slot; the header now stays put across the loading/empty/error/populated states.
- The paused banner drops its raw amber classes for the `warning` status token.
- The blank pre-hydration frame becomes a `DownloadsViewSkeleton` (pulsing queue rows on the `DownloadQueueRow` grid, `aria-busy`).
- A failed initial queue fetch now flags the store (`hydrationFailed`) and renders the `ViewEmptyState` error vocabulary with a Retry action; App boot and the retry share one `hydrateDownloadQueue()` path, and any later queue-state broadcast still recovers automatically.
- New `loadError.*` strings in both locales; the unused header `subtitle` string is removed.

**History (`HistoryView`)**
- The 4× inlined section-card chrome (rounded 24px glass panel + icon + `font-display` heading) folds into one shared `StatsSection`, with each `<section>` wired to its heading via `aria-labelledby` (so every panel is a named region).
- A `hero` variant promotes the activity graph into the page's focal panel — primary-tinted border, radial wash, icon chip, larger heading — so the page no longer reads as four identical panels; the skeleton mirrors the promoted panel to avoid reflow.
- `rounded-[24px]` joins the app radius family as `--radius-panel` (`calc(var(--radius) * 2)`) and the history-scope panels adopt `rounded-panel`.
- `HistoryRecentRow` picks up the unified `focus-ring`; RecapShelf week chips and the WeeklyRecapCard archive action swap their raw focus classes for it; RecapShelf and WeeklyRecapCard sections gain the same `aria-labelledby` heading wiring.

## Test plan

- [x] `pnpm --filter @shiranami/web typecheck`
- [x] `pnpm --filter @shiranami/web test` (335 files, 2177 tests)
- [x] `pnpm --filter @shiranami/web test:storybook`
- [x] `pnpm lint`, `pnpm lint:meta`, `pnpm format:check`
- [x] New coverage: downloads error state + retry recovery, skeleton structure, persistent page header; `StatsSection` region wiring + hero/panel variants; HistoryView named-region assertions
