### PR TITLE
build: check Rust sources out as LF on every platform

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,8 @@
 # Keep generated SQL migrations LF on every platform so the embedded-vs-on-disk
 # migration test stays stable on Windows checkouts.
 *.sql text eol=lf
+
+# Keep Rust sources LF on every platform. rustfmt.toml pins
+# `newline_style = "Unix"`, so a CRLF checkout makes `cargo fmt --check` fail on
+# every tracked file on Windows, for changes nobody made.
+*.rs text eol=lf


### PR DESCRIPTION
Out-of-band fix found while working #409. Not on the #414 board.

## Problem

`rustfmt.toml` pins `newline_style = "Unix"`. `.gitattributes` says `* text=auto`, so a Windows checkout gets CRLF. The result is that `cargo fmt --check` fails on all 490 tracked `.rs` files, for changes nobody made.

```
$ cargo fmt --all --check
Incorrect newline style in ...\src\adapters.rs
Incorrect newline style in ...\src\arch_guards.rs
Incorrect newline style in ...\src\bindings.rs
... (490 files)
```

The gate is unusable locally on Windows, and the obvious way to clear it, `cargo fmt --all`, rewrites line endings across the whole workspace. Git normalizes those back to a zero-line diff, so the churn is invisible in `git diff` but very visible in `git status`, which is its own trap.

CI never sees any of this because it runs on ubuntu, where the checkout is already LF.

## Fix

One line, plus the comment explaining it. Same fix and same reasoning as the `*.sql` rule directly above it, which exists for the same class of problem.

Repo content is unaffected. Git already stores LF, so this only changes what lands in a Windows working tree.

## Verification

On Windows, after renormalizing the checkout.

```
$ cargo fmt --all --check
$ echo $?
0
```

Was 490 failures, now clean.

## Note for existing Windows checkouts

Anyone with the repo already cloned needs a one-time renormalization to pick this up, since git will not rewrite working-tree line endings on its own.

```
git rm --cached -r .
git reset --hard HEAD
```

That touches no content and produces no diff.