### PR TITLE
feat(web): topbar + context menu polish on a shared menu primitive

### DIFF
--- a/apps/web/src/components/shared/PlaylistContextMenu/PlaylistContextMenu.test.tsx
+++ b/apps/web/src/components/shared/PlaylistContextMenu/PlaylistContextMenu.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, expect, it, vi } from 'vitest';
 import type { Playlist } from '@/types/electron';
+import { useViewStore } from '@/stores/useViewStore';
 
 import PlaylistContextMenu from './PlaylistContextMenu';
 
@@ -12,21 +14,33 @@ const playlist: Playlist = {
   updatedAt: '2026-01-01T00:00:00.000Z',
 };
 
-function renderMenu(): void {
+function renderMenu(onClose: () => void = vi.fn()): void {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   render(
     <QueryClientProvider client={client}>
-      <PlaylistContextMenu playlist={playlist} position={{ x: 10, y: 10 }} onClose={vi.fn()} />
+      <PlaylistContextMenu playlist={playlist} position={{ x: 10, y: 10 }} onClose={onClose} />
     </QueryClientProvider>
   );
 }
 
 describe('PlaylistContextMenu', () => {
-  it('renders the Open / Play / Shuffle actions', () => {
+  it('renders a menu with the Open / Play / Shuffle actions', () => {
     renderMenu();
 
-    expect(screen.getByRole('button', { name: 'Open Playlist' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Play Playlist' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Shuffle Playlist' })).toBeInTheDocument();
+    expect(screen.getByRole('menu', { name: 'Playlist actions' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Open Playlist' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Play Playlist' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Shuffle Playlist' })).toBeInTheDocument();
+  });
+
+  it('navigates to the playlist and closes when Open Playlist is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderMenu(onClose);
+
+    await user.click(screen.getByRole('menuitem', { name: 'Open Playlist' }));
+
+    expect(useViewStore.getState().activeView).toBe('playlists');
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/shared/PlaylistContextMenu/PlaylistContextMenu.tsx
+++ b/apps/web/src/components/shared/PlaylistContextMenu/PlaylistContextMenu.tsx
@@ -1,63 +1,24 @@
-import { createPortal } from 'react-dom';
-import { motion, AnimatePresence } from 'motion/react';
 import { ListMusic, Play, Shuffle } from 'lucide-react';
+import { ContextMenuSurface, Menu, MenuItem } from '@/components/ui/menu';
 import { usePlaylistContextMenu } from './PlaylistContextMenu.hooks';
 import type { IPlaylistContextMenuProps } from './PlaylistContextMenu.types';
-
-function MenuItem({
-  icon,
-  label,
-  onClick,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className="focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
-    >
-      <span className="shrink-0 w-4 h-4 flex items-center justify-center text-muted-foreground/60">
-        {icon}
-      </span>
-      {label}
-    </button>
-  );
-}
 
 export default function PlaylistContextMenu(props: IPlaylistContextMenuProps) {
   const { t, menuRef, adjustedPosition, onOpen, onPlay, onShuffle } = usePlaylistContextMenu(props);
 
-  return createPortal(
-    <AnimatePresence>
-      <motion.div
-        ref={menuRef}
-        initial={{ opacity: 0, scale: 0.95 }}
-        animate={{ opacity: 1, scale: 1 }}
-        exit={{ opacity: 0, scale: 0.95 }}
-        transition={{ duration: 0.12 }}
-        className="fixed z-50 min-w-[200px] py-1 rounded-xl bg-card border border-border/50 shadow-xl shadow-black/30"
-        style={{
-          left: adjustedPosition.x,
-          top: adjustedPosition.y,
-          transformOrigin: 'top left',
-        }}
-        onContextMenu={(event: React.MouseEvent) => event.preventDefault()}
-      >
-        <MenuItem
-          icon={<ListMusic className="w-4 h-4" />}
-          label={t('openPlaylist')}
-          onClick={onOpen}
-        />
-        <MenuItem icon={<Play className="w-4 h-4" />} label={t('playPlaylist')} onClick={onPlay} />
-        <MenuItem
-          icon={<Shuffle className="w-4 h-4" />}
-          label={t('shufflePlaylist')}
-          onClick={onShuffle}
-        />
-      </motion.div>
-    </AnimatePresence>,
-    document.body
+  return (
+    <ContextMenuSurface menuRef={menuRef} position={adjustedPosition}>
+      <Menu autoFocus onRequestClose={props.onClose} aria-label={t('playlistMenuAria')}>
+        <MenuItem icon={<ListMusic className="w-4 h-4" />} onClick={onOpen}>
+          {t('openPlaylist')}
+        </MenuItem>
+        <MenuItem icon={<Play className="w-4 h-4" />} onClick={onPlay}>
+          {t('playPlaylist')}
+        </MenuItem>
+        <MenuItem icon={<Shuffle className="w-4 h-4" />} onClick={onShuffle}>
+          {t('shufflePlaylist')}
+        </MenuItem>
+      </Menu>
+    </ContextMenuSurface>
   );
 }

--- a/apps/web/src/components/shared/TopBar/TopBar.hooks.ts
+++ b/apps/web/src/components/shared/TopBar/TopBar.hooks.ts
@@ -1,10 +1,10 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useViewStore } from '@/stores/useViewStore';
 import { useInterfaceStore } from '@/stores/useInterfaceStore';
 import { useLibraryRescan } from '@/hooks/useLibraryRescan';
 import { isScanLocked } from '@/lib/scanLock';
-import { persistLanguage, type SupportedLanguage } from '@/lib/i18n';
+import { persistLanguage, SUPPORTED_LANGUAGES, type SupportedLanguage } from '@/lib/i18n';
 import type { ITopBarProps, ITopBarView } from './TopBar.types';
 
 const VIEW_TITLE_KEYS: Record<string, string> = {
@@ -24,23 +24,37 @@ export function useTopBar({ onAddFile, onAddFolder, isScanning }: ITopBarProps):
   const { t, i18n } = useTranslation('topbar');
   const activeView = useViewStore(s => s.activeView);
   const [dropdownOpen, setDropdownOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const addMenuRef = useRef<HTMLDivElement>(null);
   const { isScanning: isRescanning, rescan } = useLibraryRescan();
   const showLanguageSwitcher = useInterfaceStore(s => s.topBarLanguageSwitcher);
 
   const scanBlocked = Boolean(isScanning) || isRescanning || isScanLocked();
 
-  // Close dropdown on click outside
-  useEffect(() => {
-    if (!dropdownOpen) return;
-    const handler = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setDropdownOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [dropdownOpen]);
+  const handleLanguageChange = (lang: SupportedLanguage) => {
+    i18n.changeLanguage(lang);
+    persistLanguage(lang);
+  };
+
+  const handleLanguageKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    const delta =
+      event.key === 'ArrowRight' || event.key === 'ArrowDown'
+        ? 1
+        : event.key === 'ArrowLeft' || event.key === 'ArrowUp'
+          ? -1
+          : 0;
+    if (delta === 0) return;
+    event.preventDefault();
+    const codes = SUPPORTED_LANGUAGES.map(lang => lang.code);
+    const current = codes.indexOf(i18n.language as SupportedLanguage);
+    const nextIndex = (Math.max(current, 0) + delta + codes.length) % codes.length;
+    handleLanguageChange(codes[nextIndex]);
+    // Radiogroup convention: selection follows focus, so move focus onto the
+    // radio that just became checked.
+    const radios = event.currentTarget
+      .closest('[role="radiogroup"]')
+      ?.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+    radios?.[nextIndex]?.focus();
+  };
 
   return {
     t,
@@ -48,9 +62,15 @@ export function useTopBar({ onAddFile, onAddFolder, isScanning }: ITopBarProps):
     isNowPlaying: activeView === 'now-playing',
     isLibraryView: activeView === 'library',
     dropdownOpen,
-    toggleDropdown: () => setDropdownOpen(v => !v),
+    onDropdownOpenChange: setDropdownOpen,
     closeDropdown: () => setDropdownOpen(false),
-    dropdownRef,
+    addMenuRef,
+    onDropdownAutoFocus: event => {
+      // The popover would focus its content wrapper; hand focus to the menu
+      // itself so arrow keys and typeahead work immediately.
+      event.preventDefault();
+      addMenuRef.current?.focus({ preventScroll: true });
+    },
     scanBlocked,
     isRescanning,
     rescanDisabled: isRescanning || isScanLocked(),
@@ -60,10 +80,8 @@ export function useTopBar({ onAddFile, onAddFolder, isScanning }: ITopBarProps):
     },
     showLanguageSwitcher,
     currentLanguage: i18n.language,
-    onLanguageChange: (lang: SupportedLanguage) => {
-      i18n.changeLanguage(lang);
-      persistLanguage(lang);
-    },
+    onLanguageChange: handleLanguageChange,
+    onLanguageKeyDown: handleLanguageKeyDown,
     onAddFolder: () => {
       onAddFolder?.();
       setDropdownOpen(false);

--- a/apps/web/src/components/shared/TopBar/TopBar.test.tsx
+++ b/apps/web/src/components/shared/TopBar/TopBar.test.tsx
@@ -1,9 +1,12 @@
 import { render, screen } from '@testing-library/react';
-import { vi, describe, it, expect } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import TopBar from './TopBar';
 import type { AppView } from '@/stores/useViewStore';
 
 let activeView: AppView = 'library';
+const changeLanguage = vi.fn();
+const persistLanguage = vi.fn();
 
 vi.mock('@/stores/useViewStore', () => ({
   useViewStore: <T,>(selector: (s: Record<string, unknown>) => T) => selector({ activeView }),
@@ -14,7 +17,7 @@ vi.mock('@/stores/useInterfaceStore', () => ({
 }));
 vi.mock('react-i18next', () => ({
   // Echo the requested key so we can assert which translation key the header used.
-  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage } }),
 }));
 vi.mock('@/hooks/useWindowControls', () => ({
   useWindowControls: () => ({
@@ -29,7 +32,18 @@ vi.mock('@/hooks/useLibraryRescan', () => ({
 }));
 vi.mock('@/lib/scanLock', () => ({ isScanLocked: () => false }));
 vi.mock('@/lib/platform', () => ({ IS_ELECTRON: false, IS_MAC: false }));
-vi.mock('@/lib/i18n', () => ({ SUPPORTED_LANGUAGES: [{ code: 'en' }], persistLanguage: vi.fn() }));
+vi.mock('@/lib/i18n', () => ({
+  SUPPORTED_LANGUAGES: [
+    { code: 'en', label: 'English' },
+    { code: 'pl', label: 'Polski' },
+  ],
+  persistLanguage: (lang: string) => persistLanguage(lang),
+}));
+
+beforeEach(() => {
+  changeLanguage.mockClear();
+  persistLanguage.mockClear();
+});
 
 describe('TopBar page title', () => {
   it.each<[AppView, string]>([
@@ -47,5 +61,83 @@ describe('TopBar page title', () => {
     activeView = 'now-playing';
     render(<TopBar />);
     expect(screen.queryByRole('heading', { level: 1 })).toBeNull();
+  });
+});
+
+describe('TopBar add dropdown', () => {
+  it('opens a menu from the trigger and fires the add actions', async () => {
+    activeView = 'library';
+    const user = userEvent.setup();
+    const onAddFolder = vi.fn();
+    render(<TopBar onAddFolder={onAddFolder} />);
+
+    const trigger = screen.getByRole('button', { name: 'add' });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('menu', { name: 'add' })).toHaveFocus();
+    expect(screen.getByRole('menuitem', { name: 'addFolder' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'addFile' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'rescan' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('menuitem', { name: 'addFolder' }));
+
+    expect(onAddFolder).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
+  it('supports arrow-key navigation and closes on Escape', async () => {
+    activeView = 'library';
+    const user = userEvent.setup();
+    render(<TopBar />);
+
+    await user.click(screen.getByRole('button', { name: 'add' }));
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('menuitem', { name: 'addFolder' })).toHaveFocus();
+
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+});
+
+describe('TopBar language segmented control', () => {
+  it('exposes a radiogroup with the active language checked', () => {
+    activeView = 'library';
+    render(<TopBar />);
+
+    const group = screen.getByRole('radiogroup', { name: 'language.label' });
+    const radios = screen.getAllByRole('radio');
+    expect(group).toBeInTheDocument();
+    expect(radios).toHaveLength(2);
+    expect(screen.getByRole('radio', { name: 'English' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Polski' })).not.toBeChecked();
+  });
+
+  it('switches and persists the language on click', async () => {
+    activeView = 'library';
+    const user = userEvent.setup();
+    render(<TopBar />);
+
+    await user.click(screen.getByRole('radio', { name: 'Polski' }));
+
+    expect(changeLanguage).toHaveBeenCalledWith('pl');
+    expect(persistLanguage).toHaveBeenCalledWith('pl');
+  });
+
+  it('moves selection with arrow keys, selection following focus', async () => {
+    activeView = 'library';
+    const user = userEvent.setup();
+    render(<TopBar />);
+
+    const english = screen.getByRole('radio', { name: 'English' });
+    english.focus();
+    await user.keyboard('{ArrowRight}');
+
+    expect(changeLanguage).toHaveBeenCalledWith('pl');
+    expect(persistLanguage).toHaveBeenCalledWith('pl');
+    expect(screen.getByRole('radio', { name: 'Polski' })).toHaveFocus();
   });
 });

--- a/apps/web/src/components/shared/TopBar/TopBar.tsx
+++ b/apps/web/src/components/shared/TopBar/TopBar.tsx
@@ -1,6 +1,8 @@
 import { Plus, FolderOpen, File, RefreshCw, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { WindowControls } from '@/components/shared/WindowControls';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Menu, MenuDivider, MenuItem } from '@/components/ui/menu';
 import { SUPPORTED_LANGUAGES } from '@/lib/i18n';
 import { useTopBar } from './TopBar.hooks';
 import type { ITopBarProps } from './TopBar.types';
@@ -12,8 +14,10 @@ export default function TopBar(props: ITopBarProps) {
     isNowPlaying,
     isLibraryView,
     dropdownOpen,
-    toggleDropdown,
-    dropdownRef,
+    onDropdownOpenChange,
+    closeDropdown,
+    addMenuRef,
+    onDropdownAutoFocus,
     scanBlocked,
     isRescanning,
     rescanDisabled,
@@ -21,19 +25,30 @@ export default function TopBar(props: ITopBarProps) {
     showLanguageSwitcher,
     currentLanguage,
     onLanguageChange,
+    onLanguageKeyDown,
     onAddFolder,
     onAddFile,
   } = useTopBar(props);
+
+  // Guard against an i18n language outside the supported set — the group must
+  // always keep exactly one tab stop.
+  const checkedLanguage = SUPPORTED_LANGUAGES.some(lang => lang.code === currentLanguage)
+    ? currentLanguage
+    : SUPPORTED_LANGUAGES[0].code;
 
   const languageButtons = SUPPORTED_LANGUAGES.map(lang => (
     <button
       key={lang.code}
       type="button"
+      role="radio"
+      aria-checked={checkedLanguage === lang.code}
+      tabIndex={checkedLanguage === lang.code ? 0 : -1}
+      aria-label={lang.label}
       onClick={() => onLanguageChange(lang.code)}
-      aria-label={t(`language.${lang.code}`)}
+      onKeyDown={onLanguageKeyDown}
       className={cn(
         'focus-ring px-2 py-1 rounded-md text-xs font-medium transition-colors',
-        currentLanguage === lang.code
+        checkedLanguage === lang.code
           ? 'bg-primary/15 text-primary'
           : 'text-muted-foreground/60 hover:text-foreground hover:bg-accent'
       )}
@@ -59,59 +74,67 @@ export default function TopBar(props: ITopBarProps) {
 
       {/* Add dropdown - only show on library view */}
       {isLibraryView && (
-        <div ref={dropdownRef} className="no-drag relative mr-2">
-          <button
-            onClick={toggleDropdown}
-            disabled={scanBlocked}
-            className={cn(
-              'focus-ring flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-colors',
-              dropdownOpen
-                ? 'bg-accent text-foreground'
-                : 'text-muted-foreground hover:text-foreground hover:bg-accent'
-            )}
-          >
-            <Plus className="w-3.5 h-3.5" />
-            <span>{scanBlocked ? t('scanning') : t('add')}</span>
-          </button>
-
-          {dropdownOpen && (
-            <div className="absolute right-0 top-full mt-1 w-44 py-1 rounded-xl bg-card border border-border/50 shadow-xl shadow-black/20 z-50">
+        <div className="no-drag mr-2">
+          <Popover open={dropdownOpen} onOpenChange={onDropdownOpenChange}>
+            <PopoverTrigger asChild>
               <button
-                onClick={onAddFolder}
-                className="focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
-              >
-                <FolderOpen className="w-4 h-4 text-muted-foreground" />
-                {t('addFolder')}
-              </button>
-              <button
-                onClick={onAddFile}
-                className="focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm text-foreground/80 hover:text-foreground hover:bg-accent transition-colors"
-              >
-                <File className="w-4 h-4 text-muted-foreground" />
-                {t('addFile')}
-              </button>
-              <div className="my-1 mx-2 h-px bg-border/40" />
-              <button
-                onClick={onRescan}
-                disabled={rescanDisabled}
-                className="focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm text-foreground/80 hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50 disabled:pointer-events-none"
-              >
-                {isRescanning ? (
-                  <Loader2 className="w-4 h-4 text-muted-foreground animate-spin" />
-                ) : (
-                  <RefreshCw className="w-4 h-4 text-muted-foreground" />
+                type="button"
+                disabled={scanBlocked}
+                aria-haspopup="menu"
+                className={cn(
+                  'focus-ring flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-colors',
+                  dropdownOpen
+                    ? 'bg-accent text-foreground'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-accent'
                 )}
-                {isRescanning ? t('rescanning') : t('rescan')}
+              >
+                <Plus className="w-3.5 h-3.5" />
+                <span>{scanBlocked ? t('scanning') : t('add')}</span>
               </button>
-            </div>
-          )}
+            </PopoverTrigger>
+            <PopoverContent
+              align="end"
+              sideOffset={4}
+              onOpenAutoFocus={onDropdownAutoFocus}
+              className="w-44 p-0 bg-card border-border/50 duration-[120ms]"
+            >
+              <Menu ref={addMenuRef} aria-label={t('add')} onRequestClose={closeDropdown}>
+                <MenuItem icon={<FolderOpen className="w-4 h-4" />} onClick={onAddFolder}>
+                  {t('addFolder')}
+                </MenuItem>
+                <MenuItem icon={<File className="w-4 h-4" />} onClick={onAddFile}>
+                  {t('addFile')}
+                </MenuItem>
+                <MenuDivider />
+                <MenuItem
+                  icon={
+                    isRescanning ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <RefreshCw className="w-4 h-4" />
+                    )
+                  }
+                  disabled={rescanDisabled}
+                  onClick={onRescan}
+                >
+                  {isRescanning ? t('rescanning') : t('rescan')}
+                </MenuItem>
+              </Menu>
+            </PopoverContent>
+          </Popover>
         </div>
       )}
 
       {/* Language segmented control — hideable via Settings · Interface
           (the picker also lives in Settings · Appearance, so nothing is lost) */}
       {showLanguageSwitcher && (
-        <div className="no-drag flex items-center gap-0.5 mr-2">{languageButtons}</div>
+        <div
+          role="radiogroup"
+          aria-label={t('language.label')}
+          className="no-drag flex items-center gap-0.5 mr-2"
+        >
+          {languageButtons}
+        </div>
       )}
 
       {/* Window controls (Windows only) */}

--- a/apps/web/src/components/shared/TopBar/TopBar.types.ts
+++ b/apps/web/src/components/shared/TopBar/TopBar.types.ts
@@ -20,12 +20,14 @@ export interface ITopBarView {
   readonly isLibraryView: boolean;
   /** Whether the Add/Rescan dropdown is open. */
   readonly dropdownOpen: boolean;
-  /** Toggle the Add/Rescan dropdown. */
-  readonly toggleDropdown: () => void;
+  /** Open/close the Add/Rescan dropdown (wired to the popover). */
+  readonly onDropdownOpenChange: (open: boolean) => void;
   /** Close the Add/Rescan dropdown. */
   readonly closeDropdown: () => void;
-  /** Ref for the dropdown wrapper — drives click-outside dismissal. */
-  readonly dropdownRef: React.RefObject<HTMLDivElement | null>;
+  /** Ref for the dropdown's menu — receives focus when the popover opens. */
+  readonly addMenuRef: React.RefObject<HTMLDivElement | null>;
+  /** Redirects the popover's open auto-focus onto the menu itself. */
+  readonly onDropdownAutoFocus: (event: Event) => void;
   /** Add/Rescan actions are blocked while any scan is in progress. */
   readonly scanBlocked: boolean;
   /** A library rescan is currently running. */
@@ -40,6 +42,8 @@ export interface ITopBarView {
   readonly currentLanguage: string;
   /** Switch language and persist the choice. */
   readonly onLanguageChange: (lang: SupportedLanguage) => void;
+  /** Radiogroup arrow-key handling — moves selection and focus together. */
+  readonly onLanguageKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
   /** Add a folder (gated by the host), then close the dropdown. */
   readonly onAddFolder: () => void;
   /** Add a single file (gated by the host), then close the dropdown. */

--- a/apps/web/src/components/shared/TrackContextMenu/PlaylistSubmenu/PlaylistSubmenu.hooks.ts
+++ b/apps/web/src/components/shared/TrackContextMenu/PlaylistSubmenu/PlaylistSubmenu.hooks.ts
@@ -16,24 +16,56 @@ export function usePlaylistSubmenu({
 }: IPlaylistSubmenuProps): IPlaylistSubmenuView {
   const { t } = useTranslation('contextMenu');
   const parentRef = useRef<HTMLDivElement>(null);
+  const rowRef = useRef<HTMLButtonElement>(null);
   const submenuRef = useRef<HTMLDivElement>(null);
   const [submenuSide, setSubmenuSide] = useState<'right' | 'left'>('right');
   const [isSubmenuOpen, setIsSubmenuOpen] = useState(false);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Keyboard opens hand focus to the panel once it mounts; hover opens don't.
+  const openedByKeyboardRef = useRef(false);
 
-  const handleMouseEnter = useCallback(() => {
+  const cancelPendingClose = useCallback(() => {
     if (closeTimerRef.current) {
       clearTimeout(closeTimerRef.current);
       closeTimerRef.current = null;
     }
-    setIsSubmenuOpen(true);
   }, []);
+
+  const handleMouseEnter = useCallback(() => {
+    cancelPendingClose();
+    setIsSubmenuOpen(true);
+  }, [cancelPendingClose]);
 
   const handleMouseLeave = useCallback(() => {
     closeTimerRef.current = setTimeout(() => {
       setIsSubmenuOpen(false);
     }, CLOSE_DELAY_MS);
   }, []);
+
+  const handleRowKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === 'Enter' || event.key === ' ' || event.key === 'ArrowRight') {
+        event.preventDefault();
+        cancelPendingClose();
+        openedByKeyboardRef.current = true;
+        setIsSubmenuOpen(true);
+      } else if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        setIsSubmenuOpen(false);
+      }
+    },
+    [cancelPendingClose]
+  );
+
+  // After a keyboard open, move focus into the panel so the picker is
+  // immediately operable (the roving track-menu focus stays on the row
+  // otherwise).
+  useEffect(() => {
+    if (!isSubmenuOpen || !openedByKeyboardRef.current) return;
+    openedByKeyboardRef.current = false;
+    const first = submenuRef.current?.querySelector<HTMLElement>('button:not([disabled]), input');
+    first?.focus({ preventScroll: true });
+  }, [isSubmenuOpen]);
 
   useEffect(() => {
     return () => {
@@ -54,6 +86,7 @@ export function usePlaylistSubmenu({
     trackIds,
     onClose,
     parentRef,
+    rowRef,
     submenuRef,
     isSubmenuOpen,
     submenuClassName: cn(
@@ -62,5 +95,6 @@ export function usePlaylistSubmenu({
     ),
     onMouseEnter: handleMouseEnter,
     onMouseLeave: handleMouseLeave,
+    onRowKeyDown: handleRowKeyDown,
   };
 }

--- a/apps/web/src/components/shared/TrackContextMenu/PlaylistSubmenu/PlaylistSubmenu.test.tsx
+++ b/apps/web/src/components/shared/TrackContextMenu/PlaylistSubmenu/PlaylistSubmenu.test.tsx
@@ -127,6 +127,32 @@ describe('PlaylistSubmenu', () => {
     expect(screen.queryByText('Late night')).toBeNull();
   });
 
+  it('opens the fly-out from the keyboard and hands focus to the picker', async () => {
+    renderSubmenu();
+    const rowButton = screen.getByRole('menuitem', { name: 'Add to Playlist' });
+    expect(rowButton).toHaveAttribute('aria-haspopup', 'menu');
+    expect(rowButton).toHaveAttribute('aria-expanded', 'false');
+
+    rowButton.focus();
+    fireEvent.keyDown(rowButton, { key: 'Enter' });
+
+    expect(await screen.findByText('Late night')).toBeInTheDocument();
+    expect(rowButton).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('button', { name: 'Late night' })).toHaveFocus();
+  });
+
+  it('closes the fly-out again on ArrowLeft from the row', async () => {
+    renderSubmenu();
+    const rowButton = screen.getByRole('menuitem', { name: 'Add to Playlist' });
+
+    rowButton.focus();
+    fireEvent.keyDown(rowButton, { key: 'ArrowRight' });
+    expect(await screen.findByText('Late night')).toBeInTheDocument();
+
+    fireEvent.keyDown(rowButton, { key: 'ArrowLeft' });
+    expect(screen.queryByText('Late night')).toBeNull();
+  });
+
   it('cancels the pending close when the pointer comes back', () => {
     vi.useFakeTimers();
     renderSubmenu();

--- a/apps/web/src/components/shared/TrackContextMenu/PlaylistSubmenu/PlaylistSubmenu.tsx
+++ b/apps/web/src/components/shared/TrackContextMenu/PlaylistSubmenu/PlaylistSubmenu.tsx
@@ -5,10 +5,11 @@ import { usePlaylistSubmenu } from './PlaylistSubmenu.hooks';
 import type { IPlaylistSubmenuProps } from './PlaylistSubmenu.types';
 
 /**
- * The "Add to Playlist" row of the track context menu and its hover fly-out.
- * The panel flips to the left when the row sits too close to the right edge of
- * the viewport, and a short grace period on mouse-leave keeps it open while the
- * pointer travels from the row into the panel.
+ * The "Add to Playlist" row of the track context menu and its fly-out. The row
+ * is a roving menuitem: hover opens the panel (with a grace period on
+ * mouse-leave so the pointer can travel into it), and Enter/Space/ArrowRight
+ * open it from the keyboard while ArrowLeft closes it again. The panel flips
+ * to the left when the row sits too close to the right edge of the viewport.
  */
 export default function PlaylistSubmenu(props: IPlaylistSubmenuProps) {
   const {
@@ -16,11 +17,13 @@ export default function PlaylistSubmenu(props: IPlaylistSubmenuProps) {
     trackIds,
     onClose,
     parentRef,
+    rowRef,
     submenuRef,
     isSubmenuOpen,
     submenuClassName,
     onMouseEnter,
     onMouseLeave,
+    onRowKeyDown,
   } = usePlaylistSubmenu(props);
 
   return (
@@ -30,10 +33,18 @@ export default function PlaylistSubmenu(props: IPlaylistSubmenuProps) {
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      <div
+      <button
+        ref={rowRef}
+        type="button"
+        role="menuitem"
+        tabIndex={-1}
+        aria-haspopup="menu"
+        aria-expanded={isSubmenuOpen}
+        onKeyDown={onRowKeyDown}
+        onMouseEnter={event => event.currentTarget.focus({ preventScroll: true })}
         className={cn(
-          'w-full flex items-center gap-2.5 px-3 py-2 text-sm transition-colors text-left cursor-default',
-          'text-foreground/80 hover:text-foreground hover:bg-accent'
+          'focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm transition-colors text-left cursor-default',
+          'text-foreground/80 hover:text-foreground hover:bg-accent focus:text-foreground focus:bg-accent'
         )}
       >
         <span className="shrink-0 w-4 h-4 flex items-center justify-center text-muted-foreground/60">
@@ -41,7 +52,7 @@ export default function PlaylistSubmenu(props: IPlaylistSubmenuProps) {
         </span>
         {label}
         <ChevronRight className="w-3.5 h-3.5 ml-auto text-muted-foreground/40" />
-      </div>
+      </button>
 
       {isSubmenuOpen && (
         <div ref={submenuRef} className={submenuClassName}>

--- a/apps/web/src/components/shared/TrackContextMenu/PlaylistSubmenu/PlaylistSubmenu.types.ts
+++ b/apps/web/src/components/shared/TrackContextMenu/PlaylistSubmenu/PlaylistSubmenu.types.ts
@@ -14,8 +14,10 @@ export interface IPlaylistSubmenuView {
   readonly trackIds: string[];
   /** Close handler forwarded to the nested picker. */
   readonly onClose: () => void;
-  /** Ref for the hoverable row — measured to pick the fly-out side. */
+  /** Ref for the hoverable row wrapper — measured to pick the fly-out side. */
   readonly parentRef: RefObject<HTMLDivElement | null>;
+  /** Ref for the row button — the roving menuitem the track menu focuses. */
+  readonly rowRef: RefObject<HTMLButtonElement | null>;
   /** Ref for the fly-out panel. */
   readonly submenuRef: RefObject<HTMLDivElement | null>;
   /** Whether the fly-out panel is mounted. */
@@ -26,4 +28,6 @@ export interface IPlaylistSubmenuView {
   readonly onMouseEnter: () => void;
   /** Starts the grace period before the fly-out closes. */
   readonly onMouseLeave: () => void;
+  /** Row keyboard handling: Enter/Space/ArrowRight open, ArrowLeft closes. */
+  readonly onRowKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
 }

--- a/apps/web/src/components/shared/TrackContextMenu/TrackContextMenu.test.tsx
+++ b/apps/web/src/components/shared/TrackContextMenu/TrackContextMenu.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Track } from '@/stores/types';
 import { useLibraryStore } from '@/stores/useLibraryStore';
+import { usePlaybackStore } from '@/stores/usePlaybackStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 
 import TrackContextMenu from './TrackContextMenu';
@@ -28,11 +30,11 @@ function seedSelection(ids: string[]): void {
   useSelectionStore.setState({ selectedTrackIds: new Set(ids), lastClickedIndex: null });
 }
 
-function renderMenu(track: Track): void {
+function renderMenu(track: Track, onClose: () => void = vi.fn()): void {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   render(
     <QueryClientProvider client={client}>
-      <TrackContextMenu track={track} position={{ x: 10, y: 10 }} onClose={vi.fn()} />
+      <TrackContextMenu track={track} position={{ x: 10, y: 10 }} onClose={onClose} />
     </QueryClientProvider>
   );
 }
@@ -40,6 +42,7 @@ function renderMenu(track: Track): void {
 beforeEach(() => {
   seedLibrary([]);
   seedSelection([]);
+  usePlaybackStore.setState({ queue: [], queueIndex: 0 });
 });
 
 afterEach(() => {
@@ -48,14 +51,15 @@ afterEach(() => {
 });
 
 describe('TrackContextMenu', () => {
-  it('renders the core single-track actions', () => {
+  it('renders a menu with the core single-track actions', () => {
     const track = makeTrack();
     seedLibrary([track]);
     renderMenu(track);
 
-    expect(screen.getByRole('button', { name: 'Play Next' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Add to Queue' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Remove from Library' })).toBeInTheDocument();
+    expect(screen.getByRole('menu', { name: 'Track actions' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Play Next' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Add to Queue' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Remove from Library' })).toBeInTheDocument();
   });
 
   it('shows the bulk header when the track is part of a multi-selection', () => {
@@ -65,5 +69,29 @@ describe('TrackContextMenu', () => {
     renderMenu(tracks[0]);
 
     expect(screen.getByText('2 selected')).toBeInTheDocument();
+  });
+
+  it('fires the action and closes when a menu item is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const track = makeTrack();
+    seedLibrary([track]);
+    renderMenu(track, onClose);
+
+    await user.click(screen.getByRole('menuitem', { name: 'Play Next' }));
+
+    expect(usePlaybackStore.getState().queue.map(t => t.id)).toContain(track.id);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('supports arrow-key roving focus from the opened menu', async () => {
+    const user = userEvent.setup();
+    const track = makeTrack();
+    seedLibrary([track]);
+    renderMenu(track);
+
+    expect(screen.getByRole('menu')).toHaveFocus();
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('menuitem', { name: 'Play Next' })).toHaveFocus();
   });
 });

--- a/apps/web/src/components/shared/TrackContextMenu/TrackContextMenu.tsx
+++ b/apps/web/src/components/shared/TrackContextMenu/TrackContextMenu.tsx
@@ -1,5 +1,3 @@
-import { createPortal } from 'react-dom';
-import { motion, AnimatePresence } from 'motion/react';
 import {
   Play,
   ListPlus,
@@ -14,53 +12,10 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { IS_ELECTRON, IS_MAC } from '@/lib/platform';
+import { ContextMenuSurface, Menu, MenuDivider, MenuItem, MenuLabel } from '@/components/ui/menu';
 import { useTrackContextMenu } from './TrackContextMenu.hooks';
 import type { ITrackContextMenuProps } from './TrackContextMenu.types';
 import { PlaylistSubmenu } from './PlaylistSubmenu';
-
-interface IMenuItemProps {
-  icon: React.ReactNode;
-  label: string;
-  onClick: () => void;
-  variant?: 'default' | 'destructive';
-  disabled?: boolean;
-  title?: string;
-}
-
-function MenuItem({
-  icon,
-  label,
-  onClick,
-  variant = 'default',
-  disabled = false,
-  title,
-}: IMenuItemProps) {
-  return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      title={title}
-      aria-disabled={disabled || undefined}
-      className={cn(
-        'focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm transition-colors text-left',
-        disabled
-          ? 'text-muted-foreground/50 cursor-not-allowed'
-          : variant === 'destructive'
-            ? 'text-destructive hover:bg-destructive/10'
-            : 'text-foreground/80 hover:text-foreground hover:bg-accent'
-      )}
-    >
-      <span className="shrink-0 w-4 h-4 flex items-center justify-center text-muted-foreground/60">
-        {icon}
-      </span>
-      {label}
-    </button>
-  );
-}
-
-function Divider() {
-  return <div className="my-1 border-t border-border/50" />;
-}
 
 export default function TrackContextMenu(props: ITrackContextMenuProps) {
   const {
@@ -102,55 +57,36 @@ export default function TrackContextMenu(props: ITrackContextMenuProps) {
   // inside the markup).
   const showSingleTrackActions = IS_ELECTRON && !isBulk;
 
-  return createPortal(
-    <AnimatePresence>
-      <motion.div
-        ref={menuRef}
-        initial={{ opacity: 0, scale: 0.95 }}
-        animate={{ opacity: 1, scale: 1 }}
-        exit={{ opacity: 0, scale: 0.95 }}
-        transition={{ duration: 0.12 }}
-        className="fixed z-50 min-w-[200px] py-1 rounded-xl bg-card border border-border/50 shadow-xl shadow-black/30"
-        style={{
-          left: adjustedPosition.x,
-          top: adjustedPosition.y,
-          transformOrigin: 'top left',
-        }}
-        onContextMenu={(e: React.MouseEvent) => e.preventDefault()}
-      >
+  return (
+    <ContextMenuSurface menuRef={menuRef} position={adjustedPosition}>
+      <Menu autoFocus onRequestClose={props.onClose} aria-label={t('trackMenuAria')}>
         {isBulk && (
           <>
-            <div className="px-3 py-1.5 text-xs text-muted-foreground/50 font-medium">
-              {t('selectedCount', { count })}
-            </div>
-            <Divider />
+            <MenuLabel>{t('selectedCount', { count })}</MenuLabel>
+            <MenuDivider />
           </>
         )}
 
-        <MenuItem icon={<Play className="w-4 h-4" />} label={t('playNext')} onClick={onPlayNext} />
-        <MenuItem
-          icon={<ListPlus className="w-4 h-4" />}
-          label={t('addToQueue')}
-          onClick={onAddToQueue}
-        />
+        <MenuItem icon={<Play className="w-4 h-4" />} onClick={onPlayNext}>
+          {t('playNext')}
+        </MenuItem>
+        <MenuItem icon={<ListPlus className="w-4 h-4" />} onClick={onAddToQueue}>
+          {t('addToQueue')}
+        </MenuItem>
 
         {showSingleTrackActions && (
-          <MenuItem
-            icon={<Radio className="w-4 h-4" />}
-            label={t('moreLikeThis')}
-            onClick={onMoreLikeThis}
-          />
+          <MenuItem icon={<Radio className="w-4 h-4" />} onClick={onMoreLikeThis}>
+            {t('moreLikeThis')}
+          </MenuItem>
         )}
 
         {showSingleTrackActions && (
-          <MenuItem
-            icon={<ThumbsDown className="w-4 h-4" />}
-            label={t('notInterested')}
-            onClick={onNotInterested}
-          />
+          <MenuItem icon={<ThumbsDown className="w-4 h-4" />} onClick={onNotInterested}>
+            {t('notInterested')}
+          </MenuItem>
         )}
 
-        <Divider />
+        <MenuDivider />
 
         <PlaylistSubmenu trackIds={targetTrackIds} onClose={onClearAndClose} />
 
@@ -160,62 +96,59 @@ export default function TrackContextMenu(props: ITrackContextMenuProps) {
               className={cn('w-4 h-4', !isBulk && isFavorite && 'fill-current text-favorite')}
             />
           }
-          label={favoriteLabel}
           onClick={onToggleFavorite}
-        />
+        >
+          {favoriteLabel}
+        </MenuItem>
 
         {showSingleTrackActions && (
-          <MenuItem
-            icon={<Share2 className="w-4 h-4" />}
-            label={t('share', { ns: 'share' })}
-            onClick={onShare}
-          />
+          <MenuItem icon={<Share2 className="w-4 h-4" />} onClick={onShare}>
+            {t('share', { ns: 'share' })}
+          </MenuItem>
         )}
 
         {showSingleTrackActions && (
           <MenuItem
             icon={<Disc3 className="w-4 h-4" />}
-            label={t('findMissingMetadata')}
             disabled={isBulkEnriching}
             title={isBulkEnriching ? t('findMissingMetadataBusy') : undefined}
             onClick={onFindMissingMetadata}
-          />
+          >
+            {t('findMissingMetadata')}
+          </MenuItem>
         )}
 
         {showSingleTrackActions && (
-          <MenuItem
-            icon={<Pencil className="w-4 h-4" />}
-            label={t('editTags')}
-            onClick={onEditTags}
-          />
+          <MenuItem icon={<Pencil className="w-4 h-4" />} onClick={onEditTags}>
+            {t('editTags')}
+          </MenuItem>
         )}
 
-        <Divider />
+        <MenuDivider />
 
         {showSingleTrackActions && (
-          <MenuItem
-            icon={<FolderOpen className="w-4 h-4" />}
-            label={showInFolderLabel}
-            onClick={onShowInFolder}
-          />
+          <MenuItem icon={<FolderOpen className="w-4 h-4" />} onClick={onShowInFolder}>
+            {showInFolderLabel}
+          </MenuItem>
         )}
 
         <MenuItem
           icon={<Trash2 className="w-4 h-4" />}
-          label={removeFromLibraryLabel}
           onClick={onRemoveFromLibrary}
           variant="destructive"
-        />
+        >
+          {removeFromLibraryLabel}
+        </MenuItem>
         {IS_ELECTRON && (
           <MenuItem
             icon={<Trash2 className="w-4 h-4" />}
-            label={deleteFromDiskLabel}
             onClick={onDeleteFromDisk}
             variant="destructive"
-          />
+          >
+            {deleteFromDiskLabel}
+          </MenuItem>
         )}
-      </motion.div>
-    </AnimatePresence>,
-    document.body
+      </Menu>
+    </ContextMenuSurface>
   );
 }

--- a/apps/web/src/components/ui/menu.test.tsx
+++ b/apps/web/src/components/ui/menu.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Menu, MenuDivider, MenuItem, MenuLabel } from './menu';
+
+function renderMenu({
+  onRequestClose = vi.fn(),
+  onDelete = vi.fn(),
+}: { onRequestClose?: () => void; onDelete?: () => void } = {}) {
+  render(
+    <Menu autoFocus aria-label="Track actions" onRequestClose={onRequestClose}>
+      <MenuLabel>2 selected</MenuLabel>
+      <MenuItem onClick={vi.fn()}>Alpha</MenuItem>
+      <MenuItem onClick={vi.fn()}>Beta</MenuItem>
+      <MenuItem disabled onClick={vi.fn()}>
+        Gamma
+      </MenuItem>
+      <MenuDivider />
+      <MenuItem variant="destructive" onClick={onDelete}>
+        Delete
+      </MenuItem>
+    </Menu>
+  );
+}
+
+function item(name: string): HTMLElement {
+  return screen.getByRole('menuitem', { name });
+}
+
+describe('Menu', () => {
+  it('renders menu semantics and takes focus on mount', () => {
+    renderMenu();
+
+    const menu = screen.getByRole('menu', { name: 'Track actions' });
+    expect(menu).toHaveFocus();
+    expect(screen.getAllByRole('menuitem')).toHaveLength(4);
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+  });
+
+  it('roves focus with arrow keys, wrapping and skipping disabled items', async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.keyboard('{ArrowDown}');
+    expect(item('Alpha')).toHaveFocus();
+
+    await user.keyboard('{ArrowDown}');
+    expect(item('Beta')).toHaveFocus();
+
+    // Gamma is disabled — skipped straight to Delete.
+    await user.keyboard('{ArrowDown}');
+    expect(item('Delete')).toHaveFocus();
+
+    // Wraps back to the top.
+    await user.keyboard('{ArrowDown}');
+    expect(item('Alpha')).toHaveFocus();
+
+    await user.keyboard('{ArrowUp}');
+    expect(item('Delete')).toHaveFocus();
+  });
+
+  it('jumps to the first and last enabled item with Home and End', async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.keyboard('{End}');
+    expect(item('Delete')).toHaveFocus();
+
+    await user.keyboard('{Home}');
+    expect(item('Alpha')).toHaveFocus();
+  });
+
+  it('moves focus by typeahead on the item label', async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    // Quick successive characters accumulate into one query.
+    await user.keyboard('be');
+    expect(item('Beta')).toHaveFocus();
+
+    // After the reset pause a new query starts from scratch.
+    const spy = vi.spyOn(Date, 'now').mockImplementation(() => new Date().getTime() + 1000);
+    await user.keyboard('d');
+    expect(item('Delete')).toHaveFocus();
+    spy.mockRestore();
+  });
+
+  it('activates the focused item with Enter', async () => {
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+    renderMenu({ onDelete });
+
+    await user.keyboard('{End}');
+    await user.keyboard('{Enter}');
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('requests close on Tab instead of tabbing away', async () => {
+    const onRequestClose = vi.fn();
+    const user = userEvent.setup();
+    renderMenu({ onRequestClose });
+
+    await user.tab();
+
+    expect(onRequestClose).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('menu')).toHaveFocus();
+  });
+
+  it('restores focus to the previously focused element on unmount', () => {
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
+
+    const { unmount } = render(
+      <Menu autoFocus aria-label="Menu">
+        <MenuItem onClick={vi.fn()}>Alpha</MenuItem>
+      </Menu>
+    );
+    expect(screen.getByRole('menu')).toHaveFocus();
+
+    unmount();
+    expect(outside).toHaveFocus();
+    outside.remove();
+  });
+});

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -1,0 +1,261 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { motion, AnimatePresence } from 'motion/react';
+import { cn } from '@/lib/utils';
+import { MENU_POP } from '@/lib/motion';
+
+/** A pause this long resets the typeahead buffer. */
+const TYPEAHEAD_RESET_MS = 500;
+
+interface IMenuProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Focus the menu container on mount and restore focus to the previously
+   * focused element on unmount. Context menus opened at a pointer position
+   * need this; popover-anchored menus let the popover own focus instead.
+   */
+  autoFocus?: boolean;
+  /** Called when the user tabs away — the host should close the menu. */
+  onRequestClose?: () => void;
+  ref?: React.Ref<HTMLDivElement | null>;
+}
+
+/**
+ * The keyboard-navigable menu container: `role=menu` with roving arrow-key
+ * focus over its `MenuItem`s (wrap-around, Home/End), label typeahead, and
+ * close-on-Tab. Escape stays with the host (context-menu dismiss hook or the
+ * popover primitive), which already owns outside-click dismissal too.
+ */
+function Menu({
+  autoFocus = false,
+  onRequestClose,
+  className,
+  onKeyDown,
+  ref,
+  children,
+  ...props
+}: IMenuProps) {
+  const innerRef = React.useRef<HTMLDivElement>(null);
+  const typeaheadRef = React.useRef({ query: '', at: 0 });
+
+  const setRefs = (node: HTMLDivElement | null) => {
+    innerRef.current = node;
+    if (typeof ref === 'function') ref(node);
+    else if (ref) ref.current = node;
+  };
+
+  React.useEffect(() => {
+    if (!autoFocus) return;
+    const previous = document.activeElement;
+    innerRef.current?.focus({ preventScroll: true });
+    return () => {
+      if (!(previous instanceof HTMLElement) || !previous.isConnected) return;
+      // Only restore when focus is still ours to give back — never steal it
+      // from wherever the user has moved on to.
+      const active = document.activeElement;
+      const menuOwnsFocus =
+        active === null || active === document.body || Boolean(innerRef.current?.contains(active));
+      if (menuOwnsFocus) previous.focus({ preventScroll: true });
+    };
+  }, [autoFocus]);
+
+  const enabledItems = (): HTMLElement[] => {
+    const node = innerRef.current;
+    if (!node) return [];
+    return Array.from(node.querySelectorAll<HTMLElement>('[role="menuitem"]')).filter(
+      el => !el.hasAttribute('disabled') && el.getAttribute('aria-disabled') !== 'true'
+    );
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+    const node = innerRef.current;
+    if (!node) return;
+    // Only steer keys while focus sits on the menu itself or one of its items —
+    // a fly-out panel (pickers, inputs) keeps its own keyboard handling.
+    const target = event.target as HTMLElement;
+    if (target !== node && target.getAttribute('role') !== 'menuitem') return;
+
+    const items = enabledItems();
+    if (items.length === 0) return;
+    const currentIndex = items.indexOf(target);
+
+    const focusItem = (index: number) => {
+      items[(index + items.length) % items.length]?.focus({ preventScroll: true });
+    };
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        focusItem(currentIndex + 1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        focusItem(currentIndex === -1 ? items.length - 1 : currentIndex - 1);
+        break;
+      case 'Home':
+        event.preventDefault();
+        focusItem(0);
+        break;
+      case 'End':
+        event.preventDefault();
+        focusItem(items.length - 1);
+        break;
+      case 'Tab':
+        // Menus close on Tab instead of joining the page's tab order.
+        event.preventDefault();
+        onRequestClose?.();
+        break;
+      default: {
+        // Typeahead. Space is excluded — it activates the focused item.
+        if (event.key.length !== 1 || event.key === ' ') return;
+        if (event.ctrlKey || event.metaKey || event.altKey) return;
+        const now = Date.now();
+        const stale = now - typeaheadRef.current.at > TYPEAHEAD_RESET_MS;
+        const query = (stale ? '' : typeaheadRef.current.query) + event.key.toLowerCase();
+        typeaheadRef.current = { query, at: now };
+
+        const start = currentIndex + 1;
+        const lookup = (q: string): HTMLElement | undefined => {
+          for (let i = 0; i < items.length; i++) {
+            const item = items[(start + i) % items.length];
+            if ((item.textContent ?? '').trim().toLowerCase().startsWith(q)) return item;
+          }
+          return undefined;
+        };
+        // Repeating one letter cycles through that letter's items instead of
+        // demanding an exact "aa..." prefix.
+        const repeatedChar = query.length > 1 && new Set(query).size === 1;
+        const match = lookup(query) ?? (repeatedChar ? lookup(query[0]) : undefined);
+        match?.focus({ preventScroll: true });
+      }
+    }
+  };
+
+  return (
+    <div
+      {...props}
+      ref={setRefs}
+      role="menu"
+      aria-orientation="vertical"
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
+      className={cn('py-1 outline-none', className)}
+    >
+      {children}
+    </div>
+  );
+}
+
+type MenuItemVariant = 'default' | 'destructive';
+
+interface IMenuItemProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Leading 16px icon slot, tinted muted like every menu row. */
+  icon?: React.ReactNode;
+  variant?: MenuItemVariant;
+}
+
+const MENU_ITEM_VARIANT_CLASSES: Record<MenuItemVariant, string> = {
+  default:
+    'text-foreground/80 hover:text-foreground hover:bg-accent focus:text-foreground focus:bg-accent active:bg-accent/70',
+  destructive:
+    'text-destructive hover:bg-destructive/10 focus:bg-destructive/10 active:bg-destructive/20',
+};
+
+function MenuItem({
+  icon,
+  variant = 'default',
+  disabled = false,
+  className,
+  onMouseEnter,
+  children,
+  ...props
+}: IMenuItemProps) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      tabIndex={-1}
+      disabled={disabled}
+      aria-disabled={disabled || undefined}
+      onMouseEnter={event => {
+        // A menu keeps a single highlighted row: hover pulls focus so the
+        // keyboard position follows the pointer and vice versa.
+        if (!disabled) event.currentTarget.focus({ preventScroll: true });
+        onMouseEnter?.(event);
+      }}
+      className={cn(
+        'focus-ring w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left transition-colors',
+        disabled
+          ? 'text-muted-foreground/50 cursor-not-allowed'
+          : MENU_ITEM_VARIANT_CLASSES[variant],
+        className
+      )}
+      {...props}
+    >
+      {icon !== undefined && (
+        <span className="shrink-0 w-4 h-4 flex items-center justify-center text-muted-foreground/60">
+          {icon}
+        </span>
+      )}
+      {children}
+    </button>
+  );
+}
+
+function MenuDivider({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      role="separator"
+      aria-orientation="horizontal"
+      className={cn('my-1 border-t border-border/50', className)}
+      {...props}
+    />
+  );
+}
+
+/** Non-interactive heading row (e.g. the bulk-selection count). */
+function MenuLabel({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('px-3 py-1.5 text-xs text-muted-foreground/50 font-medium', className)}
+      {...props}
+    />
+  );
+}
+
+interface IContextMenuSurfaceProps {
+  /** Ref to the positioned surface — the dismiss hook measures and watches it. */
+  menuRef: React.RefObject<HTMLDivElement | null>;
+  /** Viewport-adjusted position from `useContextMenuDismiss`. */
+  position: { x: number; y: number };
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * The floating chrome shared by every right-click menu: a body portal, the
+ * fixed viewport position, the card surface, and the MENU_POP enter/exit.
+ * Wrap a `Menu` in it; dismissal stays with `useContextMenuDismiss`.
+ */
+function ContextMenuSurface({ menuRef, position, className, children }: IContextMenuSurfaceProps) {
+  return createPortal(
+    <AnimatePresence>
+      <motion.div
+        ref={menuRef}
+        {...MENU_POP}
+        className={cn(
+          'fixed z-50 min-w-[200px] rounded-xl bg-card border border-border/50 shadow-xl shadow-black/30',
+          className
+        )}
+        style={{ left: position.x, top: position.y, transformOrigin: 'top left' }}
+        onContextMenu={(event: React.MouseEvent) => event.preventDefault()}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>,
+    document.body
+  );
+}
+
+export { Menu, MenuItem, MenuDivider, MenuLabel, ContextMenuSurface };

--- a/apps/web/src/lib/motion.ts
+++ b/apps/web/src/lib/motion.ts
@@ -58,6 +58,18 @@ export const STAGGER_ITEM = {
 };
 
 /**
+ * Enter/exit pop for menus and other click-anchored popups — a quick fade +
+ * scale from 95% over ~0.12s, the same recipe the popover primitive expresses
+ * as `fade-in-0 zoom-in-95`. Spread onto a motion.div inside AnimatePresence.
+ */
+export const MENU_POP = {
+  initial: { opacity: 0, scale: 0.95 },
+  animate: { opacity: 1, scale: 1 },
+  exit: { opacity: 0, scale: 0.95 },
+  transition: { duration: 0.12 },
+} as const;
+
+/**
  * View-to-view transition for the main content region. Deliberately quick
  * (~0.16s) so a tool people leave open never feels sluggish. Use with
  * AnimatePresence mode="wait" keyed on the active view. Skip under reduced

--- a/apps/web/src/locales/en/contextMenu.json
+++ b/apps/web/src/locales/en/contextMenu.json
@@ -18,6 +18,8 @@
   "shufflePlaylist": "Shuffle Playlist",
   "removeFromPlaylist": "Remove from playlist",
   "addToPlaylistAria": "Add to playlist",
+  "trackMenuAria": "Track actions",
+  "playlistMenuAria": "Playlist actions",
   "selectedCount": "{{count}} selected",
   "dragToReorder": "Drag to reorder",
   "findMissingMetadata": "Find Missing Metadata",

--- a/apps/web/src/locales/pl/contextMenu.json
+++ b/apps/web/src/locales/pl/contextMenu.json
@@ -18,6 +18,8 @@
   "shufflePlaylist": "Losuj playlistę",
   "removeFromPlaylist": "Usuń z playlisty",
   "addToPlaylistAria": "Dodaj do playlisty",
+  "trackMenuAria": "Akcje utworu",
+  "playlistMenuAria": "Akcje playlisty",
   "selectedCount": "{{count}} zaznaczonych",
   "selectedCount_one": "{{count}} zaznaczony",
   "selectedCount_few": "{{count}} zaznaczone",


### PR DESCRIPTION
## Summary

- Adds a shared menu primitive (`ui/menu.tsx`): `Menu`/`MenuItem`/`MenuDivider`/`MenuLabel` with proper `menu`/`menuitem` roles, roving arrow-key focus (wrap-around, Home/End), label typeahead, hover **and** active states, a destructive variant, close-on-Tab, and focus restore on close. The floating right-click chrome (portal, fixed positioning, card surface, enter/exit pop) is extracted into `ContextMenuSurface`, driven by a new `MENU_POP` token in `lib/motion.ts`.
- Rebuilds **TrackContextMenu** and **PlaylistContextMenu** on the primitive — the ~63 duplicated chrome lines and both local `MenuItem` copies are gone, and both menus gain full keyboard operation (they previously had none). The Add to Playlist row is now a real roving menuitem: Enter/Space/ArrowRight open the fly-out and hand focus to the picker, ArrowLeft closes it, with `aria-haspopup`/`aria-expanded` on the row. Every action and dismiss behavior stays identical.
- Rebuilds the **TopBar Add dropdown** on `ui/popover.tsx` with the shared `Menu` inside: `aria-haspopup`/`aria-expanded` on the trigger, arrow keys + typeahead, Escape and focus return via the popover, and the same 0.12s fade+scale entrance as the context menus.
- Makes the TopBar language switcher a real segmented control: `radiogroup`/`radio` with `aria-checked`, a single tab stop, and arrow keys moving selection with focus — same visual weight as before.
- New i18n keys (`trackMenuAria`, `playlistMenuAria`) added to both en and pl locales.

## Test plan

- [x] `pnpm --filter @shiranami/web typecheck`
- [x] `pnpm --filter @shiranami/web test` — 2181 tests / 334 files, including new suites: menu primitive keyboard behavior (roving focus, typeahead, Tab-close, focus restore), context-menu action wiring (Play Next fills the queue, Open Playlist navigates, both close), submenu keyboard open/close, TopBar dropdown open/action/Escape, and radiogroup click + arrow-key selection
- [x] `pnpm --filter @shiranami/web test:storybook` — 564 play + axe a11y tests
- [x] `pnpm lint` and `pnpm format:check`
- [x] `pnpm --filter @shiranami/web size` — entry 108.92 kB / total 671.76 kB, both under limits