### PR TITLE
fix(desktop): unblock the Windows test suite and correct the stale mark-imported case

### DIFF
--- a/apps/desktop-tauri/src-tauri/app.manifest
+++ b/apps/desktop-tauri/src-tauri/app.manifest
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/apps/desktop-tauri/src-tauri/build.rs
+++ b/apps/desktop-tauri/src-tauri/build.rs
@@ -1,3 +1,34 @@
 fn main() {
-    tauri_build::build();
+    let attributes = tauri_build::Attributes::new()
+        .windows_attributes(tauri_build::WindowsAttributes::new_without_app_manifest());
+    tauri_build::try_build(attributes).expect("tauri-build");
+
+    embed_app_manifest();
+}
+
+/// `tauri_build` embeds its manifest into the app binary alone, so cargo test
+/// binaries get none. `tauri-plugin-dialog` imports `TaskDialogIndirect`, which
+/// only comctl32 v6 exports, so an unmanifested test binary binds System32's
+/// v5.82 and dies at load with `STATUS_ENTRYPOINT_NOT_FOUND` before a single
+/// test runs. Linux CI never sees it, which is how the whole desktop suite could
+/// be unrunnable on Windows while the pipeline stayed green.
+///
+/// `app.manifest` holds what tauri would have embedded. Linking it here covers
+/// every target, and tauri's own copy is switched off above so the two cannot
+/// collide as a duplicate MANIFEST resource.
+fn embed_app_manifest() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
+    }
+    let Ok(dir) = std::env::var("CARGO_MANIFEST_DIR") else {
+        return;
+    };
+    let manifest = std::path::Path::new(&dir).join("app.manifest");
+
+    println!("cargo::rerun-if-changed=app.manifest");
+    println!("cargo::rustc-link-arg=/MANIFEST:EMBED");
+    println!(
+        "cargo::rustc-link-arg=/MANIFESTINPUT:{}",
+        manifest.display()
+    );
 }

--- a/apps/desktop-tauri/src-tauri/src/commands/downloader/queue_tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/downloader/queue_tests.rs
@@ -320,6 +320,11 @@ async fn cancelling_an_unknown_id_is_a_no_op() {
 ///
 /// Both drop the persisted row either way, which is the part that matters
 /// after a restart: an imported download must not be resumed.
+///
+/// Both rows are `done` before the call, which is the only thing the
+/// renderer imports. It matters because `retry` re-queues an item without
+/// leaving a trace, so an unfinished row is indistinguishable from one a
+/// retry has just revived, and `mark_imported` spares those on purpose.
 #[tokio::test]
 async fn mark_imported_drops_batch_rows_from_the_view_and_keeps_single_ones() {
     let dir = tempfile::tempdir().expect("a temp dir");
@@ -335,11 +340,25 @@ async fn mark_imported_drops_batch_rows_from_the_view_and_keeps_single_ones() {
     let batched_id = queue.enqueue(batched).await;
     let single_id = queue.enqueue(input("https://youtu.be/two")).await;
 
-    queue
+    for mut item in persistence.stored() {
+        item.status = DownloadQueueStatus::Done;
+        item.file_path = Some(format!("{}.mp3", item.id));
+        persistence.upsert(&item).await.expect("the row stores");
+    }
+
+    let restarted = queue_over(
+        Arc::clone(&persistence),
+        Arc::new(RecordingSink::default()),
+        Arc::new(StalledRunner::default()),
+        dir.path().join("downloads"),
+    );
+    restarted.hydrate_and_resume().await;
+
+    restarted
         .mark_imported(&[batched_id.clone(), single_id.clone()])
         .await;
 
-    let remaining = queue.snapshot();
+    let remaining = restarted.snapshot();
     assert_eq!(remaining.items.len(), 1, "the batch row left the view");
     assert_eq!(remaining.items[0].id, single_id);
     assert!(


### PR DESCRIPTION
Closes #409.

`Rust Checks` has been red on the `v2` tip since `25959f8f`. It is not data loss, and the shipped `state.rs` is correct. The test asserted a state the renderer cannot produce.

## Why the test was wrong

`mark_imported` deliberately spares an item that a retry has put back in flight, because that row is live state again and dropping it would lose the download on the next restart.

`requeue` erases every field when a retry re-queues an item. Status, error, progress, file path, both timestamps, enqueue time, and all four batch fields. A retried item is therefore byte-identical to a freshly enqueued one, on purpose, since the item keeps its identity. No predicate over item state can forget one and keep the other.

The renderer decides which side wins, and it never sends an unfinished row.

- The single path awaits `importTrack(item.filePath)`, and `file_path` only exists at `done`.
- The batch path passes `batchIdsToForget(...)`, which keeps only ids still batch-owned, and `requeue` clears `batch_id`.

The case predates the carve-out. It landed in `90e12d37` on 2026-08-01, the retry feature in `25959f8f` on 2026-08-16. It paused the queue and enqueued so nothing had to download, which was safe while every id was forgotten unconditionally. So it now drives both rows to `done` first, which is the only thing the call actually receives. The persistence assertion is kept, not deleted, since it is the only thing pinning "an imported download must not resume".

## Why nobody caught it locally

The entire `shiranami-desktop` test binary fails to start on Windows, for every test, not just this one.

```
process didn't exit successfully: shiranami_desktop_lib-*.exe
(exit code: 0xc0000139, STATUS_ENTRYPOINT_NOT_FOUND)
```

`tauri-plugin-dialog` imports `TaskDialogIndirect`, which only comctl32 v6 exports. `tauri-build` embeds a side-by-side manifest into the app binary and cargo test binaries get none, so the loader binds System32's v5.82 and the process dies before `main`. Linux CI never sees it, which is how the whole desktop suite could be unrunnable on Windows while the pipeline stayed green.

`app.manifest` holds what `tauri-build` would have embedded, byte for byte, and is now linked into every target. Tauri's own copy is switched off via `WindowsAttributes::new_without_app_manifest`, because two sources collide as `CVT1100: duplicate resource type:MANIFEST`.

## Verification

Run on Windows, which is where the failure lives.

Before the manifest commit, the suite could not start at all. After it, the original failure reproduced locally for the first time.

```
test mark_imported_drops_batch_rows_from_the_view_and_keeps_single_ones ... FAILED
  both persisted rows are forgotten, so a restart resumes neither
```

After the test commit.

```
cargo test -p shiranami-desktop --lib
test result: ok. 517 passed; 0 failed; 0 ignored

cargo test -p shiranami-downloader
10 suites, all ok
```

`cargo clippy -p shiranami-desktop -p shiranami-downloader --all-targets -- -D warnings -W clippy::await_holding_lock -W clippy::unwrap_used` is clean. `packages/contracts/src/generated` is unchanged, so the drift guard is untouched.

Both binaries were checked to carry exactly one manifest, extracted with `mt.exe`.

| binary | Common-Controls present |
|---|---|
| `shiranami-desktop.exe` | yes |
| `shiranami_desktop_lib-*.exe` | yes |

## Note for other Windows contributors

`cargo fmt --all --check` fails workspace-wide on a Windows checkout, reporting `Incorrect newline style` for files nobody has touched. Git checks out CRLF per `.gitattributes` while rustfmt wants Unix newlines. It is unrelated to this change and it is not worth fixing by running `cargo fmt --all`, which rewrites line endings in ~489 files that git then normalizes back to no diff.
