### PR TITLE
refactor(web): unify settings previews on a PreviewFrame primitive

### DIFF
--- a/apps/web/src/components/settings/AccentPreview/AccentPreview.tsx
+++ b/apps/web/src/components/settings/AccentPreview/AccentPreview.tsx
@@ -1,4 +1,5 @@
 import { Heart, Music2, Play } from 'lucide-react';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useAccentPreview } from './AccentPreview.hooks';
 
@@ -13,47 +14,41 @@ export default function AccentPreview() {
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="rounded-xl border border-border/30 bg-background/40 p-3"
-        role="img"
-        aria-label={title}
-      >
-        <div className="mx-auto max-w-[340px] rounded-xl border border-border/25 bg-surface/60 p-3">
-          {/* Fake track row: icon tile + title bars + favorite */}
-          <div className="flex items-center gap-3">
-            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-primary">
-              <Music2 className="size-4" />
-            </div>
-            <div className="min-w-0 flex-1 space-y-1.5">
-              <div className="h-2.5 w-28 rounded-full bg-foreground/25" />
-              <div className="h-2 w-20 rounded-full bg-muted-foreground/25" />
-            </div>
-            <Heart className="size-4 shrink-0 fill-primary/80 text-primary" />
+      <PreviewFrame label={title} canvasClassName="p-3">
+        {/* Fake track row: icon tile + title bars + favorite */}
+        <div className="flex items-center gap-3">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-primary">
+            <Music2 className="size-4" />
           </div>
-
-          {/* Progress bar with accent glow */}
-          <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted/35">
-            <div
-              className="h-full w-[62%] rounded-full bg-primary/70"
-              style={{ boxShadow: '0 0 10px rgba(var(--primary-rgb), 0.5)' }}
-            />
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <div className="h-2.5 w-28 rounded-full bg-foreground/25" />
+            <div className="h-2 w-20 rounded-full bg-muted-foreground/25" />
           </div>
+          <Heart className="size-4 shrink-0 fill-primary/80 text-primary" />
+        </div>
 
-          {/* Control row: play button (shows the computed foreground), active
+        {/* Progress bar with accent glow */}
+        <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted/35">
+          <div
+            className="h-full w-[62%] rounded-full bg-primary/70"
+            style={{ boxShadow: '0 0 10px rgba(var(--primary-rgb), 0.5)' }}
+          />
+        </div>
+
+        {/* Control row: play button (shows the computed foreground), active
               nav pill, and an "on" switch — the accent in its real habitats */}
-          <div className="mt-3 flex items-center justify-between">
-            <div className="grid size-8 place-items-center rounded-full bg-primary text-primary-foreground shadow">
-              <Play className="size-3.5 fill-current" />
-            </div>
-            <div className="rounded-md bg-primary/15 px-2.5 py-1 ring-1 ring-primary/35">
-              <div className="h-1.5 w-10 rounded-full bg-primary/80" />
-            </div>
-            <div className="flex h-4.5 w-8 items-center rounded-full bg-primary p-0.5">
-              <div className="ml-auto size-3.5 rounded-full bg-primary-foreground/95 shadow" />
-            </div>
+        <div className="mt-3 flex items-center justify-between">
+          <div className="grid size-8 place-items-center rounded-full bg-primary text-primary-foreground shadow">
+            <Play className="size-3.5 fill-current" />
+          </div>
+          <div className="rounded-md bg-primary/15 px-2.5 py-1 ring-1 ring-primary/35">
+            <div className="h-1.5 w-10 rounded-full bg-primary/80" />
+          </div>
+          <div className="flex h-4.5 w-8 items-center rounded-full bg-primary p-0.5">
+            <div className="ml-auto size-3.5 rounded-full bg-primary-foreground/95 shadow" />
           </div>
         </div>
-      </div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/CompactModePreview/CompactModePreview.tsx
+++ b/apps/web/src/components/settings/CompactModePreview/CompactModePreview.tsx
@@ -1,4 +1,5 @@
 import { Music2, Heart, Mic2, Play, SkipBack, SkipForward } from 'lucide-react';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { cn } from '@/lib/utils';
 import { useCompactModePreview } from './CompactModePreview.hooks';
@@ -29,11 +30,7 @@ export default function CompactModePreview() {
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="bg-background/40 border border-border/30 rounded-xl p-4 flex flex-col items-center justify-center gap-0"
-        role="img"
-        aria-label={title}
-      >
+      <PreviewFrame label={title} size="none" className="flex flex-col items-center justify-center">
         {/* Mock mini-player card */}
         <div
           className={cn(
@@ -103,7 +100,7 @@ export default function CompactModePreview() {
         </div>
 
         <p className="text-[10px] text-muted-foreground/60 text-center mt-2">{disclaimer}</p>
-      </div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/CrossfadePreview/CrossfadePreview.tsx
+++ b/apps/web/src/components/settings/CrossfadePreview/CrossfadePreview.tsx
@@ -1,4 +1,5 @@
 import { Music2, RadioTower } from 'lucide-react';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useCrossfadePreview } from './CrossfadePreview.hooks';
 import type { ICrossfadePreviewProps } from './CrossfadePreview.types';
@@ -17,43 +18,41 @@ export default function CrossfadePreview(props: ICrossfadePreviewProps) {
 
   return (
     <SettingsPreview title={title}>
-      <div className="rounded-xl border border-border/30 bg-background/40 p-3">
-        <div className="relative overflow-hidden rounded-lg border border-border/25 bg-surface/60 p-3">
-          <div className="mb-3 flex items-center justify-between gap-3">
-            <div className="flex items-center gap-2 text-xs text-foreground">
-              <Music2 className="size-3.5 text-primary" />
-              <span className="truncate">{outgoingLabel}</span>
-            </div>
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <RadioTower className="size-3.5" />
-              <span className="truncate">{incomingLabel}</span>
-            </div>
+      <PreviewFrame label={title} canvasClassName="p-3">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-xs text-foreground">
+            <Music2 className="size-3.5 text-primary" />
+            <span className="truncate">{outgoingLabel}</span>
           </div>
-
-          <div className="space-y-2">
-            <div className="h-2 overflow-hidden rounded-full bg-muted/30">
-              <div className="h-full w-[68%] rounded-full bg-primary/45" />
-            </div>
-            <div className="relative h-2 overflow-hidden rounded-full bg-muted/25">
-              <div
-                className="absolute inset-y-0 rounded-full bg-sky-400/45"
-                style={{
-                  left: incomingLeft,
-                  width: incomingWidth,
-                }}
-              />
-              {showBlendGlow && (
-                <div className="absolute inset-y-0 left-[48%] w-[24%] rounded-full bg-foreground/20 blur-sm" />
-              )}
-            </div>
-          </div>
-
-          <div className="mt-3 flex items-center justify-between text-[10px] text-muted-foreground">
-            <span>{statusLabel}</span>
-            <span className="tabular-nums">{durationLabel}</span>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <RadioTower className="size-3.5" />
+            <span className="truncate">{incomingLabel}</span>
           </div>
         </div>
-      </div>
+
+        <div className="space-y-2">
+          <div className="h-2 overflow-hidden rounded-full bg-muted/30">
+            <div className="h-full w-[68%] rounded-full bg-primary/45" />
+          </div>
+          <div className="relative h-2 overflow-hidden rounded-full bg-muted/25">
+            <div
+              className="absolute inset-y-0 rounded-full bg-sky-400/45"
+              style={{
+                left: incomingLeft,
+                width: incomingWidth,
+              }}
+            />
+            {showBlendGlow && (
+              <div className="absolute inset-y-0 left-[48%] w-[24%] rounded-full bg-foreground/20 blur-sm" />
+            )}
+          </div>
+        </div>
+
+        <div className="mt-3 flex items-center justify-between text-[10px] text-muted-foreground">
+          <span>{statusLabel}</span>
+          <span className="tabular-nums">{durationLabel}</span>
+        </div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/DiscordPreview/DiscordPreview.tsx
+++ b/apps/web/src/components/settings/DiscordPreview/DiscordPreview.tsx
@@ -1,4 +1,5 @@
 import { Music2 } from 'lucide-react';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { useDiscordPreview } from './DiscordPreview.hooks';
 import type { IDiscordPreviewProps } from './DiscordPreview.types';
 
@@ -13,34 +14,36 @@ export default function DiscordPreview({
   const { t } = useDiscordPreview();
 
   return (
-    <div className="rounded-lg bg-[#2b2d31] p-3 font-sans text-white/90">
-      <p className="mb-2 text-[10px] font-semibold uppercase text-white/60">
-        {t('dsc.preview.playingHeader')}
-      </p>
-      <div className="flex gap-3">
-        {showLargeImage && (
-          <div className="flex h-[60px] w-[60px] shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[#1e1f22]">
-            <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/30 to-primary/5">
-              <Music2 className="h-6 w-6 text-white/70" />
+    <PreviewFrame size="none">
+      <div className="rounded-lg bg-[#2b2d31] p-3 font-sans text-white/90">
+        <p className="mb-2 text-[10px] font-semibold uppercase text-white/60">
+          {t('dsc.preview.playingHeader')}
+        </p>
+        <div className="flex gap-3">
+          {showLargeImage && (
+            <div className="flex h-[60px] w-[60px] shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[#1e1f22]">
+              <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/30 to-primary/5">
+                <Music2 className="h-6 w-6 text-white/70" />
+              </div>
+            </div>
+          )}
+
+          <div className="flex min-w-0 flex-col justify-center gap-0.5">
+            <p className="truncate text-xs font-semibold text-white">Shiranami</p>
+            {details && <p className="truncate text-xs text-white/70">{details}</p>}
+            {state && <p className="truncate text-xs text-white/70">{state}</p>}
+            {showTimestamp && <p className="text-xs text-white/50">{t('dsc.preview.elapsed')}</p>}
+          </div>
+        </div>
+
+        {showButton && (
+          <div className="mt-2">
+            <div className="w-full rounded bg-[#4e505899] py-1.5 text-center text-xs font-medium text-white/80">
+              {t('dsc.preview.landingButton')}
             </div>
           </div>
         )}
-
-        <div className="flex min-w-0 flex-col justify-center gap-0.5">
-          <p className="truncate text-xs font-semibold text-white">Shiranami</p>
-          {details && <p className="truncate text-xs text-white/70">{details}</p>}
-          {state && <p className="truncate text-xs text-white/70">{state}</p>}
-          {showTimestamp && <p className="text-xs text-white/50">{t('dsc.preview.elapsed')}</p>}
-        </div>
       </div>
-
-      {showButton && (
-        <div className="mt-2">
-          <div className="w-full rounded bg-[#4e505899] py-1.5 text-center text-xs font-medium text-white/80">
-            {t('dsc.preview.landingButton')}
-          </div>
-        </div>
-      )}
-    </div>
+    </PreviewFrame>
   );
 }

--- a/apps/web/src/components/settings/EnrichBeforeAfterPreview/EnrichBeforeAfterPreview.tsx
+++ b/apps/web/src/components/settings/EnrichBeforeAfterPreview/EnrichBeforeAfterPreview.tsx
@@ -19,7 +19,7 @@ function TrackTagCard({ variant, title, artist, album }: ITrackTagCardProps) {
     isBefore ? 'italic text-muted-foreground/60' : 'text-muted-foreground'
   );
   return (
-    <div className="flex items-center gap-2.5 rounded-lg border border-border/30 bg-background/40 px-2.5 py-2">
+    <div className="flex items-center gap-2.5 rounded-lg border border-border/25 bg-surface/60 px-2.5 py-2">
       {isBefore ? (
         <div className="grid size-10 shrink-0 place-items-center rounded-md border border-dashed border-border/50 bg-background/60 text-muted-foreground/50">
           <ImageOff className="size-4" />

--- a/apps/web/src/components/settings/EnrichBeforeAfterPreview/EnrichBeforeAfterPreview.tsx
+++ b/apps/web/src/components/settings/EnrichBeforeAfterPreview/EnrichBeforeAfterPreview.tsx
@@ -1,5 +1,6 @@
 import { ImageOff, Music, ArrowRight } from 'lucide-react';
 import { EnrichConfidenceBadge } from '@/components/settings/EnrichConfidenceBadge';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { cn } from '@/lib/utils';
 import { useEnrichBeforeAfterPreview } from './EnrichBeforeAfterPreview.hooks';
 import type { EnrichTagCardVariant } from './EnrichBeforeAfterPreview.types';
@@ -47,35 +48,37 @@ export default function EnrichBeforeAfterPreview() {
   const { t, sampleConfidence } = useEnrichBeforeAfterPreview();
 
   return (
-    <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
-      <div className="space-y-1.5">
-        <p className="text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground/60">
-          {t('enr.beforeLabel')}
-        </p>
-        <TrackTagCard
-          variant="before"
-          title={t('enr.sampleTitle')}
-          artist={t('enr.sampleUnknownArtist')}
-          album={t('enr.sampleUnknownAlbum')}
-        />
-      </div>
-
-      <ArrowRight className="size-4 shrink-0 text-muted-foreground/50" aria-hidden="true" />
-
-      <div className="space-y-1.5">
-        <div className="flex items-center gap-1.5">
+    <PreviewFrame size="none">
+      <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+        <div className="space-y-1.5">
           <p className="text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground/60">
-            {t('enr.afterLabel')}
+            {t('enr.beforeLabel')}
           </p>
-          <EnrichConfidenceBadge confidence={sampleConfidence} />
+          <TrackTagCard
+            variant="before"
+            title={t('enr.sampleTitle')}
+            artist={t('enr.sampleUnknownArtist')}
+            album={t('enr.sampleUnknownAlbum')}
+          />
         </div>
-        <TrackTagCard
-          variant="after"
-          title={t('enr.sampleTitle')}
-          artist={t('enr.sampleArtist')}
-          album={t('enr.sampleAlbum')}
-        />
+
+        <ArrowRight className="size-4 shrink-0 text-muted-foreground/50" aria-hidden="true" />
+
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5">
+            <p className="text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground/60">
+              {t('enr.afterLabel')}
+            </p>
+            <EnrichConfidenceBadge confidence={sampleConfidence} />
+          </div>
+          <TrackTagCard
+            variant="after"
+            title={t('enr.sampleTitle')}
+            artist={t('enr.sampleArtist')}
+            album={t('enr.sampleAlbum')}
+          />
+        </div>
       </div>
-    </div>
+    </PreviewFrame>
   );
 }

--- a/apps/web/src/components/settings/EqCurvePreview/EqCurvePreview.tsx
+++ b/apps/web/src/components/settings/EqCurvePreview/EqCurvePreview.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { useEqCurvePreview, EQ_CURVE_VIEWBOX } from './EqCurvePreview.hooks';
 import type { IEqCurvePreviewProps } from './EqCurvePreview.types';
 
@@ -18,11 +19,9 @@ export default function EqCurvePreview(props: IEqCurvePreviewProps) {
   const tickLabels = ticks.map(tick => <span key={tick.freq}>{tick.label}</span>);
 
   return (
-    <div
-      className={cn(
-        'relative overflow-hidden rounded-xl border border-border/30 bg-background/40 transition-opacity',
-        disabled && 'opacity-50'
-      )}
+    <PreviewFrame
+      size="none"
+      className={cn('relative overflow-hidden p-0 transition-opacity', disabled && 'opacity-50')}
     >
       <svg
         viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
@@ -65,6 +64,6 @@ export default function EqCurvePreview(props: IEqCurvePreviewProps) {
       <div className="flex justify-between px-2 pb-1.5 text-[9px] tabular-nums text-muted-foreground/60">
         {tickLabels}
       </div>
-    </div>
+    </PreviewFrame>
   );
 }

--- a/apps/web/src/components/settings/LayoutPreview/LayoutPreview.tsx
+++ b/apps/web/src/components/settings/LayoutPreview/LayoutPreview.tsx
@@ -1,3 +1,4 @@
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useLayoutPreview } from './LayoutPreview.hooks';
 
@@ -31,36 +32,30 @@ export default function LayoutPreview() {
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="rounded-xl border border-border/30 bg-background/40 p-3"
-        role="img"
-        aria-label={title}
-      >
-        <div className="mx-auto flex h-32 max-w-[360px] gap-1.5 rounded-xl border border-border/25 bg-surface/60 p-2">
-          {/* Sidebar — not movable in v1 */}
-          <div className="w-8 shrink-0 space-y-1 rounded-md border border-border/25 bg-muted/20 p-1.5">
-            <div className="h-1 w-4 rounded-full bg-foreground/25" />
-            <div className="h-1 w-5 rounded-full bg-muted-foreground/25" />
-            <div className="h-1 w-4 rounded-full bg-muted-foreground/25" />
-          </div>
+      <PreviewFrame label={title} size="scene" canvasClassName="flex gap-1.5 p-2">
+        {/* Sidebar — not movable in v1 */}
+        <div className="w-8 shrink-0 space-y-1 rounded-md border border-border/25 bg-muted/20 p-1.5">
+          <div className="h-1 w-4 rounded-full bg-foreground/25" />
+          <div className="h-1 w-5 rounded-full bg-muted-foreground/25" />
+          <div className="h-1 w-4 rounded-full bg-muted-foreground/25" />
+        </div>
 
-          {/* Player column: top bar / [viz] / content+panel / [viz] / player bar */}
-          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-            <div className="h-2.5 shrink-0 rounded-md bg-muted/25" />
-            {visualizerOnTop && visualizerMock}
-            <div className="flex min-h-0 flex-1 gap-1.5">
-              {sidePanelOnLeft && sidePanelMock}
-              <div className="min-w-0 flex-1 rounded-md border border-border/25 bg-muted/15" />
-              {sidePanelOnRight && sidePanelMock}
-            </div>
-            {visualizerOnBottom && visualizerMock}
-            <div className="flex h-3.5 shrink-0 items-center justify-center gap-1 rounded-md bg-muted/25">
-              <div className="size-1.5 rounded-full bg-foreground/30" />
-              <div className="h-1 w-16 rounded-full bg-muted-foreground/30" />
-            </div>
+        {/* Player column: top bar / [viz] / content+panel / [viz] / player bar */}
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+          <div className="h-2.5 shrink-0 rounded-md bg-muted/25" />
+          {visualizerOnTop && visualizerMock}
+          <div className="flex min-h-0 flex-1 gap-1.5">
+            {sidePanelOnLeft && sidePanelMock}
+            <div className="min-w-0 flex-1 rounded-md border border-border/25 bg-muted/15" />
+            {sidePanelOnRight && sidePanelMock}
+          </div>
+          {visualizerOnBottom && visualizerMock}
+          <div className="flex h-3.5 shrink-0 items-center justify-center gap-1 rounded-md bg-muted/25">
+            <div className="size-1.5 rounded-full bg-foreground/30" />
+            <div className="h-1 w-16 rounded-full bg-muted-foreground/30" />
           </div>
         </div>
-      </div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/LibraryBannerPreview/LibraryBannerPreview.tsx
+++ b/apps/web/src/components/settings/LibraryBannerPreview/LibraryBannerPreview.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useLibraryBannerPreview } from './LibraryBannerPreview.hooks';
 import type { ILibraryBannerPreviewProps } from './LibraryBannerPreview.types';
@@ -8,31 +9,25 @@ export default function LibraryBannerPreview(props: ILibraryBannerPreviewProps) 
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="rounded-xl border border-border/30 bg-background/40 p-3"
-        role="img"
-        aria-label={title}
-      >
-        <div className="mx-auto max-w-[340px] rounded-xl border border-border/25 bg-surface/60 p-3">
-          <div
-            className={cn(
-              'mb-3 flex items-center gap-3 overflow-hidden rounded-lg border border-border/25 bg-primary/10 p-2 transition-all',
-              enabled ? 'h-16 opacity-100' : 'h-0 border-transparent p-0 opacity-0'
-            )}
-          >
-            <div className="size-10 shrink-0 rounded-md bg-primary/25" />
-            <div className="min-w-0 flex-1 space-y-1.5">
-              <div className="h-2.5 w-24 rounded-full bg-foreground/25" />
-              <div className="h-1.5 w-16 rounded-full bg-muted-foreground/25" />
-            </div>
-          </div>
-          <div className="grid grid-cols-3 gap-2">
-            <div className="h-16 rounded-lg bg-muted/30" />
-            <div className="h-16 rounded-lg bg-muted/25" />
-            <div className="h-16 rounded-lg bg-muted/20" />
+      <PreviewFrame label={title} canvasClassName="p-3">
+        <div
+          className={cn(
+            'mb-3 flex items-center gap-3 overflow-hidden rounded-lg border border-border/25 bg-primary/10 p-2 transition-all',
+            enabled ? 'h-16 opacity-100' : 'h-0 border-transparent p-0 opacity-0'
+          )}
+        >
+          <div className="size-10 shrink-0 rounded-md bg-primary/25" />
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <div className="h-2.5 w-24 rounded-full bg-foreground/25" />
+            <div className="h-1.5 w-16 rounded-full bg-muted-foreground/25" />
           </div>
         </div>
-      </div>
+        <div className="grid grid-cols-3 gap-2">
+          <div className="h-16 rounded-lg bg-muted/30" />
+          <div className="h-16 rounded-lg bg-muted/25" />
+          <div className="h-16 rounded-lg bg-muted/20" />
+        </div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/LoudnessPreview/LoudnessPreview.tsx
+++ b/apps/web/src/components/settings/LoudnessPreview/LoudnessPreview.tsx
@@ -1,3 +1,4 @@
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useLoudnessPreview } from './LoudnessPreview.hooks';
 import type { ILoudnessPreviewProps } from './LoudnessPreview.types';
@@ -15,24 +16,26 @@ export default function LoudnessPreview(props: ILoudnessPreviewProps) {
 
   return (
     <SettingsPreview title={title}>
-      <div className="rounded-xl border border-border/30 bg-background/40 p-3">
-        <div className="relative h-20 rounded-lg border border-border/25 bg-surface/60 px-3 pt-2 pb-3">
-          {/* Target loudness line */}
-          <div
-            className="pointer-events-none absolute inset-x-3 border-t border-dashed border-primary/50 transition-[bottom] duration-300"
-            style={{ bottom: targetLineBottom }}
-          >
-            <span className="absolute -top-3.5 right-0 text-[9px] tabular-nums text-primary/70">
-              {targetLabel}
-            </span>
-          </div>
-
-          {/* Track level bars */}
-          <div className="flex h-full items-end justify-between gap-2">{bars}</div>
+      {/* overflow-visible: the LUFS tag rides above the target line and may
+          poke past the canvas top at the loudest settings. */}
+      <PreviewFrame
+        label={title}
+        caption={caption}
+        canvasClassName="h-20 overflow-visible px-3 pt-2 pb-3"
+      >
+        {/* Target loudness line */}
+        <div
+          className="pointer-events-none absolute inset-x-3 border-t border-dashed border-primary/50 transition-[bottom] duration-300"
+          style={{ bottom: targetLineBottom }}
+        >
+          <span className="absolute -top-3.5 right-0 text-[9px] tabular-nums text-primary/70">
+            {targetLabel}
+          </span>
         </div>
 
-        <p className="mt-2 text-[10px] text-muted-foreground">{caption}</p>
-      </div>
+        {/* Track level bars */}
+        <div className="flex h-full items-end justify-between gap-2">{bars}</div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/LowPerformancePreview/LowPerformancePreview.tsx
+++ b/apps/web/src/components/settings/LowPerformancePreview/LowPerformancePreview.tsx
@@ -1,5 +1,6 @@
 import { Zap } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useLowPerformancePreview } from './LowPerformancePreview.hooks';
 import type { ILowPerformancePreviewProps } from './LowPerformancePreview.types';
@@ -13,36 +14,30 @@ export default function LowPerformancePreview(props: ILowPerformancePreviewProps
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="rounded-xl border border-border/30 bg-background/40 p-3"
-        role="img"
-        aria-label={title}
-      >
-        <div className="mx-auto max-w-[340px] rounded-xl border border-border/25 bg-surface/60 p-3">
-          <div className="mb-3 flex items-center justify-between">
-            <div className="flex items-center gap-2 text-xs text-foreground">
-              <Zap className={cn('size-3.5', enabled ? 'text-warning' : 'text-primary')} />
-              <span>{statusLabel}</span>
-            </div>
-            <div
-              className={cn(
-                'rounded-full px-2 py-0.5 text-[10px]',
-                enabled ? 'bg-warning/15 text-warning' : 'bg-primary/15 text-primary'
-              )}
-            >
-              {badgeLabel}
-            </div>
+      <PreviewFrame label={title} canvasClassName="p-3">
+        <div className="mb-3 flex items-center justify-between">
+          <div className="flex items-center gap-2 text-xs text-foreground">
+            <Zap className={cn('size-3.5', enabled ? 'text-warning' : 'text-primary')} />
+            <span>{statusLabel}</span>
           </div>
           <div
             className={cn(
-              'grid grid-cols-8 items-end gap-1 transition-opacity',
-              enabled && 'opacity-35'
+              'rounded-full px-2 py-0.5 text-[10px]',
+              enabled ? 'bg-warning/15 text-warning' : 'bg-primary/15 text-primary'
             )}
           >
-            {bars}
+            {badgeLabel}
           </div>
         </div>
-      </div>
+        <div
+          className={cn(
+            'grid grid-cols-8 items-end gap-1 transition-opacity',
+            enabled && 'opacity-35'
+          )}
+        >
+          {bars}
+        </div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/NoiseOverlayPreview/NoiseOverlayPreview.tsx
+++ b/apps/web/src/components/settings/NoiseOverlayPreview/NoiseOverlayPreview.tsx
@@ -1,4 +1,5 @@
 import { Sparkles } from 'lucide-react';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useNoiseOverlayPreview } from './NoiseOverlayPreview.hooks';
 import type { INoiseOverlayPreviewProps } from './NoiseOverlayPreview.types';
@@ -8,39 +9,33 @@ export default function NoiseOverlayPreview(props: INoiseOverlayPreviewProps) {
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="rounded-xl border border-border/30 bg-background/40 p-3"
-        role="img"
-        aria-label={title}
-      >
-        <div className="relative mx-auto h-[120px] max-w-[340px] overflow-hidden rounded-xl border border-border/25 bg-surface/60 p-3">
+      <PreviewFrame label={title} size="scene" canvasClassName="p-3">
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              'radial-gradient(circle at 18% 25%, rgba(var(--primary-rgb), 0.26), transparent 34%), linear-gradient(135deg, rgba(255,255,255,0.06), transparent)',
+          }}
+        />
+        {showNoiseLayer && (
           <div
-            className="absolute inset-0"
+            className="absolute inset-0 opacity-35"
             style={{
-              background:
-                'radial-gradient(circle at 18% 25%, rgba(var(--primary-rgb), 0.26), transparent 34%), linear-gradient(135deg, rgba(255,255,255,0.06), transparent)',
+              backgroundImage:
+                'radial-gradient(circle, rgba(255,255,255,0.45) 0.7px, transparent 0.8px)',
+              backgroundSize: '7px 7px',
             }}
           />
-          {showNoiseLayer && (
-            <div
-              className="absolute inset-0 opacity-35"
-              style={{
-                backgroundImage:
-                  'radial-gradient(circle, rgba(255,255,255,0.45) 0.7px, transparent 0.8px)',
-                backgroundSize: '7px 7px',
-              }}
-            />
-          )}
-          <div className="relative flex h-full flex-col justify-end gap-2">
-            <div className="flex items-center gap-2 text-xs text-foreground">
-              <Sparkles className="size-3.5 text-primary" />
-              <span>{statusLabel}</span>
-            </div>
-            <div className="h-2 w-28 rounded-full bg-foreground/25" />
-            <div className="h-1.5 w-20 rounded-full bg-muted-foreground/25" />
+        )}
+        <div className="relative flex h-full flex-col justify-end gap-2">
+          <div className="flex items-center gap-2 text-xs text-foreground">
+            <Sparkles className="size-3.5 text-primary" />
+            <span>{statusLabel}</span>
           </div>
+          <div className="h-2 w-28 rounded-full bg-foreground/25" />
+          <div className="h-1.5 w-20 rounded-full bg-muted-foreground/25" />
         </div>
-      </div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/NowPlayingViewPreview/NowPlayingViewPreview.tsx
+++ b/apps/web/src/components/settings/NowPlayingViewPreview/NowPlayingViewPreview.tsx
@@ -1,5 +1,6 @@
 import { Image, Maximize2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useNowPlayingViewPreview } from './NowPlayingViewPreview.hooks';
 import type { INowPlayingViewPreviewProps } from './NowPlayingViewPreview.types';
@@ -9,45 +10,39 @@ export default function NowPlayingViewPreview(props: INowPlayingViewPreviewProps
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="rounded-xl border border-border/30 bg-background/40 p-3"
-        role="img"
-        aria-label={title}
-      >
-        <div className="relative mx-auto h-[140px] max-w-[340px] overflow-hidden rounded-xl border border-border/25 bg-surface/60 p-3">
-          <div
-            className={cn(
-              'absolute inset-0 transition-opacity',
-              enabled ? 'opacity-100' : 'opacity-25'
-            )}
-            style={{
-              background:
-                'radial-gradient(circle at 22% 18%, rgba(var(--primary-rgb), 0.35), transparent 34%), linear-gradient(135deg, rgba(255,255,255,0.05), transparent)',
-            }}
-          />
-          <div className="relative flex h-full items-center gap-3">
-            <div className="flex size-20 shrink-0 items-center justify-center rounded-xl border border-border/25 bg-primary/15 text-primary">
-              <Image className="size-8" />
-            </div>
-            <div className="min-w-0 flex-1 space-y-2">
-              <div className="h-3 w-28 rounded-full bg-foreground/25" />
-              <div className="h-2 w-20 rounded-full bg-muted-foreground/25" />
-              <div className="mt-4 flex items-center gap-2">
-                <div className="size-7 rounded-full bg-primary/35" />
-                <div className="h-1.5 flex-1 rounded-full bg-muted/35" />
-              </div>
-            </div>
-            <div
-              className={cn(
-                'absolute right-3 top-3 flex size-8 items-center justify-center rounded-lg border border-border/25',
-                enabled ? 'bg-primary/20 text-primary' : 'bg-muted/20 text-muted-foreground/50'
-              )}
-            >
-              <Maximize2 className="size-3.5" />
+      <PreviewFrame label={title} size="scene" canvasClassName="p-3">
+        <div
+          className={cn(
+            'absolute inset-0 transition-opacity',
+            enabled ? 'opacity-100' : 'opacity-25'
+          )}
+          style={{
+            background:
+              'radial-gradient(circle at 22% 18%, rgba(var(--primary-rgb), 0.35), transparent 34%), linear-gradient(135deg, rgba(255,255,255,0.05), transparent)',
+          }}
+        />
+        <div className="relative flex h-full items-center gap-3">
+          <div className="flex size-20 shrink-0 items-center justify-center rounded-xl border border-border/25 bg-primary/15 text-primary">
+            <Image className="size-8" />
+          </div>
+          <div className="min-w-0 flex-1 space-y-2">
+            <div className="h-3 w-28 rounded-full bg-foreground/25" />
+            <div className="h-2 w-20 rounded-full bg-muted-foreground/25" />
+            <div className="mt-4 flex items-center gap-2">
+              <div className="size-7 rounded-full bg-primary/35" />
+              <div className="h-1.5 flex-1 rounded-full bg-muted/35" />
             </div>
           </div>
+          <div
+            className={cn(
+              'absolute right-3 top-3 flex size-8 items-center justify-center rounded-lg border border-border/25',
+              enabled ? 'bg-primary/20 text-primary' : 'bg-muted/20 text-muted-foreground/50'
+            )}
+          >
+            <Maximize2 className="size-3.5" />
+          </div>
         </div>
-      </div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/OverviewLayoutPreview/OverviewLayoutPreview.tsx
+++ b/apps/web/src/components/settings/OverviewLayoutPreview/OverviewLayoutPreview.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 import type { OverviewSectionId } from '@/lib/overview-sections';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useOverviewLayoutPreview } from './OverviewLayoutPreview.hooks';
 import type {
@@ -225,24 +226,18 @@ export default function OverviewLayoutPreview(props: IOverviewLayoutPreviewProps
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="rounded-xl border border-border/30 bg-background/40 p-3"
-        role="img"
-        aria-label={title}
-      >
-        <div className="mx-auto flex max-w-[360px] flex-col gap-1.5 rounded-xl border border-border/25 bg-surface/60 p-3">
-          {/* Greeting hero — always shown, not toggleable */}
-          <div className="flex h-9 shrink-0 items-center gap-2 rounded-lg bg-gradient-to-r from-primary/15 to-transparent px-2">
-            <div className="size-5 rounded-full bg-primary/30" />
-            <div className="space-y-1">
-              <div className="h-1.5 w-20 rounded-full bg-foreground/25" />
-              <div className="h-1 w-14 rounded-full bg-muted-foreground/25" />
-            </div>
+      <PreviewFrame label={title} canvasClassName="flex flex-col gap-1.5 p-3">
+        {/* Greeting hero — always shown, not toggleable */}
+        <div className="flex h-9 shrink-0 items-center gap-2 rounded-lg bg-gradient-to-r from-primary/15 to-transparent px-2">
+          <div className="size-5 rounded-full bg-primary/30" />
+          <div className="space-y-1">
+            <div className="h-1.5 w-20 rounded-full bg-foreground/25" />
+            <div className="h-1 w-14 rounded-full bg-muted-foreground/25" />
           </div>
-
-          {orderedBlocks}
         </div>
-      </div>
+
+        {orderedBlocks}
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/PlayerBarPreview/PlayerBarPreview.tsx
+++ b/apps/web/src/components/settings/PlayerBarPreview/PlayerBarPreview.tsx
@@ -1,5 +1,6 @@
 import { Heart, Play, SkipBack, SkipForward, Volume2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { usePlayerBarPreview } from './PlayerBarPreview.hooks';
 import type { IPlayerBarElementProps, IPlayerBarPreviewProps } from './PlayerBarPreview.types';
@@ -61,105 +62,99 @@ export default function PlayerBarPreview(props: IPlayerBarPreviewProps) {
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="rounded-xl border border-border/30 bg-background/40 p-3"
-        role="img"
-        aria-label={title}
-      >
-        {/* Full width on purpose (unlike the capped sibling mocks): the bar
-            packs ~330px of fixed-width elements, so any tighter cap starves
-            the flex-1 seek section into a centered clump. */}
-        <div className="flex h-14 w-full items-center gap-2 rounded-xl border border-border/25 bg-surface/60 px-3">
-          {/* Left: album art + title + favorite */}
-          <PlayerBarElement
-            visible={albumArt.visible}
-            highlighted={albumArt.highlighted}
-            expandedClass="max-w-10"
-          >
-            <div className="size-8 rounded-md bg-primary/20" />
-          </PlayerBarElement>
-          <div className="min-w-0 space-y-1">
-            <div className="h-1.5 w-16 rounded-full bg-foreground/25" />
-            <div className="h-1 w-11 rounded-full bg-muted-foreground/25" />
-          </div>
-          <PlayerBarElement
-            visible={favorite.visible}
-            highlighted={favorite.highlighted}
-            expandedClass="max-w-6"
-            className="p-1"
-          >
-            <Heart className="size-3 fill-favorite/70 text-favorite/70" />
-          </PlayerBarElement>
+      {/* Full width on purpose (unlike the capped sibling mocks): the bar
+          packs ~330px of fixed-width elements, so any tighter cap starves
+          the flex-1 seek section into a centered clump. */}
+      <PreviewFrame label={title} canvasClassName="flex h-14 max-w-none items-center gap-2 px-3">
+        {/* Left: album art + title + favorite */}
+        <PlayerBarElement
+          visible={albumArt.visible}
+          highlighted={albumArt.highlighted}
+          expandedClass="max-w-10"
+        >
+          <div className="size-8 rounded-md bg-primary/20" />
+        </PlayerBarElement>
+        <div className="min-w-0 space-y-1">
+          <div className="h-1.5 w-16 rounded-full bg-foreground/25" />
+          <div className="h-1 w-11 rounded-full bg-muted-foreground/25" />
+        </div>
+        <PlayerBarElement
+          visible={favorite.visible}
+          highlighted={favorite.highlighted}
+          expandedClass="max-w-6"
+          className="p-1"
+        >
+          <Heart className="size-3 fill-favorite/70 text-favorite/70" />
+        </PlayerBarElement>
 
-          {/* Center: controls + seek (always shown) */}
-          <div className="flex min-w-0 flex-1 flex-col items-center gap-1 px-1">
-            <div className="flex items-center gap-1.5">
-              <SkipBack className="size-2.5 text-muted-foreground/60" />
-              <div className="grid size-5 place-items-center rounded-full bg-primary/35">
-                <Play className="size-2 fill-foreground/80 text-foreground/80" />
+        {/* Center: controls + seek (always shown) */}
+        <div className="flex min-w-0 flex-1 flex-col items-center gap-1 px-1">
+          <div className="flex items-center gap-1.5">
+            <SkipBack className="size-2.5 text-muted-foreground/60" />
+            <div className="grid size-5 place-items-center rounded-full bg-primary/35">
+              <Play className="size-2 fill-foreground/80 text-foreground/80" />
+            </div>
+            <SkipForward className="size-2.5 text-muted-foreground/60" />
+          </div>
+          <div className="flex w-full items-center gap-1.5">
+            <PlayerBarElement
+              visible={timeLabels.visible}
+              highlighted={timeLabels.highlighted}
+              expandedClass="max-w-8"
+              className="px-0.5"
+            >
+              <span className="text-[8px] tabular-nums text-muted-foreground/70">1:24</span>
+            </PlayerBarElement>
+            {showWaveformSeekbar ? (
+              <div
+                className={cn(
+                  'flex h-4 min-w-0 flex-1 items-center gap-px rounded-md px-0.5 transition-all duration-300',
+                  waveformHighlighted && 'bg-primary/10 ring-1 ring-primary/40'
+                )}
+              >
+                {waveBarEls}
               </div>
-              <SkipForward className="size-2.5 text-muted-foreground/60" />
-            </div>
-            <div className="flex w-full items-center gap-1.5">
-              <PlayerBarElement
-                visible={timeLabels.visible}
-                highlighted={timeLabels.highlighted}
-                expandedClass="max-w-8"
-                className="px-0.5"
+            ) : (
+              <div
+                className={cn(
+                  'h-1 min-w-0 flex-1 overflow-hidden rounded-full bg-muted/35 transition-all duration-300',
+                  waveformHighlighted && 'ring-1 ring-primary/40'
+                )}
               >
-                <span className="text-[8px] tabular-nums text-muted-foreground/70">1:24</span>
-              </PlayerBarElement>
-              {showWaveformSeekbar ? (
-                <div
-                  className={cn(
-                    'flex h-4 min-w-0 flex-1 items-center gap-px rounded-md px-0.5 transition-all duration-300',
-                    waveformHighlighted && 'bg-primary/10 ring-1 ring-primary/40'
-                  )}
-                >
-                  {waveBarEls}
-                </div>
-              ) : (
-                <div
-                  className={cn(
-                    'h-1 min-w-0 flex-1 overflow-hidden rounded-full bg-muted/35 transition-all duration-300',
-                    waveformHighlighted && 'ring-1 ring-primary/40'
-                  )}
-                >
-                  <div className="h-full w-[38%] rounded-full bg-primary/55" />
-                </div>
-              )}
-              <PlayerBarElement
-                visible={timeLabels.visible}
-                highlighted={timeLabels.highlighted}
-                expandedClass="max-w-8"
-                className="px-0.5"
-              >
-                <span className="text-[8px] tabular-nums text-muted-foreground/70">3:45</span>
-              </PlayerBarElement>
-            </div>
-          </div>
-
-          {/* Right: utility buttons + volume — riding the controls band, with a
-              phantom seek-row lane below (mirrors the real PlayerBar). */}
-          <div className="flex flex-col items-end gap-1">
-            <div className="flex items-center gap-0.5">
-              {utilityButtons}
-              <PlayerBarElement
-                visible={volume.visible}
-                highlighted={volume.highlighted}
-                expandedClass="max-w-14"
-                className="gap-1 p-1"
-              >
-                <Volume2 className="size-3 shrink-0 text-muted-foreground/70" />
-                <div className="h-1 w-7 shrink-0 overflow-hidden rounded-full bg-muted/35">
-                  <div className="h-full w-2/3 rounded-full bg-foreground/40" />
-                </div>
-              </PlayerBarElement>
-            </div>
-            <div aria-hidden className={showWaveformSeekbar ? 'h-4' : 'h-1'} />
+                <div className="h-full w-[38%] rounded-full bg-primary/55" />
+              </div>
+            )}
+            <PlayerBarElement
+              visible={timeLabels.visible}
+              highlighted={timeLabels.highlighted}
+              expandedClass="max-w-8"
+              className="px-0.5"
+            >
+              <span className="text-[8px] tabular-nums text-muted-foreground/70">3:45</span>
+            </PlayerBarElement>
           </div>
         </div>
-      </div>
+
+        {/* Right: utility buttons + volume — riding the controls band, with a
+              phantom seek-row lane below (mirrors the real PlayerBar). */}
+        <div className="flex flex-col items-end gap-1">
+          <div className="flex items-center gap-0.5">
+            {utilityButtons}
+            <PlayerBarElement
+              visible={volume.visible}
+              highlighted={volume.highlighted}
+              expandedClass="max-w-14"
+              className="gap-1 p-1"
+            >
+              <Volume2 className="size-3 shrink-0 text-muted-foreground/70" />
+              <div className="h-1 w-7 shrink-0 overflow-hidden rounded-full bg-muted/35">
+                <div className="h-full w-2/3 rounded-full bg-foreground/40" />
+              </div>
+            </PlayerBarElement>
+          </div>
+          <div aria-hidden className={showWaveformSeekbar ? 'h-4' : 'h-1'} />
+        </div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/PreviewFrame/PreviewFrame.hooks.ts
+++ b/apps/web/src/components/settings/PreviewFrame/PreviewFrame.hooks.ts
@@ -1,0 +1,38 @@
+import { cn } from '@/lib/utils';
+import type { IPreviewFrameProps, IPreviewFrameView, PreviewFrameSize } from './PreviewFrame.types';
+
+/** The frosted panel every settings preview sits on. */
+const FRAME_CLASSES = 'rounded-xl border border-border/30 bg-background/40 p-3';
+
+/**
+ * The shared canvas surface. Padding is intentionally left to callers: the
+ * mocks mix `p-3`, `p-2`, and bar-style `px-3`, and tailwind-merge cannot
+ * subtract an axis from a base `p-*`.
+ */
+const CANVAS_BASE_CLASSES =
+  'relative mx-auto max-w-[360px] overflow-hidden rounded-xl border border-border/25 bg-surface/60';
+
+const CANVAS_SIZE_CLASSES: Record<Exclude<PreviewFrameSize, 'none'>, string> = {
+  scene: 'aspect-[5/2]',
+  shell: 'aspect-[10/7]',
+  auto: '',
+};
+
+/** Resolves the size preset + caller overrides into concrete class lists. */
+export function usePreviewFrame({
+  label,
+  size = 'auto',
+  className,
+  canvasClassName,
+  caption,
+  children,
+}: IPreviewFrameProps): IPreviewFrameView {
+  return {
+    label,
+    frameClassName: cn(FRAME_CLASSES, className),
+    canvasClassName:
+      size === 'none' ? null : cn(CANVAS_BASE_CLASSES, CANVAS_SIZE_CLASSES[size], canvasClassName),
+    caption,
+    children,
+  };
+}

--- a/apps/web/src/components/settings/PreviewFrame/PreviewFrame.stories.tsx
+++ b/apps/web/src/components/settings/PreviewFrame/PreviewFrame.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
+
+import PreviewFrame from './PreviewFrame';
+
+/**
+ * settings · PreviewFrame. The one preview surface every settings mock sits
+ * on: frosted frame + optional canvas with a geometry preset (`scene`,
+ * `shell`, `auto`, `none`) + optional caption slot. Every `*Preview`
+ * component renders through it so the previews share one calm rhythm.
+ */
+const meta: Meta<typeof PreviewFrame> = {
+  title: 'settings/PreviewFrame',
+  component: PreviewFrame,
+  parameters: {
+    // The mock is a labelled image; the caption is plain text — axe clean.
+    a11y: { test: 'error' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Content-sized canvas — the default for card and meter mocks. */
+export const Default: Story = {
+  args: {
+    label: 'Sample preview',
+    canvasClassName: 'p-3',
+    children: (
+      <div className="space-y-2">
+        <div className="h-2.5 w-28 rounded-full bg-foreground/25" />
+        <div className="h-2 w-20 rounded-full bg-muted-foreground/25" />
+      </div>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('img', { name: 'Sample preview' })).toBeInTheDocument();
+  },
+};
+
+/** Fixed-aspect scene canvas used by the illustrative moodbox mocks. */
+export const Scene: Story = {
+  args: {
+    label: 'Scene preview',
+    size: 'scene',
+    canvasClassName: 'p-3',
+    children: (
+      <div className="flex h-full flex-col justify-end gap-2">
+        <div className="h-2 w-28 rounded-full bg-foreground/25" />
+        <div className="h-1.5 w-20 rounded-full bg-muted-foreground/25" />
+      </div>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('img', { name: 'Scene preview' })).toBeInTheDocument();
+  },
+};
+
+/** Caption slot under the canvas, outside the announced image. */
+export const WithCaption: Story = {
+  args: {
+    label: 'Captioned preview',
+    caption: 'A short footnote about the mock.',
+    canvasClassName: 'p-3',
+    children: <div className="h-8 rounded-lg bg-muted/30" />,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('A short footnote about the mock.')).toBeInTheDocument();
+  },
+};
+
+/** `size="none"`: the frame is the image and children draw their own surface. */
+export const FrameOnly: Story = {
+  args: {
+    label: 'Frame-only preview',
+    size: 'none',
+    children: (
+      <div className="mx-auto max-w-[360px] rounded-xl border border-border/25 bg-surface/60 p-3">
+        <div className="h-2.5 w-24 rounded-full bg-foreground/25" />
+      </div>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('img', { name: 'Frame-only preview' })).toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/settings/PreviewFrame/PreviewFrame.test.tsx
+++ b/apps/web/src/components/settings/PreviewFrame/PreviewFrame.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import PreviewFrame from './PreviewFrame';
+
+describe('PreviewFrame', () => {
+  it('renders children on the canvas', () => {
+    render(
+      <PreviewFrame>
+        <span>Mock content</span>
+      </PreviewFrame>
+    );
+
+    expect(screen.getByText('Mock content')).toBeInTheDocument();
+  });
+
+  it('announces the canvas as a single labelled image', () => {
+    render(
+      <PreviewFrame label="Sample preview">
+        <span>Mock content</span>
+      </PreviewFrame>
+    );
+
+    expect(screen.getByRole('img', { name: 'Sample preview' })).toBeInTheDocument();
+  });
+
+  it('announces the frame itself when there is no canvas', () => {
+    const { container } = render(
+      <PreviewFrame label="Sample preview" size="none">
+        <span>Mock content</span>
+      </PreviewFrame>
+    );
+
+    const frame = container.firstElementChild;
+    expect(frame).toHaveAttribute('role', 'img');
+    expect(frame).toHaveAttribute('aria-label', 'Sample preview');
+  });
+
+  it('skips the image role entirely without a label', () => {
+    render(
+      <PreviewFrame>
+        <span>Mock content</span>
+      </PreviewFrame>
+    );
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('renders the caption outside the labelled image', () => {
+    render(
+      <PreviewFrame label="Sample preview" caption="A footnote">
+        <span>Mock content</span>
+      </PreviewFrame>
+    );
+
+    const caption = screen.getByText('A footnote');
+    expect(caption).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Sample preview' })).not.toContainElement(caption);
+  });
+
+  it('merges canvas overrides through the size preset', () => {
+    render(
+      <PreviewFrame size="scene" canvasClassName="p-3 max-w-none">
+        <span>Mock content</span>
+      </PreviewFrame>
+    );
+
+    const canvas = screen.getByText('Mock content').parentElement;
+    expect(canvas).toHaveClass('aspect-[5/2]', 'p-3', 'max-w-none');
+    expect(canvas).not.toHaveClass('max-w-[360px]');
+  });
+});

--- a/apps/web/src/components/settings/PreviewFrame/PreviewFrame.tsx
+++ b/apps/web/src/components/settings/PreviewFrame/PreviewFrame.tsx
@@ -1,0 +1,38 @@
+import { usePreviewFrame } from './PreviewFrame.hooks';
+import type { IPreviewFrameProps } from './PreviewFrame.types';
+
+/**
+ * The one preview surface every settings mock sits on: a frosted frame, an
+ * optional canvas with a preset geometry (`scene` / `shell` / `auto` / `none`),
+ * and an optional caption slot — so every preview down a settings page shares
+ * the same rhythm instead of hand-rolling the frame.
+ */
+export default function PreviewFrame(props: IPreviewFrameProps) {
+  const { label, frameClassName, canvasClassName, caption, children } = usePreviewFrame(props);
+
+  const labelled = label !== undefined;
+  // With no canvas the frame itself is the announced image.
+  const frameIsImage = labelled && canvasClassName === null;
+  const hasCaption = caption !== undefined && caption !== null;
+
+  return (
+    <div
+      className={frameClassName}
+      role={frameIsImage ? 'img' : undefined}
+      aria-label={frameIsImage ? label : undefined}
+    >
+      {canvasClassName === null ? (
+        children
+      ) : (
+        <div
+          className={canvasClassName}
+          role={labelled ? 'img' : undefined}
+          aria-label={labelled ? label : undefined}
+        >
+          {children}
+        </div>
+      )}
+      {hasCaption && <p className="mt-2 text-[10px] text-muted-foreground">{caption}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/PreviewFrame/PreviewFrame.types.ts
+++ b/apps/web/src/components/settings/PreviewFrame/PreviewFrame.types.ts
@@ -1,0 +1,41 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Canvas geometry preset.
+ *
+ * - `scene`  — fixed-aspect moodbox (`aspect-[5/2]`, ≈144px at the 360px cap)
+ *   for the illustrative scene mocks (room light, noise, vinyl, visualizer…).
+ * - `shell`  — taller fixed-aspect app-shell mock (`aspect-[10/7]`, ≈252px).
+ * - `auto`   — canvas surface sized by its content (cards, bars, meters).
+ * - `none`   — no canvas element; children render directly on the frame for
+ *   previews that draw their own surface (sample tiles, brand cards).
+ */
+export type PreviewFrameSize = 'scene' | 'shell' | 'auto' | 'none';
+
+export interface IPreviewFrameProps {
+  /**
+   * Accessible name for the mock. When set, the preview announces as a single
+   * image (on the canvas, or on the frame when `size` is `none`) so assistive
+   * tech skips the decorative internals.
+   */
+  readonly label?: string;
+  /** Canvas geometry preset (default `auto`). */
+  readonly size?: PreviewFrameSize;
+  /** Extra classes merged onto the frame surface. */
+  readonly className?: string;
+  /** Extra classes merged onto the canvas — layout, padding, or overrides. */
+  readonly canvasClassName?: string;
+  /** Footnote rendered under the canvas, inside the frame. */
+  readonly caption?: ReactNode;
+  /** Mock content for the canvas (or the frame itself when `size` is `none`). */
+  readonly children: ReactNode;
+}
+
+export interface IPreviewFrameView {
+  readonly label?: string;
+  readonly frameClassName: string;
+  /** Resolved canvas classes, or null when `size` is `none`. */
+  readonly canvasClassName: string | null;
+  readonly caption?: ReactNode;
+  readonly children: ReactNode;
+}

--- a/apps/web/src/components/settings/PreviewFrame/index.ts
+++ b/apps/web/src/components/settings/PreviewFrame/index.ts
@@ -1,0 +1,2 @@
+export { default as PreviewFrame } from './PreviewFrame';
+export * from './PreviewFrame.types';

--- a/apps/web/src/components/settings/ResumePreview/ResumePreview.tsx
+++ b/apps/web/src/components/settings/ResumePreview/ResumePreview.tsx
@@ -1,4 +1,5 @@
 import { Clock3 } from 'lucide-react';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useResumePreview } from './ResumePreview.hooks';
 import type { IResumePreviewProps } from './ResumePreview.types';
@@ -8,28 +9,26 @@ export default function ResumePreview(props: IResumePreviewProps) {
 
   return (
     <SettingsPreview title={title}>
-      <div className="rounded-xl border border-border/30 bg-background/40 p-3">
-        <div className="flex items-center gap-3 rounded-lg border border-border/25 bg-surface/60 p-3">
-          <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-primary">
-            <Clock3 className="size-4" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="mb-1.5 flex items-center justify-between gap-3">
-              <p className="truncate text-xs font-medium text-foreground">{trackLabel}</p>
-              <span className="text-[10px] tabular-nums text-muted-foreground/70">
-                {positionLabel}
-              </span>
-            </div>
-            <div className="h-1.5 overflow-hidden rounded-full bg-muted/35">
-              <div
-                className="h-full rounded-full bg-primary/55 transition-[width]"
-                style={{ width: progressWidth }}
-              />
-            </div>
-            <p className="mt-2 text-[10px] text-muted-foreground">{caption}</p>
-          </div>
+      <PreviewFrame label={title} canvasClassName="flex items-center gap-3 p-3">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-primary">
+          <Clock3 className="size-4" />
         </div>
-      </div>
+        <div className="min-w-0 flex-1">
+          <div className="mb-1.5 flex items-center justify-between gap-3">
+            <p className="truncate text-xs font-medium text-foreground">{trackLabel}</p>
+            <span className="text-[10px] tabular-nums text-muted-foreground/70">
+              {positionLabel}
+            </span>
+          </div>
+          <div className="h-1.5 overflow-hidden rounded-full bg-muted/35">
+            <div
+              className="h-full rounded-full bg-primary/55 transition-[width]"
+              style={{ width: progressWidth }}
+            />
+          </div>
+          <p className="mt-2 text-[10px] text-muted-foreground">{caption}</p>
+        </div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/RoomLightPreview/RoomLightPreview.tsx
+++ b/apps/web/src/components/settings/RoomLightPreview/RoomLightPreview.tsx
@@ -1,4 +1,5 @@
 import { Lamp } from 'lucide-react';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useRoomLightPreview } from './RoomLightPreview.hooks';
 import type { IRoomLightPreviewProps } from './RoomLightPreview.types';
@@ -8,36 +9,30 @@ export default function RoomLightPreview(props: IRoomLightPreviewProps) {
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="rounded-xl border border-border/30 bg-background/40 p-3"
-        role="img"
-        aria-label={title}
-      >
-        <div className="relative mx-auto h-[120px] max-w-[340px] overflow-hidden rounded-xl border border-border/25 bg-surface/60 p-3">
+      <PreviewFrame label={title} size="scene" canvasClassName="p-3">
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              'radial-gradient(circle at 18% 25%, rgba(var(--primary-rgb), 0.26), transparent 34%), linear-gradient(135deg, rgba(255,255,255,0.06), transparent)',
+          }}
+        />
+        {layerStyle && (
           <div
-            className="absolute inset-0"
-            style={{
-              background:
-                'radial-gradient(circle at 18% 25%, rgba(var(--primary-rgb), 0.26), transparent 34%), linear-gradient(135deg, rgba(255,255,255,0.06), transparent)',
-            }}
+            className="room-light room-light--preview absolute inset-0"
+            style={layerStyle}
+            data-slot="room-light-preview-layer"
           />
-          {layerStyle && (
-            <div
-              className="room-light room-light--preview absolute inset-0"
-              style={layerStyle}
-              data-slot="room-light-preview-layer"
-            />
-          )}
-          <div className="relative flex h-full flex-col justify-end gap-2">
-            <div className="flex items-center gap-2 text-xs text-foreground">
-              <Lamp className="size-3.5 text-primary" />
-              <span>{statusLabel}</span>
-            </div>
-            <div className="h-2 w-28 rounded-full bg-foreground/25" />
-            <div className="h-1.5 w-20 rounded-full bg-muted-foreground/25" />
+        )}
+        <div className="relative flex h-full flex-col justify-end gap-2">
+          <div className="flex items-center gap-2 text-xs text-foreground">
+            <Lamp className="size-3.5 text-primary" />
+            <span>{statusLabel}</span>
           </div>
+          <div className="h-2 w-28 rounded-full bg-foreground/25" />
+          <div className="h-1.5 w-20 rounded-full bg-muted-foreground/25" />
         </div>
-      </div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/SidebarPreview/SidebarPreview.tsx
+++ b/apps/web/src/components/settings/SidebarPreview/SidebarPreview.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useSidebarPreview } from './SidebarPreview.hooks';
 import type { ISidebarPreviewProps } from './SidebarPreview.types';
@@ -26,51 +27,45 @@ export default function SidebarPreview({ highlightedId = null }: ISidebarPreview
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="rounded-xl border border-border/30 bg-background/40 p-3"
-        role="img"
-        aria-label={title}
-      >
-        <div className="mx-auto flex h-[250px] max-w-[360px] overflow-hidden rounded-xl border border-border/30 bg-surface/60 shadow-sm">
-          <aside className="flex w-[132px] shrink-0 flex-col border-r border-border/30 bg-background/35 p-2">
-            <div className="mb-2 flex shrink-0 items-center gap-2 rounded-lg px-1 py-1.5">
-              <div className="size-6 rounded-md bg-primary/20" />
-              <div className="h-2.5 w-16 rounded-full bg-foreground/18" />
-            </div>
+      <PreviewFrame label={title} size="shell" canvasClassName="flex">
+        <aside className="flex w-[132px] shrink-0 flex-col border-r border-border/30 bg-background/35 p-2">
+          <div className="mb-2 flex shrink-0 items-center gap-2 rounded-lg px-1 py-1.5">
+            <div className="size-6 rounded-md bg-primary/20" />
+            <div className="h-2.5 w-16 rounded-full bg-foreground/18" />
+          </div>
 
-            <div className="min-h-0 flex-1 space-y-1 overflow-y-auto scrollbar-thin">{navRows}</div>
+          <div className="min-h-0 flex-1 space-y-1 overflow-y-auto scrollbar-thin">{navRows}</div>
 
-            {showPlaylists && (
-              <div className="mt-2 shrink-0 border-t border-border/30 pt-2">
-                <div className="mb-1.5 h-1.5 w-16 rounded-full bg-muted-foreground/25" />
-                <div className="space-y-1">
-                  <div className="h-5 rounded-md bg-muted/35" />
-                  <div className="h-5 rounded-md bg-muted/25" />
-                </div>
-              </div>
-            )}
-          </aside>
-
-          <main className="flex min-w-0 flex-1 flex-col gap-3 p-3">
-            <div className="flex items-center justify-between">
+          {showPlaylists && (
+            <div className="mt-2 shrink-0 border-t border-border/30 pt-2">
+              <div className="mb-1.5 h-1.5 w-16 rounded-full bg-muted-foreground/25" />
               <div className="space-y-1">
-                <div className="h-2.5 w-20 rounded-full bg-foreground/20" />
-                <div className="h-1.5 w-28 rounded-full bg-muted-foreground/20" />
+                <div className="h-5 rounded-md bg-muted/35" />
+                <div className="h-5 rounded-md bg-muted/25" />
               </div>
-              <div className="size-7 rounded-lg bg-primary/15" />
             </div>
-            <div className="grid grid-cols-2 gap-2">
-              <div className="h-16 rounded-lg border border-border/25 bg-muted/20" />
-              <div className="h-16 rounded-lg border border-border/25 bg-muted/15" />
+          )}
+        </aside>
+
+        <main className="flex min-w-0 flex-1 flex-col gap-3 p-3">
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <div className="h-2.5 w-20 rounded-full bg-foreground/20" />
+              <div className="h-1.5 w-28 rounded-full bg-muted-foreground/20" />
             </div>
-            <div className="mt-auto space-y-1.5">
-              <div className="h-2 rounded-full bg-muted/35" />
-              <div className="h-2 w-3/4 rounded-full bg-muted/25" />
-              <div className="h-2 w-1/2 rounded-full bg-muted/20" />
-            </div>
-          </main>
-        </div>
-      </div>
+            <div className="size-7 rounded-lg bg-primary/15" />
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <div className="h-16 rounded-lg border border-border/25 bg-muted/20" />
+            <div className="h-16 rounded-lg border border-border/25 bg-muted/15" />
+          </div>
+          <div className="mt-auto space-y-1.5">
+            <div className="h-2 rounded-full bg-muted/35" />
+            <div className="h-2 w-3/4 rounded-full bg-muted/25" />
+            <div className="h-2 w-1/2 rounded-full bg-muted/20" />
+          </div>
+        </main>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/SleepFadePreview/SleepFadePreview.tsx
+++ b/apps/web/src/components/settings/SleepFadePreview/SleepFadePreview.tsx
@@ -1,4 +1,5 @@
 import { Moon } from 'lucide-react';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useSleepFadePreview } from './SleepFadePreview.hooks';
 import type { ISleepFadePreviewProps } from './SleepFadePreview.types';
@@ -16,13 +17,10 @@ export default function SleepFadePreview(props: ISleepFadePreviewProps) {
 
   return (
     <SettingsPreview title={title}>
-      <div className="rounded-xl border border-border/30 bg-background/40 p-3">
-        <div className="relative h-16 rounded-lg border border-border/25 bg-surface/60 px-3 pt-2 pb-2">
-          <Moon className="absolute right-2 top-2 size-3.5 text-primary/60" aria-hidden="true" />
-          <div className="flex h-full items-end gap-1">{bars}</div>
-        </div>
-        <p className="mt-2 text-[10px] text-muted-foreground">{caption}</p>
-      </div>
+      <PreviewFrame label={title} caption={caption} canvasClassName="h-16 px-3 pt-2 pb-2">
+        <Moon className="absolute right-2 top-2 size-3.5 text-primary/60" aria-hidden="true" />
+        <div className="flex h-full items-end gap-1">{bars}</div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/ThemeBackgroundPreview/ThemeBackgroundPreview.tsx
+++ b/apps/web/src/components/settings/ThemeBackgroundPreview/ThemeBackgroundPreview.tsx
@@ -1,4 +1,5 @@
 import { Play } from 'lucide-react';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { useThemeBackgroundPreview } from './ThemeBackgroundPreview.hooks';
 
 /**
@@ -31,7 +32,7 @@ export default function ThemeBackgroundPreview() {
   if (!hasBackground) return null;
 
   return (
-    <div className="relative h-[148px] overflow-hidden rounded-xl border border-border/30 bg-background">
+    <PreviewFrame size="scene" canvasClassName="bg-background">
       {/* Image — same class + url() resolution as the real ThemeBackground, but
           opacity/blur are scoped here instead of via the document root vars. */}
       <div
@@ -64,6 +65,6 @@ export default function ThemeBackgroundPreview() {
           </div>
         </div>
       </div>
-    </div>
+    </PreviewFrame>
   );
 }

--- a/apps/web/src/components/settings/TopBarPreview/TopBarPreview.tsx
+++ b/apps/web/src/components/settings/TopBarPreview/TopBarPreview.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useTopBarPreview } from './TopBarPreview.hooks';
 import type { ITopBarPreviewProps } from './TopBarPreview.types';
@@ -8,35 +9,27 @@ export default function TopBarPreview(props: ITopBarPreviewProps) {
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="rounded-xl border border-border/30 bg-background/40 p-3"
-        role="img"
-        aria-label={title}
-      >
-        <div className="mx-auto flex h-10 max-w-[340px] items-center gap-2 rounded-xl border border-border/25 bg-surface/60 px-3">
-          <div className="h-2 w-14 rounded-full bg-foreground/25" />
-          <div className="flex-1" />
-          <div className="h-5 w-12 rounded-md border border-border/30 bg-muted/25" />
-          <div
-            className={cn(
-              'flex items-center gap-0.5 overflow-hidden transition-all duration-300',
-              enabled ? 'max-w-16 opacity-100' : 'max-w-0 opacity-0'
-            )}
-          >
-            <span className="rounded bg-primary/15 px-1.5 py-0.5 text-[9px] font-medium text-primary">
-              EN
-            </span>
-            <span className="px-1.5 py-0.5 text-[9px] font-medium text-muted-foreground/60">
-              PL
-            </span>
-          </div>
-          <div className="flex items-center gap-1" aria-hidden="true">
-            <div className="size-1.5 rounded-full bg-muted-foreground/30" />
-            <div className="size-1.5 rounded-full bg-muted-foreground/30" />
-            <div className="size-1.5 rounded-full bg-muted-foreground/30" />
-          </div>
+      <PreviewFrame label={title} canvasClassName="flex h-10 items-center gap-2 px-3">
+        <div className="h-2 w-14 rounded-full bg-foreground/25" />
+        <div className="flex-1" />
+        <div className="h-5 w-12 rounded-md border border-border/30 bg-muted/25" />
+        <div
+          className={cn(
+            'flex items-center gap-0.5 overflow-hidden transition-all duration-300',
+            enabled ? 'max-w-16 opacity-100' : 'max-w-0 opacity-0'
+          )}
+        >
+          <span className="rounded bg-primary/15 px-1.5 py-0.5 text-[9px] font-medium text-primary">
+            EN
+          </span>
+          <span className="px-1.5 py-0.5 text-[9px] font-medium text-muted-foreground/60">PL</span>
         </div>
-      </div>
+        <div className="flex items-center gap-1" aria-hidden="true">
+          <div className="size-1.5 rounded-full bg-muted-foreground/30" />
+          <div className="size-1.5 rounded-full bg-muted-foreground/30" />
+          <div className="size-1.5 rounded-full bg-muted-foreground/30" />
+        </div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/UiScalePreview/UiScalePreview.tsx
+++ b/apps/web/src/components/settings/UiScalePreview/UiScalePreview.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useUiScalePreview } from './UiScalePreview.hooks';
 import type { IUiScalePreviewProps, IUiScaleSampleTileProps } from './UiScalePreview.types';
@@ -64,12 +65,8 @@ export default function UiScalePreview({ scale }: IUiScalePreviewProps) {
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="rounded-xl border border-border/30 bg-background/40 p-3"
-        role="img"
-        aria-label={title}
-      >
-        <div className="mx-auto flex max-w-[340px] items-start gap-3">
+      <PreviewFrame label={title} size="none">
+        <div className="mx-auto flex max-w-[360px] items-start gap-3">
           <SampleTile label={baseLabel} factor={1} title={sampleTitle} subtitle={sampleSubtitle} />
           <SampleTile
             label={currentLabel}
@@ -79,7 +76,7 @@ export default function UiScalePreview({ scale }: IUiScalePreviewProps) {
             active
           />
         </div>
-      </div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/VinylPreview/VinylPreview.tsx
+++ b/apps/web/src/components/settings/VinylPreview/VinylPreview.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { VinylRecord } from '@/components/shared/VinylRecord';
 import { useVinylPreview } from './VinylPreview.hooks';
@@ -28,15 +29,13 @@ export default function VinylPreview(props: IVinylPreviewProps) {
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="rounded-xl border border-border/30 bg-background/40 p-3"
-        role="img"
-        aria-label={title}
+      <PreviewFrame
+        label={title}
+        size="scene"
+        canvasClassName="flex items-end justify-center gap-10 p-3 pb-4"
       >
-        <div className="relative mx-auto flex h-[150px] max-w-[340px] items-end justify-center gap-10 overflow-hidden rounded-xl border border-border/25 bg-surface/60 p-3 pb-4">
-          {stageMiniatures}
-        </div>
-      </div>
+        {stageMiniatures}
+      </PreviewFrame>
     </SettingsPreview>
   );
 }

--- a/apps/web/src/components/settings/VisualizerStylePreview/VisualizerStylePreview.tsx
+++ b/apps/web/src/components/settings/VisualizerStylePreview/VisualizerStylePreview.tsx
@@ -1,24 +1,29 @@
 import { Suspense } from 'react';
+import { PreviewFrame } from '@/components/settings/PreviewFrame';
 import { SettingsPreview } from '@/components/settings/SettingsPreview';
 import { useVisualizerStylePreview } from './VisualizerStylePreview.hooks';
+
+/** Faint blueprint grid: 1px foreground lines every 24px, theme-driven. */
+const GRID_LINE = 'color-mix(in oklab, var(--foreground) 2.5%, transparent)';
 
 export default function VisualizerStylePreview() {
   const { title, Visualizer, source } = useVisualizerStylePreview();
 
   return (
     <SettingsPreview title={title}>
-      <div
-        className="relative h-[140px] overflow-hidden rounded-xl border border-border/30"
-        style={{
-          background: 'linear-gradient(135deg, oklch(0.12 0.015 270), oklch(0.09 0.015 255))',
-        }}
-      >
+      <PreviewFrame label={title} size="scene">
+        {/* Dimmed stage backdrop for the glowing bars, from theme tokens so it
+            follows the active palette instead of a hardcoded navy. */}
+        <div
+          aria-hidden="true"
+          className="absolute inset-0"
+          style={{ background: 'linear-gradient(135deg, var(--surface), var(--background))' }}
+        />
         <div
           aria-hidden="true"
           className="absolute inset-0"
           style={{
-            backgroundImage:
-              'linear-gradient(oklch(1 0 0 / 0.025) 1px, transparent 1px), linear-gradient(90deg, oklch(1 0 0 / 0.025) 1px, transparent 1px)',
+            backgroundImage: `linear-gradient(${GRID_LINE} 1px, transparent 1px), linear-gradient(90deg, ${GRID_LINE} 1px, transparent 1px)`,
             backgroundSize: '24px 24px',
           }}
         />
@@ -27,7 +32,7 @@ export default function VisualizerStylePreview() {
             <Visualizer source={source} active />
           </Suspense>
         </div>
-      </div>
+      </PreviewFrame>
     </SettingsPreview>
   );
 }


### PR DESCRIPTION
## Summary

The 23 `settings/*Preview` components each hand-rolled the same frosted frame (`rounded-xl border border-border/30 bg-background/40 p-3`) around an inner canvas that had drifted into five different heights (250/148/140/120/40px), split max-widths (340 vs 360px), and mixed border/radius tones. This PR introduces one `PreviewFrame` primitive under `settings/` and migrates every preview onto it:

- **`PreviewFrame`** (new, follows the `SettingsPreview` folder pattern): frame surface + canvas with geometry presets — `scene` (`aspect-[5/2]` moodboxes), `shell` (`aspect-[10/7]` app-shell mock), `auto` (content-sized), `none` (frame only, for previews that draw their own surface) — plus an optional caption slot. The `role="img"`/`aria-label` handling lives in the primitive; the caption renders outside the announced image so footnotes stay readable to assistive tech.
- **All 23 previews migrated**, including the previously frameless outliers (Discord, EnrichBeforeAfter, EqCurve, ThemeBackground, VisualizerStyle) which now share the same frame rhythm. Canvas max-width is unified at 360px; canvas tone is unified at `border-border/25 bg-surface/60` (PlayerBar keeps its intentional full-width canvas, with its explanatory comment).
- **`VisualizerStylePreview` de-hardcoded**: the backdrop gradient now derives from `var(--surface)`/`var(--background)` and the blueprint grid from `color-mix` on `var(--foreground)`, so the preview follows the active theme palette instead of a fixed navy.

Mechanical refactor — no logic, props, hooks, or i18n changes; component tests and stories are untouched and passing.

## Test plan

- `pnpm typecheck` (apps/web) — clean
- `pnpm lint` + `pnpm format:check` — clean
- `pnpm test` (apps/web) — 345 files / 2320 tests pass, including all `*Preview` component tests (`role="img"` labels preserved by the primitive)
- `pnpm test:storybook` — 254 files / 586 story tests pass (a11y + play functions)
- New `PreviewFrame` unit tests + stories cover label placement, caption slot, size presets, and tailwind-merge overrides