### PR TITLE
feat(web): queue + lyrics panel polish (empty state, destructive confirm, save-as-playlist, lyrics retry, panel motion)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -436,7 +436,9 @@ function App() {
                           : undefined,
                     }}
                   >
-                    {showSidePanel && sidePanelSide === 'left' && <SidePanel side="left" />}
+                    <AnimatePresence initial={false}>
+                      {showSidePanel && sidePanelSide === 'left' && <SidePanel side="left" />}
+                    </AnimatePresence>
 
                     {/* Center content */}
                     <div className="flex-1 min-w-0 min-h-0 overflow-hidden flex flex-col">
@@ -548,7 +550,9 @@ function App() {
                       </AnimatePresence>
                     </div>
 
-                    {showSidePanel && sidePanelSide === 'right' && <SidePanel side="right" />}
+                    <AnimatePresence initial={false}>
+                      {showSidePanel && sidePanelSide === 'right' && <SidePanel side="right" />}
+                    </AnimatePresence>
 
                     {showVisualizerStrip && <VisualizerStrip />}
                   </main>

--- a/apps/web/src/components/lyrics/LyricsBody/LyricsBody.stories.tsx
+++ b/apps/web/src/components/lyrics/LyricsBody/LyricsBody.stories.tsx
@@ -14,9 +14,13 @@ const SYNCED: LyricLine[] = [
 const baseArgs = {
   activeLine: 1,
   isLoading: false,
+  isError: false,
   onLineClick: () => {},
+  onRetry: () => {},
   loadingLabel: 'Finding lyrics...',
   emptyLabel: 'No lyrics found',
+  errorLabel: "Couldn't load lyrics",
+  retryLabel: 'Retry',
   syncedDimOpacity: 0.4,
   plainOpacity: 0.85,
   syncedSpacingClassName: 'space-y-4',
@@ -28,11 +32,12 @@ const baseArgs = {
 };
 
 /**
- * lyrics · LyricsBody. The shared 4-branch lyrics render (loading → synced →
- * plain → empty) behind NowPlayingView and LyricsPanel, parameterized by each
- * surface's size-class maps, spacing, and container classes. Synced lyrics
- * render as a list of seekable line buttons; plain lyrics as a `<pre>`; the
- * loading and empty branches show a labelled spinner / music glyph. Stories
+ * lyrics · LyricsBody. The shared 5-branch lyrics render (loading → synced →
+ * plain → error → empty) behind NowPlayingView and LyricsPanel, parameterized
+ * by each surface's size-class maps, spacing, and container classes. Synced
+ * lyrics render as a list of seekable line buttons; plain lyrics as a `<pre>`;
+ * the loading and empty branches show a labelled spinner / music glyph; the
+ * error branch adds a destructive-tinted glyph plus a Retry action. Stories
  * drive each branch via args.
  */
 const meta: Meta<typeof LyricsBody> = {
@@ -108,5 +113,19 @@ export const Empty: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByText('No lyrics found')).toBeInTheDocument();
+  },
+};
+
+/** Error — the destructive-tinted failure glyph with its Retry action. */
+export const Error: Story = {
+  args: {
+    synced: null,
+    plain: null,
+    isError: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Couldn't load lyrics")).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/lyrics/LyricsBody/LyricsBody.test.tsx
+++ b/apps/web/src/components/lyrics/LyricsBody/LyricsBody.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import type { LyricLine } from '@/hooks/queries/useLyrics';
 import type { ILyricsBodyProps } from './LyricsBody.types';
@@ -16,9 +17,13 @@ function makeProps(overrides: Partial<ILyricsBodyProps> = {}): ILyricsBodyProps 
     plain: null,
     activeLine: 0,
     isLoading: false,
+    isError: false,
     onLineClick: vi.fn(),
+    onRetry: vi.fn(),
     loadingLabel: 'Finding lyrics',
     emptyLabel: 'No lyrics found',
+    errorLabel: 'Lyrics failed to load',
+    retryLabel: 'Retry',
     syncedDimOpacity: 0.4,
     plainOpacity: 0.85,
     syncedBaseClassName: 'base',
@@ -54,5 +59,23 @@ describe('LyricsBody', () => {
     render(<LyricsBody {...makeProps()} />);
 
     expect(screen.getByText('No lyrics found')).toBeInTheDocument();
+  });
+
+  it('shows the error branch with a retry action when the fetch failed', async () => {
+    const onRetry = vi.fn();
+    render(<LyricsBody {...makeProps({ isError: true, onRetry })} />);
+
+    expect(screen.getByText('Lyrics failed to load')).toBeInTheDocument();
+    expect(screen.queryByText('No lyrics found')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('keeps showing lyrics we already have even when a refetch failed', () => {
+    render(<LyricsBody {...makeProps({ isError: true, synced: SYNCED })} />);
+
+    expect(screen.getByRole('button', { name: 'Synced first line' })).toBeInTheDocument();
+    expect(screen.queryByText('Lyrics failed to load')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/lyrics/LyricsBody/LyricsBody.tsx
+++ b/apps/web/src/components/lyrics/LyricsBody/LyricsBody.tsx
@@ -1,14 +1,16 @@
 import type { ReactNode } from 'react';
-import { Loader2, Music2 } from 'lucide-react';
+import { AlertCircle, Loader2, Music2, RotateCcw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { LyricsList } from '../LyricsList';
 import { useLyricsBody } from './LyricsBody.hooks';
 import type { ILyricsBodyProps } from './LyricsBody.types';
 
 /**
- * The shared 4-branch lyrics render (loading → synced → plain → empty) behind
- * NowPlayingView and LyricsPanel, parameterized by each surface's size-class
- * maps, spacing, and container classes.
+ * The shared 5-branch lyrics render (loading → synced → plain → error → empty)
+ * behind NowPlayingView and LyricsPanel, parameterized by each surface's
+ * size-class maps, spacing, and container classes. The error branch sits after
+ * the content branches so a failed refetch never hides lyrics we already have.
  */
 export default function LyricsBody(props: ILyricsBodyProps): ReactNode {
   const { hasSynced, hasPlain, lyricsVars, syncedWrapperClassName } = useLyricsBody(props);
@@ -17,9 +19,13 @@ export default function LyricsBody(props: ILyricsBodyProps): ReactNode {
     plain,
     activeLine,
     isLoading,
+    isError,
     onLineClick,
+    onRetry,
     loadingLabel,
     emptyLabel,
+    errorLabel,
+    retryLabel,
     plainOpacity,
     syncedContainerClassName,
     syncedSpacingClassName,
@@ -70,6 +76,26 @@ export default function LyricsBody(props: ILyricsBodyProps): ReactNode {
         <pre className={plainTextClassName} style={{ opacity: plainOpacity }}>
           {plain}
         </pre>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div
+        className={cn(
+          'flex-1 flex flex-col items-center justify-center gap-3',
+          stateContainerClassName
+        )}
+      >
+        <div className="w-9 h-9 rounded-full bg-destructive/10 border border-destructive/20 flex items-center justify-center">
+          <AlertCircle className="w-4 h-4 text-destructive" aria-hidden="true" />
+        </div>
+        <p className="text-xs font-medium text-muted-foreground">{errorLabel}</p>
+        <Button variant="outline" size="sm" onClick={onRetry} className="h-7 rounded-xl px-3">
+          <RotateCcw className="size-3.5" />
+          {retryLabel}
+        </Button>
       </div>
     );
   }

--- a/apps/web/src/components/lyrics/LyricsBody/LyricsBody.types.ts
+++ b/apps/web/src/components/lyrics/LyricsBody/LyricsBody.types.ts
@@ -6,12 +6,20 @@ export interface ILyricsBodyProps {
   readonly plain: string | null;
   readonly activeLine: number;
   readonly isLoading: boolean;
+  /** The lyrics fetch failed — render the error branch (unless lyrics exist). */
+  readonly isError: boolean;
   readonly onLineClick: (time: number) => void;
+  /** Re-run the failed fetch from the error branch's Retry action. */
+  readonly onRetry: () => void;
 
   /** Label shown in the loading branch. */
   readonly loadingLabel: string;
   /** Label shown in the empty branch. */
   readonly emptyLabel: string;
+  /** Label shown in the error branch. */
+  readonly errorLabel: string;
+  /** Label for the error branch's Retry action. */
+  readonly retryLabel: string;
 
   /** Dynamic opacity for idle/past synced lines (drives the CSS vars). */
   readonly syncedDimOpacity: number;

--- a/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.hooks.ts
+++ b/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.hooks.ts
@@ -39,13 +39,15 @@ function sourceToLabel(source: LyricsSource, t: TranslateFn): string | null {
 
 export function useLyricsPanel(): ILyricsPanelView {
   const { t } = useTranslation('lyrics');
+  const { t: tCommon } = useTranslation('common');
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const lyricsPlainOpacity = useLyricsAppearanceStore(s => s.lyricsPlainOpacity);
   const lyricsPlainFontSize = useLyricsAppearanceStore(s => s.lyricsPlainFontSize);
   const lyricsSyncedDimOpacity = useLyricsAppearanceStore(s => s.lyricsSyncedDimOpacity);
   const lyricsSyncedFontSize = useLyricsAppearanceStore(s => s.lyricsSyncedFontSize);
 
-  const { synced, plain, source, activeLine, isLoading, handleLineClick } = useLyricsView();
+  const { synced, plain, source, activeLine, isLoading, isError, retry, handleLineClick } =
+    useLyricsView();
 
   const baseSizeClass = LYR_SIZE_CLASS[lyricsSyncedFontSize];
   const activeSizeClass = LYR_SIZE_CLASS[nextLyricsFontSize(lyricsSyncedFontSize)];
@@ -57,8 +59,11 @@ export function useLyricsPanel(): ILyricsPanelView {
     plain,
     activeLine,
     isLoading,
+    isError,
     sourceLabel: sourceToLabel(source, t),
+    retryLabel: tCommon('retry'),
     onLineClick: handleLineClick,
+    onRetry: retry,
     syncedDimOpacity: lyricsSyncedDimOpacity,
     plainOpacity: lyricsPlainOpacity,
     syncedBaseClassName: cn(PANEL_BASE_AFFORDANCES, baseSizeClass),

--- a/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.test.tsx
+++ b/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.test.tsx
@@ -13,6 +13,7 @@ const EMPTY_LYRICS_VIEW: ReturnType<typeof useLyricsView> = {
   activeLine: -1,
   isLoading: false,
   isError: false,
+  retry: () => {},
   handleLineClick: () => {},
 };
 

--- a/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.tsx
+++ b/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.tsx
@@ -11,8 +11,11 @@ export default function LyricsPanel({ headerAction }: ILyricsPanelProps) {
     plain,
     activeLine,
     isLoading,
+    isError,
     sourceLabel,
+    retryLabel,
     onLineClick,
+    onRetry,
     syncedDimOpacity,
     plainOpacity,
     syncedBaseClassName,
@@ -50,9 +53,13 @@ export default function LyricsPanel({ headerAction }: ILyricsPanelProps) {
         plain={plain}
         activeLine={activeLine}
         isLoading={isLoading}
+        isError={isError}
         onLineClick={onLineClick}
+        onRetry={onRetry}
         loadingLabel={t('finding')}
         emptyLabel={t('notFound')}
+        errorLabel={t('error')}
+        retryLabel={retryLabel}
         syncedDimOpacity={syncedDimOpacity}
         plainOpacity={plainOpacity}
         syncedContainerClassName="px-5 py-6"

--- a/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.tsx
+++ b/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.tsx
@@ -29,7 +29,7 @@ export default function LyricsPanel({ headerAction }: ILyricsPanelProps) {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="px-5 py-3.5 border-b border-border/20 shrink-0 flex items-center justify-between">
+      <div className="px-5 py-2 min-h-[49px] border-b border-border/20 shrink-0 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <h2 className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
             {t('title')}

--- a/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.types.ts
+++ b/apps/web/src/components/lyrics/LyricsPanel/LyricsPanel.types.ts
@@ -22,10 +22,16 @@ export interface ILyricsPanelView {
   readonly activeLine: number;
   /** Lyrics fetch in flight. */
   readonly isLoading: boolean;
+  /** Lyrics fetch failed (drives LyricsBody's error branch). */
+  readonly isError: boolean;
   /** Translated source-badge label (Local / Embedded / LRCLIB), or null when unresolved. */
   readonly sourceLabel: string | null;
+  /** Translated Retry label for the error branch. */
+  readonly retryLabel: string;
   /** Seek to a line's timestamp. */
   readonly onLineClick: (time: number) => void;
+  /** Re-run the failed lyrics fetch. */
+  readonly onRetry: () => void;
   /** Idle/past synced-line dim opacity from user prefs. */
   readonly syncedDimOpacity: number;
   /** Plain-lyrics text opacity from user prefs. */

--- a/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.test.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.test.tsx
@@ -38,6 +38,7 @@ vi.mock('@/hooks/useLyricsView', () => ({
     activeLine: -1,
     isLoading: false,
     isError: false,
+    retry: vi.fn(),
     handleLineClick: vi.fn(),
   }),
 }));

--- a/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.tsx
+++ b/apps/web/src/components/now-playing/NowPlayingView/NowPlayingView.tsx
@@ -304,9 +304,13 @@ export default function NowPlayingView() {
                         plain={lyrics.plain}
                         activeLine={lyrics.activeLine}
                         isLoading={lyrics.isLoading}
+                        isError={lyrics.isError}
                         onLineClick={lyrics.handleLineClick}
+                        onRetry={lyrics.retry}
                         loadingLabel={t('findingLyrics')}
                         emptyLabel={t('noLyrics')}
+                        errorLabel={t('lyricsError')}
+                        retryLabel={t('retry', { ns: 'common' })}
                         syncedDimOpacity={lyricsSyncedDimOpacity}
                         plainOpacity={lyricsPlainOpacity}
                         syncedWrapperClassName="contents"
@@ -319,7 +323,7 @@ export default function NowPlayingView() {
                         syncedIdleClassName={lyricsClasses.syncedIdle}
                         plainContainerClassName="pr-2 @3xl:pr-4"
                         plainTextClassName={lyricsClasses.plainText}
-                        emptyClassName="text-muted-foreground/25"
+                        emptyClassName="text-muted-foreground/60"
                       />
                     )}
                   </>

--- a/apps/web/src/components/player/QueuePanel/QueuePanel.hooks.ts
+++ b/apps/web/src/components/player/QueuePanel/QueuePanel.hooks.ts
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { useCreatePlaylistWithTracksMutation } from '@/hooks/queries/usePlaylists';
 import {
   PointerSensor,
   KeyboardSensor,
@@ -19,6 +21,8 @@ function indexOfSortableId(id: string | number): number {
 export function useQueuePanel(props: IQueuePanelProps = {}): IQueuePanelView {
   const { headerAction } = props;
   const { t } = useTranslation('queue');
+  const { t: tCommon } = useTranslation('common');
+  const { t: tToast } = useTranslation('toast');
 
   const queue = usePlaybackStore(s => s.queue);
   const queueIndex = usePlaybackStore(s => s.queueIndex);
@@ -114,8 +118,51 @@ export function useQueuePanel(props: IQueuePanelProps = {}): IQueuePanelView {
     setShowClearConfirm(false);
   }, []);
 
+  // Save-as-playlist: a name prompt in a popover (the panel's compact take on
+  // the sibling create-playlist forms), snapshotting the whole queue.
+  const [showSaveForm, setShowSaveForm] = useState(false);
+  const [saveName, setSaveName] = useState('');
+  const createWithTracks = useCreatePlaylistWithTracksMutation();
+
+  const onSaveFormOpenChange = useCallback((open: boolean) => {
+    setShowSaveForm(open);
+    if (!open) setSaveName('');
+  }, []);
+
+  const onSaveAsPlaylist = useCallback(async () => {
+    const name = saveName.trim();
+    if (!name) return;
+    // Create isn't idempotent — a double Enter/click would otherwise make two
+    // playlists. Block re-entry while the mutation is in flight.
+    if (createWithTracks.isPending) return;
+
+    const trackIds = queueRef.current.map(track => track.id);
+    try {
+      const playlist = await createWithTracks.mutateAsync({ name, trackIds });
+      setShowSaveForm(false);
+      setSaveName('');
+      toast.success(
+        tToast('createdPlaylistAddedTracks', {
+          name: playlist?.name ?? name,
+          count: trackIds.length,
+        })
+      );
+    } catch {
+      toast.error(tToast('failedCreatePlaylist'));
+    }
+  }, [saveName, createWithTracks, tToast]);
+
+  const onSaveNameKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') void onSaveAsPlaylist();
+      if (e.key === 'Escape') onSaveFormOpenChange(false);
+    },
+    [onSaveAsPlaylist, onSaveFormOpenChange]
+  );
+
   return {
     t,
+    tCommon,
     headerAction,
     hasQueue: queue.length > 0,
     nowPlayingTrack: currentTrack && queueIndex >= 0 ? currentTrack : null,
@@ -129,6 +176,14 @@ export function useQueuePanel(props: IQueuePanelProps = {}): IQueuePanelView {
     onClearConfirmOpenChange: setShowClearConfirm,
     onConfirmClear,
     onCancelClear,
+    showSaveForm,
+    onSaveFormOpenChange,
+    saveName,
+    onSaveNameChange: setSaveName,
+    onSaveNameKeyDown,
+    isSavingPlaylist: createWithTracks.isPending,
+    canSavePlaylist: saveName.trim().length > 0 && !createWithTracks.isPending,
+    onSaveAsPlaylist,
     onPlayIndex,
     onRemove,
     onDragStart,

--- a/apps/web/src/components/player/QueuePanel/QueuePanel.hooks.ts
+++ b/apps/web/src/components/player/QueuePanel/QueuePanel.hooks.ts
@@ -101,6 +101,19 @@ export function useQueuePanel(props: IQueuePanelProps = {}): IQueuePanelView {
     setActiveId(null);
   }, []);
 
+  // Clearing stops playback and drops every track — destructive enough to gate
+  // behind the same popover-confirm pattern DownloadsView uses for Cancel all.
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
+
+  const onConfirmClear = useCallback(() => {
+    clearQueue();
+    setShowClearConfirm(false);
+  }, [clearQueue]);
+
+  const onCancelClear = useCallback(() => {
+    setShowClearConfirm(false);
+  }, []);
+
   return {
     t,
     headerAction,
@@ -112,7 +125,10 @@ export function useQueuePanel(props: IQueuePanelProps = {}): IQueuePanelView {
     sortableIds,
     activeTrack,
     sensors,
-    onClear: clearQueue,
+    showClearConfirm,
+    onClearConfirmOpenChange: setShowClearConfirm,
+    onConfirmClear,
+    onCancelClear,
     onPlayIndex,
     onRemove,
     onDragStart,

--- a/apps/web/src/components/player/QueuePanel/QueuePanel.stories.tsx
+++ b/apps/web/src/components/player/QueuePanel/QueuePanel.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { within, expect } from 'storybook/test';
 import type { Track } from '@/stores/types';
 import { usePlaybackStore } from '@/stores/usePlaybackStore';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 import QueuePanel from './QueuePanel';
 
@@ -35,13 +36,14 @@ function seedQueue(tracks: Track[], index: number): void {
 }
 
 /**
- * player · QueuePanel. The play queue — a "Queue" heading with a Clear action, a
- * "Now Playing" row, and a drag-reorderable "Up Next" list, all reading
- * `usePlaybackStore`. Each row shows the track title/artist plus a remove button
- * ("Remove from queue") and a drag handle ("Drag to reorder"); the active row
- * carries an sr-only "Now Playing" label. With an empty queue it shows the
- * "Queue is empty" placeholder. Stories seed the queue and assert the structure
- * by role + name.
+ * player · QueuePanel. The play queue — a "Queue" heading with save-as-playlist
+ * and clear-queue header actions (the clear sits behind a destructive popover
+ * confirm), a "Now Playing" row, and a drag-reorderable "Up Next" list, all
+ * reading `usePlaybackStore`. Each row shows the track title/artist plus a
+ * remove button ("Remove from queue") and a drag handle ("Drag to reorder");
+ * the active row carries an sr-only "Now Playing" label. With an empty queue it
+ * shows the shared ViewEmptyState placeholder. Stories seed the queue and
+ * assert the structure by role + name.
  */
 const meta: Meta<typeof QueuePanel> = {
   title: 'player/QueuePanel',
@@ -53,9 +55,11 @@ const meta: Meta<typeof QueuePanel> = {
   },
   decorators: [
     Story => (
-      <div className="flex h-[36rem] w-80 flex-col glass border border-border/30 rounded-2xl overflow-hidden">
-        <Story />
-      </div>
+      <TooltipProvider>
+        <div className="flex h-[36rem] w-80 flex-col glass border border-border/30 rounded-2xl overflow-hidden">
+          <Story />
+        </div>
+      </TooltipProvider>
     ),
   ],
 };
@@ -84,6 +88,12 @@ export const WithQueue: Story = {
     await expect(canvas.getAllByRole('button', { name: 'Remove from queue' })).toHaveLength(4);
     // The three sortable up-next rows each carry a drag handle.
     await expect(canvas.getAllByRole('button', { name: 'Drag to reorder' })).toHaveLength(3);
+
+    // Both header actions are present and labelled.
+    await expect(
+      canvas.getByRole('button', { name: 'Save queue as playlist' })
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Clear queue' })).toBeInTheDocument();
   },
 };
 
@@ -98,7 +108,10 @@ export const Empty: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByText('Queue is empty')).toBeInTheDocument();
-    // No Clear action when there is nothing to clear.
-    await expect(canvas.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+    // No header actions when there is nothing to clear or save.
+    await expect(canvas.queryByRole('button', { name: 'Clear queue' })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Save queue as playlist' })
+    ).not.toBeInTheDocument();
   },
 };

--- a/apps/web/src/components/player/QueuePanel/QueuePanel.test.tsx
+++ b/apps/web/src/components/player/QueuePanel/QueuePanel.test.tsx
@@ -43,6 +43,18 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+const createWithTracksMutation = vi.hoisted(() => ({
+  mutateAsync: vi.fn(async (data: { name: string; trackIds: string[] }) => ({
+    id: 'pl-1',
+    name: data.name,
+  })),
+  isPending: false,
+}));
+
+vi.mock('@/hooks/queries/usePlaylists', () => ({
+  useCreatePlaylistWithTracksMutation: () => createWithTracksMutation,
+}));
+
 // Radix tooltips need a provider; pass the trigger child straight through.
 vi.mock('@/components/ui/tooltip', () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -112,6 +124,32 @@ describe('QueuePanel', () => {
 
     expect(playbackState.clearQueue).not.toHaveBeenCalled();
     expect(screen.queryByRole('button', { name: 'clearConfirmAction' })).not.toBeInTheDocument();
+  });
+
+  it('saves the whole queue as a playlist under the typed name', async () => {
+    setQueueState(
+      [makeTrack({ id: 'q0', title: 'Now' }), makeTrack({ id: 'q1', title: 'Next' })],
+      0
+    );
+    render(<QueuePanel />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'saveAsPlaylist' }));
+    await userEvent.type(screen.getByRole('textbox', { name: 'namePlaceholder' }), 'Evening mix');
+    await userEvent.click(screen.getByRole('button', { name: 'save' }));
+
+    expect(createWithTracksMutation.mutateAsync).toHaveBeenCalledWith({
+      name: 'Evening mix',
+      trackIds: ['q0', 'q1'],
+    });
+  });
+
+  it('does not save while the playlist name is empty', async () => {
+    setQueueState([makeTrack({ id: 'q0', title: 'Now' })], 0);
+    render(<QueuePanel />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'saveAsPlaylist' }));
+    expect(screen.getByRole('button', { name: 'save' })).toBeDisabled();
+    expect(createWithTracksMutation.mutateAsync).not.toHaveBeenCalled();
   });
 
   it('renders the header action passed via props', () => {

--- a/apps/web/src/components/player/QueuePanel/QueuePanel.test.tsx
+++ b/apps/web/src/components/player/QueuePanel/QueuePanel.test.tsx
@@ -59,7 +59,8 @@ describe('QueuePanel', () => {
     setQueueState([], -1);
     render(<QueuePanel />);
 
-    expect(screen.getByText('empty')).toBeInTheDocument();
+    expect(screen.getByText('emptyTitle')).toBeInTheDocument();
+    expect(screen.getByText('emptySubtitle')).toBeInTheDocument();
     expect(screen.queryByText('clear')).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/components/player/QueuePanel/QueuePanel.test.tsx
+++ b/apps/web/src/components/player/QueuePanel/QueuePanel.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
 import type { Track } from '@/stores/types';
 
 import QueuePanel from './QueuePanel';
@@ -40,6 +41,13 @@ vi.mock('react-i18next', () => ({
     t: (key: string, opts?: Record<string, unknown>) =>
       opts && 'count' in opts ? `${key}:${opts.count}` : key,
   }),
+}));
+
+// Radix tooltips need a provider; pass the trigger child straight through.
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
 }));
 
 function setQueueState(tracks: Track[], index: number): void {
@@ -84,12 +92,26 @@ describe('QueuePanel', () => {
     expect(screen.getByText('upNext:2')).toBeInTheDocument();
   });
 
-  it('clears the queue from the header action', async () => {
+  it('clears the queue only after confirming the destructive popover', async () => {
     setQueueState([makeTrack({ id: 'q0', title: 'Now' })], 0);
     render(<QueuePanel />);
 
-    await userEvent.click(screen.getByText('clear'));
+    await userEvent.click(screen.getByRole('button', { name: 'clear' }));
+    expect(playbackState.clearQueue).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'clearConfirmAction' }));
     expect(playbackState.clearQueue).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the queue when the confirm popover is dismissed', async () => {
+    setQueueState([makeTrack({ id: 'q0', title: 'Now' })], 0);
+    render(<QueuePanel />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'clear' }));
+    await userEvent.click(screen.getByRole('button', { name: 'keep' }));
+
+    expect(playbackState.clearQueue).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'clearConfirmAction' })).not.toBeInTheDocument();
   });
 
   it('renders the header action passed via props', () => {

--- a/apps/web/src/components/player/QueuePanel/QueuePanel.tsx
+++ b/apps/web/src/components/player/QueuePanel/QueuePanel.tsx
@@ -1,6 +1,7 @@
-import { Trash2, Music } from 'lucide-react';
+import { Trash2, Music, ListPlus, Loader2 } from 'lucide-react';
 import { DndContext, DragOverlay, closestCenter } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { Button } from '@/components/ui/button';
 import { IconButton } from '@/components/ui/icon-button';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
@@ -12,6 +13,7 @@ import type { IQueuePanelProps } from './QueuePanel.types';
 export default function QueuePanel(props: IQueuePanelProps) {
   const {
     t,
+    tCommon,
     headerAction,
     hasQueue,
     nowPlayingTrack,
@@ -25,6 +27,14 @@ export default function QueuePanel(props: IQueuePanelProps) {
     onClearConfirmOpenChange,
     onConfirmClear,
     onCancelClear,
+    showSaveForm,
+    onSaveFormOpenChange,
+    saveName,
+    onSaveNameChange,
+    onSaveNameKeyDown,
+    isSavingPlaylist,
+    canSavePlaylist,
+    onSaveAsPlaylist,
     onPlayIndex,
     onRemove,
     onDragStart,
@@ -53,6 +63,44 @@ export default function QueuePanel(props: IQueuePanelProps) {
           {t('title')}
         </h2>
         <div className="flex items-center gap-1">
+          {hasQueue && (
+            <Popover open={showSaveForm} onOpenChange={onSaveFormOpenChange}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <PopoverTrigger asChild>
+                    <IconButton aria-label={t('saveAsPlaylist')}>
+                      <ListPlus />
+                    </IconButton>
+                  </PopoverTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{t('saveAsPlaylist')}</TooltipContent>
+              </Tooltip>
+              <PopoverContent align="end" className="w-64">
+                <p className="text-xs font-medium text-foreground/80 mb-2">{t('saveAsPlaylist')}</p>
+                <div className="flex items-center gap-1.5">
+                  <input
+                    autoFocus
+                    value={saveName}
+                    onChange={e => onSaveNameChange(e.target.value)}
+                    onKeyDown={onSaveNameKeyDown}
+                    placeholder={tCommon('namePlaceholder')}
+                    aria-label={tCommon('namePlaceholder')}
+                    disabled={isSavingPlaylist}
+                    className="flex-1 min-w-0 px-2 py-1 rounded-lg bg-background/50 border border-border/30 text-xs text-foreground placeholder:text-muted-foreground/40 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  />
+                  <Button
+                    size="sm"
+                    onClick={() => void onSaveAsPlaylist()}
+                    disabled={!canSavePlaylist}
+                    className="h-7 bg-primary/20 px-2.5 text-primary shadow-none hover:bg-primary/30 [&_svg]:size-3.5"
+                  >
+                    {isSavingPlaylist && <Loader2 className="animate-spin" />}
+                    {tCommon('save')}
+                  </Button>
+                </div>
+              </PopoverContent>
+            </Popover>
+          )}
           {hasQueue && (
             <Popover open={showClearConfirm} onOpenChange={onClearConfirmOpenChange}>
               <Tooltip>

--- a/apps/web/src/components/player/QueuePanel/QueuePanel.tsx
+++ b/apps/web/src/components/player/QueuePanel/QueuePanel.tsx
@@ -1,6 +1,9 @@
 import { Trash2, Music } from 'lucide-react';
 import { DndContext, DragOverlay, closestCenter } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { IconButton } from '@/components/ui/icon-button';
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { ViewEmptyState } from '@/components/shared/ViewEmptyState';
 import { SortableQueueRow, DragOverlayContent, QueueItem } from '../QueueRow';
 import { useQueuePanel } from './QueuePanel.hooks';
@@ -18,7 +21,10 @@ export default function QueuePanel(props: IQueuePanelProps) {
     sortableIds,
     activeTrack,
     sensors,
-    onClear,
+    showClearConfirm,
+    onClearConfirmOpenChange,
+    onConfirmClear,
+    onCancelClear,
     onPlayIndex,
     onRemove,
     onDragStart,
@@ -42,19 +48,44 @@ export default function QueuePanel(props: IQueuePanelProps) {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="px-5 py-3.5 border-b border-border/20 shrink-0 flex items-center justify-between">
+      <div className="px-5 py-2 min-h-[49px] border-b border-border/20 shrink-0 flex items-center justify-between">
         <h2 className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground/60">
           {t('title')}
         </h2>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-1">
           {hasQueue && (
-            <button
-              onClick={onClear}
-              className="focus-ring rounded-sm flex items-center gap-1 text-[10px] font-medium text-muted-foreground/40 hover:text-destructive transition-colors"
-            >
-              <Trash2 className="w-3 h-3" />
-              {t('clear')}
-            </button>
+            <Popover open={showClearConfirm} onOpenChange={onClearConfirmOpenChange}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <PopoverTrigger asChild>
+                    <IconButton
+                      aria-label={t('clear')}
+                      className="hover:bg-destructive/15 hover:text-destructive"
+                    >
+                      <Trash2 />
+                    </IconButton>
+                  </PopoverTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{t('clear')}</TooltipContent>
+              </Tooltip>
+              <PopoverContent align="end" className="w-64">
+                <p className="text-xs text-foreground/80 mb-2">{t('clearConfirm')}</p>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={onConfirmClear}
+                    className="focus-ring flex-1 px-2 py-1 rounded-lg text-xs font-medium bg-destructive/15 text-destructive hover:bg-destructive/25 transition-colors"
+                  >
+                    {t('clearConfirmAction')}
+                  </button>
+                  <button
+                    onClick={onCancelClear}
+                    className="focus-ring flex-1 px-2 py-1 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                  >
+                    {t('keep')}
+                  </button>
+                </div>
+              </PopoverContent>
+            </Popover>
           )}
           {headerAction}
         </div>

--- a/apps/web/src/components/player/QueuePanel/QueuePanel.tsx
+++ b/apps/web/src/components/player/QueuePanel/QueuePanel.tsx
@@ -1,6 +1,7 @@
 import { Trash2, Music } from 'lucide-react';
 import { DndContext, DragOverlay, closestCenter } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { ViewEmptyState } from '@/components/shared/ViewEmptyState';
 import { SortableQueueRow, DragOverlayContent, QueueItem } from '../QueueRow';
 import { useQueuePanel } from './QueuePanel.hooks';
 import type { IQueuePanelProps } from './QueuePanel.types';
@@ -42,7 +43,7 @@ export default function QueuePanel(props: IQueuePanelProps) {
     <div className="flex flex-col h-full">
       {/* Header */}
       <div className="px-5 py-3.5 border-b border-border/20 shrink-0 flex items-center justify-between">
-        <h2 className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground/50">
+        <h2 className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground/60">
           {t('title')}
         </h2>
         <div className="flex items-center gap-3">
@@ -61,16 +62,18 @@ export default function QueuePanel(props: IQueuePanelProps) {
 
       {/* Content */}
       {!hasQueue ? (
-        <div className="flex-1 flex flex-col items-center justify-center gap-3">
-          <Music className="w-7 h-7 text-muted-foreground/20" />
-          <p className="text-xs text-muted-foreground/30 font-medium">{t('empty')}</p>
-        </div>
+        <ViewEmptyState
+          compact
+          title={t('emptyTitle')}
+          subtitle={t('emptySubtitle')}
+          icon={Music}
+        />
       ) : (
         <div className="flex flex-col flex-1 min-h-0">
           {/* Now Playing */}
           {nowPlayingTrack && (
             <div className="shrink-0 px-3 py-2">
-              <p className="text-[10px] uppercase tracking-widest text-muted-foreground/40 font-medium px-2 mb-1.5">
+              <p className="text-[10px] uppercase tracking-widest text-muted-foreground/60 font-medium px-2 mb-1.5">
                 {t('nowPlaying')}
               </p>
               <QueueItem
@@ -88,7 +91,7 @@ export default function QueuePanel(props: IQueuePanelProps) {
           {upNextRows.length > 0 && (
             <>
               <div className="shrink-0 px-3 pt-2">
-                <p className="text-[10px] uppercase tracking-widest text-muted-foreground/40 font-medium px-2 mb-1.5">
+                <p className="text-[10px] uppercase tracking-widest text-muted-foreground/60 font-medium px-2 mb-1.5">
                   {t('upNext', { count: upNextRows.length })}
                 </p>
               </div>

--- a/apps/web/src/components/player/QueuePanel/QueuePanel.types.ts
+++ b/apps/web/src/components/player/QueuePanel/QueuePanel.types.ts
@@ -24,6 +24,8 @@ export interface IQueueUpNextRow {
 export interface IQueuePanelView {
   /** Bound `queue` namespace translator. */
   readonly t: TranslateFn;
+  /** Bound `common` namespace translator (save/name-placeholder labels). */
+  readonly tCommon: TranslateFn;
   /** Header action passed through from props. */
   readonly headerAction: ReactNode;
   /** Whether the queue has any entries (drives the empty state). */
@@ -54,6 +56,22 @@ export interface IQueuePanelView {
   readonly onConfirmClear: () => void;
   /** Dismiss the confirm popover without clearing. */
   readonly onCancelClear: () => void;
+  /** Whether the save-as-playlist name popover is open. */
+  readonly showSaveForm: boolean;
+  /** Open/close the save-as-playlist popover (closing resets the name). */
+  readonly onSaveFormOpenChange: (open: boolean) => void;
+  /** The draft playlist name. */
+  readonly saveName: string;
+  /** Update the draft playlist name. */
+  readonly onSaveNameChange: (name: string) => void;
+  /** Enter saves, Escape closes — the sibling name-form conventions. */
+  readonly onSaveNameKeyDown: (e: React.KeyboardEvent) => void;
+  /** Whether the create-with-tracks mutation is in flight. */
+  readonly isSavingPlaylist: boolean;
+  /** Whether the save action is enabled (non-empty name, not already saving). */
+  readonly canSavePlaylist: boolean;
+  /** Create a playlist from the current queue under the draft name. */
+  readonly onSaveAsPlaylist: () => Promise<void>;
   /** Play (or toggle) the track at the given queue index. */
   readonly onPlayIndex: (index: number) => void;
   /** Remove the track at the given queue index. */

--- a/apps/web/src/components/player/QueuePanel/QueuePanel.types.ts
+++ b/apps/web/src/components/player/QueuePanel/QueuePanel.types.ts
@@ -46,8 +46,14 @@ export interface IQueuePanelView {
   readonly activeTrack: Track | null;
   /** dnd-kit sensors (pointer + keyboard). */
   readonly sensors: SensorDescriptor<SensorOptions>[];
-  /** Clear the entire queue. */
-  readonly onClear: () => void;
+  /** Whether the clear-queue confirm popover is open. */
+  readonly showClearConfirm: boolean;
+  /** Open/close the clear-queue confirm popover. */
+  readonly onClearConfirmOpenChange: (open: boolean) => void;
+  /** Confirm the destructive clear (empties the queue, closes the popover). */
+  readonly onConfirmClear: () => void;
+  /** Dismiss the confirm popover without clearing. */
+  readonly onCancelClear: () => void;
   /** Play (or toggle) the track at the given queue index. */
   readonly onPlayIndex: (index: number) => void;
   /** Remove the track at the given queue index. */

--- a/apps/web/src/components/player/QueueRow/QueueRow.tsx
+++ b/apps/web/src/components/player/QueueRow/QueueRow.tsx
@@ -37,7 +37,7 @@ function QueueRowBody({
         <p className="text-[10px] text-muted-foreground/50 truncate">{track.artist}</p>
       </div>
 
-      <span className="text-[10px] text-muted-foreground/30 tabular-nums shrink-0">
+      <span className="text-[10px] text-muted-foreground/50 tabular-nums shrink-0">
         {durationLabel}
       </span>
     </>
@@ -57,7 +57,7 @@ function RemoveButton({
     <motion.button
       whileTap={{ scale: 0.75 }}
       onClick={onClick}
-      className="shrink-0 p-0.5 rounded text-muted-foreground/20 opacity-0 group-hover:opacity-100 hover:text-destructive transition-all duration-150"
+      className="shrink-0 p-0.5 rounded text-muted-foreground/40 opacity-0 group-hover:opacity-100 hover:text-destructive transition-all duration-150"
       aria-label={ariaLabel}
     >
       <X className="w-3 h-3" />
@@ -83,7 +83,7 @@ export default function SortableQueueRow(props: ISortableQueueRowProps) {
       onClick={onPlay}
     >
       <button
-        className="focus-ring shrink-0 p-0.5 rounded text-muted-foreground/20 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-muted-foreground/60 transition-all duration-150 cursor-grab active:cursor-grabbing touch-none"
+        className="focus-ring shrink-0 p-0.5 rounded text-muted-foreground/40 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-muted-foreground/60 transition-all duration-150 cursor-grab active:cursor-grabbing touch-none"
         aria-label={labels.dragToReorder}
         {...attributes}
         {...listeners}

--- a/apps/web/src/components/sanctuary/SanctuaryView/SanctuaryView.test.tsx
+++ b/apps/web/src/components/sanctuary/SanctuaryView/SanctuaryView.test.tsx
@@ -29,6 +29,7 @@ vi.mock('@/hooks/useLyricsView', () => ({
     activeLine: 1,
     isLoading: false,
     isError: false,
+    retry: vi.fn(),
     handleLineClick: vi.fn(),
   }),
 }));

--- a/apps/web/src/components/shared/SidePanel/SidePanel.hooks.ts
+++ b/apps/web/src/components/shared/SidePanel/SidePanel.hooks.ts
@@ -1,12 +1,15 @@
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PanelLeft, PanelRight } from 'lucide-react';
 import { useViewStore } from '@/stores/useViewStore';
 import { usePanelSizeStore } from '@/stores/usePanelSizeStore';
 import { useLayoutStore, type SidePanelSide } from '@/stores/useLayoutStore';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 import type { ISidePanelProps, ISidePanelView } from './SidePanel.types';
 
 export function useSidePanel({ side }: ISidePanelProps): ISidePanelView {
   const { t } = useTranslation('common');
+  const reducedMotion = useReducedMotion();
   const rightPanel = useViewStore(s => s.rightPanel);
   const rightPanelWidth = usePanelSizeStore(s => s.rightPanelWidth);
   const setRightPanelWidth = usePanelSizeStore(s => s.setRightPanelWidth);
@@ -15,7 +18,13 @@ export function useSidePanel({ side }: ISidePanelProps): ISidePanelView {
 
   // App.tsx already gates rendering on rightPanel, but stay self-sufficient:
   // bail before mounting the panel chrome when there is nothing to show.
-  const content = rightPanel === 'lyrics' || rightPanel === 'queue' ? rightPanel : null;
+  const liveContent = rightPanel === 'lyrics' || rightPanel === 'queue' ? rightPanel : null;
+
+  // While AnimatePresence plays the exit, the store has already emptied — keep
+  // rendering the last content so the panel doesn't blank out mid-animation.
+  const lastContentRef = useRef<'lyrics' | 'queue' | null>(null);
+  if (liveContent) lastContentRef.current = liveContent;
+  const content = liveContent ?? lastContentRef.current;
 
   const flipTo: SidePanelSide = side === 'right' ? 'left' : 'right';
 
@@ -23,6 +32,7 @@ export function useSidePanel({ side }: ISidePanelProps): ISidePanelView {
     t,
     shouldRender: content !== null,
     content,
+    reducedMotion,
     rightPanelWidth,
     side,
     resizeEdge: side === 'right' ? 'left' : 'right',

--- a/apps/web/src/components/shared/SidePanel/SidePanel.tsx
+++ b/apps/web/src/components/shared/SidePanel/SidePanel.tsx
@@ -1,10 +1,14 @@
 import { lazy, Suspense } from 'react';
+import { motion } from 'motion/react';
 import { cn } from '@/lib/utils';
+import { IconButton } from '@/components/ui/icon-button';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { PanelResizeHandle } from '@/components/shared/PanelResizeHandle';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { RIGHT_PANEL_WIDTH_MIN, RIGHT_PANEL_WIDTH_MAX } from '@/stores/usePanelSizeStore';
+import { PANEL_SLIDE_OFFSET, PANEL_TRANSITION } from '@/lib/motion';
 import { useSidePanel } from './SidePanel.hooks';
+import { SidePanelSkeleton } from './SidePanelSkeleton';
 import type { ISidePanelProps } from './SidePanel.types';
 
 const LyricsPanel = lazy(() => import('@/components/lyrics/LyricsPanel/LyricsPanel'));
@@ -20,6 +24,7 @@ export default function SidePanel(props: ISidePanelProps) {
     t,
     shouldRender,
     content,
+    reducedMotion,
     rightPanelWidth,
     side,
     resizeEdge,
@@ -35,26 +40,36 @@ export default function SidePanel(props: ISidePanelProps) {
   const flipButton = (
     <Tooltip>
       <TooltipTrigger asChild>
-        <button
-          onClick={onFlip}
-          aria-label={flipLabel}
-          className="focus-ring rounded-sm text-muted-foreground/40 hover:text-foreground transition-colors"
-        >
-          <FlipIcon className="w-3.5 h-3.5" />
-        </button>
+        <IconButton onClick={onFlip} aria-label={flipLabel}>
+          <FlipIcon />
+        </IconButton>
       </TooltipTrigger>
       <TooltipContent side="bottom">{flipLabel}</TooltipContent>
     </Tooltip>
   );
 
+  // A gentle fade + slide from the docked edge; width stays static so the
+  // resize handle keeps full control of it. App.tsx wraps the mount site in
+  // AnimatePresence so the exit leg plays before unmount.
+  const slideOffset = side === 'right' ? PANEL_SLIDE_OFFSET : -PANEL_SLIDE_OFFSET;
+  const motionProps = reducedMotion
+    ? {}
+    : {
+        initial: { opacity: 0, x: slideOffset },
+        animate: { opacity: 1, x: 0 },
+        exit: { opacity: 0, x: slideOffset },
+        transition: PANEL_TRANSITION,
+      };
+
   return (
-    <div
+    <motion.div
       id="player-side-panel"
       className={cn(
         'relative border-border/30 shrink-0 flex flex-col overflow-hidden bg-surface/30',
         side === 'right' ? 'border-l' : 'border-r'
       )}
       style={{ width: rightPanelWidth }}
+      {...motionProps}
     >
       <PanelResizeHandle
         edge={resizeEdge}
@@ -67,7 +82,7 @@ export default function SidePanel(props: ISidePanelProps) {
         aria-controls="player-side-panel"
       />
       <ErrorBoundary viewName="RightPanel">
-        <Suspense fallback={null}>
+        <Suspense fallback={<SidePanelSkeleton />}>
           {content === 'lyrics' ? (
             <LyricsPanel headerAction={flipButton} />
           ) : (
@@ -75,6 +90,6 @@ export default function SidePanel(props: ISidePanelProps) {
           )}
         </Suspense>
       </ErrorBoundary>
-    </div>
+    </motion.div>
   );
 }

--- a/apps/web/src/components/shared/SidePanel/SidePanel.types.ts
+++ b/apps/web/src/components/shared/SidePanel/SidePanel.types.ts
@@ -12,6 +12,8 @@ export interface ISidePanelView {
   readonly shouldRender: boolean;
   /** Which content the panel shows (only meaningful when `shouldRender`). */
   readonly content: 'lyrics' | 'queue' | null;
+  /** Skip the enter/exit motion when the OS prefers reduced motion. */
+  readonly reducedMotion: boolean;
   /** Persisted shared width of the panel, in px. */
   readonly rightPanelWidth: number;
   /** The side the panel docks on (drives border + resize-handle edge). */

--- a/apps/web/src/components/shared/SidePanel/SidePanelSkeleton/SidePanelSkeleton.hooks.ts
+++ b/apps/web/src/components/shared/SidePanel/SidePanelSkeleton/SidePanelSkeleton.hooks.ts
@@ -1,0 +1,16 @@
+import type { ISidePanelSkeletonView } from './SidePanelSkeleton.types';
+
+/**
+ * The skeleton takes no props; the hook supplies the placeholder-row keys so
+ * the shell stays a logic-free frame. Six rows sketch a plausible track list
+ * without implying a specific queue length.
+ */
+const ROW_COUNT = 6;
+
+const ROW_KEYS: readonly number[] = Array.from({ length: ROW_COUNT }, (_, index) => index);
+
+export function useSidePanelSkeleton(): ISidePanelSkeletonView {
+  return {
+    rowKeys: ROW_KEYS,
+  };
+}

--- a/apps/web/src/components/shared/SidePanel/SidePanelSkeleton/SidePanelSkeleton.stories.tsx
+++ b/apps/web/src/components/shared/SidePanel/SidePanelSkeleton/SidePanelSkeleton.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
+
+import SidePanelSkeleton from './SidePanelSkeleton';
+
+/**
+ * shared · SidePanelSkeleton. The Suspense fallback shown inside the docked
+ * side panel while a lazy lyrics/queue chunk loads: a reserved header strip
+ * (title chip + header-action chip) above six shimmering track-shaped rows, so
+ * the panel frame never flashes empty. It takes no props and has no
+ * interactive surface; the story pins the `aria-busy` contract and the row
+ * anatomy at the panel's docked width.
+ */
+const meta: Meta<typeof SidePanelSkeleton> = {
+  title: 'shared/SidePanelSkeleton',
+  component: SidePanelSkeleton,
+  parameters: {
+    // The frame is aria-busy with no readable copy and no focusable
+    // descendants — every placeholder is an inert div — so axe passes clean.
+    a11y: { test: 'error' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SidePanelSkeleton>;
+
+/** Docked width — the header strip plus six track-shaped placeholder rows. */
+export const Default: Story = {
+  decorators: [
+    Story => (
+      <div className="flex h-[32rem] w-80 flex-col border border-border/30 rounded-2xl overflow-hidden">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const frame = canvasElement.querySelector('[aria-busy="true"]');
+    await expect(frame).not.toBeNull();
+    // Header strip + row column — the loaded panel's two regions.
+    await expect(frame?.children).toHaveLength(2);
+    await expect(frame?.children[1].children).toHaveLength(6);
+    // Nothing is clickable while loading.
+    await expect(canvasElement.querySelector('button')).toBeNull();
+  },
+};

--- a/apps/web/src/components/shared/SidePanel/SidePanelSkeleton/SidePanelSkeleton.test.tsx
+++ b/apps/web/src/components/shared/SidePanel/SidePanelSkeleton/SidePanelSkeleton.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import SidePanelSkeleton from './SidePanelSkeleton';
+
+describe('SidePanelSkeleton', () => {
+  it('marks the whole frame busy while a panel chunk loads', () => {
+    const { container } = render(<SidePanelSkeleton />);
+
+    expect(container.querySelector('[aria-busy="true"]')).not.toBeNull();
+  });
+
+  it('reserves the header strip so the panel chrome does not shift in', () => {
+    const { container } = render(<SidePanelSkeleton />);
+
+    const frame = container.querySelector('[aria-busy="true"]');
+    // Header strip + row column.
+    expect(frame?.children).toHaveLength(2);
+    // Title chip + header-action chip.
+    expect(frame?.children[0].children).toHaveLength(2);
+  });
+
+  it('sketches six track-shaped placeholder rows', () => {
+    const { container } = render(<SidePanelSkeleton />);
+
+    const frame = container.querySelector('[aria-busy="true"]');
+    expect(frame?.children[1].children).toHaveLength(6);
+  });
+
+  it('renders no readable copy or interactive controls while loading', () => {
+    const { container } = render(<SidePanelSkeleton />);
+
+    expect(container.textContent).toBe('');
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+});

--- a/apps/web/src/components/shared/SidePanel/SidePanelSkeleton/SidePanelSkeleton.tsx
+++ b/apps/web/src/components/shared/SidePanel/SidePanelSkeleton/SidePanelSkeleton.tsx
@@ -1,0 +1,32 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { useSidePanelSkeleton } from './SidePanelSkeleton.hooks';
+
+/**
+ * Suspense fallback for the lazily loaded lyrics/queue panels — mirrors the
+ * panel chrome (header strip + a column of track-shaped rows) so the docked
+ * frame doesn't flash empty while a panel chunk loads.
+ */
+export default function SidePanelSkeleton() {
+  const { rowKeys } = useSidePanelSkeleton();
+
+  // Lifted out of JSX (no-jsx-computation): build the rows above the return.
+  const rows = rowKeys.map(key => (
+    <div key={key} className="flex items-center gap-3 px-2 py-1.5">
+      <Skeleton className="size-9 rounded-lg shrink-0" />
+      <div className="flex-1 min-w-0">
+        <Skeleton className="h-3 w-3/4" />
+        <Skeleton className="h-2.5 w-1/2 mt-1.5" />
+      </div>
+    </div>
+  ));
+
+  return (
+    <div className="flex flex-col h-full" aria-busy="true">
+      <div className="px-5 py-2 min-h-[49px] border-b border-border/20 shrink-0 flex items-center justify-between">
+        <Skeleton className="h-3 w-16" />
+        <Skeleton className="size-7 rounded-lg" />
+      </div>
+      <div className="px-3 py-3 flex flex-col gap-1">{rows}</div>
+    </div>
+  );
+}

--- a/apps/web/src/components/shared/SidePanel/SidePanelSkeleton/SidePanelSkeleton.types.ts
+++ b/apps/web/src/components/shared/SidePanel/SidePanelSkeleton/SidePanelSkeleton.types.ts
@@ -1,0 +1,4 @@
+export interface ISidePanelSkeletonView {
+  /** Stable keys for the placeholder rows filling the panel while a chunk loads. */
+  readonly rowKeys: readonly number[];
+}

--- a/apps/web/src/components/shared/SidePanel/SidePanelSkeleton/index.ts
+++ b/apps/web/src/components/shared/SidePanel/SidePanelSkeleton/index.ts
@@ -1,0 +1,2 @@
+export { default as SidePanelSkeleton } from './SidePanelSkeleton';
+export * from './SidePanelSkeleton.types';

--- a/apps/web/src/hooks/queries/usePlaylists.ts
+++ b/apps/web/src/hooks/queries/usePlaylists.ts
@@ -127,6 +127,19 @@ export function useCreatePlaylistMutation() {
   });
 }
 
+export function useCreatePlaylistWithTracksMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (data: { name: string; trackIds: string[] }) => {
+      return await window.electronAPI.db.playlists.createWithTracks(data);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: playlistKeys.all });
+    },
+  });
+}
+
 export function useUpdatePlaylistMutation() {
   const queryClient = useQueryClient();
 

--- a/apps/web/src/hooks/useLyricsView.ts
+++ b/apps/web/src/hooks/useLyricsView.ts
@@ -14,6 +14,8 @@ interface UseLyricsViewResult {
   activeLine: number;
   isLoading: boolean;
   isError: boolean;
+  /** Re-run the failed lyrics fetch (drives the error-branch Retry action). */
+  retry: () => void;
   /** Seek to a line's timestamp. */
   handleLineClick: (time: number) => void;
 }
@@ -32,7 +34,7 @@ export function useLyricsView(): UseLyricsViewResult {
   const currentTrack = usePlaybackStore(s => s.currentTrack);
   const seek = usePlaybackStore(s => s.seek);
 
-  const { data, isLoading, isError } = useLyricsQuery(
+  const { data, isLoading, isError, refetch } = useLyricsQuery(
     currentTrack?.id ?? null,
     currentTrack?.title ?? '',
     currentTrack?.artist ?? '',
@@ -54,5 +56,9 @@ export function useLyricsView(): UseLyricsViewResult {
 
   const handleLineClick = useCallback((time: number) => seek(time), [seek]);
 
-  return { synced, plain, source, activeLine, isLoading, isError, handleLineClick };
+  const retry = useCallback(() => {
+    void refetch();
+  }, [refetch]);
+
+  return { synced, plain, source, activeLine, isLoading, isError, retry, handleLineClick };
 }

--- a/apps/web/src/lib/motion.ts
+++ b/apps/web/src/lib/motion.ts
@@ -70,3 +70,13 @@ export const VIEW_TRANSITION = {
   exit: { opacity: 0, y: -6 },
   transition: { duration: 0.16, ease: EASE_OUT_SOFT },
 };
+
+/**
+ * Docked side-panel enter/exit — a gentle fade + short slide from the panel's
+ * docked edge. Use with AnimatePresence around the mount site and negate the
+ * offset when docked left; width stays static (the resize handle owns it) so
+ * only the panel itself glides. Skip under reduced motion (render without the
+ * motion props).
+ */
+export const PANEL_SLIDE_OFFSET = 24;
+export const PANEL_TRANSITION = { duration: 0.18, ease: EASE_OUT_SOFT };

--- a/apps/web/src/locales/en/lyrics.json
+++ b/apps/web/src/locales/en/lyrics.json
@@ -2,6 +2,7 @@
   "title": "Lyrics",
   "finding": "Finding lyrics...",
   "notFound": "No lyrics found",
+  "error": "Couldn't load lyrics",
   "sourceLocal": "Local",
   "sourceEmbedded": "Embedded",
   "sourceLrclib": "LRCLIB",

--- a/apps/web/src/locales/en/nowPlaying.json
+++ b/apps/web/src/locales/en/nowPlaying.json
@@ -5,6 +5,7 @@
   "eq": "Equalizer",
   "findingLyrics": "Finding lyrics...",
   "noLyrics": "No lyrics available",
+  "lyricsError": "Couldn't load lyrics",
   "showLyrics": "Show lyrics",
   "hideLyrics": "Hide lyrics",
   "showQueue": "Show queue",

--- a/apps/web/src/locales/en/queue.json
+++ b/apps/web/src/locales/en/queue.json
@@ -1,6 +1,9 @@
 {
   "title": "Queue",
-  "clear": "Clear",
+  "clear": "Clear queue",
+  "clearConfirm": "Clear the queue? Playback will stop and all tracks will be removed.",
+  "clearConfirmAction": "Clear queue",
+  "keep": "Keep",
   "emptyTitle": "Queue is empty",
   "emptySubtitle": "Tracks you queue up will appear here.",
   "nowPlaying": "Now Playing",

--- a/apps/web/src/locales/en/queue.json
+++ b/apps/web/src/locales/en/queue.json
@@ -1,7 +1,8 @@
 {
   "title": "Queue",
   "clear": "Clear",
-  "empty": "Queue is empty",
+  "emptyTitle": "Queue is empty",
+  "emptySubtitle": "Tracks you queue up will appear here.",
   "nowPlaying": "Now Playing",
   "upNext": "Up Next ({{count}})",
   "remove": "Remove from queue",

--- a/apps/web/src/locales/en/queue.json
+++ b/apps/web/src/locales/en/queue.json
@@ -4,6 +4,7 @@
   "clearConfirm": "Clear the queue? Playback will stop and all tracks will be removed.",
   "clearConfirmAction": "Clear queue",
   "keep": "Keep",
+  "saveAsPlaylist": "Save queue as playlist",
   "emptyTitle": "Queue is empty",
   "emptySubtitle": "Tracks you queue up will appear here.",
   "nowPlaying": "Now Playing",

--- a/apps/web/src/locales/pl/lyrics.json
+++ b/apps/web/src/locales/pl/lyrics.json
@@ -2,6 +2,7 @@
   "title": "Tekst piosenki",
   "finding": "Szukam tekstu...",
   "notFound": "Nie znaleziono tekstu",
+  "error": "Nie udało się wczytać tekstu",
   "sourceLocal": "Lokalny",
   "sourceEmbedded": "Osadzony",
   "sourceLrclib": "LRCLIB",

--- a/apps/web/src/locales/pl/nowPlaying.json
+++ b/apps/web/src/locales/pl/nowPlaying.json
@@ -5,6 +5,7 @@
   "eq": "Korektor",
   "findingLyrics": "Szukanie tekstu...",
   "noLyrics": "Tekst niedostępny",
+  "lyricsError": "Nie udało się wczytać tekstu",
   "showLyrics": "Pokaż tekst",
   "hideLyrics": "Ukryj tekst",
   "showQueue": "Pokaż kolejkę",

--- a/apps/web/src/locales/pl/queue.json
+++ b/apps/web/src/locales/pl/queue.json
@@ -1,6 +1,9 @@
 {
   "title": "Kolejka",
-  "clear": "Wyczyść",
+  "clear": "Wyczyść kolejkę",
+  "clearConfirm": "Wyczyścić kolejkę? Odtwarzanie zostanie zatrzymane, a wszystkie utwory usunięte.",
+  "clearConfirmAction": "Wyczyść kolejkę",
+  "keep": "Zachowaj",
   "emptyTitle": "Kolejka jest pusta",
   "emptySubtitle": "Utwory dodane do kolejki pojawią się tutaj.",
   "nowPlaying": "Teraz odtwarzane",

--- a/apps/web/src/locales/pl/queue.json
+++ b/apps/web/src/locales/pl/queue.json
@@ -4,6 +4,7 @@
   "clearConfirm": "Wyczyścić kolejkę? Odtwarzanie zostanie zatrzymane, a wszystkie utwory usunięte.",
   "clearConfirmAction": "Wyczyść kolejkę",
   "keep": "Zachowaj",
+  "saveAsPlaylist": "Zapisz kolejkę jako playlistę",
   "emptyTitle": "Kolejka jest pusta",
   "emptySubtitle": "Utwory dodane do kolejki pojawią się tutaj.",
   "nowPlaying": "Teraz odtwarzane",

--- a/apps/web/src/locales/pl/queue.json
+++ b/apps/web/src/locales/pl/queue.json
@@ -1,7 +1,8 @@
 {
   "title": "Kolejka",
   "clear": "Wyczyść",
-  "empty": "Kolejka jest pusta",
+  "emptyTitle": "Kolejka jest pusta",
+  "emptySubtitle": "Utwory dodane do kolejki pojawią się tutaj.",
   "nowPlaying": "Teraz odtwarzane",
   "upNext": "Następne ({{count}})",
   "remove": "Usuń z kolejki",


### PR DESCRIPTION
## Summary

Polish pass over the docked side panels (queue + lyrics), building on the v2 foundation pass (status tokens, focus recipe, primitives):

- **QueuePanel empty state** now uses the shared `ViewEmptyState` vocabulary (compact variant for the narrow panel) instead of a bare icon with /30-opacity text.
- **Clear queue** is now a destructive popover confirm (same pattern as DownloadsView's Cancel all), triggered from a labelled `IconButton` with the shared focus treatment — clearing stops playback and drops every track, so it deserved a gate.
- **New: Save queue as playlist** — a `ListPlus` header action opens a name popover (sibling name-form conventions: autofocus, Enter saves, Escape closes, disabled while pending) and snapshots the whole queue via the existing `db:playlists:create-with-tracks` command through a new `useCreatePlaylistWithTracksMutation`; success/failure surface through the existing playlist toasts.
- **LyricsBody error branch** — a real failure state (destructive-tinted glyph + Retry wired to the query refetch), visually distinct from "No lyrics found". Ordered after the content branches so a failed refetch never hides lyrics we already have. Wired in both LyricsPanel and NowPlayingView.
- **SidePanel** — Suspense fallback is now a `SidePanelSkeleton` (header strip + track-shaped rows) instead of `null`; the flip button is an `IconButton` with the shared focus ring; the panel gets gentle enter/exit motion via new `PANEL_SLIDE_OFFSET`/`PANEL_TRANSITION` tokens in `lib/motion.ts` (AnimatePresence at the App mount sites, skipped under reduced motion, width left to the resize handle).
- **Contrast floor** — near-invisible muted text (`text-muted-foreground/30`-ish) raised to readable levels across the panels: section labels, panel titles, queue-row durations, and the lyrics empty label in NowPlayingView.

All new user-facing strings go through i18n with keys added to both `en` and `pl` locales.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` (apps/web) — 334 files / 2175 tests pass, including new coverage: clear-confirm flow (confirm + dismiss), save-as-playlist (happy path + empty-name guard), LyricsBody error branch (retry click + content-over-error precedence), SidePanelSkeleton anatomy
- [x] `pnpm test:storybook` — 248 files / 566 tests pass; stories updated for the new header actions, the LyricsBody Error branch, and the new SidePanelSkeleton
- [x] `pnpm lint` + `pnpm format:check` — clean
- [ ] Manual: open the queue panel → clear-queue confirm, save-as-playlist toast, panel flip/skeleton/enter-exit motion; kill lyrics network → error branch + retry